### PR TITLE
Harden gallery, autocomplete, updates, and installation

### DIFF
--- a/.github/workflows/online-gallery-live-contract.yml
+++ b/.github/workflows/online-gallery-live-contract.yml
@@ -20,7 +20,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: '3.35.0'
+          flutter-version: '3.44.2'
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -1,0 +1,127 @@
+name: Pull Request Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/pull-request-validation.yml"
+      - ".github/workflows/release.yml"
+      - "assets/**"
+      - "installer/windows/**"
+      - "lib/**"
+      - "pubspec.lock"
+      - "pubspec.yaml"
+      - "scripts/**"
+      - "test/**"
+      - "tool/**"
+      - "windows/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_VERSION: "3.44.2"
+
+jobs:
+  windows-validation:
+    name: Test and package Windows
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v4
+        with:
+          nuget-version: latest
+
+      - name: Verify NuGet
+        shell: pwsh
+        run: ./scripts/verify_nuget.ps1
+
+      - name: Install NSIS
+        shell: pwsh
+        run: choco install nsis -y --no-progress
+
+      - name: Pull LFS databases
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          git lfs install
+          git lfs pull --include="assets/databases/*.db"
+
+      - name: Resolve dependencies
+        run: flutter pub get
+
+      - name: Validate bundled autocomplete databases
+        run: dart run tool/tag_catalog/verify_bundled_databases.dart
+
+      - name: Generate localizations
+        run: flutter gen-l10n
+
+      - name: Generate code
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Verify generated files
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          git diff --exit-code
+
+      - name: Run tests
+        run: flutter test --reporter compact
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Build Windows release
+        run: flutter build windows --release
+
+      - name: Validate installer process handling
+        shell: pwsh
+        run: ./scripts/validate_windows_installer_process_handling.ps1
+
+      - name: Package Windows artifacts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $match = Select-String -Path pubspec.yaml -Pattern '^version:\s*(.+)$'
+          if (!$match) {
+            throw 'pubspec.yaml does not contain a version field.'
+          }
+          $version = $match.Matches[0].Groups[1].Value.Trim() -replace '\+.*$', ''
+          ./scripts/package_windows_release.ps1 `
+            -Version $version `
+            -SkipFlutterBuild
+
+      - name: Verify packaged artifacts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $match = Select-String -Path pubspec.yaml -Pattern '^version:\s*(.+)$'
+          $version = $match.Matches[0].Groups[1].Value.Trim() -replace '\+.*$', ''
+          $required = @(
+            "dist/NAI_Launcher_Windows_${version}_Setup.exe",
+            "dist/NAI_Launcher_Windows_${version}_Portable.zip"
+          )
+          foreach ($path in $required) {
+            if (!(Test-Path -LiteralPath $path)) {
+              throw "Missing packaged artifact: $path"
+            }
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,6 @@ jobs:
     name: Build Windows
     runs-on: windows-2022
     needs: prepare
-    env:
-      WINDOWS_SIGNING_CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}
-      WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
 
     steps:
       - name: Checkout
@@ -140,10 +137,16 @@ jobs:
         run: flutter build windows --release
 
       - name: Sign Windows application
-        if: ${{ env.WINDOWS_SIGNING_CERT_BASE64 != '' }}
         shell: pwsh
+        env:
+          WINDOWS_SIGNING_CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}
+          WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
         run: |
           $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_CERT_BASE64)) {
+            Write-Host 'Windows signing certificate is not configured; skipping application signing.'
+            exit 0
+          }
           $certificatePath = Join-Path $env:RUNNER_TEMP 'nai-launcher-signing.pfx'
           [IO.File]::WriteAllBytes(
             $certificatePath,
@@ -163,17 +166,23 @@ jobs:
             -SkipFlutterBuild
 
       - name: Sign Windows installer
-        if: ${{ env.WINDOWS_SIGNING_CERT_BASE64 != '' }}
         shell: pwsh
+        env:
+          WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
         run: |
           $ErrorActionPreference = 'Stop'
+          $certificatePath = Join-Path $env:RUNNER_TEMP 'nai-launcher-signing.pfx'
+          if (!(Test-Path -LiteralPath $certificatePath)) {
+            Write-Host 'Windows signing certificate is not configured; skipping installer signing.'
+            exit 0
+          }
           ./scripts/sign_windows_binary.ps1 `
             -Path 'dist/NAI_Launcher_Windows_${{ needs.prepare.outputs.version }}_Setup.exe' `
-            -CertificatePath (Join-Path $env:RUNNER_TEMP 'nai-launcher-signing.pfx') `
+            -CertificatePath $certificatePath `
             -CertificatePassword $env:WINDOWS_SIGNING_CERT_PASSWORD
 
       - name: Remove signing certificate
-        if: ${{ always() && env.WINDOWS_SIGNING_CERT_BASE64 != '' }}
+        if: ${{ always() }}
         shell: pwsh
         run: Remove-Item -LiteralPath (Join-Path $env:RUNNER_TEMP 'nai-launcher-signing.pfx') -Force -ErrorAction SilentlyContinue
 

--- a/installer/windows/nai_launcher.nsi
+++ b/installer/windows/nai_launcher.nsi
@@ -13,6 +13,10 @@
   !define OUT_FILE "NAI_Launcher_Windows_Setup.exe"
 !endif
 
+!ifndef INSTALL_DIR
+  !define INSTALL_DIR "$LOCALAPPDATA\Programs\Aaalice NAI Launcher"
+!endif
+
 !ifndef APP_NAME
   !define APP_NAME "Aaalice NAI Launcher"
 !endif
@@ -29,15 +33,20 @@
   !define UNINSTALL_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\Aaalice NAI Launcher"
 !endif
 
+!ifndef PROCESS_QUERY_ACCESS
+  !define PROCESS_QUERY_ACCESS 0x00001000
+!endif
+
 Name "${APP_NAME}"
 OutFile "${OUT_FILE}"
-InstallDir "$LOCALAPPDATA\Programs\Aaalice NAI Launcher"
+InstallDir "${INSTALL_DIR}"
 InstallDirRegKey HKCU "${UNINSTALL_KEY}" "InstallLocation"
 RequestExecutionLevel user
 SetCompressor /SOLID lzma
 Unicode true
 
 !define /math PROCESS_PATH_BUFFER_BYTES ${NSIS_MAX_STRLEN} * 2
+!define PROCESS_ENTRY_SIZE 556
 
 !define MUI_ABORTWARNING
 !define MUI_FINISHPAGE_RUN "$INSTDIR\${APP_EXE}"
@@ -55,8 +64,11 @@ LangString AppRunningPrompt ${LANG_SIMPCHINESE} "检测到 ${APP_NAME} 仍在运
 LangString AppRunningPrompt ${LANG_ENGLISH} "${APP_NAME} is still running (closing its window may only hide it to the tray). Close it and continue setup?"
 LangString AppCloseFailed ${LANG_SIMPCHINESE} "无法关闭正在运行的 ${APP_NAME}。请从系统托盘退出应用后重试。"
 LangString AppCloseFailed ${LANG_ENGLISH} "Unable to close ${APP_NAME}. Exit it from the system tray and try again."
+LangString AppInspectionFailed ${LANG_SIMPCHINESE} "无法确认正在运行的 ${APP_NAME} 是否来自当前安装目录。为避免覆盖占用中的文件，请从系统托盘手动退出应用后重试。"
+LangString AppInspectionFailed ${LANG_ENGLISH} "Setup could not verify whether a running ${APP_NAME} belongs to this installation. Exit the app from the system tray and try again to avoid overwriting files in use."
 
 Var TargetProcessId
+Var ProcessInspectionFailed
 
 !macro DefineProcessFunctions Prefix
 Function ${Prefix}FindInstalledAppProcess
@@ -72,48 +84,77 @@ Function ${Prefix}FindInstalledAppProcess
   Push $R9
 
   StrCpy $TargetProcessId "0"
+  StrCpy $ProcessInspectionFailed "0"
   ClearErrors
   GetFullPathName $R9 "$INSTDIR\${APP_EXE}"
-  IfErrors find_process_done
+  IfErrors find_process_snapshot_failed
 
-  System::Alloc 65536
-  Pop $R0
-  StrCpy $R1 $R0
-  System::Call 'kernel32::K32EnumProcesses(p R0, i 65536, *i .R2) i .R3'
-  StrCmp $R3 "0" find_process_cleanup
-  IntOp $R2 $R2 / 4
-  StrCpy $R3 "0"
+  System::Call 'kernel32::CreateToolhelp32Snapshot(i 0x00000002, i 0) p .R0'
+  StrCmp $R0 "-1" find_process_snapshot_failed
+  StrCmp $R0 "0" find_process_snapshot_failed
+
+  System::Call '*(i ${PROCESS_ENTRY_SIZE}, i, i, p, i, i, i, i, i, &w260) p .R1'
+  StrCmp $R1 "0" find_process_enumeration_failed
+  System::Call 'kernel32::Process32FirstW(p R0, p R1) i .R2 ?e'
+  Pop $R3
+  StrCmp $R2 "0" find_process_enumeration_done
 
 find_process_loop:
-  IntCmp $R3 $R2 find_process_cleanup
-  System::Call '*$R1(i .R4)'
-  StrCmp $R4 "0" find_process_next
-  System::Call 'kernel32::OpenProcess(i 0x00001000, i 0, i R4) p .R5'
-  StrCmp $R5 "0" find_process_next
+  System::Call '*$R1(i, i, i .R4, p, i, i, i, i, i, &w260 .R8)'
+  System::Call 'kernel32::lstrcmpiW(w R8, w "${APP_EXE}") i .R3'
+  StrCmp $R3 "0" 0 find_process_next
+
+  System::Call 'kernel32::OpenProcess(i ${PROCESS_QUERY_ACCESS}, i 0, i R4) p .R5'
+  StrCmp $R5 "0" find_process_inspection_failed
   System::Alloc ${PROCESS_PATH_BUFFER_BYTES}
   Pop $R6
+  StrCmp $R6 "0" find_process_close_failed_handle
   StrCpy $R7 ${NSIS_MAX_STRLEN}
   System::Call 'kernel32::QueryFullProcessImageNameW(p R5, i 0, p R6, *i R7) i .R8'
   System::Call 'kernel32::CloseHandle(p R5)'
-  StrCmp $R8 "0" find_process_free_path
+  StrCmp $R8 "0" find_process_free_path_failed
   System::Call '*$R6(&w${NSIS_MAX_STRLEN} .R7)'
   System::Call 'kernel32::lstrcmpiW(w R7, w R9) i .R8'
   StrCmp $R8 "0" find_process_found
 
-find_process_free_path:
   System::Free $R6
 
 find_process_next:
-  IntOp $R1 $R1 + 4
-  IntOp $R3 $R3 + 1
-  Goto find_process_loop
+  System::Call 'kernel32::Process32NextW(p R0, p R1) i .R2 ?e'
+  Pop $R3
+  StrCmp $R2 "0" find_process_enumeration_done find_process_loop
+
+find_process_enumeration_done:
+  StrCmp $R3 "18" find_process_cleanup
+  Goto find_process_inspection_failed
 
 find_process_found:
   System::Free $R6
   StrCpy $TargetProcessId $R4
+  Goto find_process_cleanup
+
+find_process_free_path_failed:
+  System::Free $R6
+  Goto find_process_inspection_failed
+
+find_process_close_failed_handle:
+  System::Call 'kernel32::CloseHandle(p R5)'
+
+find_process_inspection_failed:
+  StrCpy $ProcessInspectionFailed "1"
 
 find_process_cleanup:
-  System::Free $R0
+  System::Free $R1
+  System::Call 'kernel32::CloseHandle(p R0)'
+  Goto find_process_done
+
+find_process_enumeration_failed:
+  StrCpy $ProcessInspectionFailed "1"
+  System::Call 'kernel32::CloseHandle(p R0)'
+  Goto find_process_done
+
+find_process_snapshot_failed:
+  StrCpy $ProcessInspectionFailed "1"
 
 find_process_done:
   Pop $R9
@@ -130,6 +171,7 @@ FunctionEnd
 
 Function ${Prefix}EnsureAppClosed
   Call ${Prefix}FindInstalledAppProcess
+  StrCmp $ProcessInspectionFailed "1" process_inspection_failed
   StrCmp $TargetProcessId "0" app_closed
 
   IfSilent close_app 0
@@ -139,6 +181,7 @@ close_app:
   nsExec::ExecToLog '"$SYSDIR\taskkill.exe" /PID $TargetProcessId /T /F'
   Sleep 1000
   Call ${Prefix}FindInstalledAppProcess
+  StrCmp $ProcessInspectionFailed "1" process_inspection_failed
   StrCmp $TargetProcessId "0" app_closed
 
   IfSilent silent_close_failed 0
@@ -147,6 +190,15 @@ close_app:
 
 silent_close_failed:
   SetErrorLevel 2
+  Quit
+
+process_inspection_failed:
+  IfSilent silent_inspection_failed 0
+  MessageBox MB_ICONSTOP|MB_OK "$(AppInspectionFailed)"
+  Abort
+
+silent_inspection_failed:
+  SetErrorLevel 3
   Quit
 
 cancel_install:

--- a/installer/windows/nai_launcher.nsi
+++ b/installer/windows/nai_launcher.nsi
@@ -1,8 +1,5 @@
 !include "MUI2.nsh"
 !include "LogicLib.nsh"
-!include "StrFunc.nsh"
-
-${StrStr}
 
 !ifndef VERSION
   !define VERSION "0.0.0"
@@ -16,10 +13,21 @@ ${StrStr}
   !define OUT_FILE "NAI_Launcher_Windows_Setup.exe"
 !endif
 
-!define APP_NAME "Aaalice NAI Launcher"
-!define APP_EXE "nai_launcher.exe"
-!define PUBLISHER "Aaalice"
-!define UNINSTALL_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\Aaalice NAI Launcher"
+!ifndef APP_NAME
+  !define APP_NAME "Aaalice NAI Launcher"
+!endif
+
+!ifndef APP_EXE
+  !define APP_EXE "nai_launcher.exe"
+!endif
+
+!ifndef PUBLISHER
+  !define PUBLISHER "Aaalice"
+!endif
+
+!ifndef UNINSTALL_KEY
+  !define UNINSTALL_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\Aaalice NAI Launcher"
+!endif
 
 Name "${APP_NAME}"
 OutFile "${OUT_FILE}"
@@ -28,6 +36,8 @@ InstallDirRegKey HKCU "${UNINSTALL_KEY}" "InstallLocation"
 RequestExecutionLevel user
 SetCompressor /SOLID lzma
 Unicode true
+
+!define /math PROCESS_PATH_BUFFER_BYTES ${NSIS_MAX_STRLEN} * 2
 
 !define MUI_ABORTWARNING
 !define MUI_FINISHPAGE_RUN "$INSTDIR\${APP_EXE}"
@@ -46,33 +56,90 @@ LangString AppRunningPrompt ${LANG_ENGLISH} "${APP_NAME} is still running (closi
 LangString AppCloseFailed ${LANG_SIMPCHINESE} "无法关闭正在运行的 ${APP_NAME}。请从系统托盘退出应用后重试。"
 LangString AppCloseFailed ${LANG_ENGLISH} "Unable to close ${APP_NAME}. Exit it from the system tray and try again."
 
-Function CheckAppRunning
-  nsExec::ExecToStack '"$SYSDIR\tasklist.exe" /FI "IMAGENAME eq ${APP_EXE}" /NH'
-  Pop $R0
-  Pop $R1
-  ${StrStr} $R2 $R1 "${APP_EXE}"
-  StrCmp $R2 "" 0 app_is_running
-  Push "0"
-  Return
+Var TargetProcessId
 
-app_is_running:
-  Push "1"
+!macro DefineProcessFunctions Prefix
+Function ${Prefix}FindInstalledAppProcess
+  Push $R0
+  Push $R1
+  Push $R2
+  Push $R3
+  Push $R4
+  Push $R5
+  Push $R6
+  Push $R7
+  Push $R8
+  Push $R9
+
+  StrCpy $TargetProcessId "0"
+  ClearErrors
+  GetFullPathName $R9 "$INSTDIR\${APP_EXE}"
+  IfErrors find_process_done
+
+  System::Alloc 65536
+  Pop $R0
+  StrCpy $R1 $R0
+  System::Call 'kernel32::K32EnumProcesses(p R0, i 65536, *i .R2) i .R3'
+  StrCmp $R3 "0" find_process_cleanup
+  IntOp $R2 $R2 / 4
+  StrCpy $R3 "0"
+
+find_process_loop:
+  IntCmp $R3 $R2 find_process_cleanup
+  System::Call '*$R1(i .R4)'
+  StrCmp $R4 "0" find_process_next
+  System::Call 'kernel32::OpenProcess(i 0x00001000, i 0, i R4) p .R5'
+  StrCmp $R5 "0" find_process_next
+  System::Alloc ${PROCESS_PATH_BUFFER_BYTES}
+  Pop $R6
+  StrCpy $R7 ${NSIS_MAX_STRLEN}
+  System::Call 'kernel32::QueryFullProcessImageNameW(p R5, i 0, p R6, *i R7) i .R8'
+  System::Call 'kernel32::CloseHandle(p R5)'
+  StrCmp $R8 "0" find_process_free_path
+  System::Call '*$R6(&w${NSIS_MAX_STRLEN} .R7)'
+  System::Call 'kernel32::lstrcmpiW(w R7, w R9) i .R8'
+  StrCmp $R8 "0" find_process_found
+
+find_process_free_path:
+  System::Free $R6
+
+find_process_next:
+  IntOp $R1 $R1 + 4
+  IntOp $R3 $R3 + 1
+  Goto find_process_loop
+
+find_process_found:
+  System::Free $R6
+  StrCpy $TargetProcessId $R4
+
+find_process_cleanup:
+  System::Free $R0
+
+find_process_done:
+  Pop $R9
+  Pop $R8
+  Pop $R7
+  Pop $R6
+  Pop $R5
+  Pop $R4
+  Pop $R3
+  Pop $R2
+  Pop $R1
+  Pop $R0
 FunctionEnd
 
-Function EnsureAppClosed
-  Call CheckAppRunning
-  Pop $R0
-  StrCmp $R0 "0" app_closed
+Function ${Prefix}EnsureAppClosed
+  Call ${Prefix}FindInstalledAppProcess
+  StrCmp $TargetProcessId "0" app_closed
 
   IfSilent close_app 0
   MessageBox MB_ICONEXCLAMATION|MB_OKCANCEL "$(AppRunningPrompt)" IDOK close_app IDCANCEL cancel_install
 
 close_app:
-  nsExec::ExecToLog '"$SYSDIR\taskkill.exe" /IM ${APP_EXE} /T /F'
+  nsExec::ExecToLog '"$SYSDIR\taskkill.exe" /PID $TargetProcessId /T /F'
   Sleep 1000
-  Call CheckAppRunning
-  Pop $R0
-  StrCmp $R0 "0" app_closed
+  Call ${Prefix}FindInstalledAppProcess
+  StrCmp $TargetProcessId "0" app_closed
 
   IfSilent silent_close_failed 0
   MessageBox MB_ICONSTOP|MB_OK "$(AppCloseFailed)"
@@ -87,6 +154,10 @@ cancel_install:
 
 app_closed:
 FunctionEnd
+!macroend
+
+!insertmacro DefineProcessFunctions ""
+!insertmacro DefineProcessFunctions "un."
 
 Section "${APP_NAME}" SecMain
   SectionIn RO
@@ -118,7 +189,7 @@ Section "Desktop Shortcut" SecDesktop
 SectionEnd
 
 Section "Uninstall"
-  nsExec::ExecToLog 'taskkill /IM ${APP_EXE} /F'
+  Call un.EnsureAppClosed
 
   Delete "$DESKTOP\${APP_NAME}.lnk"
   Delete "$SMPROGRAMS\${APP_NAME}\${APP_NAME}.lnk"

--- a/lib/core/autocomplete/completion_models.dart
+++ b/lib/core/autocomplete/completion_models.dart
@@ -220,6 +220,11 @@ abstract interface class CancellableTranslationResolver
   void cancelPending();
 }
 
