### PR TITLE
auto-claude: 022-vibe-isolate

### DIFF
--- a/lib/core/utils/vibe_file_parser.dart
+++ b/lib/core/utils/vibe_file_parser.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:isolate';
 
 import 'package:flutter/foundation.dart';
 import 'package:png_chunks_extract/png_chunks_extract.dart' as png_extract;
@@ -103,6 +104,24 @@ class VibeFileParser {
         }
         throw FormatException('Unsupported file type: $extension');
     }
+  }
+
+  /// 从 PNG 文件解析 Vibe 参考（Isolate 版本）
+  ///
+  /// 在单独的 isolate 中执行解析，避免阻塞 UI 线程
+  /// 适用于大文件或批量处理场景
+  static Future<VibeReference> fromPngInIsolate(
+    String fileName,
+    Uint8List bytes, {
+    double defaultStrength = 0.6,
+  }) async {
+    return Isolate.run(() async {
+      return fromPng(
+        fileName,
+        bytes,
+        defaultStrength: defaultStrength,
+      );
+    });
   }
 
   /// 从 PNG 文件解析 Vibe 参考

--- a/lib/core/utils/vibe_image_embedder.dart
+++ b/lib/core/utils/vibe_image_embedder.dart
@@ -75,6 +75,18 @@ class VibeImageEmbedder {
     });
   }
 
+  /// 在 isolate 中嵌入 vibe 元数据
+  ///
+  /// 对于大文件或需要避免阻塞 UI 线程的场景，使用此方法
+  static Future<Uint8List> embedVibeToImageInIsolate(
+    Uint8List imageBytes,
+    VibeReference vibeReference,
+  ) async {
+    return Isolate.run(
+      () => embedVibeToImage(imageBytes, vibeReference),
+    ).then((result) => result);
+  }
+
   static Future<VibeReference> extractVibeFromImage(
     Uint8List imageBytes,
   ) async {

--- a/lib/core/utils/vibe_image_embedder.dart
+++ b/lib/core/utils/vibe_image_embedder.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:image/image.dart' as img;
@@ -106,6 +107,15 @@ class VibeImageEmbedder {
         throw VibeExtractException('Failed to extract vibe metadata: $e');
       }
     });
