### PR TITLE
固定词列表添加时过滤已关联词库条目

### DIFF
--- a/lib/presentation/providers/fixed_tags_provider.dart
+++ b/lib/presentation/providers/fixed_tags_provider.dart
@@ -331,6 +331,22 @@ List<FixedTagEntry> inferFixedTagCategories(
   ];
 }
 
+/// 排除已经从词库添加到固定词列表的条目。
+List<TagLibraryEntry> filterUnlinkedLibraryEntries({
+  required List<TagLibraryEntry> libraryEntries,
+  required List<FixedTagEntry> fixedEntries,
+}) {
+  final linkedEntryIds = fixedEntries
+      .map((entry) => entry.sourceEntryId)
+      .whereType<String>()
+      .toSet();
+  if (linkedEntryIds.isEmpty) return libraryEntries;
+
+  return libraryEntries
+      .where((entry) => !linkedEntryIds.contains(entry.id))
+      .toList();
+}
+
 /// 在筛选后的可见条目内重排，保持隐藏条目的相对位置。
 List<FixedTagEntry> reorderFixedTagsWithinVisibleIds({
   required List<FixedTagEntry> entries,

--- a/lib/presentation/widgets/prompt/fixed_tags_dialog.dart
+++ b/lib/presentation/widgets/prompt/fixed_tags_dialog.dart
@@ -1023,12 +1023,15 @@ class _FixedTagsDialogState extends ConsumerState<FixedTagsDialog> {
   /// 显示词库选择器
   void _showLibraryPicker(ThemeData theme, FixedTagPromptType promptType) {
     final libraryState = ref.read(tagLibraryPageNotifierProvider);
-    final entries = libraryState.entries;
-
-    if (entries.isEmpty) {
+    if (libraryState.entries.isEmpty) {
       AppToast.info(context, context.l10n.fixedTags_libraryEmpty);
       return;
     }
+
+    final entries = filterUnlinkedLibraryEntries(
+      libraryEntries: libraryState.entries,
+      fixedEntries: ref.read(fixedTagsNotifierProvider).entries,
+    );
 
     showDialog(
       context: context,

--- a/test/presentation/providers/fixed_tags_provider_test.dart
+++ b/test/presentation/providers/fixed_tags_provider_test.dart
@@ -190,6 +190,55 @@ void main() {
     );
   });
 
+  group('library picker filtering', () {
+    test('excludes library entries already linked from any fixed-tag list', () {
+      final available = TagLibraryEntry.create(name: 'available', content: 'a');
+      final linkedPositive = TagLibraryEntry.create(
+        name: 'positive',
+        content: 'b',
+      );
+      final linkedNegative = TagLibraryEntry.create(
+        name: 'negative',
+        content: 'c',
+      );
+      final manualFixedTag = FixedTagEntry.create(name: 'manual', content: 'd');
+
+      final filtered = filterUnlinkedLibraryEntries(
+        libraryEntries: [linkedPositive, available, linkedNegative],
+        fixedEntries: [
+          FixedTagEntry.create(
+            name: linkedPositive.name,
+            content: linkedPositive.content,
+            sourceEntryId: linkedPositive.id,
+          ),
+          FixedTagEntry.create(
+            name: linkedNegative.name,
+            content: linkedNegative.content,
+            promptType: FixedTagPromptType.negative,
+            sourceEntryId: linkedNegative.id,
+          ),
+          manualFixedTag,
+        ],
+      );
+
+      expect(filtered, [available]);
+    });
+
+    test('preserves the original list when no fixed tag is library-linked', () {
+      final entries = [
+        TagLibraryEntry.create(name: 'first', content: 'a'),
+        TagLibraryEntry.create(name: 'second', content: 'b'),
+      ];
+
+      final filtered = filterUnlinkedLibraryEntries(
+        libraryEntries: entries,
+        fixedEntries: [FixedTagEntry.create(name: 'manual', content: 'a')],
+      );
+
+      expect(identical(filtered, entries), isTrue);
+    });
+  });
+
   group('filtered reorder', () {
     test('reorders only visible ids while preserving hidden entries', () {
       final a1 = FixedTagEntry.create(


### PR DESCRIPTION
## Problem
从词库添加固定词时，已经关联到固定词列表的条目仍会显示，可能被重复添加。

## Solution
在打开词库选择器时过滤所有已关联的词库条目，仅显示尚未添加的条目；手动创建的固定词不受影响。

### Testing
- Added provider tests for filtering linked entries across prompt types.
- Added coverage ensuring the original list is preserved when no entries are linked.