### PR TITLE
Align transparent background control with the prompt layout

### DIFF
--- a/lib/presentation/screens/generation/widgets/generation_param_sections.dart
+++ b/lib/presentation/screens/generation/widgets/generation_param_sections.dart
@@ -10,6 +10,7 @@ import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/themed_dropdown.dart';
 import '../../../widgets/common/themed_input.dart';
 import '../../../widgets/common/themed_slider.dart';
+import 'generation_toggle_button.dart';
 import 'size_selector.dart';
 
 /// 生成参数分节控件集
@@ -103,7 +104,7 @@ class SizeSection extends ConsumerWidget {
             const Spacer(),
             // 端到端 ×2 放大：模型按基础分辨率生成，服务端输出边长翻倍
             if (size.supportsE2eUpscale)
-              _ToggleButton(
+              GenerationToggleButton(
                 label: '×${E2eUpscale.factor}',
                 isEnabled: size.e2eUpscale,
                 onChanged: (value) {
@@ -298,9 +299,6 @@ class CfgScaleSection extends ConsumerWidget {
           decrisp: params.decrisp,
           varietyPlus: params.varietyPlus,
           isV3Model: params.isV3Model,
-          supportsTransparentBackground:
-              params.capabilities.supportsTransparentBackground,
-          transparentBackground: params.transparentBackground,
           supportsVarietyPlus: params.capabilities.supportsVarietyPlus,
         ),
       ),
@@ -314,22 +312,9 @@ class CfgScaleSection extends ConsumerWidget {
               context.l10n.generation_cfgScale(data.scale.toStringAsFixed(1)),
             ),
             const Spacer(),
-            // 透明背景 (仅 V5)：勾选后正向提示词补 transparent background
-            if (data.supportsTransparentBackground) ...[
-              _ToggleButton(
-                label: context.l10n.generation_transparentBackground,
-                isEnabled: data.transparentBackground,
-                onChanged: (value) {
-                  ref
-                      .read(generationParamsNotifierProvider.notifier)
-                      .updateTransparentBackground(value);
-                },
-              ),
-              const SizedBox(width: 8),
-            ],
             // Decrisp (仅 V3 模型)
             if (data.isV3Model) ...[
-              _ToggleButton(
+              GenerationToggleButton(
                 label: 'Decrisp',
                 isEnabled: data.decrisp,
                 onChanged: (value) {
@@ -342,7 +327,7 @@ class CfgScaleSection extends ConsumerWidget {
             ],
             // Variety+ (V3-V4.5；V5 不支持 skip_cfg_above_sigma)
             if (data.supportsVarietyPlus)
-              _ToggleButton(
+              GenerationToggleButton(
                 label: 'Variety+',
                 isEnabled: data.varietyPlus,
                 onChanged: (value) {
@@ -814,100 +799,6 @@ class _SmeaOptions extends StatelessWidget {
           const SizedBox(width: 4),
           Text(label, style: TextStyle(fontSize: 13, color: color)),
         ],
-      ),
-    );
-  }
-}
-
-/// 通用切换按钮 (用于 Variety+, Decrisp 等)
-class _ToggleButton extends StatefulWidget {
-  final String label;
-  final bool isEnabled;
-  final ValueChanged<bool> onChanged;
-
-  const _ToggleButton({
-    required this.label,
-    required this.isEnabled,
-    required this.onChanged,
-  });
-
-  @override
-  State<_ToggleButton> createState() => _ToggleButtonState();
-}
-
-class _ToggleButtonState extends State<_ToggleButton> {
-  bool _isHovered = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
-
-    // 计算背景色
-    Color backgroundColor;
-    if (widget.isEnabled) {
-      backgroundColor = _isHovered
-          ? theme.colorScheme.primary.withValues(alpha: 0.85)
-          : theme.colorScheme.primary;
-    } else {
-      final baseColor = isDark
-          ? Colors.white.withValues(alpha: 0.08)
-          : Colors.black.withValues(alpha: 0.05);
-      backgroundColor = _isHovered
-          ? (isDark
-                ? Colors.white.withValues(alpha: 0.15)
-                : Colors.black.withValues(alpha: 0.1))
-          : baseColor;
-    }
-
-    return MouseRegion(
-      onEnter: (_) => setState(() => _isHovered = true),
-      onExit: (_) => setState(() => _isHovered = false),
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        onTap: () => widget.onChanged(!widget.isEnabled),
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 150),
-          curve: Curves.easeInOut,
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
-          decoration: BoxDecoration(
-            color: backgroundColor,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: widget.isEnabled
-                  ? theme.colorScheme.primary
-                  : (_isHovered
-                        ? theme.colorScheme.outline.withValues(alpha: 0.4)
-                        : theme.colorScheme.outline.withValues(alpha: 0.2)),
-              width: 1,
-            ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (widget.isEnabled) ...[
-                Icon(
-                  Icons.check_rounded,
-                  size: 14,
-                  color: theme.colorScheme.onPrimary,
-                ),
-                const SizedBox(width: 4),
-              ],
-              Text(
-                widget.label,
-                style: TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w500,
-                  color: widget.isEnabled
-                      ? theme.colorScheme.onPrimary
-                      : theme.colorScheme.onSurface.withValues(
-                          alpha: _isHovered ? 0.8 : 0.6,
-                        ),
-                ),
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/presentation/screens/generation/widgets/generation_toggle_button.dart
+++ b/lib/presentation/screens/generation/widgets/generation_toggle_button.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+/// Compact pill toggle shared by generation controls.
+class GenerationToggleButton extends StatefulWidget {
+  const GenerationToggleButton({
+    super.key,
+    required this.label,
+    required this.isEnabled,
+    required this.onChanged,
+  });
+
+  final String label;
+  final bool isEnabled;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  State<GenerationToggleButton> createState() => _GenerationToggleButtonState();
+}
+
+class _GenerationToggleButtonState extends State<GenerationToggleButton> {
+  bool _isHovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    Color backgroundColor;
+    if (widget.isEnabled) {
+      backgroundColor = _isHovered
+          ? theme.colorScheme.primary.withValues(alpha: 0.85)
+          : theme.colorScheme.primary;
+    } else {
+      final baseColor = isDark
+          ? Colors.white.withValues(alpha: 0.08)
+          : Colors.black.withValues(alpha: 0.05);
+      backgroundColor = _isHovered
+          ? (isDark
+                ? Colors.white.withValues(alpha: 0.15)
+                : Colors.black.withValues(alpha: 0.1))
+          : baseColor;
+    }
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _isHovered = true),
+      onExit: (_) => setState(() => _isHovered = false),
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () => widget.onChanged(!widget.isEnabled),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeInOut,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: widget.isEnabled
+                  ? theme.colorScheme.primary
+                  : (_isHovered
+                        ? theme.colorScheme.outline.withValues(alpha: 0.4)
+                        : theme.colorScheme.outline.withValues(alpha: 0.2)),
+              width: 1,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (widget.isEnabled) ...[
+                Icon(
+                  Icons.check_rounded,
+                  size: 14,
+                  color: theme.colorScheme.onPrimary,
+                ),
+                const SizedBox(width: 4),
+              ],
+              Text(
+                widget.label,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: widget.isEnabled
+                      ? theme.colorScheme.onPrimary
+                      : theme.colorScheme.onSurface.withValues(
+                          alpha: _isHovered ? 0.8 : 0.6,
+                        ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/generation/widgets/prompt_input.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_input.dart
@@ -12,6 +12,8 @@ import '../../../../core/utils/nai_prompt_formatter.dart';
 import '../../../../core/utils/sd_to_nai_converter.dart';
 import '../../../../data/models/character/character_prompt.dart';
 import '../../../../data/models/fixed_tag/fixed_tag_entry.dart';
+import '../../../../data/models/image/image_params.dart'
+    show ImageParamsExtension;
 import '../../../../data/models/prompt/prompt_preset_mode.dart';
 import '../../../../data/services/alias_resolver_service.dart';
 import '../../../providers/character_prompt_provider.dart';
@@ -39,6 +41,7 @@ import '../../../widgets/prompt/fixed_tags_button.dart';
 import '../../../providers/pending_prompt_provider.dart';
 import '../../../prompt_assistant/providers/prompt_assistant_config_provider.dart';
 import '../../../prompt_assistant/providers/prompt_assistant_history_provider.dart';
+import 'generation_toggle_button.dart';
 
 bool usesRichPromptTypeTooltip(TargetPlatform platform) =>
     platform != TargetPlatform.windows;
@@ -463,7 +466,7 @@ class _PromptInputWidgetState extends ConsumerState<PromptInputWidget> {
 
         // 提示词编辑区域（autoGrow 时随内容自增高，否则填充可用高度）
         if (widget.autoGrow) editor else Expanded(child: editor),
-        _PromptTokenCountFooter(
+        _PromptFooter(
           target: _isNegativeMode
               ? PromptTokenCountTarget.negative
               : PromptTokenCountTarget.positive,
@@ -1014,7 +1017,7 @@ class _PromptInputWidgetState extends ConsumerState<PromptInputWidget> {
             },
           ),
         ),
-        const _PromptTokenCountFooter(
+        const _PromptFooter(
           target: PromptTokenCountTarget.positive,
           topPadding: 4,
         ),
@@ -1023,11 +1026,8 @@ class _PromptInputWidgetState extends ConsumerState<PromptInputWidget> {
   }
 }
 
-class _PromptTokenCountFooter extends ConsumerWidget {
-  const _PromptTokenCountFooter({
-    required this.target,
-    required this.topPadding,
-  });
+class _PromptFooter extends ConsumerWidget {
+  const _PromptFooter({required this.target, required this.topPadding});
 
   final PromptTokenCountTarget target;
   final double topPadding;
@@ -1035,10 +1035,41 @@ class _PromptTokenCountFooter extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tokenUsage = ref.watch(promptTokenUsageProvider(target));
+    final transparentBackground = ref.watch(
+      generationParamsNotifierProvider.select(
+        (params) => (
+          supported: params.capabilities.supportsTransparentBackground,
+          enabled: params.transparentBackground,
+        ),
+      ),
+    );
+    final showTransparentBackground =
+        target == PromptTokenCountTarget.positive &&
+        transparentBackground.supported;
+
     return Padding(
       padding: EdgeInsets.only(top: topPadding),
-      child: RepaintBoundary(
-        child: PromptTokenCountAsyncBar(usage: tokenUsage),
+      child: Row(
+        children: [
+          if (showTransparentBackground) ...[
+            GenerationToggleButton(
+              key: const ValueKey('generation_transparent_background_toggle'),
+              label: context.l10n.generation_transparentBackground,
+              isEnabled: transparentBackground.enabled,
+              onChanged: (value) {
+                ref
+                    .read(generationParamsNotifierProvider.notifier)
+                    .updateTransparentBackground(value);
+              },
+            ),
+            const SizedBox(width: 8),
+          ],
+          Expanded(
+            child: RepaintBoundary(
+              child: PromptTokenCountAsyncBar(usage: tokenUsage),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/test/presentation/screens/generation/widgets/prompt_input_compact_test.dart
+++ b/test/presentation/screens/generation/widgets/prompt_input_compact_test.dart
@@ -42,9 +42,55 @@ void main() {
 
     expect(find.text('12 / 512'), findsOneWidget);
   });
+
+  testWidgets('V5 紧凑模式会在提示词框下方显示透明背景开关', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localStorageServiceProvider.overrideWith(
+            (ref) => _TestLocalStorageService(
+              defaultModel: 'nai-diffusion-5-curated',
+            ),
+          ),
+          promptTokenUsageProvider(
+            PromptTokenCountTarget.positive,
+          ).overrideWith(
+            (ref) async => const PromptTokenUsage(usedTokens: 12, limit: 703),
+          ),
+        ],
+        child: const MaterialApp(
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 720,
+                height: 160,
+                child: PromptInputWidget(compact: true),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      find.byKey(const ValueKey('generation_transparent_background_toggle')),
+      findsOneWidget,
+    );
+    expect(find.text('12 / 703'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class _TestLocalStorageService extends LocalStorageService {
+  _TestLocalStorageService({this.defaultModel = 'nai-diffusion-4-5-full'});
+
+  final String defaultModel;
+
   @override
   bool getEnablePromptWeightScroll() => true;
 
@@ -70,7 +116,10 @@ class _TestLocalStorageService extends LocalStorageService {
   String getLastNegativePrompt() => '';
 
   @override
-  String getDefaultModel() => 'nai-diffusion-4-5-full';
+  String getDefaultModel() => defaultModel;
+
+  @override
+  bool getLastTransparentBackground() => false;
 
   @override
   String getDefaultSampler() => 'k_euler_ancestral';

--- a/test/presentation/screens/generation/widgets/prompt_input_test.dart
+++ b/test/presentation/screens/generation/widgets/prompt_input_test.dart
@@ -11,6 +11,7 @@ import 'package:nai_launcher/presentation/prompt_assistant/providers/prompt_assi
 import 'package:nai_launcher/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart';
 import 'package:nai_launcher/presentation/providers/character_prompt_provider.dart';
 import 'package:nai_launcher/presentation/providers/prompt_token_counter_provider.dart';
+import 'package:nai_launcher/presentation/screens/generation/widgets/generation_toggle_button.dart';
 import 'package:nai_launcher/presentation/screens/generation/widgets/prompt_input.dart';
 import 'package:nai_launcher/presentation/widgets/common/themed_input.dart';
 import 'package:nai_launcher/presentation/widgets/common/weight_adjust_toolbar.dart';
@@ -66,6 +67,78 @@ void main() {
       findsOneWidget,
     );
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('V5 透明背景开关位于正向提示词框左下角', (tester) async {
+    final storage = _TestLocalStorageService(
+      defaultModel: 'nai-diffusion-5-curated',
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localStorageServiceProvider.overrideWith((ref) => storage),
+          characterPromptNotifierProvider.overrideWith(
+            _TestCharacterPromptNotifier.new,
+          ),
+          promptTokenUsageProvider(
+            PromptTokenCountTarget.positive,
+          ).overrideWith(
+            (ref) async => const PromptTokenUsage(usedTokens: 0, limit: 703),
+          ),
+          promptTokenUsageProvider(
+            PromptTokenCountTarget.negative,
+          ).overrideWith(
+            (ref) async => const PromptTokenUsage(usedTokens: 0, limit: 703),
+          ),
+        ],
+        child: const MaterialApp(
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: Scaffold(
+            body: SizedBox(
+              width: 960,
+              height: 420,
+              child: PromptInputWidget(autoGrow: true),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final promptField = find
+        .descendant(
+          of: find.byKey(const ValueKey('generation_prompt_positive_input')),
+          matching: find.byType(TextField),
+        )
+        .first;
+    final toggle = find.byKey(
+      const ValueKey('generation_transparent_background_toggle'),
+    );
+
+    expect(toggle, findsOneWidget);
+    expect(
+      tester.getTopLeft(toggle).dy,
+      greaterThanOrEqualTo(tester.getBottomLeft(promptField).dy),
+    );
+    expect(
+      tester.getTopLeft(toggle).dx,
+      closeTo(tester.getTopLeft(promptField).dx, 1),
+    );
+    expect(tester.widget<GenerationToggleButton>(toggle).isEnabled, isFalse);
+
+    await tester.tap(toggle);
+    await tester.pump();
+
+    expect(tester.widget<GenerationToggleButton>(toggle).isEnabled, isTrue);
+    expect(storage.savedTransparentBackground, isTrue);
+
+    await tester.tap(find.byIcon(Icons.block).first);
+    await tester.pump();
+
+    expect(toggle, findsNothing);
   });
 
   testWidgets('Ctrl+F 搜索选中命中且编辑提示词不重置光标', (tester) async {
@@ -417,9 +490,14 @@ void main() {
 }
 
 class _TestLocalStorageService extends LocalStorageService {
-  _TestLocalStorageService({this.enablePromptWeightScroll = true});
+  _TestLocalStorageService({
+    this.enablePromptWeightScroll = true,
+    this.defaultModel = 'nai-diffusion-4-5-full',
+  });
 
   final bool enablePromptWeightScroll;
+  final String defaultModel;
+  bool? savedTransparentBackground;
 
   @override
   bool getEnablePromptWeightScroll() => enablePromptWeightScroll;
@@ -452,7 +530,15 @@ class _TestLocalStorageService extends LocalStorageService {
   Future<void> setLastNegativePrompt(String prompt) async {}
 
   @override
-  String getDefaultModel() => 'nai-diffusion-4-5-full';
+  String getDefaultModel() => defaultModel;
+
+  @override
+  bool getLastTransparentBackground() => false;
+
+  @override
+  Future<void> setLastTransparentBackground(bool value) async {
+    savedTransparentBackground = value;
+  }
 
   @override
   String getDefaultSampler() => 'k_euler_ancestral';


### PR DESCRIPTION
## Summary

- Move the V5 transparent background toggle from the CFG Scale row to the lower-left footer of the positive prompt editor, matching the current NovelAI web layout.
- Keep the control hidden for unsupported models and the undesired-content tab while preserving the prompt token counter on the right.
- Reuse the generation pill toggle style and add regression coverage for web-style and compact layouts.

## Validation

- `flutter pub get`
- `flutter test --reporter compact` (`1937` passed, `1` skipped)
- `flutter analyze` (`No issues found`)
- `flutter build windows --release`
- `git diff --cached --check`

## Screenshots

- Not attached yet because no active debug hot-reload session was available for the repository capture script.