+  }
+
+  /// 在 isolate 中提取 vibe 元数据
+  ///
+  /// 对于大文件或需要避免阻塞 UI 线程的场景，使用此方法
+  static Future<VibeReference> extractVibeFromImageInIsolate(
+    Uint8List imageBytes,
+  ) async {
+    return Isolate.run(() => extractVibeFromImage(imageBytes)).then((result) => result);
   }
 
   static void _ensureValidPng(Uint8List imageBytes) {

--- a/lib/data/services/vibe_metadata_service.dart
+++ b/lib/data/services/vibe_metadata_service.dart
@@ -23,7 +23,7 @@ class VibeMetadataService {
     double defaultStrength = 0.6,
   }) async {
     try {
-      final reference = await VibeFileParser.fromPng(
+      final reference = await VibeFileParser.fromPngInIsolate(
         'image.png',
         image,
         defaultStrength: defaultStrength,
@@ -81,8 +81,8 @@ class VibeMetadataService {
       // 提取文件名
       final fileName = filePath.split(Platform.pathSeparator).last;
 
-      // 解析 Vibe 数据
-      final reference = await VibeFileParser.fromPng(
+      // 解析 Vibe 数据 (使用 isolate 避免阻塞 UI 线程)
+      final reference = await VibeFileParser.fromPngInIsolate(
         fileName,
         bytes,
         defaultStrength: defaultStrength,
@@ -120,7 +120,7 @@ class VibeMetadataService {
   /// 返回 true 如果图片包含 NovelAI_Vibe_Encoding_Base64 iTXt 块
   Future<bool> hasVibeMetadata(Uint8List image) async {
     try {
-      final reference = await VibeFileParser.fromPng(
+      final reference = await VibeFileParser.fromPngInIsolate(
         'image.png',
         image,
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -322,10 +322,10 @@ packages:
     dependency: transitive
     description:
       name: custom_lint_visitor
-      sha256: "8aeb3b6ae2bb765e7716b93d1d10e8356d04e0ff6d7592de6ee04e0dd7d6587d"
+      sha256: bfe9b7a09c4775a587b58d10ebb871d4fe618237639b1e84d5ec62d7dfef25f9
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.0+6.7.0"
+    version: "1.0.0+6.11.0"
   dart_style:
     dependency: transitive
     description:
@@ -774,18 +774,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -822,10 +822,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -1302,7 +1302,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
@@ -1403,10 +1403,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   state_notifier:
     dependency: transitive
     description:
@@ -1435,10 +1435,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   super_clipboard:
     dependency: "direct main"
     description:
@@ -1483,26 +1483,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.25.7"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   timeago:
     dependency: "direct main"
     description:
@@ -1683,10 +1683,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   volume_controller:
     dependency: transitive
     description:

--- a/test/core/utils/vibe_image_embedder_test.dart
+++ b/test/core/utils/vibe_image_embedder_test.dart
@@ -84,6 +84,132 @@ void main() {
         throwsA(isA<NoVibeDataException>()),
       );
     });
+
+    group('isolate methods', () {
+      test(
+        'embedVibeToImageInIsolate should produce extractable vibe metadata',
+        () async {
+          final imageBytes = _createInMemoryPngBytes();
+          const reference = VibeReference(
+            displayName: 'Isolate Test Vibe',
+            vibeEncoding: 'aXNvbGF0ZV90ZXN0X2VuY29kaW5n',
+            strength: 0.8,
+            infoExtracted: 0.9,
+            sourceType: VibeSourceType.png,
+          );
+
+          final embeddedBytes =
+              await VibeImageEmbedder.embedVibeToImageInIsolate(
+            imageBytes,
+            reference,
+          );
+
+          expect(embeddedBytes.length, greaterThan(imageBytes.length));
+
+          final extracted = await VibeImageEmbedder.extractVibeFromImage(
+            embeddedBytes,
+          );
+          expect(extracted, reference);
+        },
+      );
+
+      test(
+        'extractVibeFromImageInIsolate should extract vibe metadata correctly',
+        () async {
+          final imageBytes = _createInMemoryPngBytes();
+          const reference = VibeReference(
+            displayName: 'Extract Isolate Test',
+            vibeEncoding: 'ZXh0cmFjdF9pc29sYXRlX3Rlc3Q=',
+            strength: 0.65,
+            infoExtracted: 0.75,
+            sourceType: VibeSourceType.naiv4vibe,
+          );
+
+          final embeddedBytes = await VibeImageEmbedder.embedVibeToImage(
+            imageBytes,
+            reference,
+          );
+
+          final extracted =
+              await VibeImageEmbedder.extractVibeFromImageInIsolate(
+            embeddedBytes,
+          );
+
+          expect(extracted, reference);
+        },
+      );
+
+      test(
+        'embedVibeToImageInIsolate and extractVibeFromImageInIsolate '
+        'should work together in round trip',
+        () async {
+          final imageBytes = _createInMemoryPngBytes();
+          const original = VibeReference(
+            displayName: 'Full Isolate Round Trip',
+            vibeEncoding: 'ZnVsbF9pc29sYXRlX3JvdW5kX3RyaXA=',
+            strength: 0.55,
+            infoExtracted: 0.88,
+            sourceType: VibeSourceType.rawImage,
+          );
+
+          final embeddedBytes =
+              await VibeImageEmbedder.embedVibeToImageInIsolate(
+            imageBytes,
+            original,
+          );
+          final extracted =
+              await VibeImageEmbedder.extractVibeFromImageInIsolate(
+            embeddedBytes,
+          );
+
+          expect(extracted, original);
+        },
+      );
+
+      test(
+        'embedVibeToImageInIsolate should throw on non-PNG bytes',
+        () async {
+          final nonPngBytes = Uint8List.fromList(
+            utf8.encode('not a png file'),
+          );
+          const reference = VibeReference(
+            displayName: 'Invalid Isolate Input',
+            vibeEncoding: 'aW52YWxpZA==',
+          );
+
+          await expectLater(
+            VibeImageEmbedder.embedVibeToImageInIsolate(nonPngBytes, reference),
+            throwsA(isA<InvalidImageFormatException>()),
+          );
+        },
+      );
+
+      test(
+        'extractVibeFromImageInIsolate should throw on non-PNG bytes',
+        () async {
+          final nonPngBytes = Uint8List.fromList(
+            utf8.encode('not a png file'),
+          );
+
+          await expectLater(
+            VibeImageEmbedder.extractVibeFromImageInIsolate(nonPngBytes),
+            throwsA(isA<InvalidImageFormatException>()),
+          );
+        },
+      );
+
+      test(
+        'extractVibeFromImageInIsolate should throw when PNG has no vibe data',
+        () async {
+          final imageBytes = _createInMemoryPngBytes();
+
+          await expectLater(
+            VibeImageEmbedder.extractVibeFromImageInIsolate(imageBytes),
+            throwsA(isA<NoVibeDataException>()),
+          );
+        },
+      );
+    });
   });
 }
 


### PR DESCRIPTION
当前Vibe提取操作在主线程执行(见vibe_image_embedder.dart和gallery_database_service.dart第1057行)，处理大图片时会阻塞UI。应使用Flutter的compute()或Isolate机制在后台线程执行。