+abstract interface class ScopedTranslationResolver
+    implements TranslationResolver {
+  TranslationResolver createScope();
+}
+
 class CompletionState {
   const CompletionState({
     this.query,

--- a/lib/core/autocomplete/completion_models.dart
+++ b/lib/core/autocomplete/completion_models.dart
@@ -215,6 +215,11 @@ abstract interface class TranslationResolver {
   });
 }
 
+abstract interface class CancellableTranslationResolver
+    implements TranslationResolver {
+  void cancelPending();
+}
+
 class CompletionState {
   const CompletionState({
     this.query,

--- a/lib/core/autocomplete/completion_orchestrator.dart
+++ b/lib/core/autocomplete/completion_orchestrator.dart
@@ -18,7 +18,9 @@ class CompletionOrchestrator extends ChangeNotifier {
     Duration llmDebounceDuration = const Duration(milliseconds: 400),
   }) : _localSources = localSources,
        _dictionaryTranslations = dictionaryTranslations,
-       _llmTranslations = llmTranslations,
+       _llmTranslations = llmTranslations is ScopedTranslationResolver
+           ? llmTranslations.createScope()
+           : llmTranslations,
        _danbooru = danbooru,
        _libraryAliases = libraryAliases,
        _llmDebounceDuration = llmDebounceDuration;

--- a/lib/core/autocomplete/completion_orchestrator.dart
+++ b/lib/core/autocomplete/completion_orchestrator.dart
@@ -15,24 +15,29 @@ class CompletionOrchestrator extends ChangeNotifier {
     required TranslationResolver llmTranslations,
     required DanbooruCompletionSource danbooru,
     CompletionSource? libraryAliases,
+    Duration llmDebounceDuration = const Duration(milliseconds: 400),
   }) : _localSources = localSources,
        _dictionaryTranslations = dictionaryTranslations,
        _llmTranslations = llmTranslations,
        _danbooru = danbooru,
-       _libraryAliases = libraryAliases;
+       _libraryAliases = libraryAliases,
+       _llmDebounceDuration = llmDebounceDuration;
 
   final List<CompletionSource> _localSources;
   final TranslationResolver _dictionaryTranslations;
   final TranslationResolver _llmTranslations;
   final DanbooruCompletionSource _danbooru;
   final CompletionSource? _libraryAliases;
+  final Duration _llmDebounceDuration;
 
   CompletionState _state = const CompletionState();
   CompletionState get state => _state;
 
   Timer? _remoteDebounce;
+  Timer? _llmDebounce;
   int _sequence = 0;
   final Set<String> _llmRequested = {};
+  bool _llmStartedForSequence = false;
   bool _disposed = false;
 
   /// Stops every in-flight completion branch and clears the visible snapshot.
@@ -42,7 +47,7 @@ class CompletionOrchestrator extends ChangeNotifier {
   /// from reopening a popup that the user already dismissed.
   void cancel() {
     _sequence++;
-    _llmRequested.clear();
+    _cancelPendingLlmTranslation();
     _remoteDebounce?.cancel();
     _danbooru.cancelPending();
     _emit(const CompletionState());
@@ -53,7 +58,7 @@ class CompletionOrchestrator extends ChangeNotifier {
     AutocompleteSettings settings,
   ) async {
     final sequence = ++_sequence;
-    _llmRequested.clear();
+    _cancelPendingLlmTranslation();
     _remoteDebounce?.cancel();
     _danbooru.cancelPending();
     final isRelatedQuery = query.relatedTag != null && query.token.isEmpty;
@@ -129,7 +134,7 @@ class CompletionOrchestrator extends ChangeNotifier {
         isRemoteLoading: canLoadRemote,
       ),
     );
-    _scheduleLlmTranslations(candidates, query, sequence, settings);
+    _scheduleLlmTranslations(query, sequence, settings);
 
     if (!canLoadRemote) {
       _emit(_state.copyWith(isRemoteLoading: false));
@@ -228,7 +233,7 @@ class CompletionOrchestrator extends ChangeNotifier {
         clearRemoteError: remoteError == null,
       ),
     );
-    _scheduleLlmTranslations(merged, query, sequence, settings);
+    _scheduleLlmTranslations(query, sequence, settings);
   }
 
   List<CompletionCandidate> _mergeRemoteWithoutReordering({
@@ -265,41 +270,48 @@ class CompletionOrchestrator extends ChangeNotifier {
   }
 
   void _scheduleLlmTranslations(
-    List<CompletionCandidate> candidates,
     CompletionQuery query,
     int sequence,
     AutocompleteSettings settings,
   ) {
+    if (_llmStartedForSequence) return;
+    _llmDebounce?.cancel();
+    _llmDebounce = null;
     if (query.kind == CompletionQueryKind.libraryAlias ||
         !settings.showTranslations ||
         !settings.llmTranslationEnabled ||
         !query.locale.toLowerCase().startsWith('zh')) {
       return;
     }
-    final missing = candidates
-        .where(
-          (candidate) =>
-              candidate.translation?.isNotEmpty != true &&
-              !_llmRequested.contains(candidate.canonicalTag),
-        )
-        .take(8)
-        .map((candidate) => candidate.canonicalTag)
-        .toList();
-    if (missing.isEmpty) return;
-    _llmRequested.addAll(missing);
-    final missingSet = missing.toSet();
-    _emit(
-      _state.copyWith(
-        candidates: _state.candidates
-            .map(
-              (candidate) => missingSet.contains(candidate.canonicalTag)
-                  ? candidate.copyWith(isTranslating: true)
-                  : candidate,
-            )
-            .toList(growable: false),
-      ),
-    );
-    unawaited(_resolveLlm(missing, query, sequence));
+    _llmDebounce = Timer(_llmDebounceDuration, () {
+      _llmDebounce = null;
+      if (!_isCurrent(sequence) || _llmStartedForSequence) return;
+      final missing = _state.candidates
+          .where(
+            (candidate) =>
+                candidate.translation?.isNotEmpty != true &&
+                !_llmRequested.contains(candidate.canonicalTag),
+          )
+          .take(8)
+          .map((candidate) => candidate.canonicalTag)
+          .toList();
+      if (missing.isEmpty) return;
+      _llmStartedForSequence = true;
+      _llmRequested.addAll(missing);
+      final missingSet = missing.toSet();
+      _emit(
+        _state.copyWith(
+          candidates: _state.candidates
+              .map(
+                (candidate) => missingSet.contains(candidate.canonicalTag)
+                    ? candidate.copyWith(isTranslating: true)
+                    : candidate,
+              )
+              .toList(growable: false),
+        ),
+      );
+      unawaited(_resolveLlm(missing, query, sequence));
+    });
   }
 
   Future<void> _resolveLlm(
@@ -350,6 +362,17 @@ class CompletionOrchestrator extends ChangeNotifier {
 
   bool _isCurrent(int sequence) => !_disposed && sequence == _sequence;
 
+  void _cancelPendingLlmTranslation() {
+    _llmDebounce?.cancel();
+    _llmDebounce = null;
+    _llmRequested.clear();
+    _llmStartedForSequence = false;
+    final resolver = _llmTranslations;
+    if (resolver is CancellableTranslationResolver) {
+      resolver.cancelPending();
+    }
+  }
+
   void _emit(CompletionState value) {
     if (_disposed) return;
     _state = value;
@@ -360,6 +383,7 @@ class CompletionOrchestrator extends ChangeNotifier {
   void dispose() {
     _disposed = true;
     _sequence++;
+    _cancelPendingLlmTranslation();
     _remoteDebounce?.cancel();
     _danbooru.cancelPending();
     super.dispose();

--- a/lib/core/autocomplete/llm_translation_resolver.dart
+++ b/lib/core/autocomplete/llm_translation_resolver.dart
@@ -4,7 +4,8 @@ import '../../presentation/prompt_assistant/services/prompt_assistant_service.da
 import 'autocomplete_cache_database.dart';
 import 'completion_models.dart';
 
-class LlmTranslationResolver implements CancellableTranslationResolver {
+class LlmTranslationResolver
+    implements CancellableTranslationResolver, ScopedTranslationResolver {
   LlmTranslationResolver({
     required PromptAssistantService service,
     required AutocompleteCacheDatabase cache,
@@ -18,6 +19,13 @@ class LlmTranslationResolver implements CancellableTranslationResolver {
   final bool Function() _isEnabled;
   int _generation = 0;
   String? _activeSessionId;
+
+  @override
+  TranslationResolver createScope() => LlmTranslationResolver(
+    service: _service,
+    cache: _cache,
+    isEnabled: _isEnabled,
+  );
 
   @override
   void cancelPending() {

--- a/lib/core/autocomplete/llm_translation_resolver.dart
+++ b/lib/core/autocomplete/llm_translation_resolver.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
+
 import '../../presentation/prompt_assistant/services/prompt_assistant_service.dart';
 import 'autocomplete_cache_database.dart';
 import 'completion_models.dart';
 
-class LlmTranslationResolver implements TranslationResolver {
+class LlmTranslationResolver implements CancellableTranslationResolver {
   LlmTranslationResolver({
     required PromptAssistantService service,
     required AutocompleteCacheDatabase cache,
@@ -14,12 +16,30 @@ class LlmTranslationResolver implements TranslationResolver {
   final PromptAssistantService _service;
   final AutocompleteCacheDatabase _cache;
   final bool Function() _isEnabled;
+  int _generation = 0;
+  String? _activeSessionId;
+
+  @override
+  void cancelPending() {
+    _generation++;
+    _cancelActiveSession();
+  }
+
+  void _cancelActiveSession() {
+    final sessionId = _activeSessionId;
+    _activeSessionId = null;
+    if (sessionId != null) {
+      unawaited(_service.cancelCurrentTask(sessionId: sessionId));
+    }
+  }
 
   @override
   Future<Map<String, String>> resolve(
     List<String> canonicalTags, {
     required String locale,
   }) async {
+    _cancelActiveSession();
+    final generation = ++_generation;
     if (!_isEnabled() || !locale.toLowerCase().startsWith('zh')) {
       return const {};
     }
@@ -37,19 +57,29 @@ class LlmTranslationResolver implements TranslationResolver {
       routeFingerprint: route,
       promptVersion: PromptAssistantService.tagTranslationPromptVersion,
     );
+    if (generation != _generation) return const {};
     final missing = tags.where((tag) => !cached.containsKey(tag)).toList();
     if (missing.isEmpty) return cached;
 
-    final response = await _service.translateTags(
-      missing,
-      sessionId: 'autocomplete-tags-${DateTime.now().microsecondsSinceEpoch}',
-    );
-    await _cache.putAiTranslations(
-      translations: response.translations,
-      locale: locale,
-      routeFingerprint: route,
-      promptVersion: PromptAssistantService.tagTranslationPromptVersion,
-    );
-    return {...cached, ...response.translations};
+    final sessionId =
+        'autocomplete-tags-${DateTime.now().microsecondsSinceEpoch}-$generation';
+    _activeSessionId = sessionId;
+    try {
+      final response = await _service.translateTags(
+        missing,
+        sessionId: sessionId,
+      );
+      if (generation != _generation) return const {};
+      await _cache.putAiTranslations(
+        translations: response.translations,
+        locale: locale,
+        routeFingerprint: route,
+        promptVersion: PromptAssistantService.tagTranslationPromptVersion,
+      );
+      if (generation != _generation) return const {};
+      return {...cached, ...response.translations};
+    } finally {
+      if (_activeSessionId == sessionId) _activeSessionId = null;
+    }
   }
 }

--- a/lib/core/database/asset_database_manager.dart
+++ b/lib/core/database/asset_database_manager.dart
@@ -254,9 +254,21 @@ class AssetDatabaseManager {
     if (await marker.exists()) return;
     await _removeLegacyTranslationDatabase(assetDbDir);
     final runtimeDb = p.join(appDir.path, 'databases', 'danbooru.db');
-    for (final suffix in ['', '-wal', '-shm', '.version']) {
-      await File('$runtimeDb$suffix').deleteIfExists();
+    final runtimeDbFile = File(runtimeDb);
+    if (await runtimeDbFile.exists()) {
+      final db = await databaseFactoryFfi.openDatabase(
+        runtimeDb,
+        options: OpenDatabaseOptions(singleInstance: false),
+      );
+      try {
+        // danbooru.db also stores the local gallery. Only the obsolete tag
+        // cache is disposable during the autocomplete migration.
+        await db.execute('DROP TABLE IF EXISTS danbooru_tags');
+      } finally {
+        await db.close();
+      }
     }
+    await File('$runtimeDb.version').deleteIfExists();
     await marker.writeAsString(
       DateTime.now().toUtc().toIso8601String(),
       encoding: utf8,

--- a/lib/core/services/anlas_calculator.dart
+++ b/lib/core/services/anlas_calculator.dart
@@ -77,7 +77,6 @@ class AnlasCalculator {
       smeaDyn: params.effectiveSmeaDyn,
       model: params.model,
       subscriptionTier: isOpus ? opusTier : 0,
-      hasBaseImage: params.action != ImageGenerationAction.generate,
       hasCharacterReference: _usesPreciseReferences(params),
       strength: switch (params.action) {
         ImageGenerationAction.img2img => params.strength,
@@ -100,7 +99,6 @@ class AnlasCalculator {
     required bool smeaDyn,
     required String model,
     int subscriptionTier = 0,
-    bool hasBaseImage = false,
     bool hasCharacterReference = false,
     double strength = 1.0,
     int extraPerSampleCost = 0,
@@ -123,7 +121,6 @@ class AnlasCalculator {
         smeaDyn: smeaDyn,
         model: model,
         subscriptionTier: isFirstImageInRequest ? subscriptionTier : 0,
-        hasBaseImage: hasBaseImage,
         hasCharacterReference: hasCharacterReference,
         strength: strength,
       );
@@ -175,7 +172,6 @@ class AnlasCalculator {
     required String model,
     bool isOpus = false,
     int subscriptionTier = 0,
-    bool hasBaseImage = false,
     bool hasCharacterReference = false,
     double strength = 1.0,
   }) {
@@ -215,7 +211,6 @@ class AnlasCalculator {
           isOpus: isOpus || subscriptionTier >= opusTier,
           steps: steps,
           resolution: r,
-          hasBaseImage: hasBaseImage,
           hasCharacterReference: hasCharacterReference,
         )
         ? 1
@@ -228,15 +223,15 @@ class AnlasCalculator {
   }
 
   /// 检查是否满足 Opus 免费条件
+  ///
+  /// 网页端按订阅、角色参考、步数和分辨率判断；请求是否携带基础图不参与判定。
   static bool _isOpusFree({
     required bool isOpus,
     required int steps,
     required int resolution,
-    required bool hasBaseImage,
     required bool hasCharacterReference,
   }) {
     return isOpus &&
-        !hasBaseImage &&
         !hasCharacterReference &&
         steps <= 28 &&
         resolution <= 1024 * 1024;
@@ -254,14 +249,7 @@ class AnlasCalculator {
 
   /// 检查当前参数是否满足 Opus 免费条件
   static bool isOpusFreeGeneration(ImageParams params, {required bool isOpus}) {
-    if (!isOpus) return false;
-    if (params.steps > 28) return false;
-    if (params.nSamples > 1) return false;
-    if (params.action != ImageGenerationAction.generate) return false;
-    if (_usesPreciseReferences(params)) return false;
-
-    final resolution = params.width * params.height;
-    return resolution <= 1024 * 1024;
+    return calculate(params, isOpus: isOpus) == 0;
   }
 
   /// 计算导演工具（augment-image）的 Anlas 消耗

--- a/lib/core/services/update_installer_service.dart
+++ b/lib/core/services/update_installer_service.dart
@@ -37,6 +37,7 @@ class UpdateDownloadCancelledException implements Exception {
 }
 
 typedef AppShutdownHandler = Future<void> Function(int code);
+typedef UpdateSha256Calculator = Future<String> Function(File file);
 
 /// 一次下载的实时进度快照。
 class UpdateDownloadProgress {
@@ -103,6 +104,7 @@ class UpdateInstallerService {
   final Dio _dio;
   final AppInstallationService _installationService;
   final AppShutdownHandler _shutdownHandler;
+  final UpdateSha256Calculator _sha256Calculator;
   final Directory? _updateDirectoryOverride;
 
   static const Duration _speedSampleWindow = Duration(milliseconds: 500);
@@ -118,10 +120,12 @@ class UpdateInstallerService {
     required AppInstallationService installationService,
     AppShutdownHandler shutdownHandler =
         DesktopAppShutdownService.shutdownAndExit,
+    UpdateSha256Calculator? sha256Calculator,
     Directory? updateDirectory,
   }) : _dio = dio,
        _installationService = installationService,
        _shutdownHandler = shutdownHandler,
+       _sha256Calculator = sha256Calculator ?? calculateSha256,
        _updateDirectoryOverride = updateDirectory;
 
   bool get supportsInAppInstall => _installationService.supportsInAppInstall;
@@ -149,11 +153,15 @@ class UpdateInstallerService {
 
     final updateDir = await _ensureUpdateDir();
     await _cleanupStaleFiles(updateDir);
+    _throwIfCancelled(cancelToken);
     final targetFile = File(p.join(updateDir.path, asset.fileName));
 
     if (await targetFile.exists()) {
-      if (await _isPackageValid(targetFile, asset)) {
+      final isValid = await _isPackageValid(targetFile, asset);
+      _throwIfCancelled(cancelToken);
+      if (isValid) {
         final length = await targetFile.length();
+        _throwIfCancelled(cancelToken);
         onProgress?.call(
           UpdateDownloadProgress(
             receivedBytes: length,
@@ -203,11 +211,10 @@ class UpdateInstallerService {
       throw UpdateInstallException('下载更新包失败', originalError: error);
     }
 
-    if (cancelToken?.isCancelled ?? false) {
-      throw const UpdateDownloadCancelledException();
-    }
+    _throwIfCancelled(cancelToken);
 
     final fileLength = await partFile.length();
+    _throwIfCancelled(cancelToken);
     if (asset.size != null && fileLength != asset.size) {
       await _deleteQuietly(partFile);
       throw UpdateInstallException(
@@ -216,7 +223,8 @@ class UpdateInstallerService {
       );
     }
 
-    final actualSha256 = await calculateSha256(partFile);
+    final actualSha256 = await _sha256Calculator(partFile);
+    _throwIfCancelled(cancelToken);
     if (!equalsSha256(actualSha256, expectedSha256)) {
       await _deleteQuietly(partFile);
       throw UpdateInstallException(
@@ -576,7 +584,7 @@ class UpdateInstallerService {
     if (asset.size != null && await file.length() != asset.size) return false;
     final expected = asset.sha256;
     if (expected == null || expected.isEmpty) return false;
-    return equalsSha256(await calculateSha256(file), expected);
+    return equalsSha256(await _sha256Calculator(file), expected);
   }
 
   Future<Directory> _ensureUpdateDir() async {
@@ -637,6 +645,12 @@ class UpdateInstallerService {
   static bool _isDiskFull(FileSystemException error) {
     final code = error.osError?.errorCode;
     return code == 112 || code == 28 || code == 39;
+  }
+
+  static void _throwIfCancelled(CancelToken? cancelToken) {
+    if (cancelToken?.isCancelled ?? false) {
+      throw const UpdateDownloadCancelledException();
+    }
   }
 
   static Future<String> calculateSha256(File file) async {

--- a/lib/presentation/providers/cost_estimate_provider.dart
+++ b/lib/presentation/providers/cost_estimate_provider.dart
@@ -157,9 +157,6 @@ int estimatedCost(Ref ref) {
     smeaDyn: params.effectiveSmeaDyn,
     model: params.model,
     subscriptionTier: subscriptionTier,
-    // Opus 免费额度只看角色参考、分辨率和步数，不排除以图生图和局部重绘：
-    // 网页端的判定函数同样不接收动作类型，小图重绘实测也不扣点。
-    hasBaseImage: false,
     hasCharacterReference: params.isV45Model && params.hasPreciseReferences,
     strength: requestInput.strength,
     extraPerSampleCost: AnlasCalculator.resolvePreciseReferenceExtraCost(

--- a/lib/presentation/providers/cost_estimate_provider.dart
+++ b/lib/presentation/providers/cost_estimate_provider.dart
@@ -157,7 +157,9 @@ int estimatedCost(Ref ref) {
     smeaDyn: params.effectiveSmeaDyn,
     model: params.model,
     subscriptionTier: subscriptionTier,
-    hasBaseImage: params.action != ImageGenerationAction.generate,
+    // Opus 免费额度只看角色参考、分辨率和步数，不排除以图生图和局部重绘：
+    // 网页端的判定函数同样不接收动作类型，小图重绘实测也不扣点。
+    hasBaseImage: false,
     hasCharacterReference: params.isV45Model && params.hasPreciseReferences,
     strength: requestInput.strength,
     extraPerSampleCost: AnlasCalculator.resolvePreciseReferenceExtraCost(

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -405,6 +405,7 @@ class OnlineGalleryState {
 class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   static const int _pageSize = 40;
   static const int _maxConcurrentDetailRequests = 6;
+  static const int _maxFilteredEmptyPagesPerLoad = 5;
 
   CancelToken? _cancelToken;
   int _requestGeneration = 0;
@@ -436,6 +437,9 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
 
   void _cancelCurrentRequest() {
     _beginRequest();
+    if (state.isLoading || state.isLoadingMore) {
+      state = state.copyWith(isLoading: false, isLoadingMore: false);
+    }
   }
 
   bool _isCurrentRequest(int generation, String cacheKey) {
@@ -693,51 +697,73 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         aiTagConfig = await adapter.getConfig(cancelToken: _cancelToken);
         if (!_isCurrentRequest(generation, cacheKey)) return;
       }
-      final GalleryPage page;
-      if (state.viewMode == GalleryViewMode.popular) {
-        page = await adapter.ranking(
-          GalleryRankingRequest(
-            cursor: cursor,
-            pageSize: sourceId == GallerySourceId.aiTag
-                ? (aiTagConfig?.pageSize ?? 60)
-                : _pageSize,
-            kind: sourceId == GallerySourceId.aiTag
-                ? GalleryRankingKind.aiTagMonthly
-                : _rankingKind(state.popularScale),
-            date: state.popularDate,
-            period: state.aiTagPopularPeriod,
-            query: state.popularQuery,
-            prompt: state.popularPromptQuery,
-            ratings: state.selectedRatings,
-            blacklistTags: blacklist,
-          ),
-          cancelToken: _cancelToken,
-        );
-      } else {
-        final query = sourceId == GallerySourceId.aiTag
-            ? state.searchQuery.trim()
-            : buildOnlineGallerySearchQuery(
-                state.searchQuery,
-                fuzzyMatch: state.fuzzySearchEnabled,
-              );
-        page = await adapter.search(
-          GallerySearchRequest(
-            cursor: cursor,
-            pageSize: sourceId == GallerySourceId.aiTag
-                ? (aiTagConfig?.pageSize ?? 60)
-                : _pageSize,
-            query: query,
-            prompt: state.promptQuery,
-            timeRange: state.aiTagTimeRange,
-            ratings: state.selectedRatings,
-            dateStart: state.dateRangeStart,
-            dateEnd: state.dateRangeEnd,
-            blacklistTags: blacklist,
-          ),
-          cancelToken: _cancelToken,
-        );
+      var requestCursor = cursor;
+      var pagesFetched = 0;
+      var stalledCursor = false;
+      final visitedCursors = <String>{};
+      late GalleryPage page;
+      while (true) {
+        pagesFetched++;
+        visitedCursors.add(requestCursor);
+        if (state.viewMode == GalleryViewMode.popular) {
+          page = await adapter.ranking(
+            GalleryRankingRequest(
+              cursor: requestCursor,
+              pageSize: sourceId == GallerySourceId.aiTag
+                  ? (aiTagConfig?.pageSize ?? 60)
+                  : _pageSize,
+              kind: sourceId == GallerySourceId.aiTag
+                  ? GalleryRankingKind.aiTagMonthly
+                  : _rankingKind(state.popularScale),
+              date: state.popularDate,
+              period: state.aiTagPopularPeriod,
+              query: state.popularQuery,
+              prompt: state.popularPromptQuery,
+              ratings: state.selectedRatings,
+              blacklistTags: blacklist,
+            ),
+            cancelToken: _cancelToken,
+          );
+        } else {
+          final query = sourceId == GallerySourceId.aiTag
+              ? state.searchQuery.trim()
+              : buildOnlineGallerySearchQuery(
+                  state.searchQuery,
+                  fuzzyMatch: state.fuzzySearchEnabled,
+                );
+          page = await adapter.search(
+            GallerySearchRequest(
+              cursor: requestCursor,
+              pageSize: sourceId == GallerySourceId.aiTag
+                  ? (aiTagConfig?.pageSize ?? 60)
+                  : _pageSize,
+              query: query,
+              prompt: state.promptQuery,
+              timeRange: state.aiTagTimeRange,
+              ratings: state.selectedRatings,
+              dateStart: state.dateRangeStart,
+              dateEnd: state.dateRangeEnd,
+              blacklistTags: blacklist,
+            ),
+            cancelToken: _cancelToken,
+          );
+        }
+        if (!_isCurrentRequest(generation, cacheKey)) return;
+        final nextCursor = page.nextCursor;
+        final filteredEmptyPage = page.rawItemCount > 0 && page.items.isEmpty;
+        stalledCursor =
+            filteredEmptyPage &&
+            nextCursor != null &&
+            visitedCursors.contains(nextCursor);
+        final shouldContinue =
+            filteredEmptyPage &&
+            page.hasMore &&
+            nextCursor != null &&
+            !stalledCursor &&
+            pagesFetched < _maxFilteredEmptyPagesPerLoad;
+        if (!shouldContinue) break;
+        requestCursor = nextCursor;
       }
-      if (!_isCurrentRequest(generation, cacheKey)) return;
       final baseItems = refresh ? const <GalleryItem>[] : cache.posts;
       final existingKeys = baseItems.map(onlineGalleryPostKey).toSet();
       final uniqueNew = <GalleryItem>[];
@@ -745,7 +771,8 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         if (existingKeys.add(onlineGalleryPostKey(item))) uniqueNew.add(item);
       }
       final duplicatePage =
-          !refresh && page.rawItemCount > 0 && uniqueNew.isEmpty;
+          !refresh && page.items.isNotEmpty && uniqueNew.isEmpty;
+      final endedByDuplicatePage = duplicatePage || stalledCursor;
       final merged = [...baseItems, ...uniqueNew];
       final parsedPage = galleryCursorPage(
         page.cursor,
@@ -754,11 +781,12 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       final nextCache = ModeCache(
         posts: List.unmodifiable(merged),
         page: parsedPage,
-        nextCursor: duplicatePage ? null : page.nextCursor,
+        nextCursor: endedByDuplicatePage ? null : page.nextCursor,
         total: page.total,
-        hasMore: !duplicatePage && page.hasMore && page.nextCursor != null,
+        hasMore:
+            !endedByDuplicatePage && page.hasMore && page.nextCursor != null,
         scrollOffset: refresh ? 0 : cache.scrollOffset,
-        endedByDuplicatePage: duplicatePage,
+        endedByDuplicatePage: endedByDuplicatePage,
       );
       final gelbooruCredentialsBecameInvalid =
           sourceId == GallerySourceId.gelbooru &&

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -774,9 +774,14 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
           !refresh && page.items.isNotEmpty && uniqueNew.isEmpty;
       final endedByDuplicatePage = duplicatePage || stalledCursor;
       final merged = [...baseItems, ...uniqueNew];
+      final isInitialLoad =
+          !refresh && cache.posts.isEmpty && cache.page == 1 && cursor == '1';
+      final firstRequestedPage = refresh || isInitialLoad
+          ? galleryCursorPage(cursor)
+          : cache.page + 1;
       final parsedPage = galleryCursorPage(
         page.cursor,
-        fallback: refresh ? 1 : cache.page + 1,
+        fallback: firstRequestedPage + pagesFetched - 1,
       );
       final nextCache = ModeCache(
         posts: List.unmodifiable(merged),

--- a/lib/presentation/providers/update_provider.dart
+++ b/lib/presentation/providers/update_provider.dart
@@ -285,7 +285,6 @@ class UpdateStateNotifier extends _$UpdateStateNotifier {
               );
             },
           );
-      if (cancelToken.isCancelled) return;
       state = state.copyWith(
         status: UpdateStatus.downloaded,
         downloadedUpdate: downloaded,

--- a/lib/presentation/screens/online_gallery/online_gallery_screen.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen.dart
@@ -246,7 +246,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
 
   /// 构建底部分页条
   Widget _buildPaginationBar(ThemeData theme, OnlineGalleryState state) {
-    if (state.posts.isEmpty && !state.isLoading) {
+    if (state.posts.isEmpty && !state.isLoading && !state.hasMore) {
       return const SizedBox.shrink();
     }
 

--- a/lib/presentation/widgets/image_editor/image_editor_screen_types.dart
+++ b/lib/presentation/widgets/image_editor/image_editor_screen_types.dart
@@ -36,7 +36,6 @@ class ImageEditorFocusedInpaintCostConfig {
       smeaDyn: smeaDyn,
       model: model,
       subscriptionTier: subscriptionTier,
-      hasBaseImage: true,
       strength: strength,
       extraPerSampleCost: extraPerSampleCost,
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,7 +6,7 @@ packages:
     description:
       name: _fe_analyzer_shared
       sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "67.0.0"
   analyzer:
@@ -14,7 +14,7 @@ packages:
     description:
       name: analyzer
       sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.4.1"
   analyzer_plugin:
@@ -22,7 +22,7 @@ packages:
     description:
       name: analyzer_plugin
       sha256: "9661b30b13a685efaee9f02e5d01ed9f2b423bd889d28a304d02d704aee69161"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.11.3"
   archive:
@@ -30,7 +30,7 @@ packages:
     description:
       name: archive
       sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.6.1"
   args:
@@ -38,7 +38,7 @@ packages:
     description:
       name: args
       sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
   async:
@@ -46,7 +46,7 @@ packages:
     description:
       name: async
       sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
   audioplayers:
@@ -54,7 +54,7 @@ packages:
     description:
       name: audioplayers
       sha256: "2ba4bb2944baacbdd5372ff8254a8e7feb8c10d7739545e392f5605a8f618745"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.8.1"
   audioplayers_android:
@@ -62,7 +62,7 @@ packages:
     description:
       name: audioplayers_android
       sha256: f5ff5b15620fbab8cb0849e9636c48e2b96c3f0f71723bbbe2ad3c761b205f05
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.3.0"
   audioplayers_darwin:
@@ -70,7 +70,7 @@ packages:
     description:
       name: audioplayers_darwin
       sha256: "1ca553add991384ecf421b9569da850f3ab2472ffb83f6970b0416365abc51be"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
   audioplayers_linux:
@@ -78,7 +78,7 @@ packages:
     description:
       name: audioplayers_linux
       sha256: "15178b726b7cdee5364d0463c8d445630c4e0fb7d26612b73c767e7d25de9417"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.3.0"
   audioplayers_platform_interface:
@@ -86,7 +86,7 @@ packages:
     description:
       name: audioplayers_platform_interface
       sha256: "765f6f0e6dca55cb471c9483fc77700564b3484d19198aca4ebb5147c6c85acb"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.0"
   audioplayers_web:
@@ -94,7 +94,7 @@ packages:
     description:
       name: audioplayers_web
       sha256: ae1e0103c865a03e273f6d13d97b93f5595eac09915729cd5e37ef96e2857319
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.3.0"
   audioplayers_windows:
@@ -102,7 +102,7 @@ packages:
     description:
       name: audioplayers_windows
       sha256: a70ae82bba2dfcb6eb03dd4815d737a2d46d33ea5a96a03f535cfcaac490e413
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.4.1"
   boolean_selector:
@@ -110,7 +110,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   build:
@@ -118,7 +118,7 @@ packages:
     description:
       name: build
       sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   build_config:
@@ -126,7 +126,7 @@ packages:
     description:
       name: build_config
       sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   build_daemon:
@@ -134,7 +134,7 @@ packages:
     description:
       name: build_daemon
       sha256: "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.5"
   build_resolvers:
@@ -142,7 +142,7 @@ packages:
     description:
       name: build_resolvers
       sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   build_runner:
@@ -150,7 +150,7 @@ packages:
     description:
       name: build_runner
       sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.13"
   build_runner_core:
@@ -158,7 +158,7 @@ packages:
     description:
       name: build_runner_core
       sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.3.2"
   built_collection:
@@ -166,7 +166,7 @@ packages:
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
@@ -174,7 +174,7 @@ packages:
     description:
       name: built_value
       sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.12.7"
   cached_network_image:
@@ -182,7 +182,7 @@ packages:
     description:
       name: cached_network_image
       sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
   cached_network_image_platform_interface:
@@ -190,7 +190,7 @@ packages:
     description:
       name: cached_network_image_platform_interface
       sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.1"
   cached_network_image_web:
@@ -198,7 +198,7 @@ packages:
     description:
       name: cached_network_image_web
       sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   characters:
@@ -206,7 +206,7 @@ packages:
     description:
       name: characters
       sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
   checked_yaml:
@@ -214,7 +214,7 @@ packages:
     description:
       name: checked_yaml
       sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
   clock:
@@ -222,7 +222,7 @@ packages:
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   code_assets:
@@ -230,7 +230,7 @@ packages:
     description:
       name: code_assets
       sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   code_builder:
@@ -238,7 +238,7 @@ packages:
     description:
       name: code_builder
       sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.11.1"
   collection:
@@ -246,7 +246,7 @@ packages:
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
   convert:
@@ -254,7 +254,7 @@ packages:
     description:
       name: convert
       sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   cross_file:
@@ -262,7 +262,7 @@ packages:
     description:
       name: cross_file
       sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.5+4"
   crypto:
@@ -270,7 +270,7 @@ packages:
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   cryptography:
@@ -278,7 +278,7 @@ packages:
     description:
       name: cryptography
       sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.9.0"
   csslib:
@@ -286,7 +286,7 @@ packages:
     description:
       name: csslib
       sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   csv:
@@ -294,7 +294,7 @@ packages:
     description:
       name: csv
       sha256: c6aa2679b2a18cb57652920f674488d89712efaf4d3fdf2e537215b35fc19d6c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
   custom_lint_core:
@@ -302,7 +302,7 @@ packages:
     description:
       name: custom_lint_core
       sha256: a85e8f78f4c52f6c63cdaf8c872eb573db0231dcdf3c3a5906d493c1f8bc20e6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.3"
   dart_sentencepiece_tokenizer:
@@ -310,7 +310,7 @@ packages:
     description:
       name: dart_sentencepiece_tokenizer
       sha256: "85825632845cf6427ea0cd13dfba96b4341cf63525165155e5b9b97011239289"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
   dart_style:
@@ -318,7 +318,7 @@ packages:
     description:
       name: dart_style
       sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
   dbus:
@@ -326,7 +326,7 @@ packages:
     description:
       name: dbus
       sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.14"
   device_info_plus:
@@ -334,7 +334,7 @@ packages:
     description:
       name: device_info_plus
       sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "10.1.2"
   device_info_plus_platform_interface:
@@ -342,7 +342,7 @@ packages:
     description:
       name: device_info_plus_platform_interface
       sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
   dio:
@@ -350,7 +350,7 @@ packages:
     description:
       name: dio
       sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.11.0"
   dio_http2_adapter:
@@ -358,7 +358,7 @@ packages:
     description:
       name: dio_http2_adapter
       sha256: c48daafd9cded83368ba0b7d731db6bc9d0413fe21727abf1575780b7c8a74a1
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.8.0"
   dio_web_adapter:
@@ -366,7 +366,7 @@ packages:
     description:
       name: dio_web_adapter
       sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   emoji_picker_flutter:
@@ -374,7 +374,7 @@ packages:
     description:
       name: emoji_picker_flutter
       sha256: "7c6681783e06710608df27be0e38aa4ba73ca1ccac370bb0e7a1320723ae4bca"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   equatable:
@@ -382,7 +382,7 @@ packages:
     description:
       name: equatable
       sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   fake_async:
@@ -390,7 +390,7 @@ packages:
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
   ffi:
@@ -398,7 +398,7 @@ packages:
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   file:
@@ -406,7 +406,7 @@ packages:
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
   file_picker:
@@ -414,7 +414,7 @@ packages:
     description:
       name: file_picker
       sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.3.7"
   fixnum:
@@ -422,7 +422,7 @@ packages:
     description:
       name: fixnum
       sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   fl_chart:
@@ -430,7 +430,7 @@ packages:
     description:
       name: fl_chart
       sha256: d0f0d49112f2f4b192481c16d05b6418bd7820e021e265a3c22db98acf7ed7fb
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.68.0"
   flex_color_scheme:
@@ -438,7 +438,7 @@ packages:
     description:
       name: flex_color_scheme
       sha256: "32914024a4f404d90ff449f58d279191675b28e7c08824046baf06826e99d984"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.3.1"
   flex_seed_scheme:
@@ -446,7 +446,7 @@ packages:
     description:
       name: flex_seed_scheme
       sha256: "4cee2f1d07259f77e8b36f4ec5f35499d19e74e17c7dce5b819554914082bc01"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   flutter:
@@ -459,7 +459,7 @@ packages:
     description:
       name: flutter_cache_manager
       sha256: "1de7849213b4c73c85aca7e0ac687a9a5d82ccdb594366b9dcc26cb6a2189cd2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.4.2"
   flutter_driver:
@@ -472,7 +472,7 @@ packages:
     description:
       name: flutter_inappwebview
       sha256: "80092d13d3e29b6227e25b67973c67c7210bd5e35c4b747ca908e31eb71a46d5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.5"
   flutter_inappwebview_android:
@@ -480,7 +480,7 @@ packages:
     description:
       name: flutter_inappwebview_android
       sha256: "62557c15a5c2db5d195cb3892aab74fcaec266d7b86d59a6f0027abd672cddba"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.3"
   flutter_inappwebview_internal_annotations:
@@ -488,7 +488,7 @@ packages:
     description:
       name: flutter_inappwebview_internal_annotations
       sha256: e30fba942e3debea7b7e6cdd4f0f59ce89dd403a9865193e3221293b6d1544c6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   flutter_inappwebview_ios:
@@ -496,7 +496,7 @@ packages:
     description:
       name: flutter_inappwebview_ios
       sha256: "5818cf9b26cf0cbb0f62ff50772217d41ea8d3d9cc00279c45f8aabaa1b4025d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   flutter_inappwebview_macos:
@@ -504,7 +504,7 @@ packages:
     description:
       name: flutter_inappwebview_macos
       sha256: c1fbb86af1a3738e3541364d7d1866315ffb0468a1a77e34198c9be571287da1
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   flutter_inappwebview_platform_interface:
@@ -512,7 +512,7 @@ packages:
     description:
       name: flutter_inappwebview_platform_interface
       sha256: cf5323e194096b6ede7a1ca808c3e0a078e4b33cc3f6338977d75b4024ba2500
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0+1"
   flutter_inappwebview_web:
@@ -520,7 +520,7 @@ packages:
     description:
       name: flutter_inappwebview_web
       sha256: "55f89c83b0a0d3b7893306b3bb545ba4770a4df018204917148ebb42dc14a598"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   flutter_inappwebview_windows:
@@ -528,7 +528,7 @@ packages:
     description:
       name: flutter_inappwebview_windows
       sha256: "8b4d3a46078a2cdc636c4a3d10d10f2a16882f6be607962dbfff8874d1642055"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
   flutter_lints:
@@ -536,7 +536,7 @@ packages:
     description:
       name: flutter_lints
       sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   flutter_localizations:
@@ -549,7 +549,7 @@ packages:
     description:
       name: flutter_markdown_plus
       sha256: fce641d6c2106cc495de1cd603f97a4f9d615a97a64011928ded380dbdade935
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.12"
   flutter_plugin_android_lifecycle:
@@ -557,7 +557,7 @@ packages:
     description:
       name: flutter_plugin_android_lifecycle
       sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.35"
   flutter_riverpod:
@@ -565,7 +565,7 @@ packages:
     description:
       name: flutter_riverpod
       sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
   flutter_secure_storage:
@@ -573,7 +573,7 @@ packages:
     description:
       name: flutter_secure_storage
       sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "9.2.4"
   flutter_secure_storage_linux:
@@ -581,7 +581,7 @@ packages:
     description:
       name: flutter_secure_storage_linux
       sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
   flutter_secure_storage_macos:
@@ -589,7 +589,7 @@ packages:
     description:
       name: flutter_secure_storage_macos
       sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
   flutter_secure_storage_platform_interface:
@@ -597,7 +597,7 @@ packages:
     description:
       name: flutter_secure_storage_platform_interface
       sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   flutter_secure_storage_web:
@@ -605,7 +605,7 @@ packages:
     description:
       name: flutter_secure_storage_web
       sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   flutter_secure_storage_windows:
@@ -613,7 +613,7 @@ packages:
     description:
       name: flutter_secure_storage_windows
       sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   flutter_staggered_grid_view:
@@ -621,7 +621,7 @@ packages:
     description:
       name: flutter_staggered_grid_view
       sha256: "19e7abb550c96fbfeb546b23f3ff356ee7c59a019a651f8f102a4ba9b7349395"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
   flutter_test:
@@ -639,7 +639,7 @@ packages:
     description:
       name: freezed
       sha256: a434911f643466d78462625df76fd9eb13e57348ff43fe1f77bbe909522c67a1
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.2"
   freezed_annotation:
@@ -647,7 +647,7 @@ packages:
     description:
       name: freezed_annotation
       sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
   frontend_server_client:
@@ -655,7 +655,7 @@ packages:
     description:
       name: frontend_server_client
       sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   fuchsia_remote_debug_protocol:
@@ -668,7 +668,7 @@ packages:
     description:
       name: glob
       sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   go_router:
@@ -676,7 +676,7 @@ packages:
     description:
       name: go_router
       sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "14.8.1"
   google_fonts:
@@ -684,7 +684,7 @@ packages:
     description:
       name: google_fonts
       sha256: ba03d03bcaa2f6cb7bd920e3b5027181db75ab524f8891c8bc3aa603885b8055
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.3.3"
   graphs:
@@ -692,7 +692,7 @@ packages:
     description:
       name: graphs
       sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   hive:
@@ -700,7 +700,7 @@ packages:
     description:
       name: hive
       sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   hive_flutter:
@@ -708,7 +708,7 @@ packages:
     description:
       name: hive_flutter
       sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   hive_generator:
@@ -716,7 +716,7 @@ packages:
     description:
       name: hive_generator
       sha256: "06cb8f58ace74de61f63500564931f9505368f45f98958bd7a6c35ba24159db4"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   hooks:
@@ -724,7 +724,7 @@ packages:
     description:
       name: hooks
       sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   html:
@@ -732,7 +732,7 @@ packages:
     description:
       name: html
       sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.15.6"
   http:
@@ -740,7 +740,7 @@ packages:
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
   http2:
@@ -748,7 +748,7 @@ packages:
     description:
       name: http2
       sha256: "382d3aefc5bd6dc68c6b892d7664f29b5beb3251611ae946a98d35158a82bbfa"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   http_multi_server:
@@ -756,7 +756,7 @@ packages:
     description:
       name: http_multi_server
       sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
   http_parser:
@@ -764,7 +764,7 @@ packages:
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
   image:
@@ -772,7 +772,7 @@ packages:
     description:
       name: image
       sha256: f31d52537dc417fdcde36088fdf11d191026fd5e4fae742491ebd40e5a8bea7d
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.3.0"
   integration_test:
@@ -785,7 +785,7 @@ packages:
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.20.2"
   io:
@@ -793,7 +793,7 @@ packages:
     description:
       name: io
       sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   irondash_engine_context:
@@ -801,7 +801,7 @@ packages:
     description:
       name: irondash_engine_context
       sha256: "2bb0bc13dfda9f5aaef8dde06ecc5feb1379f5bb387d59716d799554f3f305d7"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.5"
   irondash_message_channel:
@@ -809,7 +809,7 @@ packages:
     description:
       name: irondash_message_channel
       sha256: b4101669776509c76133b8917ab8cfc704d3ad92a8c450b92934dd8884a2f060
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
   jni:
@@ -817,7 +817,7 @@ packages:
     description:
       name: jni
       sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   jni_flutter:
@@ -825,7 +825,7 @@ packages:
     description:
       name: jni_flutter
       sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   jni_util:
@@ -833,7 +833,7 @@ packages:
     description:
       name: jni_util
       sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   js:
@@ -841,7 +841,7 @@ packages:
     description:
       name: js
       sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
   json_annotation:
@@ -849,7 +849,7 @@ packages:
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
   json_serializable:
@@ -857,7 +857,7 @@ packages:
     description:
       name: json_serializable
       sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.8.0"
   leak_tracker:
@@ -865,7 +865,7 @@ packages:
     description:
       name: leak_tracker
       sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "11.0.2"
   leak_tracker_flutter_testing:
@@ -873,7 +873,7 @@ packages:
     description:
       name: leak_tracker_flutter_testing
       sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.10"
   leak_tracker_testing:
@@ -881,7 +881,7 @@ packages:
     description:
       name: leak_tracker_testing
       sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   lints:
@@ -889,7 +889,7 @@ packages:
     description:
       name: lints
       sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   logger:
@@ -897,7 +897,7 @@ packages:
     description:
       name: logger
       sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
   logging:
@@ -905,7 +905,7 @@ packages:
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   markdown:
@@ -913,7 +913,7 @@ packages:
     description:
       name: markdown
       sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.3.1"
   matcher:
@@ -921,7 +921,7 @@ packages:
     description:
       name: matcher
       sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.19"
   material_color_utilities:
@@ -929,7 +929,7 @@ packages:
     description:
       name: material_color_utilities
       sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
   media_kit:
@@ -937,7 +937,7 @@ packages:
     description:
       name: media_kit
       sha256: ae9e79597500c7ad6083a3c7b7b7544ddabfceacce7ae5c9709b0ec16a5d6643
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.6"
   media_kit_libs_macos_video:
@@ -945,7 +945,7 @@ packages:
     description:
       name: media_kit_libs_macos_video
       sha256: f26aa1452b665df288e360393758f84b911f70ffb3878032e1aabba23aa1032d
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.4"
   media_kit_libs_windows_video:
@@ -953,7 +953,7 @@ packages:
     description:
       name: media_kit_libs_windows_video
       sha256: dff76da2778729ab650229e6b4ec6ec111eb5151431002cbd7ea304ff1f112ab
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.11"
   media_kit_video:
@@ -961,7 +961,7 @@ packages:
     description:
       name: media_kit_video
       sha256: "813858c3fe84eb46679eb698695f60665e2bfbef757766fac4d2e683f926e15a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   menu_base:
@@ -969,7 +969,7 @@ packages:
     description:
       name: menu_base
       sha256: "820368014a171bd1241030278e6c2617354f492f5c703d7b7d4570a6b8b84405"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.1"
   meta:
@@ -977,7 +977,7 @@ packages:
     description:
       name: meta
       sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
   mime:
@@ -985,7 +985,7 @@ packages:
     description:
       name: mime
       sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   mocktail:
@@ -993,7 +993,7 @@ packages:
     description:
       name: mocktail
       sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   msgpack_dart:
@@ -1001,7 +1001,7 @@ packages:
     description:
       name: msgpack_dart
       sha256: c2d235ed01f364719b5296aecf43ac330f0d7bc865fa134d0d7910a40454dffb
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   objective_c:
@@ -1009,7 +1009,7 @@ packages:
     description:
       name: objective_c
       sha256: b7fb95a6d9a4f009edd63dc5ac69f07420b23a16161c6dd8660290b59c602e8e
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "9.5.0"
   octo_image:
@@ -1017,7 +1017,7 @@ packages:
     description:
       name: octo_image
       sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   onnxruntime:
@@ -1025,7 +1025,7 @@ packages:
     description:
       name: onnxruntime
       sha256: e77ec05acafc135cc5fe7bcdf11b101b39f06513c9d5e9fa02cb1929f6bac72a
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
   package_config:
@@ -1033,7 +1033,7 @@ packages:
     description:
       name: package_config
       sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   package_info_plus:
@@ -1041,7 +1041,7 @@ packages:
     description:
       name: package_info_plus
       sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.3.1"
   package_info_plus_platform_interface:
@@ -1049,7 +1049,7 @@ packages:
     description:
       name: package_info_plus_platform_interface
       sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   path:
@@ -1057,7 +1057,7 @@ packages:
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   path_provider:
@@ -1065,7 +1065,7 @@ packages:
     description:
       name: path_provider
       sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.6"
   path_provider_android:
@@ -1073,7 +1073,7 @@ packages:
     description:
       name: path_provider_android
       sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   path_provider_foundation:
@@ -1081,7 +1081,7 @@ packages:
     description:
       name: path_provider_foundation
       sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.0"
   path_provider_linux:
@@ -1089,7 +1089,7 @@ packages:
     description:
       name: path_provider_linux
       sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
   path_provider_platform_interface:
@@ -1097,7 +1097,7 @@ packages:
     description:
       name: path_provider_platform_interface
       sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   path_provider_windows:
@@ -1105,7 +1105,7 @@ packages:
     description:
       name: path_provider_windows
       sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   permission_handler:
@@ -1113,7 +1113,7 @@ packages:
     description:
       name: permission_handler
       sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "11.4.0"
   permission_handler_android:
@@ -1121,23 +1121,23 @@ packages:
     description:
       name: permission_handler_android
       sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "12.1.0"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: "11b7e94a9d2fbee23c27f0cae0105c6266c03fd83b9a2eda6cf09141fc82624b"
-      url: "https://pub.flutter-io.cn"
+      sha256: f49cb15a064ea9d974fc7fbb302099353b7b170d07284e86e264561579e5bcf8
+      url: "https://pub.dev"
     source: hosted
-    version: "9.5.0"
+    version: "9.6.1"
   permission_handler_html:
     dependency: transitive
     description:
       name: permission_handler_html
       sha256: "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.4+1"
   permission_handler_platform_interface:
@@ -1145,7 +1145,7 @@ packages:
     description:
       name: permission_handler_platform_interface
       sha256: a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.4.0"
   permission_handler_windows:
@@ -1153,7 +1153,7 @@ packages:
     description:
       name: permission_handler_windows
       sha256: caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
   petitparser:
@@ -1161,7 +1161,7 @@ packages:
     description:
       name: petitparser
       sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
   pixel_snap:
@@ -1169,7 +1169,7 @@ packages:
     description:
       name: pixel_snap
       sha256: "677410ea37b07cd37ecb6d5e6c0d8d7615a7cf3bd92ba406fd1ac57e937d1fb0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.5"
   platform:
@@ -1177,7 +1177,7 @@ packages:
     description:
       name: platform
       sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
@@ -1185,7 +1185,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
   png_chunks_extract:
@@ -1193,7 +1193,7 @@ packages:
     description:
       name: png_chunks_extract
       sha256: "948b9f102d7c18931aeb104823878c8bc93f1e2808bb89483a113a924678763c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   pool:
@@ -1201,7 +1201,7 @@ packages:
     description:
       name: pool
       sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
   process:
@@ -1209,7 +1209,7 @@ packages:
     description:
       name: process
       sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.5"
   pub_semver:
@@ -1217,7 +1217,7 @@ packages:
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   pubspec_parse:
@@ -1225,7 +1225,7 @@ packages:
     description:
       name: pubspec_parse
       sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   record_use:
@@ -1233,7 +1233,7 @@ packages:
     description:
       name: record_use
       sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
   riverpod:
@@ -1241,7 +1241,7 @@ packages:
     description:
       name: riverpod
       sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
   riverpod_analyzer_utils:
@@ -1249,7 +1249,7 @@ packages:
     description:
       name: riverpod_analyzer_utils
       sha256: "8b71f03fc47ae27d13769496a1746332df4cec43918aeba9aff1e232783a780f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
   riverpod_annotation:
@@ -1257,7 +1257,7 @@ packages:
     description:
       name: riverpod_annotation
       sha256: e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
   riverpod_generator:
@@ -1265,7 +1265,7 @@ packages:
     description:
       name: riverpod_generator
       sha256: d451608bf17a372025fc36058863737636625dfdb7e3cbf6142e0dfeb366ab22
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
   rxdart:
@@ -1273,7 +1273,7 @@ packages:
     description:
       name: rxdart
       sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
   safe_local_storage:
@@ -1281,7 +1281,7 @@ packages:
     description:
       name: safe_local_storage
       sha256: "494b982d5edb71030650ea463d939670e91b232b588323dc75229d2c5f23e7b7"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.6"
   screen_brightness_android:
@@ -1289,7 +1289,7 @@ packages:
     description:
       name: screen_brightness_android
       sha256: "2008ad8e9527cc968f7a4de1ec58b476d495b3c612a149dbd6550c4f046da147"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.6"
   screen_brightness_platform_interface:
@@ -1297,7 +1297,7 @@ packages:
     description:
       name: screen_brightness_platform_interface
       sha256: "2de60c0ba569b898950029cc1f7e9dd72bda44a22beb5054aac331cb6fce2ff2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   screen_retriever:
@@ -1305,7 +1305,7 @@ packages:
     description:
       name: screen_retriever
       sha256: "6ee02c8a1158e6dae7ca430da79436e3b1c9563c8cf02f524af997c201ac2b90"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.9"
   share_plus:
@@ -1313,7 +1313,7 @@ packages:
     description:
       name: share_plus
       sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "10.1.4"
   share_plus_platform_interface:
@@ -1321,7 +1321,7 @@ packages:
     description:
       name: share_plus_platform_interface
       sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.2"
   shared_preferences:
@@ -1329,7 +1329,7 @@ packages:
     description:
       name: shared_preferences
       sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.5"
   shared_preferences_android:
@@ -1337,7 +1337,7 @@ packages:
     description:
       name: shared_preferences_android
       sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.27"
   shared_preferences_foundation:
@@ -1345,7 +1345,7 @@ packages:
     description:
       name: shared_preferences_foundation
       sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.6"
   shared_preferences_linux:
@@ -1353,7 +1353,7 @@ packages:
     description:
       name: shared_preferences_linux
       sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
@@ -1361,7 +1361,7 @@ packages:
     description:
       name: shared_preferences_platform_interface
       sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   shared_preferences_web:
@@ -1369,7 +1369,7 @@ packages:
     description:
       name: shared_preferences_web
       sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.3"
   shared_preferences_windows:
@@ -1377,7 +1377,7 @@ packages:
     description:
       name: shared_preferences_windows
       sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   shelf:
@@ -1385,7 +1385,7 @@ packages:
     description:
       name: shelf
       sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
   shelf_web_socket:
@@ -1393,7 +1393,7 @@ packages:
     description:
       name: shelf_web_socket
       sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   shortid:
@@ -1401,7 +1401,7 @@ packages:
     description:
       name: shortid
       sha256: d0b40e3dbb50497dad107e19c54ca7de0d1a274eb9b4404991e443dadb9ebedb
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.2"
   sky_engine:
@@ -1414,7 +1414,7 @@ packages:
     description:
       name: source_gen
       sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   source_helper:
@@ -1422,7 +1422,7 @@ packages:
     description:
       name: source_helper
       sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.5"
   source_span:
@@ -1430,7 +1430,7 @@ packages:
     description:
       name: source_span
       sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
   sqflite:
@@ -1438,7 +1438,7 @@ packages:
     description:
       name: sqflite
       sha256: "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.3"
   sqflite_android:
@@ -1446,7 +1446,7 @@ packages:
     description:
       name: sqflite_android
       sha256: d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.3"
   sqflite_common:
@@ -1454,7 +1454,7 @@ packages:
     description:
       name: sqflite_common
       sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.11"
   sqflite_common_ffi:
@@ -1462,7 +1462,7 @@ packages:
     description:
       name: sqflite_common_ffi
       sha256: "8d7b8749a516cbf6e9057f9b480b716ad14fc4f3d3873ca6938919cc626d9025"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.7+1"
   sqflite_darwin:
@@ -1470,7 +1470,7 @@ packages:
     description:
       name: sqflite_darwin
       sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.3+1"
   sqflite_platform_interface:
@@ -1478,7 +1478,7 @@ packages:
     description:
       name: sqflite_platform_interface
       sha256: f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   sqlite3:
@@ -1486,7 +1486,7 @@ packages:
     description:
       name: sqlite3
       sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.9.4"
   sqlite3_flutter_libs:
@@ -1494,7 +1494,7 @@ packages:
     description:
       name: sqlite3_flutter_libs
       sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.42"
   stack_trace:
@@ -1502,7 +1502,7 @@ packages:
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
   state_notifier:
@@ -1510,7 +1510,7 @@ packages:
     description:
       name: state_notifier
       sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   stream_channel:
@@ -1518,7 +1518,7 @@ packages:
     description:
       name: stream_channel
       sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   stream_transform:
@@ -1526,7 +1526,7 @@ packages:
     description:
       name: stream_transform
       sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   string_scanner:
@@ -1534,7 +1534,7 @@ packages:
     description:
       name: string_scanner
       sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
   super_clipboard:
@@ -1542,7 +1542,7 @@ packages:
     description:
       name: super_clipboard
       sha256: "4a6ae6dfaa282ec1f2bff750976f535517ed8ca842d5deae13985eb11c00ac1f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.24"
   super_drag_and_drop:
@@ -1550,7 +1550,7 @@ packages:
     description:
       name: super_drag_and_drop
       sha256: e1ea1528916a728b3d0c3007c0af1303947026011f78564279af68d8856a0205
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.24"
   super_native_extensions:
@@ -1558,7 +1558,7 @@ packages:
     description:
       name: super_native_extensions
       sha256: a433bba8186cd6b707560c42535bf284804665231c00bca86faf1aa4968b7637
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.24"
   sync_http:
@@ -1566,23 +1566,23 @@ packages:
     description:
       name: sync_http
       sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
   synchronized:
     dependency: "direct main"
     description:
       name: synchronized
-      sha256: "61894a1956de6b4fc1aefd0892e109514a1a706cbece3ac59decd90ff5a7a423"
-      url: "https://pub.flutter-io.cn"
+      sha256: "3a7b5d17422dd0f8d5c6c14feaa5a1c65638b9455f871a96f08437562c046931"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.4.1+1"
+    version: "3.4.1+2"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
   test_api:
@@ -1590,7 +1590,7 @@ packages:
     description:
       name: test_api
       sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
   timeago:
@@ -1598,7 +1598,7 @@ packages:
     description:
       name: timeago
       sha256: b05159406a97e1cbb2b9ee4faa9fb096fe0e2dfcd8b08fcd2a00553450d3422e
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.7.1"
   timing:
@@ -1606,7 +1606,7 @@ packages:
     description:
       name: timing
       sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   tray_manager:
@@ -1614,7 +1614,7 @@ packages:
     description:
       name: tray_manager
       sha256: bdc3ac6c36f3d12d871459e4a9822705ce5a1165a17fa837103bc842719bf3f7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.4"
   typed_data:
@@ -1622,7 +1622,7 @@ packages:
     description:
       name: typed_data
       sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   universal_platform:
@@ -1630,7 +1630,7 @@ packages:
     description:
       name: universal_platform
       sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   uri_parser:
@@ -1638,7 +1638,7 @@ packages:
     description:
       name: uri_parser
       sha256: "051c62e5f693de98ca9f130ee707f8916e2266945565926be3ff20659f7853ce"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   url_launcher:
@@ -1646,7 +1646,7 @@ packages:
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.3.2"
   url_launcher_android:
@@ -1654,7 +1654,7 @@ packages:
     description:
       name: url_launcher_android
       sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.3.32"
   url_launcher_ios:
@@ -1662,7 +1662,7 @@ packages:
     description:
       name: url_launcher_ios
       sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.4.1"
   url_launcher_linux:
@@ -1670,7 +1670,7 @@ packages:
     description:
       name: url_launcher_linux
       sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
   url_launcher_macos:
@@ -1678,7 +1678,7 @@ packages:
     description:
       name: url_launcher_macos
       sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.5"
   url_launcher_platform_interface:
@@ -1686,7 +1686,7 @@ packages:
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   url_launcher_web:
@@ -1694,7 +1694,7 @@ packages:
     description:
       name: url_launcher_web
       sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.3"
   url_launcher_windows:
@@ -1702,7 +1702,7 @@ packages:
     description:
       name: url_launcher_windows
       sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.5"
   uuid:
@@ -1710,7 +1710,7 @@ packages:
     description:
       name: uuid
       sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.6.0"
   vector_math:
@@ -1718,23 +1718,23 @@ packages:
     description:
       name: vector_math
       sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   video_player:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d"
-      url: "https://pub.flutter-io.cn"
+      sha256: "8c837b570dccb9ae6ff73d2e0b03c7e708bfefd3bd1194faa7f3e7f200dfc399"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.14.0"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
       sha256: e229676f8fade3e0124482495aaa2b548872cc4018b6268adfca4868be16aa74
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
   video_player_avfoundation:
@@ -1742,7 +1742,7 @@ packages:
     description:
       name: video_player_avfoundation
       sha256: c238f5f0a26845cd0bcc2956049b63065a4d3c40ddfc22c3414cd170bef7fff9
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
   video_player_media_kit:
@@ -1750,7 +1750,7 @@ packages:
     description:
       name: video_player_media_kit
       sha256: "5dedd1b830c52924c1b36f06adee7a70ce15f82fedbc8115988d49028b45255c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.7"
   video_player_platform_interface:
@@ -1758,7 +1758,7 @@ packages:
     description:
       name: video_player_platform_interface
       sha256: "92c0fbabe20c788e71fd10d26cea998d0d253282e65d145aed0818731cf593ce"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.9.0"
   video_player_web:
@@ -1766,7 +1766,7 @@ packages:
     description:
       name: video_player_web
       sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
   visibility_detector:
@@ -1774,7 +1774,7 @@ packages:
     description:
       name: visibility_detector
       sha256: dd5cc11e13494f432d15939c3aa8ae76844c42b723398643ce9addb88a5ed420
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.4.0+2"
   vm_service:
@@ -1782,7 +1782,7 @@ packages:
     description:
       name: vm_service
       sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "15.2.0"
   volume_controller:
@@ -1790,7 +1790,7 @@ packages:
     description:
       name: volume_controller
       sha256: "851b43150972f96fa04a16af1080be9cabcd740c1b7e91dc3f5be9461ff45010"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.6.0"
   wakelock_plus:
@@ -1798,7 +1798,7 @@ packages:
     description:
       name: wakelock_plus
       sha256: "61713aa82b7f85c21c9f4cd0a148abd75f38a74ec645fcb1e446f882c82fd09b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
   wakelock_plus_platform_interface:
@@ -1806,7 +1806,7 @@ packages:
     description:
       name: wakelock_plus_platform_interface
       sha256: "0618d1799f0b28bcf98255b4ee8313e6fc4d38589dc4ee5fe5840d57d1aff6da"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
   watcher:
@@ -1814,7 +1814,7 @@ packages:
     description:
       name: watcher
       sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   web:
@@ -1822,7 +1822,7 @@ packages:
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   web_socket:
@@ -1830,7 +1830,7 @@ packages:
     description:
       name: web_socket
       sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   web_socket_channel:
@@ -1838,7 +1838,7 @@ packages:
     description:
       name: web_socket_channel
       sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
   webdriver:
@@ -1846,7 +1846,7 @@ packages:
     description:
       name: webdriver
       sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   win32:
@@ -1854,7 +1854,7 @@ packages:
     description:
       name: win32
       sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
   win32_registry:
@@ -1862,7 +1862,7 @@ packages:
     description:
       name: win32_registry
       sha256: "21ec76dfc731550fd3e2ce7a33a9ea90b828fdf19a5c3bcf556fa992cfa99852"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.5"
   window_manager:
@@ -1870,7 +1870,7 @@ packages:
     description:
       name: window_manager
       sha256: "8699323b30da4cdbe2aa2e7c9de567a6abd8a97d9a5c850a3c86dcd0b34bbfbf"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.9"
   xdg_directories:
@@ -1878,7 +1878,7 @@ packages:
     description:
       name: xdg_directories
       sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   xml:
@@ -1886,7 +1886,7 @@ packages:
     description:
       name: xml
       sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
   yaml:
@@ -1894,7 +1894,7 @@ packages:
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
 sdks:

--- a/scripts/validate_windows_installer_process_handling.ps1
+++ b/scripts/validate_windows_installer_process_handling.ps1
@@ -1,0 +1,246 @@
+param(
+  [string]$MakensisPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-MakensisPath {
+  if (-not [string]::IsNullOrWhiteSpace($MakensisPath)) {
+    if (-not (Test-Path -LiteralPath $MakensisPath)) {
+      throw "makensis.exe was not found: $MakensisPath"
+    }
+    return (Resolve-Path -LiteralPath $MakensisPath).Path
+  }
+
+  $command = Get-Command 'makensis.exe' -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+  if ($command) {
+    return $command.Source
+  }
+
+  foreach ($candidate in @(
+      "${env:ProgramFiles(x86)}\NSIS\makensis.exe",
+      "$env:ProgramFiles\NSIS\makensis.exe"
+    )) {
+    if (Test-Path -LiteralPath $candidate) {
+      return $candidate
+    }
+  }
+
+  throw 'makensis.exe was not found. Install NSIS or pass -MakensisPath.'
+}
+
+function Invoke-Makensis {
+  param(
+    [Parameter(Mandatory)]
+    [string]$OutputPath,
+    [Parameter(Mandatory)]
+    [string]$InstallPath,
+    [Parameter(Mandatory)]
+    [string]$SourcePath,
+    [Parameter(Mandatory)]
+    [string]$UninstallKey,
+    [string]$ProcessQueryAccess
+  )
+
+  $arguments = @(
+    '/INPUTCHARSET',
+    'UTF8',
+    '/DVERSION=0.0.0-test',
+    '/DAPP_NAME=Aaalice NAI Launcher Process Test',
+    '/DAPP_EXE=nai_launcher_process_test.exe',
+    '/DPUBLISHER=Aaalice Test',
+    "/DUNINSTALL_KEY=$UninstallKey",
+    "/DINSTALL_DIR=$InstallPath",
+    "/DSOURCE_DIR=$SourcePath",
+    "/DOUT_FILE=$OutputPath"
+  )
+  if (-not [string]::IsNullOrWhiteSpace($ProcessQueryAccess)) {
+    $arguments += "/DPROCESS_QUERY_ACCESS=$ProcessQueryAccess"
+  }
+  $arguments += $script:NsisScript
+
+  & $script:Makensis @arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "makensis.exe failed with exit code $LASTEXITCODE"
+  }
+  if (-not (Test-Path -LiteralPath $OutputPath)) {
+    throw "NSIS did not produce the expected installer: $OutputPath"
+  }
+}
+
+function Start-HiddenProcess {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Path
+  )
+
+  $process = Start-Process `
+    -FilePath $Path `
+    -ArgumentList @('-t', '127.0.0.1') `
+    -WindowStyle Hidden `
+    -PassThru
+  [void]$script:StartedProcesses.Add($process)
+  Start-Sleep -Milliseconds 300
+  $process.Refresh()
+  if ($process.HasExited) {
+    throw "Test process exited unexpectedly: $Path"
+  }
+  return $process
+}
+
+function Invoke-SilentExecutable {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Path
+  )
+
+  $process = Start-Process `
+    -FilePath $Path `
+    -ArgumentList '/S' `
+    -WindowStyle Hidden `
+    -Wait `
+    -PassThru
+  return $process.ExitCode
+}
+
+function Assert-ProcessState {
+  param(
+    [Parameter(Mandatory)]
+    [System.Diagnostics.Process]$Process,
+    [Parameter(Mandatory)]
+    [bool]$HasExited,
+    [Parameter(Mandatory)]
+    [string]$Message
+  )
+
+  $Process.Refresh()
+  if ($Process.HasExited -ne $HasExited) {
+    throw $Message
+  }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$script:NsisScript = Join-Path $repoRoot 'installer\windows\nai_launcher.nsi'
+$script:Makensis = Get-MakensisPath
+$script:StartedProcesses = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
+$testId = [Guid]::NewGuid().ToString('N')
+$tempRoot = Join-Path $env:TEMP "nai-launcher-installer-process-$testId"
+$sourceDir = Join-Path $tempRoot 'source'
+$installDir = Join-Path $tempRoot 'installed'
+$otherDir = Join-Path $tempRoot 'other'
+$outputDir = Join-Path $tempRoot 'output'
+$appName = 'nai_launcher_process_test.exe'
+$uninstallKey = "Software\Aaalice\InstallerProcessTest\$testId"
+
+try {
+  foreach ($directory in @($sourceDir, $installDir, $otherDir, $outputDir)) {
+    [void](New-Item -ItemType Directory -Path $directory -Force)
+  }
+
+  $ping = Join-Path $env:SystemRoot 'System32\ping.exe'
+  Copy-Item -LiteralPath $ping -Destination (Join-Path $sourceDir $appName)
+  Copy-Item -LiteralPath $ping -Destination (Join-Path $installDir $appName)
+  Copy-Item -LiteralPath $ping -Destination (Join-Path $otherDir $appName)
+  Set-Content `
+    -LiteralPath (Join-Path $sourceDir 'source-version.txt') `
+    -Value 'new installer payload' `
+    -Encoding UTF8
+
+  $normalInstaller = Join-Path $outputDir 'normal-setup.exe'
+  Invoke-Makensis `
+    -OutputPath $normalInstaller `
+    -InstallPath $installDir `
+    -SourcePath $sourceDir `
+    -UninstallKey $uninstallKey
+
+  $targetProcess = Start-HiddenProcess -Path (Join-Path $installDir $appName)
+  $otherProcess = Start-HiddenProcess -Path (Join-Path $otherDir $appName)
+
+  $installExit = Invoke-SilentExecutable -Path $normalInstaller
+  if ($installExit -ne 0) {
+    throw "Normal silent installer exited with code $installExit"
+  }
+  Assert-ProcessState `
+    -Process $targetProcess `
+    -HasExited $true `
+    -Message 'The installer did not stop the executable from its own install directory.'
+  Assert-ProcessState `
+    -Process $otherProcess `
+    -HasExited $false `
+    -Message 'The installer stopped a same-named executable from another directory.'
+  if (-not (Test-Path -LiteralPath (Join-Path $installDir 'source-version.txt'))) {
+    throw 'The normal installer did not copy its payload.'
+  }
+
+  $uninstaller = Join-Path $installDir 'Uninstall.exe'
+  $uninstallExit = Invoke-SilentExecutable -Path $uninstaller
+  if ($uninstallExit -ne 0) {
+    throw "Silent uninstaller exited with code $uninstallExit"
+  }
+  Assert-ProcessState `
+    -Process $otherProcess `
+    -HasExited $false `
+    -Message 'The uninstaller stopped a same-named executable from another directory.'
+
+  [void](New-Item -ItemType Directory -Path $installDir -Force)
+  Copy-Item -LiteralPath $ping -Destination (Join-Path $installDir $appName)
+  Set-Content `
+    -LiteralPath (Join-Path $installDir 'existing-version.txt') `
+    -Value 'existing installation' `
+    -Encoding UTF8
+
+  $blockedInstaller = Join-Path $outputDir 'blocked-setup.exe'
+  Invoke-Makensis `
+    -OutputPath $blockedInstaller `
+    -InstallPath $installDir `
+    -SourcePath $sourceDir `
+    -UninstallKey $uninstallKey `
+    -ProcessQueryAccess '0xFFFFFFFF'
+
+  $unreadableTarget = Start-HiddenProcess -Path (Join-Path $installDir $appName)
+  $blockedExit = Invoke-SilentExecutable -Path $blockedInstaller
+  if ($blockedExit -ne 3) {
+    throw "Fail-closed installer exited with code $blockedExit instead of 3."
+  }
+  Assert-ProcessState `
+    -Process $unreadableTarget `
+    -HasExited $false `
+    -Message 'The fail-closed installer stopped a process whose path it could not inspect.'
+  if (-not (Test-Path -LiteralPath (Join-Path $installDir 'existing-version.txt'))) {
+    throw 'The fail-closed installer modified the existing installation.'
+  }
+  if (Test-Path -LiteralPath (Join-Path $installDir 'source-version.txt')) {
+    throw 'The fail-closed installer copied files after process inspection failed.'
+  }
+
+  Write-Host 'Windows installer process isolation and fail-closed checks passed.'
+} finally {
+  foreach ($process in $script:StartedProcesses) {
+    try {
+      $process.Refresh()
+      if (-not $process.HasExited) {
+        Stop-Process -Id $process.Id -Force
+      }
+    } catch {
+      Write-Warning "Failed to stop test process $($process.Id): $($_.Exception.Message)"
+    }
+  }
+
+  $registryPath = "HKCU:\$uninstallKey"
+  if (Test-Path -LiteralPath $registryPath) {
+    Remove-Item -LiteralPath $registryPath -Recurse -Force
+  }
+
+  if (Test-Path -LiteralPath $tempRoot) {
+    $resolvedTemp = [System.IO.Path]::GetFullPath($tempRoot)
+    $resolvedBase = [System.IO.Path]::GetFullPath($env:TEMP).TrimEnd('\') + '\'
+    if (-not $resolvedTemp.StartsWith(
+        $resolvedBase,
+        [System.StringComparison]::OrdinalIgnoreCase
+      )) {
+      throw "Refusing to remove a test directory outside TEMP: $resolvedTemp"
+    }
+    Remove-Item -LiteralPath $resolvedTemp -Recurse -Force
+  }
+}

--- a/test/core/autocomplete/completion_orchestrator_test.dart
+++ b/test/core/autocomplete/completion_orchestrator_test.dart
@@ -347,6 +347,7 @@ void main() {
         dictionaryTranslations: _Translations(const {}),
         llmTranslations: llm,
         danbooru: _FakeDanbooru(),
+        llmDebounceDuration: Duration.zero,
       );
       addTearDown(orchestrator.dispose);
 
@@ -380,6 +381,40 @@ void main() {
       );
     },
   );
+
+  test('debounces LLM translations and cancels a superseded request', () async {
+    final llm = _CancellableRecordingTranslations();
+    final orchestrator = CompletionOrchestrator(
+      localSources: [_TokenCandidateSource()],
+      dictionaryTranslations: _Translations(const {}),
+      llmTranslations: llm,
+      danbooru: _FakeDanbooru(),
+      llmDebounceDuration: const Duration(milliseconds: 30),
+    );
+    addTearDown(orchestrator.dispose);
+    const settings = AutocompleteSettings(
+      danbooruEnabled: false,
+      llmTranslationEnabled: true,
+    );
+
+    await orchestrator.query(_query('first'), settings);
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await orchestrator.query(_query('second'), settings);
+    await Future<void>.delayed(const Duration(milliseconds: 40));
+
+    expect(llm.requestedBatches, [
+      ['second_tag'],
+    ]);
+    await orchestrator.query(_query('third'), settings);
+    expect(llm.cancelCount, 1);
+    await Future<void>.delayed(const Duration(milliseconds: 40));
+    expect(llm.requestedBatches.last, ['third_tag']);
+
+    llm.completeActive({'third_tag': '第三个标签'});
+    await Future<void>.delayed(Duration.zero);
+    expect(orchestrator.state.query?.token, 'third');
+    expect(orchestrator.state.candidates.single.translation, '第三个标签');
+  });
 }
 
 CompletionQuery _query(
@@ -415,6 +450,13 @@ class _Source implements CompletionSource {
   @override
   Future<List<CompletionCandidate>> search(CompletionQuery query) async =>
       values;
+}
+
+class _TokenCandidateSource implements CompletionSource {
+  @override
+  Future<List<CompletionCandidate>> search(CompletionQuery query) async => [
+    _candidate('${query.token}_tag', CompletionSourceKind.base),
+  ];
 }
 
 class _RecordingRelatedSource implements CompletionSource {
@@ -487,6 +529,38 @@ class _RecordingTranslations implements TranslationResolver {
   }
 
   void complete(Map<String, String> values) => _completer.complete(values);
+}
+
+class _CancellableRecordingTranslations
+    implements CancellableTranslationResolver {
+  final List<List<String>> requestedBatches = [];
+  Completer<Map<String, String>>? _active;
+  int cancelCount = 0;
+
+  @override
+  Future<Map<String, String>> resolve(
+    List<String> canonicalTags, {
+    required String locale,
+  }) {
+    requestedBatches.add(List.unmodifiable(canonicalTags));
+    _active = Completer<Map<String, String>>();
+    return _active!.future;
+  }
+
+  @override
+  void cancelPending() {
+    final active = _active;
+    _active = null;
+    if (active == null || active.isCompleted) return;
+    cancelCount++;
+    active.completeError(StateError('translation request cancelled'));
+  }
+
+  void completeActive(Map<String, String> values) {
+    final active = _active;
+    _active = null;
+    active!.complete(values);
+  }
 }
 
 class _FakeDanbooru extends DanbooruCompletionSource {

--- a/test/core/autocomplete/completion_orchestrator_test.dart
+++ b/test/core/autocomplete/completion_orchestrator_test.dart
@@ -415,6 +415,43 @@ void main() {
     expect(orchestrator.state.query?.token, 'third');
     expect(orchestrator.state.candidates.single.translation, '第三个标签');
   });
+
+  test('isolates LLM cancellation between orchestrators', () async {
+    final sharedLlm = _ScopedRecordingTranslations();
+    final first = CompletionOrchestrator(
+      localSources: [_TokenCandidateSource()],
+      dictionaryTranslations: _Translations(const {}),
+      llmTranslations: sharedLlm,
+      danbooru: _FakeDanbooru(),
+      llmDebounceDuration: Duration.zero,
+    );
+    final second = CompletionOrchestrator(
+      localSources: [_TokenCandidateSource()],
+      dictionaryTranslations: _Translations(const {}),
+      llmTranslations: sharedLlm,
+      danbooru: _FakeDanbooru(),
+      llmDebounceDuration: Duration.zero,
+    );
+    addTearDown(first.dispose);
+    addTearDown(second.dispose);
+    const settings = AutocompleteSettings(
+      danbooruEnabled: false,
+      llmTranslationEnabled: true,
+    );
+
+    await first.query(_query('positive'), settings);
+    await second.query(_query('negative'), settings);
+    await Future<void>.delayed(Duration.zero);
+    expect(sharedLlm.scopes, hasLength(2));
+
+    first.cancel();
+
+    expect(sharedLlm.scopes[0].cancelCount, 1);
+    expect(sharedLlm.scopes[1].cancelCount, 0);
+    sharedLlm.scopes[1].completeActive({'negative_tag': '负面标签'});
+    await Future<void>.delayed(Duration.zero);
+    expect(second.state.candidates.single.translation, '负面标签');
+  });
 }
 
 CompletionQuery _query(
@@ -560,6 +597,25 @@ class _CancellableRecordingTranslations
     final active = _active;
     _active = null;
     active!.complete(values);
+  }
+}
+
+class _ScopedRecordingTranslations implements ScopedTranslationResolver {
+  final List<_CancellableRecordingTranslations> scopes = [];
+
+  @override
+  TranslationResolver createScope() {
+    final scope = _CancellableRecordingTranslations();
+    scopes.add(scope);
+    return scope;
+  }
+
+  @override
+  Future<Map<String, String>> resolve(
+    List<String> canonicalTags, {
+    required String locale,
+  }) {
+    throw StateError('A scoped resolver must not be used directly.');
   }
 }
 

--- a/test/core/autocomplete/llm_translation_resolver_test.dart
+++ b/test/core/autocomplete/llm_translation_resolver_test.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nai_launcher/core/autocomplete/autocomplete_cache_database.dart';
+import 'package:nai_launcher/core/autocomplete/llm_translation_resolver.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/services/prompt_assistant_service.dart';
+
+void main() {
+  test('cancelPending cancels the active Prompt Assistant session', () async {
+    final service = _MockPromptAssistantService();
+    final cache = _FakeAutocompleteCacheDatabase();
+    final response = Completer<TagTranslationBatchResult>();
+    final requestStarted = Completer<void>();
+    late String sessionId;
+    when(service.translateRouteFingerprint).thenReturn('test-route');
+    when(
+      () => service.translateTags(any(), sessionId: any(named: 'sessionId')),
+    ).thenAnswer((invocation) {
+      sessionId = invocation.namedArguments[#sessionId] as String;
+      requestStarted.complete();
+      return response.future;
+    });
+    when(
+      () => service.cancelCurrentTask(sessionId: any(named: 'sessionId')),
+    ).thenAnswer((_) async {});
+    final resolver = LlmTranslationResolver(
+      service: service,
+      cache: cache,
+      isEnabled: () => true,
+    );
+
+    final result = resolver.resolve(['blue_eyes'], locale: 'zh-CN');
+    await requestStarted.future;
+    resolver.cancelPending();
+
+    verify(() => service.cancelCurrentTask(sessionId: sessionId)).called(1);
+    response.complete(
+      const TagTranslationBatchResult(
+        translations: {'blue_eyes': '蓝眼睛'},
+        routeFingerprint: 'test-route',
+      ),
+    );
+    expect(await result, isEmpty);
+    expect(cache.writes, isEmpty);
+  });
+}
+
+class _MockPromptAssistantService extends Mock
+    implements PromptAssistantService {}
+
+class _FakeAutocompleteCacheDatabase extends AutocompleteCacheDatabase {
+  final List<Map<String, String>> writes = [];
+
+  @override
+  Future<Map<String, String>> getAiTranslations({
+    required List<String> tags,
+    required String locale,
+    required String routeFingerprint,
+    required int promptVersion,
+  }) async => const {};
+
+  @override
+  Future<void> putAiTranslations({
+    required Map<String, String> translations,
+    required String locale,
+    required String routeFingerprint,
+    required int promptVersion,
+  }) async {
+    writes.add(translations);
+  }
+}

--- a/test/core/database/asset_database_manager_test.dart
+++ b/test/core/database/asset_database_manager_test.dart
@@ -125,6 +125,59 @@ void main() {
     }
     expect(await File(p.join(dbDir.path, 'translation.db')).exists(), isFalse);
   });
+
+  test('legacy autocomplete migration preserves local gallery data', () async {
+    final runtimeDir = await Directory(
+      p.join(appSupportDir.path, 'databases'),
+    ).create(recursive: true);
+    final runtimePath = p.join(runtimeDir.path, 'danbooru.db');
+    final runtimeDb = sqlite3.open(runtimePath);
+    runtimeDb.execute('''
+      CREATE TABLE gallery_images(id INTEGER PRIMARY KEY, file_path TEXT);
+      INSERT INTO gallery_images(file_path) VALUES ('C:/gallery/image.png');
+      CREATE TABLE gallery_favorites(image_id INTEGER PRIMARY KEY);
+      INSERT INTO gallery_favorites(image_id) VALUES (1);
+      CREATE TABLE danbooru_tags(tag TEXT PRIMARY KEY);
+      INSERT INTO danbooru_tags(tag) VALUES ('legacy_tag');
+    ''');
+    runtimeDb.dispose();
+
+    await AssetDatabaseManager.initialize();
+
+    final migratedDb = sqlite3.open(runtimePath);
+    try {
+      expect(
+        migratedDb
+            .select('SELECT file_path FROM gallery_images')
+            .single['file_path'],
+        'C:/gallery/image.png',
+      );
+      expect(
+        migratedDb
+            .select('SELECT image_id FROM gallery_favorites')
+            .single['image_id'],
+        1,
+      );
+      expect(
+        migratedDb.select(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'danbooru_tags'",
+        ),
+        isEmpty,
+      );
+    } finally {
+      migratedDb.dispose();
+    }
+    expect(
+      await File(
+        p.join(
+          appSupportDir.path,
+          'asset_databases',
+          '.autocomplete-v1-migrated',
+        ),
+      ).exists(),
+      isTrue,
+    );
+  });
 }
 
 Future<File> _createCatalogFixture(String directory) async {

--- a/test/core/services/anlas_calculator_test.dart
+++ b/test/core/services/anlas_calculator_test.dart
@@ -188,7 +188,7 @@ void main() {
       expect(cost, 80);
     });
 
-    test('does not apply the Opus free image to base-image requests', () {
+    test('applies the Opus free image to eligible redraw requests', () {
       final cost = AnlasCalculator.calculateRequestCost(
         width: 1024,
         height: 1024,
@@ -199,11 +199,36 @@ void main() {
         smeaDyn: false,
         model: model,
         subscriptionTier: AnlasCalculator.opusTier,
-        hasBaseImage: true,
         strength: 0.5,
       );
 
-      expect(cost, 10);
+      expect(cost, 0);
+    });
+
+    test('uses the request calculator for Opus redraw eligibility', () {
+      const eligible = ImageParams(
+        model: model,
+        action: ImageGenerationAction.infill,
+        width: 832,
+        height: 1216,
+        steps: 28,
+      );
+      const overStepLimit = ImageParams(
+        model: model,
+        action: ImageGenerationAction.infill,
+        width: 832,
+        height: 1216,
+        steps: 29,
+      );
+
+      expect(
+        AnlasCalculator.isOpusFreeGeneration(eligible, isOpus: true),
+        isTrue,
+      );
+      expect(
+        AnlasCalculator.isOpusFreeGeneration(overStepLimit, isOpus: true),
+        isFalse,
+      );
     });
 
     test('does not apply the Opus free image with character references', () {

--- a/test/core/services/update_installer_service_test.dart
+++ b/test/core/services/update_installer_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
@@ -115,6 +116,76 @@ void main() {
         }
       },
     );
+
+    test('cancelling during checksum keeps the resumable part file', () async {
+      final payload = List<int>.generate(64 * 1024, (index) => index % 251);
+      final source = File('${tempDir.path}/checksum-source.bin');
+      await source.writeAsBytes(payload);
+      final hash = await UpdateInstallerService.calculateSha256(source);
+      const fileName = 'checksum-cancel.zip';
+      final updateDir = Directory('${tempDir.path}/updates')..createSync();
+      final hashStarted = Completer<void>();
+      final releaseHash = Completer<void>();
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((request) async {
+        request.response.headers.contentLength = payload.length;
+        request.response.add(payload);
+        await request.response.close();
+      });
+
+      try {
+        final asset = ReleaseAssetInfo(
+          type: ReleaseAssetType.windowsPortable,
+          platform: 'windows',
+          fileName: fileName,
+          downloadUrl: 'http://127.0.0.1:${server.port}/update.zip',
+          sha256: hash,
+          size: payload.length,
+        );
+        final versionInfo = VersionInfo(
+          version: '9.9.9',
+          currentVersion: '1.0.0',
+          releaseNotes: 'checksum cancellation test',
+          primaryAsset: asset,
+          assets: [asset],
+          isNewer: true,
+        );
+        final cancelToken = CancelToken();
+        final service = UpdateInstallerService(
+          dio: Dio(),
+          installationService: _SupportedInstallationService(),
+          updateDirectory: updateDir,
+          sha256Calculator: (file) async {
+            if (file.path.endsWith('.part')) {
+              hashStarted.complete();
+              await releaseHash.future;
+            }
+            return UpdateInstallerService.calculateSha256(file);
+          },
+        );
+
+        final download = service.downloadUpdate(
+          versionInfo,
+          cancelToken: cancelToken,
+        );
+        await hashStarted.future;
+        cancelToken.cancel('cancelled during checksum');
+        releaseHash.complete();
+
+        await expectLater(
+          download,
+          throwsA(isA<UpdateDownloadCancelledException>()),
+        );
+        expect(await File('${updateDir.path}/$fileName.part').exists(), isTrue);
+        expect(await File('${updateDir.path}/$fileName').exists(), isFalse);
+        expect(
+          await File('${updateDir.path}/pending_update.json').exists(),
+          isFalse,
+        );
+      } finally {
+        await server.close(force: true);
+      }
+    });
 
     test('consumes updater result exactly once', () async {
       final updateDir = Directory('${tempDir.path}/updates')..createSync();

--- a/test/presentation/providers/cost_estimate_provider_test.dart
+++ b/test/presentation/providers/cost_estimate_provider_test.dart
@@ -93,7 +93,7 @@ void main() {
       },
     );
 
-    test('should charge Opus img2img requests with redraw strength', () {
+    test('should charge Opus img2img above the free resolution', () {
       final subscription = container.read(
         subscriptionNotifierProvider.notifier,
       );
@@ -105,13 +105,14 @@ void main() {
         UserSubscription(tier: AnlasCalculator.opusTier, active: true),
       );
       paramsNotifier.updateAction(ImageGenerationAction.img2img);
-      paramsNotifier.setSourceImage(_buildPng(width: 1024, height: 1024));
-      paramsNotifier.updateSize(1024, 1024);
+      paramsNotifier.setSourceImage(_buildPng(width: 1536, height: 1024));
+      paramsNotifier.updateSize(1536, 1024);
+      paramsNotifier.updateSteps(28);
       paramsNotifier.updateStrength(0.5);
 
       final params = container.read(generationParamsNotifierProvider);
       final expected = AnlasCalculator.calculateRequestCost(
-        width: 1024,
+        width: 1536,
         height: 1024,
         steps: params.steps,
         batchCount: params.nSamples,
@@ -120,12 +121,71 @@ void main() {
         smeaDyn: params.effectiveSmeaDyn,
         model: params.model,
         subscriptionTier: AnlasCalculator.opusTier,
-        hasBaseImage: true,
         strength: 0.5,
       );
 
       expect(expected, greaterThan(0));
       expect(container.read(estimatedCostProvider), expected);
+    });
+
+    test('should keep small Opus img2img requests free', () {
+      // Opus 免费额度不排除以图生图：分辨率和步数达标时服务端同样不扣点。
+      final subscription = container.read(
+        subscriptionNotifierProvider.notifier,
+      );
+      final paramsNotifier = container.read(
+        generationParamsNotifierProvider.notifier,
+      );
+
+      subscription.state = const SubscriptionState.loaded(
+        UserSubscription(tier: AnlasCalculator.opusTier, active: true),
+      );
+      paramsNotifier.updateAction(ImageGenerationAction.img2img);
+      paramsNotifier.setSourceImage(_buildPng(width: 832, height: 1216));
+      paramsNotifier.updateSize(832, 1216);
+      paramsNotifier.updateSteps(28);
+      paramsNotifier.updateStrength(0.5);
+
+      expect(container.read(estimatedCostProvider), 0);
+    });
+
+    test('should keep small Opus inpaint requests free', () {
+      final subscription = container.read(
+        subscriptionNotifierProvider.notifier,
+      );
+      final paramsNotifier = container.read(
+        generationParamsNotifierProvider.notifier,
+      );
+
+      subscription.state = const SubscriptionState.loaded(
+        UserSubscription(tier: AnlasCalculator.opusTier, active: true),
+      );
+      paramsNotifier.updateAction(ImageGenerationAction.infill);
+      paramsNotifier.setSourceImage(_buildPng(width: 832, height: 1216));
+      paramsNotifier.updateSize(832, 1216);
+      paramsNotifier.updateSteps(28);
+
+      expect(container.read(estimatedCostProvider), 0);
+    });
+
+    test('should still charge free-size requests beyond the step limit', () {
+      final subscription = container.read(
+        subscriptionNotifierProvider.notifier,
+      );
+      final paramsNotifier = container.read(
+        generationParamsNotifierProvider.notifier,
+      );
+
+      subscription.state = const SubscriptionState.loaded(
+        UserSubscription(tier: AnlasCalculator.opusTier, active: true),
+      );
+      paramsNotifier.updateAction(ImageGenerationAction.img2img);
+      paramsNotifier.setSourceImage(_buildPng(width: 832, height: 1216));
+      paramsNotifier.updateSize(832, 1216);
+      paramsNotifier.updateSteps(29);
+      paramsNotifier.updateStrength(0.5);
+
+      expect(container.read(estimatedCostProvider), greaterThan(0));
     });
 
     test(

--- a/test/presentation/providers/online_gallery_pagination_test.dart
+++ b/test/presentation/providers/online_gallery_pagination_test.dart
@@ -213,7 +213,7 @@ void main() {
     },
   );
 
-  test('filtered empty pages advance without ending pagination', () async {
+  test('filtered empty Danbooru cursors advance the visible page', () async {
     final adapter = _FakeGalleryAdapter(
       GallerySourceId.danbooru,
       onSearch: (request, _) async {
@@ -221,10 +221,11 @@ void main() {
           '1' => _page(
             request.cursor,
             const [],
-            nextCursor: '2',
+            nextCursor: 'b900',
             rawItemCount: 40,
           ),
-          '2' => _page(request.cursor, [_item(2)], nextCursor: '3'),
+          'b900' => _page(request.cursor, [_item(2)], nextCursor: 'b800'),
+          'b800' => _page(request.cursor, [_item(3)], nextCursor: 'b700'),
           _ => _page(request.cursor, const [], nextCursor: null),
         };
       },
@@ -234,13 +235,64 @@ void main() {
 
     await container.read(onlineGalleryNotifierProvider.notifier).loadPosts();
 
-    final state = container.read(onlineGalleryNotifierProvider);
-    expect(adapter.searchCursors, ['1', '2']);
+    var state = container.read(onlineGalleryNotifierProvider);
+    expect(adapter.searchCursors, ['1', 'b900']);
     expect(state.posts.single.id, 2);
     expect(state.page, 2);
-    expect(state.currentCache.nextCursor, '3');
+    expect(state.currentCache.nextCursor, 'b800');
     expect(state.hasMore, isTrue);
     expect(state.currentCache.endedByDuplicatePage, isFalse);
+
+    await container.read(onlineGalleryNotifierProvider.notifier).loadMore();
+
+    state = container.read(onlineGalleryNotifierProvider);
+    expect(adapter.searchCursors, ['1', 'b900', 'b800']);
+    expect(state.posts.map((item) => item.id), [2, 3]);
+    expect(state.page, 3);
+    expect(state.currentCache.nextCursor, 'b700');
+  });
+
+  test('continues after a full batch of filtered empty cursors', () async {
+    const nextCursorByCursor = {
+      '1': 'b900',
+      'b900': 'b800',
+      'b800': 'b700',
+      'b700': 'b600',
+      'b600': 'b500',
+    };
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async {
+        if (request.cursor == 'b500') {
+          return _page(request.cursor, [_item(6)], nextCursor: 'b400');
+        }
+        return _page(
+          request.cursor,
+          const [],
+          nextCursor: nextCursorByCursor[request.cursor],
+          rawItemCount: 40,
+        );
+      },
+    );
+    final container = _container(danbooru: adapter);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.loadPosts();
+
+    var state = container.read(onlineGalleryNotifierProvider);
+    expect(state.posts, isEmpty);
+    expect(state.page, 5);
+    expect(state.currentCache.nextCursor, 'b500');
+    expect(state.hasMore, isTrue);
+
+    await notifier.loadMore();
+
+    state = container.read(onlineGalleryNotifierProvider);
+    expect(adapter.searchCursors.last, 'b500');
+    expect(state.posts.single.id, 6);
+    expect(state.page, 6);
+    expect(state.currentCache.nextCursor, 'b400');
   });
 
   test(

--- a/test/presentation/providers/online_gallery_pagination_test.dart
+++ b/test/presentation/providers/online_gallery_pagination_test.dart
@@ -166,6 +166,84 @@ void main() {
   );
 
   test(
+    'switching to a cached source clears loading from the cancelled request',
+    () async {
+      final pendingRefresh = Completer<GalleryPage>();
+      var danbooruRequests = 0;
+      final danbooru = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) {
+          danbooruRequests++;
+          if (danbooruRequests == 1) {
+            return Future.value(
+              _page(request.cursor, [_item(11)], nextCursor: null),
+            );
+          }
+          return pendingRefresh.future;
+        },
+      );
+      final safebooru = _FakeGalleryAdapter(
+        GallerySourceId.safebooru,
+        onSearch: (request, _) async => _page(request.cursor, [
+          _item(22, source: GallerySourceId.safebooru),
+        ], nextCursor: null),
+      );
+      final container = _container(danbooru: danbooru, safebooru: safebooru);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.loadPosts();
+      await notifier.setSource(GallerySourceId.safebooru);
+      await notifier.setSource(GallerySourceId.danbooru);
+      final refresh = notifier.refresh();
+      await Future<void>.delayed(Duration.zero);
+      expect(container.read(onlineGalleryNotifierProvider).isLoading, isTrue);
+
+      await notifier.setSource(GallerySourceId.safebooru);
+
+      var state = container.read(onlineGalleryNotifierProvider);
+      expect(state.posts.single.id, 22);
+      expect(state.isLoading, isFalse);
+      expect(state.isLoadingMore, isFalse);
+      pendingRefresh.complete(_page('1', [_item(99)], nextCursor: null));
+      await refresh;
+      state = container.read(onlineGalleryNotifierProvider);
+      expect(state.posts.single.id, 22);
+      expect(state.isLoading, isFalse);
+    },
+  );
+
+  test('filtered empty pages advance without ending pagination', () async {
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async {
+        return switch (request.cursor) {
+          '1' => _page(
+            request.cursor,
+            const [],
+            nextCursor: '2',
+            rawItemCount: 40,
+          ),
+          '2' => _page(request.cursor, [_item(2)], nextCursor: '3'),
+          _ => _page(request.cursor, const [], nextCursor: null),
+        };
+      },
+    );
+    final container = _container(danbooru: adapter);
+    addTearDown(container.dispose);
+
+    await container.read(onlineGalleryNotifierProvider.notifier).loadPosts();
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(adapter.searchCursors, ['1', '2']);
+    expect(state.posts.single.id, 2);
+    expect(state.page, 2);
+    expect(state.currentCache.nextCursor, '3');
+    expect(state.hasMore, isTrue);
+    expect(state.currentCache.endedByDuplicatePage, isFalse);
+  });
+
+  test(
     'late results from a cancelled source cannot overwrite the new source',
     () async {
       final latePage = Completer<GalleryPage>();
@@ -273,13 +351,14 @@ GalleryPage _page(
   String cursor,
   List<GalleryItem> items, {
   required String? nextCursor,
+  int? rawItemCount,
 }) {
   return GalleryPage(
     items: items,
     cursor: cursor,
     nextCursor: nextCursor,
     hasMore: nextCursor != null,
-    rawItemCount: items.length,
+    rawItemCount: rawItemCount ?? items.length,
   );
 }
 

--- a/test/presentation/providers/update_provider_test.dart
+++ b/test/presentation/providers/update_provider_test.dart
@@ -1,0 +1,88 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nai_launcher/core/services/app_installation_service.dart';
+import 'package:nai_launcher/core/services/update_check_service.dart';
+import 'package:nai_launcher/core/services/update_installer_service.dart';
+import 'package:nai_launcher/data/models/version/release_asset_info.dart';
+import 'package:nai_launcher/data/models/version/version_info.dart';
+import 'package:nai_launcher/presentation/providers/update_provider.dart';
+
+void main() {
+  test(
+    'completed download wins a cancellation at the commit boundary',
+    () async {
+      const asset = ReleaseAssetInfo(
+        type: ReleaseAssetType.windowsPortable,
+        platform: 'windows',
+        fileName: 'update.zip',
+        downloadUrl: 'https://example.test/update.zip',
+        sha256: 'hash',
+        size: 7,
+      );
+      const versionInfo = VersionInfo(
+        version: '2.0.0',
+        currentVersion: '1.0.0',
+        releaseNotes: 'test',
+        primaryAsset: asset,
+        assets: [asset],
+        isNewer: true,
+      );
+      final downloaded = DownloadedUpdate(
+        file: File('update.zip'),
+        asset: asset,
+        version: versionInfo.version,
+      );
+      final checkService = _MockUpdateCheckService();
+      when(
+        () => checkService.checkForUpdates(ignoreSkipped: false),
+      ).thenAnswer((_) async => versionInfo);
+      when(checkService.clearReminder).thenAnswer((_) async {});
+      final container = ProviderContainer(
+        overrides: [
+          updateCheckServiceProvider.overrideWithValue(checkService),
+          updateInstallerServiceProvider.overrideWithValue(
+            _CommitBoundaryInstaller(downloaded),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(updateStateNotifierProvider.notifier);
+
+      await notifier.checkForUpdates();
+      await notifier.downloadUpdate();
+
+      final state = container.read(updateStateNotifierProvider);
+      expect(state.status, UpdateStatus.downloaded);
+      expect(state.downloadedUpdate, same(downloaded));
+      expect(state.downloadProgress, 1);
+    },
+  );
+}
+
+class _MockUpdateCheckService extends Mock implements UpdateCheckService {}
+
+class _SupportedInstallationService extends AppInstallationService {
+  @override
+  bool get supportsInAppInstall => true;
+}
+
+class _CommitBoundaryInstaller extends UpdateInstallerService {
+  _CommitBoundaryInstaller(this.downloaded)
+    : super(dio: Dio(), installationService: _SupportedInstallationService());
+
+  final DownloadedUpdate downloaded;
+
+  @override
+  Future<DownloadedUpdate> downloadUpdate(
+    VersionInfo versionInfo, {
+    void Function(UpdateDownloadProgress progress)? onProgress,
+    CancelToken? cancelToken,
+  }) async {
+    cancelToken?.cancel('completed at the cancellation boundary');
+    return downloaded;
+  }
+}

--- a/test/presentation/widgets/image_editor/image_editor_screen_inpaint_brush_test.dart
+++ b/test/presentation/widgets/image_editor/image_editor_screen_inpaint_brush_test.dart
@@ -14,6 +14,20 @@ import 'package:nai_launcher/presentation/widgets/image_editor/image_editor_scre
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  test('focused inpaint keeps eligible Opus redraws free', () {
+    const config = ImageEditorFocusedInpaintCostConfig(
+      model: 'nai-diffusion-4-full',
+      steps: 28,
+      batchCount: 1,
+      batchSize: 1,
+      smea: false,
+      smeaDyn: false,
+      subscriptionTier: 3,
+    );
+
+    expect(config.estimate(width: 832, height: 1216), 0);
+  });
+
   testWidgets('non-focused inpaint brush commits mask strokes on the image', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- Preserve local gallery images and favorites during the autocomplete database migration by removing only the obsolete tag table.
- Give every autocomplete input its own cancellable LLM translation scope, so querying or disposing one input cannot cancel another input's translation.
- Keep online-gallery requests source-safe and advance the logical page across filtered Danbooru b{id} cursors, including a full batch of empty filtered pages.
- Apply the same Opus free-redraw rule to main generation, Image2Image, inpaint, and Focused Inpaint estimates through the shared calculator.
- Honor update cancellation through checksum and package-commit boundaries while retaining resumable partial downloads.
- Restrict installer and uninstaller termination to the launcher under the selected install directory; block safely when a same-named process path cannot be inspected.
- Run tests, analysis, Windows release build, installer process-isolation checks, and installer/portable packaging in a new pull-request CI workflow.

## Validation

- flutter pub get
- dart run tool/tag_catalog/verify_bundled_databases.dart
- flutter gen-l10n
- dart run build_runner build --delete-conflicting-outputs (2002 outputs, 4254 actions)
- Review regression suites: 65 passed
- flutter test --reporter compact: 1720 passed, 1 skipped
- flutter analyze: No issues found
- scripts/verify_nuget.ps1: NuGet 6.5.0.154
- flutter build windows --release
- scripts/validate_windows_installer_process_handling.ps1: target-only termination, same-name isolation, uninstall isolation, and unreadable-path fail-closed checks passed
- scripts/package_windows_release.ps1 -Version 1.5.2 -SkipFlutterBuild: installer and portable package created
- Installer SHA-256: 5C724D2EB5893570D7D572AF4292000622F3E5AF01B1566449D71A41C915DE84
- Portable SHA-256: 0831BF9AB5B37DA772AB70540D80CF424E75280F171470DDF38B5A55B281841F

## Scope Notes

- Based on origin/main at 178621dc58695a6adb476b90ab5b0b482a9eab8f (1.5.2).
- Includes 13 commits across 26 files: 1669 additions and 402 deletions.
- pubspec.lock hosted sources are normalized from the Flutter China mirror to pub.dev; resolved versions update only within existing constraints.
- Generated Riverpod, localization, and Windows plugin files produced no content changes.
- No packaged assets, Git LFS database changes, build outputs, local AI instruction files, logs, or uncommitted NAI5/tokenizer/model work are included.

## Screenshots

Not captured because this PR changes behavior, installation, pricing, and CI paths without introducing a new visual layout.