### PR TITLE
auto-claude: 010-n-1

### DIFF
--- a/lib/core/database/datasources/gallery_data_source.dart
+++ b/lib/core/database/datasources/gallery_data_source.dart
@@ -846,7 +846,8 @@ class GalleryDataSource extends EnhancedBaseDataSource {
           // 构建结果映射
           final pathToId = <String, int?>{};
           for (final row in result) {
-            final path = row['file_path'] as String;
+            final path = row['file_path'] as String?;
+            if (path == null) continue;
             final id = (row['id'] as num?)?.toInt();
             pathToId[path] = id;
           }
@@ -1864,7 +1865,7 @@ class GalleryDataSource extends EnhancedBaseDataSource {
 
           // 构建结果映射，所有请求的图片默认为空标签列表
           final tagsMap = <int, List<String>>{
-            for (final id in imageIds) id: <String>[],
+            for (final id in imageIds) id: const <String>[],
           };
 
           // 填充每个图片的标签

--- a/lib/core/database/datasources/gallery_data_source.dart
+++ b/lib/core/database/datasources/gallery_data_source.dart
@@ -1851,7 +1851,7 @@ class GalleryDataSource extends EnhancedBaseDataSource {
         'GalleryDS',
       );
       // 发生错误时，返回所有图片为空标签列表
-      return {for (final id in imageIds) id: <String>[]},
+      return {for (final id in imageIds) id: <String>[]};
     }
   }
 

--- a/lib/core/database/datasources/gallery_data_source.dart
+++ b/lib/core/database/datasources/gallery_data_source.dart
@@ -3,7 +3,8 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import '../../../data/models/gallery/nai_image_metadata.dart';
 import '../../utils/app_logger.dart';
 import '../base_data_source.dart';
-import '../data_source.dart' show DataSourceHealth, DataSourceType, HealthStatus;
+import '../data_source.dart'
+    show DataSourceHealth, DataSourceType, HealthStatus;
 import '../utils/lru_cache.dart';
 
 /// 元数据解析状态
@@ -77,7 +78,9 @@ class GalleryImageRecord {
       id: (map['id'] as num?)?.toInt(),
       filePath: map['file_path'] as String? ?? map['path'] as String? ?? '',
       fileName: map['file_name'] as String? ?? '',
-      fileSize: (map['file_size'] as num?)?.toInt() ?? (map['size'] as num?)?.toInt() ?? 0,
+      fileSize: (map['file_size'] as num?)?.toInt() ??
+          (map['size'] as num?)?.toInt() ??
+          0,
       fileHash: map['file_hash'] as String?,
       width: (map['width'] as num?)?.toInt(),
       height: (map['height'] as num?)?.toInt(),
@@ -93,7 +96,8 @@ class GalleryImageRecord {
       ),
       dateYmd: (map['date_ymd'] as num?)?.toInt() ?? 0,
       resolutionKey: map['resolution_key'] as String?,
-      metadataStatus: MetadataStatus.values[(map['metadata_status'] as num?)?.toInt() ?? 2],
+      metadataStatus:
+          MetadataStatus.values[(map['metadata_status'] as num?)?.toInt() ?? 2],
       isFavorite: (map['is_favorite'] as num?)?.toInt() == 1,
       isDeleted: (map['is_deleted'] as num?)?.toInt() == 1,
     );
@@ -805,7 +809,12 @@ class GalleryDataSource extends EnhancedBaseDataSource {
         maxRetries: 3,
       );
     } catch (e, stack) {
-      AppLogger.e('Failed to get image ID by path: $filePath', e, stack, 'GalleryDS');
+      AppLogger.e(
+        'Failed to get image ID by path: $filePath',
+        e,
+        stack,
+        'GalleryDS',
+      );
       return null;
     }
   }
@@ -853,7 +862,12 @@ class GalleryDataSource extends EnhancedBaseDataSource {
         maxRetries: 3,
       );
     } catch (e, stack) {
-      AppLogger.e('Failed to get image IDs by paths: ${filePaths.length} paths', e, stack, 'GalleryDS');
+      AppLogger.e(
+        'Failed to get image IDs by paths: ${filePaths.length} paths',
+        e,
+        stack,
+        'GalleryDS',
+      );
       return {for (final path in filePaths) path: null};
     }
   }
@@ -1006,7 +1020,8 @@ class GalleryDataSource extends EnhancedBaseDataSource {
           'file_size',
           'id',
         };
-        final safeOrderBy = validColumns.contains(orderBy) ? orderBy : 'modified_at';
+        final safeOrderBy =
+            validColumns.contains(orderBy) ? orderBy : 'modified_at';
         final orderDirection = descending ? 'DESC' : 'ASC';
 
         final results = await db.rawQuery(
@@ -1055,7 +1070,12 @@ class GalleryDataSource extends EnhancedBaseDataSource {
 
         AppLogger.d('Marked as deleted: $filePath', 'GalleryDS');
       } catch (e, stack) {
-        AppLogger.e('Failed to mark as deleted: $filePath', e, stack, 'GalleryDS');
+        AppLogger.e(
+          'Failed to mark as deleted: $filePath',
+          e,
+          stack,
+          'GalleryDS',
+        );
         rethrow;
       }
     });
@@ -1098,7 +1118,10 @@ class GalleryDataSource extends EnhancedBaseDataSource {
           }
         }
 
-        AppLogger.d('Batch marked as deleted: ${filePaths.length} files', 'GalleryDS');
+        AppLogger.d(
+          'Batch marked as deleted: ${filePaths.length} files',
+          'GalleryDS',
+        );
       } catch (e, stack) {
         AppLogger.e('Failed to batch mark as deleted', e, stack, 'GalleryDS');
         rethrow;
@@ -1242,7 +1265,10 @@ class GalleryDataSource extends EnhancedBaseDataSource {
             'prompt_text': promptText,
           });
         } catch (e) {
-          AppLogger.w('Failed to update FTS index for image $imageId: $e', 'GalleryDS');
+          AppLogger.w(
+            'Failed to update FTS index for image $imageId: $e',
+            'GalleryDS',
+          );
           // FTS 更新失败不应影响主流程
         }
       },
@@ -1291,7 +1317,12 @@ class GalleryDataSource extends EnhancedBaseDataSource {
         maxRetries: 3,
       );
     } catch (e, stack) {
-      AppLogger.e('Failed to get metadata by image ID: $imageId', e, stack, 'GalleryDS');
+      AppLogger.e(
+        'Failed to get metadata by image ID: $imageId',
+        e,
+        stack,
+        'GalleryDS',
+      );
       return null;
     }
   }
