### PR TITLE
auto-claude: 025-tag

### DIFF
--- a/lib/core/services/lazy_data_source_service.dart
+++ b/lib/core/services/lazy_data_source_service.dart
@@ -128,7 +128,7 @@ class UnifiedDataSourceManager {
     final futures = _services.map((service) async {
       try {
         // 设置进度回调
-        service.onProgress = (progress, message) {
+        service.onProgress = (progress, message, {processedCount, totalCount}) {
           progressMap[service.serviceName] = DataSourceInitProgress(
             sourceName: service.serviceName,
             overallProgress: progress,

--- a/lib/core/services/lazy_data_source_service.dart
+++ b/lib/core/services/lazy_data_source_service.dart
@@ -46,8 +46,10 @@ class DataSourceInitProgress {
 /// 刷新进度回调
 typedef DataSourceProgressCallback = void Function(
   double progress,
-  String? message,
-);
+  String? message, {
+  int? processedCount,
+  int? totalCount,
+});
 
 /// 懒加载数据源接口
 /// 统一共现数据、翻译数据、Danbooru标签的数据源架构

--- a/lib/data/services/random_prompt_generator.dart
+++ b/lib/data/services/random_prompt_generator.dart
@@ -19,11 +19,9 @@ import '../models/prompt/tag_group.dart';
 import '../models/prompt/tag_library.dart';
 import '../models/prompt/tag_scope.dart';
 import '../models/prompt/weighted_tag.dart';
-import '../models/prompt/wordlist_entry.dart';
 import 'bracket_formatter.dart';
 import 'character_count_resolver.dart';
 import 'sequential_state_service.dart';
-import 'strategies/character_tag_generator.dart';
 import 'strategies/nai_style_generator_strategy.dart';
 import 'strategies/preset_generator_strategy.dart';
 import 'strategies/wordlist_generator_strategy.dart';
@@ -48,7 +46,6 @@ class RandomPromptGenerator {
   final BracketFormatter _bracketFormatter;
   final CharacterCountResolver _characterCountResolver;
   final VariableReplacementService _variableReplacementService;
-  final CharacterTagGenerator _characterTagGenerator;
   final NaiStyleGeneratorStrategy _naiStyleGenerator;
   final PresetGeneratorStrategy _presetGeneratorStrategy;
   final WordlistGeneratorStrategy _wordlistGeneratorStrategy;
@@ -63,7 +60,6 @@ class RandomPromptGenerator {
         _bracketFormatter = BracketFormatter(),
         _characterCountResolver = CharacterCountResolver(),
         _variableReplacementService = VariableReplacementService(),
-        _characterTagGenerator = CharacterTagGenerator(),
         _naiStyleGenerator = NaiStyleGeneratorStrategy(),
         _presetGeneratorStrategy = PresetGeneratorStrategy(),
         _wordlistGeneratorStrategy = WordlistGeneratorStrategy();

--- a/lib/data/services/strategies/preset_generator_strategy.dart
+++ b/lib/data/services/strategies/preset_generator_strategy.dart
@@ -503,7 +503,7 @@ class PresetGeneratorStrategy {
     return RandomPromptResult.multiCharacter(
       mainPrompt: mainTags.join(', '),
       characters: characters,
-      seed: random is Random ? random.hashCode : null,
+      seed: random.hashCode,
     );
   }
 

--- a/lib/data/services/strategies/wordlist_generator_strategy.dart
+++ b/lib/data/services/strategies/wordlist_generator_strategy.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 
-import '../../../core/utils/app_logger.dart';
 import '../../models/character/character_prompt.dart';
 import '../../models/prompt/algorithm_config.dart';
 import '../../models/prompt/random_prompt_result.dart';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3616,6 +3616,20 @@
   "viewer_tooltip_save": "Save",
   "viewer_tooltip_reuse_params": "Reuse Parameters",
   "viewer_tooltip_copy_image": "Copy Image",
-  "viewer_tooltip_favorite": "Favorite"
+  "viewer_tooltip_favorite": "Favorite",
+
+  "backgroundTask_downloadedCount": "Downloaded {count} tags",
+  "@backgroundTask_downloadedCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "backgroundTask_downloadedCountWithTotal": "Downloaded {count}/{total} tags",
+  "@backgroundTask_downloadedCountWithTotal": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  }
 
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3621,14 +3621,14 @@
   "backgroundTask_downloadedCount": "Downloaded {count} tags",
   "@backgroundTask_downloadedCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {"type": "int", "format": "decimalPattern"}
     }
   },
   "backgroundTask_downloadedCountWithTotal": "Downloaded {count}/{total} tags",
   "@backgroundTask_downloadedCountWithTotal": {
     "placeholders": {
-      "count": {"type": "int"},
-      "total": {"type": "int"}
+      "count": {"type": "int", "format": "decimalPattern"},
+      "total": {"type": "int", "format": "decimalPattern"}
     }
   }
 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13600,6 +13600,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Favorite'**
   String get viewer_tooltip_favorite;
+
+  /// No description provided for @backgroundTask_downloadedCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloaded {count} tags'**
+  String backgroundTask_downloadedCount(int count);
+
+  /// No description provided for @backgroundTask_downloadedCountWithTotal.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloaded {count}/{total} tags'**
+  String backgroundTask_downloadedCountWithTotal(int count, int total);
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7214,4 +7214,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get viewer_tooltip_favorite => 'Favorite';
+
+  @override
+  String backgroundTask_downloadedCount(int count) {
+    return 'Downloaded $count tags';
+  }
+
+  @override
+  String backgroundTask_downloadedCountWithTotal(int count, int total) {
+    return 'Downloaded $count/$total tags';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7214,4 +7214,14 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get viewer_tooltip_favorite => '收藏';
+
+  @override
+  String backgroundTask_downloadedCount(int count) {
+    return '已下载 $count 个标签';
+  }
+
+  @override
+  String backgroundTask_downloadedCountWithTotal(int count, int total) {
+    return '已下载 $count/$total 个标签';
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3269,6 +3269,20 @@
   "settings_hivePathSaved": "数据存储路径已保存，重启后生效",
   "settings_restartRequiredTitle": "需要重启应用",
   "settings_changePathConfirm": "更改数据存储路径后，需要重启应用才能生效。\\n\\n新路径将在下次启动时生效。是否继续？",
-  "settings_resetPathConfirm": "重置数据存储路径后，需要重启应用才能生效。\\n\\n默认路径将在下次启动时生效。是否继续？"
+  "settings_resetPathConfirm": "重置数据存储路径后，需要重启应用才能生效。\\n\\n默认路径将在下次启动时生效。是否继续？",
+
+  "backgroundTask_downloadedCount": "已下载 {count} 个标签",
+  "@backgroundTask_downloadedCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "backgroundTask_downloadedCountWithTotal": "已下载 {count}/{total} 个标签",
+  "@backgroundTask_downloadedCountWithTotal": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  }
 
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3274,14 +3274,14 @@
   "backgroundTask_downloadedCount": "已下载 {count} 个标签",
   "@backgroundTask_downloadedCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {"type": "int", "format": "decimalPattern"}
     }
   },
   "backgroundTask_downloadedCountWithTotal": "已下载 {count}/{total} 个标签",
   "@backgroundTask_downloadedCountWithTotal": {
     "placeholders": {
-      "count": {"type": "int"},
-      "total": {"type": "int"}
+      "count": {"type": "int", "format": "decimalPattern"},
+      "total": {"type": "int", "format": "decimalPattern"}
     }
   }
 

--- a/lib/presentation/providers/background_refresh_provider.dart
+++ b/lib/presentation/providers/background_refresh_provider.dart
@@ -193,7 +193,7 @@ class BackgroundRefreshNotifier extends _$BackgroundRefreshNotifier {
       AppLogger.i('Background refreshing: ${service.serviceName}', 'BackgroundRefresh');
 
       // 设置进度回调
-      service.onProgress = (progress, message) {
+      service.onProgress = (progress, message, {processedCount, totalCount}) {
         state = state.copyWith(
           currentPhase: message ?? '正在更新 ${service.serviceName}...',
         );

--- a/lib/presentation/providers/background_task_provider.dart
+++ b/lib/presentation/providers/background_task_provider.dart
@@ -239,7 +239,13 @@ class BackgroundTaskNotifier extends _$BackgroundTaskNotifier {
   }
 
   /// 更新任务进度
-  void updateProgress(String id, double progress, {String? message}) {
+  void updateProgress(
+    String id,
+    double progress, {
+    String? message,
+    int? processedCount,
+    int? totalCount,
+  }) {
     if (state.isPaused) return;
 
     final taskIndex = state.tasks.indexWhere((t) => t.id == id);
@@ -248,6 +254,8 @@ class BackgroundTaskNotifier extends _$BackgroundTaskNotifier {
     final updatedTask = state.tasks[taskIndex].copyWith(
       progress: progress.clamp(0.0, 1.0),
       message: message,
+      processedCount: processedCount,
+      totalCount: totalCount,
     );
 
     final newTasks = [...state.tasks];

--- a/lib/presentation/providers/background_task_provider.dart
+++ b/lib/presentation/providers/background_task_provider.dart
@@ -26,6 +26,8 @@ class BackgroundTask {
   final DateTime? startTime;
   final DateTime? endTime;
   final String? error;
+  final int? processedCount;
+  final int? totalCount;
 
   const BackgroundTask({
     required this.id,
@@ -37,6 +39,8 @@ class BackgroundTask {
     this.startTime,
     this.endTime,
     this.error,
+    this.processedCount,
+    this.totalCount,
   });
 
   BackgroundTask copyWith({
@@ -49,6 +53,8 @@ class BackgroundTask {
     DateTime? startTime,
     DateTime? endTime,
     String? error,
+    int? processedCount,
+    int? totalCount,
   }) {
     return BackgroundTask(
       id: id ?? this.id,
@@ -60,6 +66,8 @@ class BackgroundTask {
       startTime: startTime ?? this.startTime,
       endTime: endTime ?? this.endTime,
       error: error ?? this.error,
+      processedCount: processedCount ?? this.processedCount,
+      totalCount: totalCount ?? this.totalCount,
     );
   }
 

--- a/lib/presentation/providers/data_source_cache_provider.dart
+++ b/lib/presentation/providers/data_source_cache_provider.dart
@@ -118,7 +118,7 @@ class DanbooruTagsCacheNotifier extends _$DanbooruTagsCacheNotifier {
     state = state.copyWith(isRefreshing: true, progress: 0.0, error: null);
 
     final service = ref.read(danbooruTagsLazyServiceProvider);
-    service.onProgress = (progress, message) {
+    service.onProgress = (progress, message, {processedCount, totalCount}) {
       state = state.copyWith(progress: progress, message: message);
     };
 

--- a/lib/presentation/providers/warmup_provider.dart
+++ b/lib/presentation/providers/warmup_provider.dart
@@ -625,11 +625,13 @@ class WarmupNotifier extends _$WarmupNotifier {
   }) async {
     final service = ref.read(danbooruTagsLazyServiceProvider);
 
-    service.onProgress = (progress, message) {
+    service.onProgress = (progress, message, {processedCount, totalCount}) {
       ref.read(backgroundTaskNotifierProvider.notifier).updateProgress(
         taskId,
         progress,
         message: message,
+        processedCount: processedCount,
+        totalCount: totalCount,
       );
     };
 

--- a/lib/presentation/providers/warmup_provider.dart
+++ b/lib/presentation/providers/warmup_provider.dart
@@ -445,7 +445,7 @@ class WarmupNotifier extends _$WarmupNotifier {
       state = state.copyWith(subTaskMessage: '正在检查标签数据...');
 
       // 设置进度回调
-      service.onProgress = (progress, message) {
+      service.onProgress = (progress, message, {processedCount, totalCount}) {
         state = state.copyWith(subTaskMessage: message);
       };
 

--- a/lib/presentation/widgets/background/background_task_indicator.dart
+++ b/lib/presentation/widgets/background/background_task_indicator.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nai_launcher/core/utils/localization_extension.dart';
 
 import '../../providers/background_task_provider.dart' show BackgroundTask, backgroundTaskNotifierProvider;
 
@@ -45,7 +46,7 @@ class BackgroundTaskIndicator extends ConsumerWidget {
               const SizedBox(height: 8),
               _buildProgressBar(task.progress, colorScheme),
               const SizedBox(height: 4),
-              _buildProgressInfo(task, theme, colorScheme),
+              _buildProgressInfo(context, task, theme, colorScheme),
             ],
           ),
         ),
@@ -106,6 +107,7 @@ class BackgroundTaskIndicator extends ConsumerWidget {
   }
 
   Widget _buildProgressInfo(
+    BuildContext context,
     BackgroundTask task,
     ThemeData theme,
     ColorScheme colorScheme,
@@ -114,7 +116,7 @@ class BackgroundTaskIndicator extends ConsumerWidget {
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Text(
-          task.message ?? '${(task.progress * 100).toInt()}%',
+          _getProgressText(context, task),
           style: theme.textTheme.bodySmall?.copyWith(
             color: colorScheme.onSurfaceVariant,
           ),
@@ -131,6 +133,26 @@ class BackgroundTaskIndicator extends ConsumerWidget {
           ),
       ],
     );
+  }
+
+  /// 获取进度文本
+  /// 优先级：localized count text > message > percentage
+  String _getProgressText(BuildContext context, BackgroundTask task) {
+    final l10n = context.l10n;
+
+    // 如果有处理数量，显示本地化计数文本
+    if (task.processedCount != null && task.processedCount! > 0) {
+      if (task.totalCount != null && task.totalCount! > 0) {
+        return l10n.backgroundTask_downloadedCountWithTotal(
+          task.processedCount!,
+          task.totalCount!,
+        );
+      }
+      return l10n.backgroundTask_downloadedCount(task.processedCount!);
+    }
+
+    // 回退到消息或百分比
+    return task.message ?? '${(task.progress * 100).toInt()}%';
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -322,10 +322,10 @@ packages:
     dependency: transitive
     description:
       name: custom_lint_visitor
-      sha256: "8aeb3b6ae2bb765e7716b93d1d10e8356d04e0ff6d7592de6ee04e0dd7d6587d"
+      sha256: bfe9b7a09c4775a587b58d10ebb871d4fe618237639b1e84d5ec62d7dfef25f9
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.0+6.7.0"
+    version: "1.0.0+6.11.0"
   dart_style:
     dependency: transitive
     description:
@@ -774,18 +774,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -822,10 +822,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -1302,7 +1302,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
@@ -1403,10 +1403,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   state_notifier:
     dependency: transitive
     description:
@@ -1435,10 +1435,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   super_clipboard:
     dependency: "direct main"
     description:
@@ -1483,26 +1483,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.25.7"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   timeago:
     dependency: "direct main"
     description:
@@ -1683,10 +1683,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   volume_controller:
     dependency: transitive
     description:


### PR DESCRIPTION
Enhance the artist tag synchronization progress display to show detailed quantitative information including actual progress bar completion percentage and tag count display (e.g., "500/1000 tags" or "已下载 500 个标签"). Currently the background task indicator in the bottom-right corner only shows an indeterminate loading spinner without actual progress details.

The artist tag sync (`artist_tags_sync`) runs as a background task after app warmup completes, downloading Danbooru artist tags (category=1) via `DanbooruTagsLazyService._fetchArtistTags()`. The progress is reported through `DataSourceProgressCallback` but only includes a percentage and message string, lacking structured count data for rich UI display.