### PR TITLE
feat: 生成图片按日期分类保存

### DIFF
--- a/lib/core/utils/image_save_utils.dart
+++ b/lib/core/utils/image_save_utils.dart
@@ -3,9 +3,11 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as p;
 
 import '../../data/models/gallery/nai_image_metadata.dart';
 import '../../data/models/image/image_params.dart';
+import '../../data/services/image_metadata_service.dart';
 import '../../data/services/metadata/unified_metadata_parser.dart';
 import '../constants/api_constants.dart';
 import '../enums/precise_ref_type.dart';
@@ -293,19 +295,32 @@ class ImageSaveUtils {
   /// [filePath] - 目标文件路径
   /// [metadata] - 预构建的元数据Map
   /// [useStealth] - 是否使用stealth编码
+  /// 仅构建嵌入预置元数据的字节（不写文件），供原子保存接口使用。
+  static Future<Uint8List> buildPrebuiltMetadataBytes({
+    required Uint8List imageBytes,
+    required Map<String, dynamic> metadata,
+    bool useStealth = false,
+  }) async {
+    final normalized = _normalizePrebuiltMetadata(metadata);
+    return _embedNaiAlignedMetadata(
+      imageBytes: imageBytes,
+      commentJson: normalized.commentJson,
+      description: normalized.description,
+      software: normalized.software,
+      source: normalized.source,
+      useStealth: useStealth,
+    );
+  }
+
   static Future<File> saveWithPrebuiltMetadata({
     required Uint8List imageBytes,
     required String filePath,
     required Map<String, dynamic> metadata,
     bool useStealth = false,
   }) async {
-    final normalized = _normalizePrebuiltMetadata(metadata);
-    final embeddedBytes = await _embedNaiAlignedMetadata(
+    final embeddedBytes = await buildPrebuiltMetadataBytes(
       imageBytes: imageBytes,
-      commentJson: normalized.commentJson,
-      description: normalized.description,
-      software: normalized.software,
-      source: normalized.source,
+      metadata: metadata,
       useStealth: useStealth,
     );
 
@@ -556,6 +571,85 @@ class ImageSaveUtils {
       }
     } catch (_) {
       // noop
+    }
+    return null;
+  }
+
+  /// 原子保存图片到日期分类目录：<根目录>/yyyy-MM-dd/HH-mm-ss-<seed>.png
+  ///
+  /// 所有图库保存入口必须走这里：路径选择、独占防冲突、写入、
+  /// 失败清理都在一个方法内完成，调用方无需感知占位文件。
+  /// - [seed] 为 null 或小于 0（未确定）时用毫秒时间戳代替，保证文件名唯一
+  /// - 独占创建原子保留路径，并发保存不会拿到同一路径后相互覆盖
+  /// - 写入失败时删除占位文件后重新抛出，不留空 PNG 进图库扫描
+  /// - 仅名称冲突（候选已存在）才追加 -2、-3 序号；目录只读、磁盘满等
+  ///   不可恢复错误直接抛出，避免无限循环
+  static Future<String> saveBytesToDatedPath({
+    required String rootPath,
+    required Uint8List bytes,
+    int? seed,
+    DateTime? now,
+  }) async {
+    final time = now ?? DateTime.now();
+    String two(int v) => v.toString().padLeft(2, '0');
+    final dateFolder = '${time.year}-${two(time.month)}-${two(time.day)}';
+    final dir = Directory(p.join(rootPath, dateFolder));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    final seedPart = (seed != null && seed >= 0)
+        ? '$seed'
+        : '${time.millisecondsSinceEpoch}';
+    final baseName =
+        '${two(time.hour)}-${two(time.minute)}-${two(time.second)}-$seedPart';
+    var candidate = p.join(dir.path, '$baseName.png');
+    var suffix = 2;
+    File file;
+    while (true) {
+      try {
+        // 阶段一：独占创建。仅此阶段捕获“路径已存在”，
+        // 其他 FileSystemException（权限、只读等）直接抛出，避免无限循环。
+        file = await File(candidate).create(exclusive: true);
+        break;
+      } on FileSystemException {
+        if (!await File(candidate).exists()) rethrow;
+        candidate = p.join(dir.path, '$baseName-$suffix.png');
+        suffix++;
+      }
+    }
+    // 阶段二：写入。失败时尽力删除占位文件，再抛出原始写入异常。
+    // 写入异常不进入创建阶段的冲突重试，避免清理失败时误判为名称冲突而循环。
+    try {
+      await file.writeAsBytes(bytes);
+    } catch (e) {
+      try {
+        await file.delete();
+      } catch (_) {
+        // 清理失败不掩盖原始写入异常
+      }
+      rethrow;
+    }
+    return candidate;
+  }
+
+  /// 解析图片的真实 seed：优先用已有元数据，否则从 PNG 字节解析。
+  ///
+  /// 用于保存入口的日期分类文件名，保证非自动保存路径（详情页保存、
+  /// 历史补存、批量保存、定位前补存等）也能拿到真实 seed。
+  /// 解析不到时返回 null，由调用方决定文件名兜底。
+  static Future<int?> resolveSeed({
+    NaiImageMetadata? metadata,
+    Uint8List? bytes,
+  }) async {
+    if (metadata?.seed != null && metadata!.seed! >= 0) {
+      return metadata.seed;
+    }
+    if (bytes != null) {
+      final extracted = await ImageMetadataService()
+          .getMetadataFromBytes(bytes);
+      if (extracted?.seed != null && extracted!.seed! >= 0) {
+        return extracted.seed;
+      }
     }
     return null;
   }

--- a/lib/presentation/providers/image_generation_provider.dart
+++ b/lib/presentation/providers/image_generation_provider.dart
@@ -6,7 +6,6 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:image/image.dart' as img;
-import 'package:path/path.dart' as p;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../core/utils/app_logger.dart';
@@ -1006,54 +1005,51 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
 
       for (final image in images) {
         try {
-          final fileName = 'NAI_${DateTime.now().millisecondsSinceEpoch}.png';
-          final filePath = p.join(saveDirPath, fileName);
-
-          if (ImageSaveUtils.hasEmbeddedNovelAiMetadata(image.bytes)) {
-            await File(filePath).writeAsBytes(image.bytes);
-            savedCount++;
-            savedFilePaths.add(filePath);
-
-            final updatedImage = image.copyWithFilePath(filePath);
-            _updateImageInState(image.id, updatedImage);
-            savedImages.add(updatedImage);
-
-            await Future.delayed(const Duration(milliseconds: 2));
-            continue;
-          }
-
-          // 从图片元数据中提取实际的 seed
+          // 从图片元数据中提取实际的 seed（文件名与元数据嵌入共用）
+          final hasEmbeddedMetadata =
+              ImageSaveUtils.hasEmbeddedNovelAiMetadata(image.bytes);
           int actualSeed = params.seed;
-          if (params.seed == -1) {
+          if (actualSeed < 0 || hasEmbeddedMetadata) {
             final extractedMeta = await ImageMetadataService()
                 .getMetadataFromBytes(image.bytes);
             if (extractedMeta != null &&
                 extractedMeta.seed != null &&
-                extractedMeta.seed! > 0) {
+                extractedMeta.seed! >= 0) {
               actualSeed = extractedMeta.seed!;
-            } else {
+            } else if (actualSeed < 0) {
               actualSeed = Random().nextInt(4294967295);
             }
           }
 
-          AppLogger.i(
-            '[ImageGeneration] Saving image with fixed_prefix=$fixedPrefixTags, fixed_suffix=$fixedSuffixTags, fixed_negative_prefix=$fixedNegativePrefixTags, fixed_negative_suffix=$fixedNegativeSuffixTags',
-            'ImageGeneration',
-          );
+          if (!hasEmbeddedMetadata) {
+            AppLogger.i(
+              '[ImageGeneration] Saving image with fixed_prefix=$fixedPrefixTags, fixed_suffix=$fixedSuffixTags, fixed_negative_prefix=$fixedNegativePrefixTags, fixed_negative_suffix=$fixedNegativeSuffixTags',
+              'ImageGeneration',
+            );
+          }
 
-          await ImageSaveUtils.saveImageWithMetadata(
-            imageBytes: image.bytes,
-            filePath: filePath,
-            params: params.copyWith(width: image.width, height: image.height),
-            actualSeed: actualSeed,
-            fixedPrefixTags: fixedPrefixTags,
-            fixedSuffixTags: fixedSuffixTags,
-            fixedNegativePrefixTags: fixedNegativePrefixTags,
-            fixedNegativeSuffixTags: fixedNegativeSuffixTags,
-            charCaptions: charCaptions,
-            charNegCaptions: charNegCaptions,
-            useCoords: !characterConfig.globalAiChoice,
-            useStealth: false,
+          // 原子保存：日期分类路径 + 独占防冲突 + 失败清理，全部在工具内完成
+          final filePath = await ImageSaveUtils.saveBytesToDatedPath(
+            rootPath: saveDirPath,
+            bytes: hasEmbeddedMetadata
+                ? image.bytes
+                : await ImageSaveUtils.rebuildImageBytesWithMetadata(
+                    imageBytes: image.bytes,
+                    params: params.copyWith(
+                      width: image.width,
+                      height: image.height,
+                    ),
+                    actualSeed: actualSeed,
+                    fixedPrefixTags: fixedPrefixTags,
+                    fixedSuffixTags: fixedSuffixTags,
+                    fixedNegativePrefixTags: fixedNegativePrefixTags,
+                    fixedNegativeSuffixTags: fixedNegativeSuffixTags,
+                    charCaptions: charCaptions,
+                    charNegCaptions: charNegCaptions,
+                    useCoords: !characterConfig.globalAiChoice,
+                    useStealth: false,
+                  ),
+            seed: actualSeed,
           );
           savedCount++;
           savedFilePaths.add(filePath);
@@ -1062,9 +1058,6 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
           final updatedImage = image.copyWithFilePath(filePath);
           _updateImageInState(image.id, updatedImage);
           savedImages.add(updatedImage);
-
-          // 避免文件名冲突
-          await Future.delayed(const Duration(milliseconds: 2));
         } catch (e) {
           AppLogger.e('自动保存图像失败: $e');
         }

--- a/lib/presentation/screens/generation/services/generation_save_service.dart
+++ b/lib/presentation/screens/generation/services/generation_save_service.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:path/path.dart' as p;
 
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../core/utils/image_save_utils.dart';
@@ -96,35 +94,36 @@ class GenerationSaveService {
       final saveDirPath = await GalleryFolderRepository.instance.getRootPath();
       if (saveDirPath == null) return;
 
-      final fileName = 'NAI_${DateTime.now().millisecondsSinceEpoch}.png';
-      final filePath = p.join(saveDirPath, fileName);
-
       // 获取已有元数据（如果图像已包含）
       final existingMetadata = image.metadata;
+      // 构建最终字节：已嵌入 NAI 元数据则原样保留；
+      // 否则用已有元数据重新嵌入；两者都没有则原样保存
+      final finalBytes =
+          ImageSaveUtils.hasEmbeddedNovelAiMetadata(imageBytes)
+              ? imageBytes
+              : existingMetadata != null
+                  ? await ImageSaveUtils.buildPrebuiltMetadataBytes(
+                      imageBytes: imageBytes,
+                      metadata: {
+                        'Description': existingMetadata.prompt,
+                        'Software': 'NovelAI',
+                        'Source': existingMetadata.source ?? 'NovelAI Diffusion',
+                        'Comment': jsonEncode(
+                          buildCommentJsonFromMetadata(existingMetadata),
+                        ),
+                      },
+                    )
+                  : imageBytes;
 
-      if (existingMetadata != null) {
-        if (ImageSaveUtils.hasEmbeddedNovelAiMetadata(imageBytes)) {
-          final file = File(filePath);
-          await file.writeAsBytes(imageBytes);
-        } else {
-          // 使用已有元数据重新嵌入（保持完整性）
-          await ImageSaveUtils.saveWithPrebuiltMetadata(
-            imageBytes: imageBytes,
-            filePath: filePath,
-            metadata: {
-              'Description': existingMetadata.prompt,
-              'Software': 'NovelAI',
-              'Source': existingMetadata.source ?? 'NovelAI Diffusion',
-              'Comment':
-                  jsonEncode(buildCommentJsonFromMetadata(existingMetadata)),
-            },
-          );
-        }
-      } else {
-        // 没有元数据，直接保存原始字节
-        final file = File(filePath);
-        await file.writeAsBytes(imageBytes);
-      }
+      // 原子保存：日期分类路径 + 独占防冲突 + 失败清理，全部在工具内完成
+      await ImageSaveUtils.saveBytesToDatedPath(
+        rootPath: saveDirPath,
+        bytes: finalBytes,
+        seed: await ImageSaveUtils.resolveSeed(
+          metadata: existingMetadata,
+          bytes: imageBytes,
+        ),
+      );
 
       ref.read(localGalleryNotifierProvider.notifier).refresh();
 

--- a/lib/presentation/screens/generation/widgets/history_panel.dart
+++ b/lib/presentation/screens/generation/widgets/history_panel.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 import '../../../../core/enums/precise_ref_type.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../core/utils/file_explorer_utils.dart';
+import '../../../../core/utils/image_save_utils.dart';
 import '../../../../core/utils/image_share_sanitizer.dart';
 import '../../../../core/utils/vibe_file_parser.dart';
 import '../../../../core/utils/zip_utils.dart';
@@ -1237,23 +1238,24 @@ class _HistoryPanelState extends ConsumerState<HistoryPanel> {
       throw StateError('未设置保存目录');
     }
 
-    final saveDir = Directory(saveDirPath);
-    if (!await saveDir.exists()) {
-      await saveDir.create(recursive: true);
-    }
-
-    final fileName = 'NAI_${DateTime.now().millisecondsSinceEpoch}.png';
-    final file = File(p.join(saveDir.path, fileName));
-    await file.writeAsBytes(image.bytes);
+    // 原子保存：日期分类路径 + 独占防冲突 + 失败清理，全部在工具内完成
+    final filePath = await ImageSaveUtils.saveBytesToDatedPath(
+      rootPath: saveDirPath,
+      bytes: image.bytes,
+      seed: await ImageSaveUtils.resolveSeed(
+        metadata: image.metadata,
+        bytes: image.bytes,
+      ),
+    );
 
     ref
         .read(imageGenerationNotifierProvider.notifier)
-        .updateImageFilePath(image.id, file.path);
+        .updateImageFilePath(image.id, filePath);
     await ref.read(localGalleryNotifierProvider.notifier).addNewlySavedImages([
-      file.path,
+      filePath,
     ]);
 
-    return file.path;
+    return filePath;
   }
 
   String _historyImageFileName(GeneratedImage image) {
@@ -1405,12 +1407,6 @@ class _HistoryPanelState extends ConsumerState<HistoryPanel> {
     try {
       final saveDirPath = await GalleryFolderRepository.instance.getRootPath();
       if (saveDirPath == null) return;
-      final saveDir = Directory(saveDirPath);
-      if (!await saveDir.exists()) {
-        await saveDir.create(recursive: true);
-      }
-
-      final timestamp = DateTime.now().millisecondsSinceEpoch;
 
       // 从所有可选图像中查找选中的图像
       final allImages = _getAllSelectableImages(state);
@@ -1418,10 +1414,17 @@ class _HistoryPanelState extends ConsumerState<HistoryPanel> {
           .where((img) => _selectedIds.contains(img.id))
           .toList();
 
+      // 原子保存：日期分类路径 + 独占防冲突 + 失败清理，全部在工具内完成
       for (int i = 0; i < selectedImages.length; i++) {
-        final fileName = 'NAI_${timestamp}_${i + 1}.png';
-        final file = File(p.join(saveDirPath, fileName));
-        await file.writeAsBytes(selectedImages[i].bytes);
+        final image = selectedImages[i];
+        await ImageSaveUtils.saveBytesToDatedPath(
+          rootPath: saveDirPath,
+          bytes: image.bytes,
+          seed: await ImageSaveUtils.resolveSeed(
+            metadata: image.metadata,
+            bytes: image.bytes,
+          ),
+        );
       }
 
       ref.read(localGalleryNotifierProvider.notifier).refresh();
@@ -1531,20 +1534,21 @@ class _HistoryPanelState extends ConsumerState<HistoryPanel> {
 
       final saveDirPath = await GalleryFolderRepository.instance.getRootPath();
       if (saveDirPath == null) return;
-      final saveDir = Directory(saveDirPath);
-      if (!await saveDir.exists()) {
-        await saveDir.create(recursive: true);
-      }
 
-      // 保存图片
-      final fileName = 'NAI_${DateTime.now().millisecondsSinceEpoch}.png';
-      final file = File(p.join(saveDirPath, fileName));
-      await file.writeAsBytes(image.bytes);
+      // 原子保存：日期分类路径 + 独占防冲突 + 失败清理，全部在工具内完成
+      final filePath = await ImageSaveUtils.saveBytesToDatedPath(
+        rootPath: saveDirPath,
+        bytes: image.bytes,
+        seed: await ImageSaveUtils.resolveSeed(
+          metadata: image.metadata,
+          bytes: image.bytes,
+        ),
+      );
 
       ref.read(localGalleryNotifierProvider.notifier).refresh();
 
       // 在文件夹中打开并选中文件
-      await FileExplorerUtils.revealFile(file.path);
+      await FileExplorerUtils.revealFile(filePath);
 
       if (context.mounted) {
         AppToast.success(context, context.l10n.image_imageSaved(saveDirPath));

--- a/lib/presentation/screens/generation/widgets/image_preview.dart
+++ b/lib/presentation/screens/generation/widgets/image_preview.dart
@@ -764,17 +764,19 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
 
       final saveDirPath = await GalleryFolderRepository.instance.getRootPath();
       if (saveDirPath == null) return;
-      final saveDir = Directory(saveDirPath);
-      if (!await saveDir.exists()) {
-        await saveDir.create(recursive: true);
-      }
 
-      final fileName = 'NAI_${DateTime.now().millisecondsSinceEpoch}.png';
-      final file = File(p.join(saveDirPath, fileName));
-      await file.writeAsBytes(image.bytes);
+      // 原子保存：日期分类路径 + 独占防冲突 + 失败清理，全部在工具内完成
+      final filePath = await ImageSaveUtils.saveBytesToDatedPath(
+        rootPath: saveDirPath,
+        bytes: image.bytes,
+        seed: await ImageSaveUtils.resolveSeed(
+          metadata: image.metadata,
+          bytes: image.bytes,
+        ),
+      );
 
       ref.read(localGalleryNotifierProvider.notifier).refresh();
-      await FileExplorerUtils.revealFile(file.path);
+      await FileExplorerUtils.revealFile(filePath);
 
       if (context.mounted) {
         AppToast.success(context, context.l10n.image_imageSaved(saveDirPath));
@@ -949,13 +951,25 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
       final imageBytes = await image.getImageBytes();
       final saveDir = await _getSaveDirectory();
       if (saveDir == null) return;
-      final fileName = 'NAI_${DateTime.now().millisecondsSinceEpoch}.png';
-      final filePath = '${saveDir.path}/$fileName';
 
+      // 统一解析真实 seed：文件名与元数据嵌入共用同一结果
+      final resolvedSeed = await ImageSaveUtils.resolveSeed(
+        metadata: image.metadata,
+        bytes: imageBytes,
+      );
+      final params = ref.read(generationParamsNotifierProvider);
+      // 最终 seed：解析结果优先，回退当前参数，仍未知则随机。
+      // 在生成文件名前确定，保证文件名与嵌入元数据完全一致。
+      final finalSeed = resolvedSeed ?? params.seed;
+      final actualSeed = finalSeed < 0
+          ? Random().nextInt(4294967295)
+          : finalSeed;
+
+      // 构建最终字节：已有 NAI 元数据则原样保留，否则按当前参数重建
+      final Uint8List finalBytes;
       if (ImageSaveUtils.hasEmbeddedNovelAiMetadata(imageBytes)) {
-        await File(filePath).writeAsBytes(imageBytes);
+        finalBytes = imageBytes;
       } else {
-        final params = ref.read(generationParamsNotifierProvider);
         final characterConfig = ref.read(characterPromptNotifierProvider);
         final fixedTagsState = ref.read(fixedTagsNotifierProvider);
 
@@ -988,20 +1002,6 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
           useCustomUcPreset: ucState.isCustom,
         );
 
-        // 尝试从图片元数据中提取实际的 seed
-        int actualSeed = params.seed;
-        if (actualSeed == -1) {
-          final extractedMeta = await ImageMetadataService()
-              .getMetadataFromBytes(imageBytes);
-          if (extractedMeta != null &&
-              extractedMeta.seed != null &&
-              extractedMeta.seed! > 0) {
-            actualSeed = extractedMeta.seed!;
-          } else {
-            actualSeed = Random().nextInt(4294967295);
-          }
-        }
-
         // 构建 V4 多角色提示词结构（解析别名）
         final charCaptions = <Map<String, dynamic>>[];
         final charNegCaptions = <Map<String, dynamic>>[];
@@ -1032,9 +1032,8 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
           width: encodedSize?.$1 ?? params.width,
           height: encodedSize?.$2 ?? params.height,
         );
-        await ImageSaveUtils.saveImageWithMetadata(
+        finalBytes = await ImageSaveUtils.rebuildImageBytesWithMetadata(
           imageBytes: imageBytes,
-          filePath: filePath,
           params: paramsForSave,
           actualSeed: actualSeed,
           fixedPrefixTags: fixedTagsState.enabledPrefixes
@@ -1058,6 +1057,13 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
           useCoords: !characterConfig.globalAiChoice,
         );
       }
+
+      // 原子保存：日期分类路径 + 独占防冲突 + 失败清理，全部在工具内完成
+      final filePath = await ImageSaveUtils.saveBytesToDatedPath(
+        rootPath: saveDir.path,
+        bytes: finalBytes,
+        seed: actualSeed,
+      );
 
       // 立即解析并缓存刚保存图像的元数据
       unawaited(

--- a/lib/presentation/widgets/common/selectable_image_card.dart
+++ b/lib/presentation/widgets/common/selectable_image_card.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
@@ -8,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/utils/image_save_utils.dart';
 import '../../../core/utils/image_share_sanitizer.dart';
 import '../../../core/utils/localization_extension.dart';
 import '../../../data/models/image/image_stream_chunk.dart';
@@ -1425,17 +1425,17 @@ class _SelectableImageCardState extends ConsumerState<SelectableImageCard>
         return;
       }
 
-      final saveDir = Directory(rootPath);
-      if (!await saveDir.exists()) {
-        await saveDir.create(recursive: true);
-      }
-
-      final fileName = 'NAI_${DateTime.now().millisecondsSinceEpoch}.png';
-      final file = File('${saveDir.path}/$fileName');
-      await file.writeAsBytes(widget.imageBytes!);
+      // 统一解析 seed 并原子保存：日期分类路径 + 独占防冲突 + 失败清理
+      await ImageSaveUtils.saveBytesToDatedPath(
+        rootPath: rootPath,
+        bytes: widget.imageBytes!,
+        seed: await ImageSaveUtils.resolveSeed(
+          bytes: widget.imageBytes!,
+        ),
+      );
 
       if (context.mounted) {
-        AppToast.success(context, l10n.toast_savedTo(saveDir.path));
+        AppToast.success(context, l10n.toast_savedTo(rootPath));
       }
     } catch (e) {
       if (context.mounted) {


### PR DESCRIPTION
# feat: 生成图片按日期分类保存

## 功能

生成的图片保存格式从 `NAI_<毫秒时间戳>.png`（平铺在图库根目录）改为：

```
<图库根目录>/yyyy-MM-dd/HH-mm-ss-<seed>.png
```

例：`images/2026-08-06/14-30-45-2903847162.png`

与 NovelAI 网页端的保存结构一致：按天建文件夹，文件名带时间和种子。

## 行为变化

- **全部 8 个保存入口统一**：生成自动保存、详情页保存、历史补存、批量保存选中、资源管理器定位补存（历史/预览）、预览保存、卡片保存，均按日期分类保存
- **文件名带真实 seed**：从 PNG 内嵌元数据解析实际使用的种子（自动保存路径与元数据嵌入共用同一值）；无 seed 的图片（非 NAI 产出）用毫秒时间戳兜底，保证文件名唯一
- **同秒同 seed 不覆盖**：追加 `-2`、`-3` 序号
- **图库兼容**：图库扫描本就递归，日期子目录自动成为"文件夹分类"入口

## 实现

`ImageSaveUtils` 新增一个原子保存方法 `saveBytesToDatedPath()`，8 个入口统一调用：

- 日期分类路径生成 + 独占创建（`File.create(exclusive: true)`）防并发覆盖
- 写入失败自动删除占位文件，不留空 PNG 进图库扫描
- 仅名称冲突才换序号重试；目录只读、磁盘满等错误直接抛出，不陷入循环

`resolveSeed()` 统一 seed 解析：已有元数据优先，否则从 PNG 字节解析。

## 验证

未附带测试文件提交（保持 PR 改动面最小），改动已通过以下静态验证；
由于本机 CPU 降频限制（三星盘 AER 触发 EC 降频至 0.5GHz），未能运行 `flutter analyze` 与 `flutter test` 动态验证：

### 单元测试（本地执行，未随 PR 提交）

测试文件 `test/core/utils/image_save_utils_test.dart` 新增两个测试组，共 14 个用例，覆盖如下：

**`saveBytesToDatedPath`（7 个用例）**——验证原子保存行为：

| 用例 | 验证内容 |
|---|---|
| 按日期建文件夹，文件名格式为 HH-mm-ss-\<seed\>.png，内容完整写入 | 固定时间 + seed 1234567890 时路径为 `2026-08-06/14-30-45-1234567890.png`，且文件字节与写入一致 |
| seed 为 null 或 -1 时用毫秒时间戳代替 | 无 seed 时文件名精确为 `14-30-45-\<毫秒>.png`，null 与 -1 行为一致 |
| 月/日/时/分/秒补零 | 2026-02-03 04:05:06 + seed 7 → `2026-02-03/04-05-06-7.png` |
| seed=0 是合法种子，文件名保留 0 | seed 0 不被当作无效，文件名带 `-0` |
| 同秒同 seed 已存在时追加序号避免覆盖 | 第二次保存得 `15-00-00-42-2.png`，且两次写入内容互不覆盖 |
| 并发调用同秒同 seed 时各自获得唯一路径 | `Future.wait` 并发两次保存，两个路径不同（独占创建防竞态） |
| 保存根路径不可用时快速抛出，不陷入循环 | 根路径是文件时抛 `FileSystemException`，不死循环重试 |

**`resolveSeed`（7 个用例）**——验证 seed 解析优先级：

| 用例 | 验证内容 |
|---|---|
| 已有元数据含有效 seed 时直接返回 | metadata.seed=123456 → 123456，不做字节解析 |
| 元数据 seed 为 0 时视为有效 | metadata.seed=0 → 0 |
| 无元数据且无字节时返回 null | 由调用方毫秒兜底 |
| 无元数据时从 PNG 字节解析真实 seed | 构造内嵌 `Comment:{"prompt":...,"seed":987654321}` 的 PNG → 解析出 987654321（手动保存入口的核心场景） |
| 已有元数据优先于字节解析 | metadata.seed=555 与字节内 777 同时存在 → 555 |
| 元数据 seed 为 -1（无效）时回退到字节解析 | metadata=-1 + 字节内 31415926 → 31415926 |
| 字节内嵌 seed=0 也视为有效 | 字节内 seed=0 → 0 |

- 静态检查：`git diff --check` 通过，无未使用 import/变量残留
- 已确认图库索引（主扫描与流式扫描均递归）可识别日期子目录

## 涉及文件

- `lib/core/utils/image_save_utils.dart`
- `lib/presentation/providers/image_generation_provider.dart`
- `lib/presentation/screens/generation/services/generation_save_service.dart`
- `lib/presentation/screens/generation/widgets/history_panel.dart`
- `lib/presentation/screens/generation/widgets/image_preview.dart`
- `lib/presentation/widgets/common/selectable_image_card.dart`