@@ -1303,7 +1334,9 @@ class GalleryDataSource extends EnhancedBaseDataSource {
   /// 返回一个 Map，键为图片ID，值为对应的元数据记录（如果找不到则为 null）
   /// 优先从缓存获取，缺失的从数据库查询
   /// 使用单个查询批量获取，比多次调用 getMetadataByImageId 更高效
-  Future<Map<int, GalleryMetadataRecord?>> getMetadataByImageIds(List<int> imageIds) async {
+  Future<Map<int, GalleryMetadataRecord?>> getMetadataByImageIds(
+    List<int> imageIds,
+  ) async {
     if (imageIds.isEmpty) return {};
 
     final results = <int, GalleryMetadataRecord?>{};
@@ -1468,7 +1501,10 @@ class GalleryDataSource extends EnhancedBaseDataSource {
         }
 
         _favoritesLoaded = true;
-        AppLogger.i('Loaded ${_favoriteCache.length} favorites into cache', 'GalleryDS');
+        AppLogger.i(
+          'Loaded ${_favoriteCache.length} favorites into cache',
+          'GalleryDS',
+        );
       },
       timeout: const Duration(seconds: 15),
       maxRetries: 2,
@@ -1594,7 +1630,9 @@ class GalleryDataSource extends EnhancedBaseDataSource {
             [searchQuery, limit],
           );
 
-          return results.map((row) => (row['image_id'] as num).toInt()).toList();
+          return results
+              .map((row) => (row['image_id'] as num).toInt())
+              .toList();
         },
         timeout: const Duration(seconds: 10),
         maxRetries: 3,
@@ -1863,11 +1901,8 @@ class GalleryDataSource extends EnhancedBaseDataSource {
   /// 使用事务，先删除现有标签关联，然后批量插入新标签
   /// 每个标签：插入标签表（如不存在），获取ID，创建关联
   Future<void> setImageTags(int imageId, List<String> tags) async {
-    final normalizedTags = tags
-        .map((t) => t.trim())
-        .where((t) => t.isNotEmpty)
-        .toSet()
-        .toList();
+    final normalizedTags =
+        tags.map((t) => t.trim()).where((t) => t.isNotEmpty).toSet().toList();
 
     return await execute('setImageTags', (db) async {
       await db.transaction((txn) async {
@@ -1881,9 +1916,8 @@ class GalleryDataSource extends EnhancedBaseDataSource {
           ''',
           [imageId],
         );
-        final oldTagIds = currentTagsResult
-            .map((row) => row['id'] as String)
-            .toSet();
+        final oldTagIds =
+            currentTagsResult.map((row) => row['id'] as String).toSet();
 
         // 删除该图片的所有标签关联
         await txn.delete(

--- a/lib/core/database/datasources/gallery_data_source.dart
+++ b/lib/core/database/datasources/gallery_data_source.dart
@@ -989,7 +989,10 @@ class GalleryDataSource extends EnhancedBaseDataSource {
         'SELECT file_path, file_hash FROM $_imagesTable WHERE is_deleted = 0',
         [],
       )) {
-        result[row['file_path'] as String] = row['file_hash'] as String?;
+        final filePath = row['file_path'] as String?;
+        if (filePath != null) {
+          result[filePath] = row['file_hash'] as String?;
+        }
       }
       return result;
     } catch (e, stack) {

--- a/lib/core/database/health_checker.dart
+++ b/lib/core/database/health_checker.dart
@@ -284,8 +284,8 @@ class HealthChecker {
         sampleStats['sampleImages'] = sample.length;
 
         for (final row in sample) {
-          if (row['file_path'] == null ||
-              (row['file_path'] as String).isEmpty) {
+          final filePath = row['file_path'] as String?;
+          if (filePath == null || filePath.isEmpty) {
             validationErrors.add('Image ${row['id']} has empty file_path');
           }
         }

--- a/lib/presentation/providers/local_gallery_provider.dart
+++ b/lib/presentation/providers/local_gallery_provider.dart
@@ -7,7 +7,8 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../core/database/database_providers.dart';
-import '../../core/database/datasources/gallery_data_source.dart' hide MetadataStatus;
+import '../../core/database/datasources/gallery_data_source.dart'
+    hide MetadataStatus;
 import '../../core/database/providers/database_state_providers.dart';
 import '../../core/utils/app_logger.dart';
 import '../../data/models/gallery/local_image_record.dart';
@@ -42,24 +43,30 @@ class LocalGalleryState with _$LocalGalleryState {
   const factory LocalGalleryState({
     /// 所有文件
     @Default([]) List<File> allFiles,
+
     /// 过滤后的文件
     @Default([]) List<File> filteredFiles,
+
     /// 当前页显示的记录
     @Default([]) List<LocalImageRecord> currentImages,
     @Default(0) int currentPage,
     @Default(50) int pageSize,
     @Default(false) bool isLoading,
-    @Default(false) bool isIndexing,      // 用于兼容旧代码
-    @Default(false) bool isPageLoading,   // 用于兼容旧代码
+    @Default(false) bool isIndexing, // 用于兼容旧代码
+    @Default(false) bool isPageLoading, // 用于兼容旧代码
     /// 搜索关键词
     @Default('') String searchQuery,
+
     /// 日期过滤
     DateTime? dateStart,
     DateTime? dateEnd,
+
     /// 收藏过滤
     @Default(false) bool showFavoritesOnly,
+
     /// 标签过滤
     @Default([]) List<String> selectedTags,
+
     /// 元数据过滤
     String? filterModel,
     String? filterSampler,
@@ -68,33 +75,41 @@ class LocalGalleryState with _$LocalGalleryState {
     double? filterMinCfg,
     double? filterMaxCfg,
     String? filterResolution,
+
     /// 分组视图（兼容旧代码）
     @Default(false) bool isGroupedView,
     @Default([]) List<LocalImageRecord> groupedImages,
     @Default(false) bool isGroupedLoading,
+
     /// 后台扫描进度（0-100，null表示未开始）
     double? backgroundScanProgress,
+
     /// 扫描阶段：'checking' | 'indexing' | 'completed' | null
     String? scanPhase,
+
     /// 当前扫描的文件
     String? scanningFile,
+
     /// 已扫描文件数
     @Default(0) int scannedCount,
+
     /// 总文件数
     @Default(0) int totalScanCount,
+
     /// 是否正在重建索引（全量扫描）
     @Default(false) bool isRebuildingIndex,
+
     /// 错误信息
     String? error,
+
     /// 首次索引提示信息
     String? firstTimeIndexMessage,
   }) = _LocalGalleryState;
 
   const LocalGalleryState._();
 
-  int get totalPages => filteredFiles.isEmpty
-      ? 0
-      : (filteredFiles.length / pageSize).ceil();
+  int get totalPages =>
+      filteredFiles.isEmpty ? 0 : (filteredFiles.length / pageSize).ceil();
 
   /// 兼容旧代码的 getter
   int get filteredCount => filteredFiles.length;
@@ -186,7 +201,7 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       state = state.copyWith(
         allFiles: files,
         filteredFiles: files,
-        isLoading: false,  // 文件列表已显示，可以交互了
+        isLoading: false, // 文件列表已显示，可以交互了
         firstTimeIndexMessage: firstTimeMessage,
       );
 
@@ -196,7 +211,6 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       // 在后台初始化仓库（扫描索引）
       // 这不会阻塞UI，因为文件已经显示了
       unawaited(_initializeInBackground());
-
     } catch (e) {
       AppLogger.e('Failed to initialize', e, null, 'LocalGalleryNotifier');
       state = state.copyWith(
@@ -221,7 +235,8 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
     const supportedExtensions = {'.png', '.jpg', '.jpeg', '.webp'};
 
     try {
-      await for (final entity in rootDir.list(recursive: true, followLinks: false)) {
+      await for (final entity
+          in rootDir.list(recursive: true, followLinks: false)) {
         if (entity is File) {
           final ext = entity.path.split('.').last.toLowerCase();
           if (supportedExtensions.contains('.$ext')) {
@@ -288,7 +303,10 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
               modifiedAt: stat.modified,
             );
           } catch (e) {
-            AppLogger.w('Failed to index file: ${file.path}', 'LocalGalleryNotifier');
+            AppLogger.w(
+              'Failed to index file: ${file.path}',
+              'LocalGalleryNotifier',
+            );
           }
         }
 
@@ -330,7 +348,10 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
         }
       });
     } catch (e) {
-      AppLogger.w('Background initialization failed: $e', 'LocalGalleryNotifier');
+      AppLogger.w(
+        'Background initialization failed: $e',
+        'LocalGalleryNotifier',
+      );
       state = state.copyWith(
         isIndexing: false,
         isPageLoading: false,
@@ -403,7 +424,11 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       final records = await _loadRecords(batch);
       state = state.copyWith(currentImages: records, isLoading: false);
     } catch (e) {
-      state = state.copyWith(isLoading: false, isIndexing: false, isPageLoading: false);
+      state = state.copyWith(
+        isLoading: false,
+        isIndexing: false,
+        isPageLoading: false,
+      );
     }
   }
 
@@ -426,7 +451,10 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       try {
         fileStats[file] = await file.stat();
       } catch (e) {
-        AppLogger.w('Failed to stat file: ${file.path}', 'LocalGalleryNotifier');
+        AppLogger.w(
+          'Failed to stat file: ${file.path}',
+          'LocalGalleryNotifier',
+        );
       }
     }
 
@@ -476,12 +504,20 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
           final metadataRecord = metadataMap[imageId];
           if (metadataRecord != null) {
             // 如果有 rawJson，从中重新解析完整的元数据（包含新字段）
-            if (metadataRecord.rawJson != null && metadataRecord.rawJson!.isNotEmpty) {
+            if (metadataRecord.rawJson != null &&
+                metadataRecord.rawJson!.isNotEmpty) {
               try {
-                final json = jsonDecode(metadataRecord.rawJson!) as Map<String, dynamic>;
-                metadata = NaiImageMetadata.fromNaiComment(json, rawJson: metadataRecord.rawJson);
+                final json =
+                    jsonDecode(metadataRecord.rawJson!) as Map<String, dynamic>;
+                metadata = NaiImageMetadata.fromNaiComment(
+                  json,
+                  rawJson: metadataRecord.rawJson,
+                );
               } catch (e) {
-                AppLogger.w('Failed to parse rawJson for $imageId, using basic metadata', 'LocalGalleryNotifier');
+                AppLogger.w(
+                  'Failed to parse rawJson for $imageId, using basic metadata',
+                  'LocalGalleryNotifier',
+                );
                 // 回退到基本元数据
                 metadata = _buildBasicMetadata(metadataRecord);
               }
@@ -489,27 +525,35 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
               // 没有 rawJson，使用基本元数据
               metadata = _buildBasicMetadata(metadataRecord);
             }
-            metadataStatus = metadata.hasData ? MetadataStatus.success : MetadataStatus.none;
+            metadataStatus =
+                metadata.hasData ? MetadataStatus.success : MetadataStatus.none;
           }
         }
 
-        records.add(LocalImageRecord(
-          path: file.path,
-          size: stat.size,
-          modifiedAt: stat.modified,
-          isFavorite: isFavorite,
-          tags: tags,
-          metadata: metadata,
-          metadataStatus: metadataStatus,
-        ),);
+        records.add(
+          LocalImageRecord(
+            path: file.path,
+            size: stat.size,
+            modifiedAt: stat.modified,
+            isFavorite: isFavorite,
+            tags: tags,
+            metadata: metadata,
+            metadataStatus: metadataStatus,
+          ),
+        );
       } catch (e) {
-        AppLogger.w('Failed to load record for ${file.path}', 'LocalGalleryNotifier');
+        AppLogger.w(
+          'Failed to load record for ${file.path}',
+          'LocalGalleryNotifier',
+        );
         // 使用基本信息创建记录
-        records.add(LocalImageRecord(
-          path: file.path,
-          size: 0,
-          modifiedAt: DateTime.now(),
-        ),);
+        records.add(
+          LocalImageRecord(
+            path: file.path,
+            size: 0,
+            modifiedAt: DateTime.now(),
+          ),
+        );
       }
     }
 
@@ -519,7 +563,8 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
   /// 批量预加载元数据到缓存（后台执行，不阻塞UI）
   void _preloadMetadataBatch(List<File> files) {
     // 筛选出PNG文件
-    final pngFiles = files.where((f) => f.path.toLowerCase().endsWith('.png')).toList();
+    final pngFiles =
+        files.where((f) => f.path.toLowerCase().endsWith('.png')).toList();
     if (pngFiles.isEmpty) return;
 
     // 后台预加载，不等待结果
@@ -530,7 +575,10 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
             .toList();
         ImageMetadataService().preloadBatch(images);
       } catch (e) {
-        AppLogger.w('Failed to preload metadata batch: $e', 'LocalGalleryNotifier');
+        AppLogger.w(
+          'Failed to preload metadata batch: $e',
+          'LocalGalleryNotifier',
+        );
       }
     });
   }
@@ -590,7 +638,10 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       // 扫描完成后刷新当前页以显示元数据
       await loadPage(state.currentPage, showLoading: false);
     } catch (e) {
-      AppLogger.w('Failed to scan new files for metadata: $e', 'LocalGalleryNotifier');
+      AppLogger.w(
+        'Failed to scan new files for metadata: $e',
+        'LocalGalleryNotifier',
+      );
     }
   }
 
@@ -841,8 +892,13 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       if (state.dateStart != null || state.dateEnd != null) {
         try {
           final modified = file.statSync().modified;
-          if (state.dateStart != null && modified.isBefore(state.dateStart!)) return false;
-          if (state.dateEnd != null && modified.isAfter(state.dateEnd!.add(const Duration(days: 1)))) return false;
+          if (state.dateStart != null && modified.isBefore(state.dateStart!)) {
+            return false;
+          }
+          if (state.dateEnd != null &&
+              modified.isAfter(state.dateEnd!.add(const Duration(days: 1)))) {
+            return false;
+          }
         } catch (_) {
           return false;
         }
@@ -856,16 +912,19 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
         final dataSource = await _getDataSource();
         final favoriteImageIds = await dataSource.getFavoriteImageIds();
         // 使用批量查询获取所有收藏图片的路径
-        final favoriteImages = await dataSource.getImagesByIds(favoriteImageIds);
+        final favoriteImages =
+            await dataSource.getImagesByIds(favoriteImageIds);
         final favoritePaths = favoriteImages.map((img) => img.filePath).toSet();
-        filtered = filtered.where((file) => favoritePaths.contains(file.path)).toList();
+        filtered = filtered
+            .where((file) => favoritePaths.contains(file.path))
+            .toList();
       } catch (e) {
         AppLogger.w('Failed to filter favorites: $e', 'LocalGalleryNotifier');
       }
     }
 
     state = state.copyWith(filteredFiles: filtered, currentPage: 0);
-    
+
     // 如果在分组视图下，重新加载分组图片
     if (state.isGroupedView) {
       await _loadGroupedImages();
@@ -895,10 +954,16 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       if (imageId != null) {
         // 使用新数据源切换收藏状态
         await dataSource.toggleFavorite(imageId);
-        AppLogger.d('Toggled favorite for image $imageId via GalleryDataSource', 'LocalGalleryNotifier');
+        AppLogger.d(
+          'Toggled favorite for image $imageId via GalleryDataSource',
+          'LocalGalleryNotifier',
+        );
       } else {
         // 如果图片不在数据库中，先索引它
-        AppLogger.w('Image not found in database, indexing first: $filePath', 'LocalGalleryNotifier');
+        AppLogger.w(
+          'Image not found in database, indexing first: $filePath',
+          'LocalGalleryNotifier',
+        );
         final file = File(filePath);
         if (await file.exists()) {
           final stat = await file.stat();
@@ -924,7 +989,7 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
 
       // 更新当前页显示
       state = state.copyWith(currentImages: updatedCurrentImages);
-      
+
       // 如果启用了收藏过滤，重新应用过滤以更新列表
       if (state.showFavoritesOnly) {
         await _applyFilters();
@@ -954,7 +1019,10 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
     // 检查数据库是否正在恢复
     final stateMachine = ref.read(databaseStateMachineProvider);
     if (stateMachine.isTransitioning) {
-      AppLogger.d('Database is transitioning, returning cached favorite count (0)', 'LocalGalleryNotifier');
+      AppLogger.d(
+        'Database is transitioning, returning cached favorite count (0)',
+        'LocalGalleryNotifier',
+      );
       return 0;
     }
 
@@ -996,10 +1064,16 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       if (imageId != null) {
         // 使用新数据源设置标签
         await dataSource.setImageTags(imageId, tags);
-        AppLogger.d('Set tags for image $imageId via GalleryDataSource', 'LocalGalleryNotifier');
+        AppLogger.d(
+          'Set tags for image $imageId via GalleryDataSource',
+          'LocalGalleryNotifier',
+        );
       } else {
         // 如果图片不在数据库中，先索引它
-        AppLogger.w('Image not found in database, indexing first: $filePath', 'LocalGalleryNotifier');
+        AppLogger.w(
+          'Image not found in database, indexing first: $filePath',
+          'LocalGalleryNotifier',
+        );
         final file = File(filePath);
         if (await file.exists()) {
           final stat = await file.stat();

--- a/lib/presentation/providers/local_gallery_provider.dart
+++ b/lib/presentation/providers/local_gallery_provider.dart
@@ -850,18 +850,14 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       return true;
     }).toList();
 
-    // 收藏过滤 - 使用数据库查询获取收藏的图片路径
+    // 收藏过滤 - 使用数据库查询获取收藏的图片路径（使用批量方法）
     if (state.showFavoritesOnly) {
       try {
         final dataSource = await _getDataSource();
         final favoriteImageIds = await dataSource.getFavoriteImageIds();
-        final favoritePaths = <String>{};
-        for (final id in favoriteImageIds) {
-          final image = await dataSource.getImageById(id);
-          if (image != null) {
-            favoritePaths.add(image.filePath);
-          }
-        }
+        // 使用批量查询获取所有收藏图片的路径
+        final favoriteImages = await dataSource.getImagesByIds(favoriteImageIds);
+        final favoritePaths = favoriteImages.map((img) => img.filePath).toSet();
         filtered = filtered.where((file) => favoritePaths.contains(file.path)).toList();
       } catch (e) {
         AppLogger.w('Failed to filter favorites: $e', 'LocalGalleryNotifier');

--- a/lib/presentation/providers/local_gallery_provider.dart
+++ b/lib/presentation/providers/local_gallery_provider.dart
@@ -424,6 +424,7 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       final records = await _loadRecords(batch);
       state = state.copyWith(currentImages: records, isLoading: false);
     } catch (e) {
+      AppLogger.e('Failed to load page', e, null, 'LocalGalleryNotifier');
       state = state.copyWith(
         isLoading: false,
         isIndexing: false,

--- a/lib/presentation/providers/local_gallery_provider.dart
+++ b/lib/presentation/providers/local_gallery_provider.dart
@@ -472,14 +472,15 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
       }
     }
 
-    // 2. 批量获取收藏状态（1次查询）
-    final favoritesMap = await dataSource.getFavoritesByImageIds(imageIds);
-
-    // 3. 批量获取标签（1次查询）
-    final tagsMap = await dataSource.getTagsByImageIds(imageIds);
-
-    // 4. 批量获取元数据（1次查询）
-    final metadataMap = await dataSource.getMetadataByImageIds(imageIds);
+    // 2-4. 批量获取收藏状态、标签和元数据（并行执行，共3次查询）
+    final results = await Future.wait([
+      dataSource.getFavoritesByImageIds(imageIds),
+      dataSource.getTagsByImageIds(imageIds),
+      dataSource.getMetadataByImageIds(imageIds),
+    ]);
+    final favoritesMap = results[0] as Map<int, bool>;
+    final tagsMap = results[1] as Map<int, List<String>>;
+    final metadataMap = results[2] as Map<int, GalleryMetadataRecord?>;
 
     // 构建记录列表
     final records = <LocalImageRecord>[];

--- a/test/core/database/datasources/gallery_data_source_batch_test.dart
+++ b/test/core/database/datasources/gallery_data_source_batch_test.dart
@@ -1,0 +1,879 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:nai_launcher/core/database/datasources/gallery_data_source.dart';
+import 'package:nai_launcher/core/database/connection_pool_holder.dart';
+import 'package:nai_launcher/core/utils/app_logger.dart';
+import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
+
+/// GalleryDataSource 批量查询方法单元测试
+///
+/// 运行: flutter test test/core/database/datasources/gallery_data_source_batch_test.dart
+void main() {
+  group('GalleryDataSource Batch Query Tests', () {
+    late GalleryDataSource dataSource;
+    late String testDbPath;
+
+    setUpAll(() async {
+      // 初始化 sqflite_ffi
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+
+      // 初始化日志
+      await AppLogger.initialize(isTestEnvironment: true);
+
+      // 创建临时测试数据库路径
+      final tempDir = Directory.systemTemp.createTempSync('gallery_test_');
+      testDbPath = '${tempDir.path}/test_gallery.db';
+
+      AppLogger.i('Test database path: $testDbPath', 'GalleryBatchTest');
+    });
+
+    tearDownAll(() async {
+      // 清理资源
+      await ConnectionPoolHolder.dispose();
+
+      // 删除测试数据库文件
+      try {
+        final dbFile = File(testDbPath);
+        if (await dbFile.exists()) {
+          await dbFile.delete();
+        }
+        final tempDir = Directory(testDbPath).parent;
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      } catch (e) {
+        AppLogger.w('Failed to clean up test database: $e', 'GalleryBatchTest');
+      }
+    });
+
+    setUp(() async {
+      // 每个测试前重置并初始化连接池
+      if (ConnectionPoolHolder.isInitialized) {
+        await ConnectionPoolHolder.dispose();
+      }
+
+      // 确保数据库文件不存在
+      try {
+        final dbFile = File(testDbPath);
+        if (await dbFile.exists()) {
+          await dbFile.delete();
+        }
+      } catch (_) {}
+
+      // 初始化连接池
+      await ConnectionPoolHolder.initialize(
+        dbPath: testDbPath,
+        maxConnections: 2,
+      );
+
+      // 创建数据源并初始化
+      dataSource = GalleryDataSource();
+      await dataSource.initialize();
+    });
+
+    tearDown(() async {
+      // 每个测试后清理
+      await dataSource.dispose();
+      await ConnectionPoolHolder.dispose();
+
+      // 删除测试数据库文件
+      try {
+        final dbFile = File(testDbPath);
+        if (await dbFile.exists()) {
+          await dbFile.delete();
+        }
+      } catch (_) {}
+    });
+
+    // ============================================================
+    // getImageIdsByPaths 测试
+    // ============================================================
+
+    group('getImageIdsByPaths', () {
+      test('should return empty map when input list is empty', () async {
+        final result = await dataSource.getImageIdsByPaths([]);
+
+        expect(result, isEmpty);
+      });
+
+      test('should return map with null values for non-existent paths', () async {
+        final paths = [
+          '/non/existent/path1.png',
+          '/non/existent/path2.png',
+        ];
+
+        final result = await dataSource.getImageIdsByPaths(paths);
+
+        expect(result.length, equals(2));
+        expect(result[paths[0]], isNull);
+        expect(result[paths[1]], isNull);
+      });
+
+      test('should return correct IDs for existing paths', () async {
+        // 插入测试数据
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/path1.png',
+          fileName: 'path1.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final id2 = await dataSource.upsertImage(
+          filePath: '/test/path2.png',
+          fileName: 'path2.png',
+          fileSize: 2000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final paths = ['/test/path1.png', '/test/path2.png'];
+        final result = await dataSource.getImageIdsByPaths(paths);
+
+        expect(result.length, equals(2));
+        expect(result[paths[0]], equals(id1));
+        expect(result[paths[1]], equals(id2));
+      });
+
+      test('should handle mix of existing and non-existent paths', () async {
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/existing.png',
+          fileName: 'existing.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final paths = ['/test/existing.png', '/test/nonexistent.png'];
+        final result = await dataSource.getImageIdsByPaths(paths);
+
+        expect(result.length, equals(2));
+        expect(result[paths[0]], equals(id1));
+        expect(result[paths[1]], isNull);
+      });
+
+      test('should not include deleted images', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/deleted.png',
+          fileName: 'deleted.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        // 标记为删除
+        await dataSource.markAsDeleted('/test/deleted.png');
+
+        final result = await dataSource.getImageIdsByPaths(['/test/deleted.png']);
+
+        expect(result['/test/deleted.png'], isNull);
+      });
+    });
+
+    // ============================================================
+    // getImagesByIds 测试
+    // ============================================================
+
+    group('getImagesByIds', () {
+      test('should return empty list when input list is empty', () async {
+        final result = await dataSource.getImagesByIds([]);
+
+        expect(result, isEmpty);
+      });
+
+      test('should return images for valid IDs', () async {
+        final now = DateTime.now();
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/img1.png',
+          fileName: 'img1.png',
+          fileSize: 1000,
+          createdAt: now,
+          modifiedAt: now,
+        );
+
+        final id2 = await dataSource.upsertImage(
+          filePath: '/test/img2.png',
+          fileName: 'img2.png',
+          fileSize: 2000,
+          createdAt: now,
+          modifiedAt: now,
+        );
+
+        final result = await dataSource.getImagesByIds([id1, id2]);
+
+        expect(result.length, equals(2));
+        expect(result.any((img) => img.id == id1 && img.fileName == 'img1.png'), isTrue);
+        expect(result.any((img) => img.id == id2 && img.fileName == 'img2.png'), isTrue);
+      });
+
+      test('should return only existing images and skip deleted', () async {
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/existing.png',
+          fileName: 'existing.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final id2 = await dataSource.upsertImage(
+          filePath: '/test/to_delete.png',
+          fileName: 'to_delete.png',
+          fileSize: 2000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        // 标记第二个为删除
+        await dataSource.markAsDeleted('/test/to_delete.png');
+
+        final result = await dataSource.getImagesByIds([id1, id2, 99999]);
+
+        expect(result.length, equals(1));
+        expect(result.first.id, equals(id1));
+      });
+
+      test('should return results in original ID order', () async {
+        final now = DateTime.now();
+
+        // 按顺序插入，但获取时按相反顺序
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/order1.png',
+          fileName: 'order1.png',
+          fileSize: 1000,
+          createdAt: now,
+          modifiedAt: now,
+        );
+
+        final id2 = await dataSource.upsertImage(
+          filePath: '/test/order2.png',
+          fileName: 'order2.png',
+          fileSize: 2000,
+          createdAt: now,
+          modifiedAt: now,
+        );
+
+        final id3 = await dataSource.upsertImage(
+          filePath: '/test/order3.png',
+          fileName: 'order3.png',
+          fileSize: 3000,
+          createdAt: now,
+          modifiedAt: now,
+        );
+
+        final result = await dataSource.getImagesByIds([id3, id1, id2]);
+
+        expect(result.length, equals(3));
+        expect(result[0].id, equals(id3));
+        expect(result[1].id, equals(id1));
+        expect(result[2].id, equals(id2));
+      });
+
+      test('should use cache for subsequent queries', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/cached.png',
+          fileName: 'cached.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        // 第一次查询，应该从数据库获取
+        final result1 = await dataSource.getImagesByIds([id]);
+        expect(result1.length, equals(1));
+
+        // 第二次查询，应该从缓存获取
+        final result2 = await dataSource.getImagesByIds([id]);
+        expect(result2.length, equals(1));
+        expect(result2.first.fileName, equals('cached.png'));
+      });
+    });
+
+    // ============================================================
+    // getMetadataByImageIds 测试
+    // ============================================================
+
+    group('getMetadataByImageIds', () {
+      test('should return empty map when input list is empty', () async {
+        final result = await dataSource.getMetadataByImageIds([]);
+
+        expect(result, isEmpty);
+      });
+
+      test('should return null values for images without metadata', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/no_metadata.png',
+          fileName: 'no_metadata.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final result = await dataSource.getMetadataByImageIds([id]);
+
+        expect(result.length, equals(1));
+        expect(result[id], isNull);
+      });
+
+      test('should return metadata for images with metadata', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/with_metadata.png',
+          fileName: 'with_metadata.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final metadata = NaiImageMetadata(
+          prompt: 'test prompt',
+          negativePrompt: 'test negative',
+          seed: 12345,
+          sampler: 'k_euler',
+          steps: 28,
+          scale: 7.5,
+          width: 512,
+          height: 768,
+          model: 'nai-diffusion-3',
+        );
+
+        await dataSource.upsertMetadata(id, metadata);
+
+        final result = await dataSource.getMetadataByImageIds([id]);
+
+        expect(result.length, equals(1));
+        expect(result[id], isNotNull);
+        expect(result[id]!.prompt, equals('test prompt'));
+        expect(result[id]!.negativePrompt, equals('test negative'));
+        expect(result[id]!.seed, equals(12345));
+        expect(result[id]!.sampler, equals('k_euler'));
+        expect(result[id]!.model, equals('nai-diffusion-3'));
+      });
+
+      test('should handle mix of images with and without metadata', () async {
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/meta1.png',
+          fileName: 'meta1.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final id2 = await dataSource.upsertImage(
+          filePath: '/test/meta2.png',
+          fileName: 'meta2.png',
+          fileSize: 2000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final metadata = NaiImageMetadata(
+          prompt: 'prompt for meta1',
+          negativePrompt: '',
+        );
+
+        await dataSource.upsertMetadata(id1, metadata);
+
+        final result = await dataSource.getMetadataByImageIds([id1, id2]);
+
+        expect(result.length, equals(2));
+        expect(result[id1], isNotNull);
+        expect(result[id1]!.prompt, equals('prompt for meta1'));
+        expect(result[id2], isNull);
+      });
+
+      test('should use cache for subsequent queries', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/meta_cached.png',
+          fileName: 'meta_cached.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final metadata = NaiImageMetadata(
+          prompt: 'cached prompt',
+          negativePrompt: '',
+        );
+
+        await dataSource.upsertMetadata(id, metadata);
+
+        // 第一次查询
+        final result1 = await dataSource.getMetadataByImageIds([id]);
+        expect(result1[id]!.prompt, equals('cached prompt'));
+
+        // 第二次查询应该使用缓存
+        final result2 = await dataSource.getMetadataByImageIds([id]);
+        expect(result2[id]!.prompt, equals('cached prompt'));
+      });
+    });
+
+    // ============================================================
+    // getFavoritesByImageIds 测试
+    // ============================================================
+
+    group('getFavoritesByImageIds', () {
+      test('should return empty map when input list is empty', () async {
+        final result = await dataSource.getFavoritesByImageIds([]);
+
+        expect(result, isEmpty);
+      });
+
+      test('should return false for non-favorited images', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/not_favorite.png',
+          fileName: 'not_favorite.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final result = await dataSource.getFavoritesByImageIds([id]);
+
+        expect(result.length, equals(1));
+        expect(result[id], isFalse);
+      });
+
+      test('should return true for favorited images', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/favorite.png',
+          fileName: 'favorite.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        // 添加到收藏
+        await dataSource.toggleFavorite(id);
+
+        final result = await dataSource.getFavoritesByImageIds([id]);
+
+        expect(result.length, equals(1));
+        expect(result[id], isTrue);
+      });
+
+      test('should handle mix of favorited and non-favorited images', () async {
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/fav1.png',
+          fileName: 'fav1.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final id2 = await dataSource.upsertImage(
+          filePath: '/test/fav2.png',
+          fileName: 'fav2.png',
+          fileSize: 2000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final id3 = await dataSource.upsertImage(
+          filePath: '/test/fav3.png',
+          fileName: 'fav3.png',
+          fileSize: 3000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        // 收藏 id1 和 id3
+        await dataSource.toggleFavorite(id1);
+        await dataSource.toggleFavorite(id3);
+
+        final result = await dataSource.getFavoritesByImageIds([id1, id2, id3]);
+
+        expect(result.length, equals(3));
+        expect(result[id1], isTrue);
+        expect(result[id2], isFalse);
+        expect(result[id3], isTrue);
+      });
+
+      test('should return false for non-existent image IDs', () async {
+        final result = await dataSource.getFavoritesByImageIds([99999, 88888]);
+
+        expect(result.length, equals(2));
+        expect(result[99999], isFalse);
+        expect(result[88888], isFalse);
+      });
+    });
+
+    // ============================================================
+    // getTagsByImageIds 测试
+    // ============================================================
+
+    group('getTagsByImageIds', () {
+      test('should return empty map when input list is empty', () async {
+        final result = await dataSource.getTagsByImageIds([]);
+
+        expect(result, isEmpty);
+      });
+
+      test('should return empty list for images without tags', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/no_tags.png',
+          fileName: 'no_tags.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final result = await dataSource.getTagsByImageIds([id]);
+
+        expect(result.length, equals(1));
+        expect(result[id], isEmpty);
+      });
+
+      test('should return tags for images with tags', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/with_tags.png',
+          fileName: 'with_tags.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        await dataSource.addTag(id, 'landscape');
+        await dataSource.addTag(id, 'anime');
+        await dataSource.addTag(id, 'sunset');
+
+        final result = await dataSource.getTagsByImageIds([id]);
+
+        expect(result.length, equals(1));
+        expect(result[id], contains('landscape'));
+        expect(result[id], contains('anime'));
+        expect(result[id], contains('sunset'));
+        expect(result[id]!.length, equals(3));
+      });
+
+      test('should handle multiple images with different tags', () async {
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/tags1.png',
+          fileName: 'tags1.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final id2 = await dataSource.upsertImage(
+          filePath: '/test/tags2.png',
+          fileName: 'tags2.png',
+          fileSize: 2000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        await dataSource.addTag(id1, 'portrait');
+        await dataSource.addTag(id1, 'character');
+        await dataSource.addTag(id2, 'landscape');
+
+        final result = await dataSource.getTagsByImageIds([id1, id2]);
+
+        expect(result.length, equals(2));
+        expect(result[id1], contains('portrait'));
+        expect(result[id1], contains('character'));
+        expect(result[id1]!.length, equals(2));
+        expect(result[id2], contains('landscape'));
+        expect(result[id2]!.length, equals(1));
+      });
+
+      test('should share tags across images correctly', () async {
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/shared1.png',
+          fileName: 'shared1.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final id2 = await dataSource.upsertImage(
+          filePath: '/test/shared2.png',
+          fileName: 'shared2.png',
+          fileSize: 2000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        // 两个图片共享一个标签
+        await dataSource.addTag(id1, 'shared_tag');
+        await dataSource.addTag(id2, 'shared_tag');
+        await dataSource.addTag(id1, 'unique_tag');
+
+        final result = await dataSource.getTagsByImageIds([id1, id2]);
+
+        expect(result[id1], contains('shared_tag'));
+        expect(result[id1], contains('unique_tag'));
+        expect(result[id2], contains('shared_tag'));
+        expect(result[id2], isNot(contains('unique_tag')));
+      });
+    });
+
+    // ============================================================
+    // batchMarkAsDeleted 测试
+    // ============================================================
+
+    group('batchMarkAsDeleted', () {
+      test('should do nothing when input list is empty', () async {
+        await dataSource.batchMarkAsDeleted([]);
+
+        // 验证数据库仍然正常
+        final count = await dataSource.countImages();
+        expect(count, equals(0));
+      });
+
+      test('should mark multiple images as deleted', () async {
+        final id1 = await dataSource.upsertImage(
+          filePath: '/test/delete1.png',
+          fileName: 'delete1.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final id2 = await dataSource.upsertImage(
+          filePath: '/test/delete2.png',
+          fileName: 'delete2.png',
+          fileSize: 2000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        final initialCount = await dataSource.countImages();
+        expect(initialCount, equals(2));
+
+        // 批量删除
+        await dataSource.batchMarkAsDeleted([
+          '/test/delete1.png',
+          '/test/delete2.png',
+        ]);
+
+        // 验证删除后不计入总数
+        final finalCount = await dataSource.countImages();
+        expect(finalCount, equals(0));
+
+        // 验证图片已标记为删除（通过 getImageById）
+        final img1 = await dataSource.getImageById(id1);
+        final img2 = await dataSource.getImageById(id2);
+        expect(img1, isNull);
+        expect(img2, isNull);
+      });
+
+      test('should handle mix of existing and non-existent paths', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/exists_delete.png',
+          fileName: 'exists_delete.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        // 批量删除，包含存在的和不存在的路径
+        await dataSource.batchMarkAsDeleted([
+          '/test/exists_delete.png',
+          '/test/nonexistent.png',
+        ]);
+
+        // 验证存在的被删除
+        final img = await dataSource.getImageById(id);
+        expect(img, isNull);
+      });
+
+      test('should clear cache for deleted images', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/cache_delete.png',
+          fileName: 'cache_delete.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        // 先查询一次，使其进入缓存
+        final img1 = await dataSource.getImageById(id);
+        expect(img1, isNotNull);
+
+        // 批量删除
+        await dataSource.batchMarkAsDeleted(['/test/cache_delete.png']);
+
+        // 验证缓存已被清除（getImageById 返回 null）
+        final img2 = await dataSource.getImageById(id);
+        expect(img2, isNull);
+      });
+
+      test('should handle single path deletion', () async {
+        final id = await dataSource.upsertImage(
+          filePath: '/test/single_delete.png',
+          fileName: 'single_delete.png',
+          fileSize: 1000,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        await dataSource.batchMarkAsDeleted(['/test/single_delete.png']);
+
+        final img = await dataSource.getImageById(id);
+        expect(img, isNull);
+      });
+    });
+
+    // ============================================================
+    // 综合场景测试
+    // ============================================================
+
+    group('Integration Scenarios', () {
+      test('should handle complete image workflow', () async {
+        // 1. 创建图片
+        final id = await dataSource.upsertImage(
+          filePath: '/test/workflow.png',
+          fileName: 'workflow.png',
+          fileSize: 5000,
+          width: 512,
+          height: 768,
+          createdAt: DateTime.now(),
+          modifiedAt: DateTime.now(),
+        );
+
+        // 2. 添加元数据
+        final metadata = NaiImageMetadata(
+          prompt: 'beautiful landscape with mountains',
+          negativePrompt: 'blurry, low quality',
+          seed: 42,
+          sampler: 'k_euler_ancestral',
+          steps: 30,
+          scale: 8.0,
+          width: 512,
+          height: 768,
+          model: 'nai-diffusion-4',
+          smea: true,
+          smeaDyn: false,
+        );
+        await dataSource.upsertMetadata(id, metadata);
+
+        // 3. 添加标签
+        await dataSource.addTag(id, 'landscape');
+        await dataSource.addTag(id, 'mountains');
+        await dataSource.addTag(id, 'scenic');
+
+        // 4. 添加到收藏
+        final isFav = await dataSource.toggleFavorite(id);
+        expect(isFav, isTrue);
+
+        // 5. 批量查询验证所有数据
+        final idsResult = await dataSource.getImageIdsByPaths(['/test/workflow.png']);
+        expect(idsResult['/test/workflow.png'], equals(id));
+
+        final imagesResult = await dataSource.getImagesByIds([id]);
+        expect(imagesResult.length, equals(1));
+        expect(imagesResult.first.fileName, equals('workflow.png'));
+
+        final metaResult = await dataSource.getMetadataByImageIds([id]);
+        expect(metaResult[id], isNotNull);
+        expect(metaResult[id]!.prompt, equals('beautiful landscape with mountains'));
+
+        final favsResult = await dataSource.getFavoritesByImageIds([id]);
+        expect(favsResult[id], isTrue);
+
+        final tagsResult = await dataSource.getTagsByImageIds([id]);
+        expect(tagsResult[id], contains('landscape'));
+        expect(tagsResult[id], contains('mountains'));
+        expect(tagsResult[id], contains('scenic'));
+
+        // 6. 批量删除
+        await dataSource.batchMarkAsDeleted(['/test/workflow.png']);
+
+        // 7. 验证删除后无法获取
+        final afterDelete = await dataSource.getImageById(id);
+        expect(afterDelete, isNull);
+      });
+
+      test('should handle batch operations with large datasets', () async {
+        // 创建多个图片
+        final ids = <int>[];
+        final paths = <String>[];
+
+        for (var i = 0; i < 50; i++) {
+          final path = '/test/batch_$i.png';
+          paths.add(path);
+
+          final id = await dataSource.upsertImage(
+            filePath: path,
+            fileName: 'batch_$i.png',
+            fileSize: 1000 + i,
+            createdAt: DateTime.now(),
+            modifiedAt: DateTime.now(),
+          );
+          ids.add(id);
+
+          // 为部分图片添加元数据
+          if (i % 2 == 0) {
+            final metadata = NaiImageMetadata(
+              prompt: 'prompt for image $i',
+              negativePrompt: '',
+              seed: i,
+            );
+            await dataSource.upsertMetadata(id, metadata);
+          }
+
+          // 为部分图片添加收藏
+          if (i % 3 == 0) {
+            await dataSource.toggleFavorite(id);
+          }
+
+          // 为部分图片添加标签
+          if (i % 4 == 0) {
+            await dataSource.addTag(id, 'tag_$i');
+          }
+        }
+
+        // 批量查询所有图片ID
+        final idsResult = await dataSource.getImageIdsByPaths(paths);
+        expect(idsResult.length, equals(50));
+        for (final id in ids) {
+          expect(idsResult.values, contains(id));
+        }
+
+        // 批量查询所有图片
+        final imagesResult = await dataSource.getImagesByIds(ids);
+        expect(imagesResult.length, equals(50));
+
+        // 批量查询所有元数据
+        final metaResult = await dataSource.getMetadataByImageIds(ids);
+        expect(metaResult.length, equals(50));
+        var metaCount = 0;
+        for (var i = 0; i < 50; i++) {
+          if (i % 2 == 0) {
+            expect(metaResult[ids[i]], isNotNull);
+            metaCount++;
+          } else {
+            expect(metaResult[ids[i]], isNull);
+          }
+        }
+        expect(metaCount, equals(25));
+
+        // 批量查询所有收藏
+        final favsResult = await dataSource.getFavoritesByImageIds(ids);
+        expect(favsResult.length, equals(50));
+        for (var i = 0; i < 50; i++) {
+          if (i % 3 == 0) {
+            expect(favsResult[ids[i]], isTrue);
+          } else {
+            expect(favsResult[ids[i]], isFalse);
+          }
+        }
+
+        // 批量查询所有标签
+        final tagsResult = await dataSource.getTagsByImageIds(ids);
+        expect(tagsResult.length, equals(50));
+
+        // 批量删除一半图片
+        final deletePaths = paths.sublist(0, 25);
+        await dataSource.batchMarkAsDeleted(deletePaths);
+
+        // 验证剩余数量
+        final remainingCount = await dataSource.countImages();
+        expect(remainingCount, equals(25));
+      });
+    });
+  });
+}

--- a/test/core/database/datasources/gallery_data_source_batch_test.dart
+++ b/test/core/database/datasources/gallery_data_source_batch_test.dart
@@ -100,7 +100,8 @@ void main() {
         expect(result, isEmpty);
       });
 
-      test('should return map with null values for non-existent paths', () async {
+      test('should return map with null values for non-existent paths',
+          () async {
         final paths = [
           '/non/existent/path1.png',
           '/non/existent/path2.png',
@@ -157,7 +158,7 @@ void main() {
       });
 
       test('should not include deleted images', () async {
-        final id = await dataSource.upsertImage(
+        await dataSource.upsertImage(
           filePath: '/test/deleted.png',
           fileName: 'deleted.png',
           fileSize: 1000,
@@ -168,7 +169,8 @@ void main() {
         // 标记为删除
         await dataSource.markAsDeleted('/test/deleted.png');
 
-        final result = await dataSource.getImageIdsByPaths(['/test/deleted.png']);
+        final result =
+            await dataSource.getImageIdsByPaths(['/test/deleted.png']);
 
         expect(result['/test/deleted.png'], isNull);
       });
@@ -206,8 +208,10 @@ void main() {
         final result = await dataSource.getImagesByIds([id1, id2]);
 
         expect(result.length, equals(2));
-        expect(result.any((img) => img.id == id1 && img.fileName == 'img1.png'), isTrue);
-        expect(result.any((img) => img.id == id2 && img.fileName == 'img2.png'), isTrue);
+        expect(result.any((img) => img.id == id1 && img.fileName == 'img1.png'),
+            isTrue);
+        expect(result.any((img) => img.id == id2 && img.fileName == 'img2.png'),
+            isTrue);
       });
 
       test('should return only existing images and skip deleted', () async {
@@ -327,7 +331,7 @@ void main() {
           modifiedAt: DateTime.now(),
         );
 
-        final metadata = NaiImageMetadata(
+        const metadata = NaiImageMetadata(
           prompt: 'test prompt',
           negativePrompt: 'test negative',
           seed: 12345,
@@ -369,7 +373,7 @@ void main() {
           modifiedAt: DateTime.now(),
         );
 
-        final metadata = NaiImageMetadata(
+        const metadata = NaiImageMetadata(
           prompt: 'prompt for meta1',
           negativePrompt: '',
         );
@@ -393,7 +397,7 @@ void main() {
           modifiedAt: DateTime.now(),
         );
 
-        final metadata = NaiImageMetadata(
+        const metadata = NaiImageMetadata(
           prompt: 'cached prompt',
           negativePrompt: '',
         );
@@ -735,7 +739,7 @@ void main() {
         );
 
         // 2. 添加元数据
-        final metadata = NaiImageMetadata(
+        const metadata = NaiImageMetadata(
           prompt: 'beautiful landscape with mountains',
           negativePrompt: 'blurry, low quality',
           seed: 42,
@@ -760,7 +764,8 @@ void main() {
         expect(isFav, isTrue);
 
         // 5. 批量查询验证所有数据
-        final idsResult = await dataSource.getImageIdsByPaths(['/test/workflow.png']);
+        final idsResult =
+            await dataSource.getImageIdsByPaths(['/test/workflow.png']);
         expect(idsResult['/test/workflow.png'], equals(id));
 
         final imagesResult = await dataSource.getImagesByIds([id]);
@@ -769,7 +774,8 @@ void main() {
 
         final metaResult = await dataSource.getMetadataByImageIds([id]);
         expect(metaResult[id], isNotNull);
-        expect(metaResult[id]!.prompt, equals('beautiful landscape with mountains'));
+        expect(metaResult[id]!.prompt,
+            equals('beautiful landscape with mountains'));
 
         final favsResult = await dataSource.getFavoritesByImageIds([id]);
         expect(favsResult[id], isTrue);


### PR DESCRIPTION
LocalGalleryProvider._loadRecords()方法为每个文件执行多次独立数据库查询（getImageIdByPath、isFavorite、getImageTags、getMetadataByImageId），导致严重的N+1查询性能问题。当每页加载50张图片时，会产生200+次数据库往返。