### PR TITLE
固定词悬浮时显示缩略图预览

### DIFF
--- a/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
+++ b/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
@@ -5,6 +5,7 @@ import '../../../../core/utils/localization_extension.dart';
 import '../../../../data/models/fixed_tag/fixed_tag_entry.dart';
 import '../../../../data/models/tag_library/tag_library_entry.dart';
 import '../../../widgets/common/app_toast.dart';
+import '../../../widgets/common/hover_image_preview.dart';
 import '../../../widgets/common/thumbnail_display.dart';
 
 typedef SidebarDragHandleBuilder = Widget Function(Widget child);
@@ -66,7 +67,7 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
         ? Colors.white
         : foreground;
 
-    return MouseRegion(
+    final tile = MouseRegion(
       onEnter: (_) => setState(() => _isHovering = true),
       onExit: (_) => setState(() => _isHovering = false),
       child: InkWell(
@@ -111,6 +112,19 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
           ),
         ),
       ),
+    );
+
+    final libraryEntry = widget.libraryEntry;
+    if (libraryEntry == null || !libraryEntry.hasThumbnail) return tile;
+
+    return HoverImagePreview.file(
+      imagePath: libraryEntry.thumbnail!,
+      previewMaxSize: 320,
+      hoverDelay: const Duration(milliseconds: 300),
+      imageOffsetX: libraryEntry.thumbnailOffsetX,
+      imageOffsetY: libraryEntry.thumbnailOffsetY,
+      imageScale: libraryEntry.thumbnailScale,
+      child: tile,
     );
   }
 

--- a/lib/presentation/widgets/common/hover_image_preview.dart
+++ b/lib/presentation/widgets/common/hover_image_preview.dart
@@ -1,29 +1,69 @@
+import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 
 import 'decoded_memory_image.dart';
+import 'thumbnail_display.dart';
 
 /// 鼠标悬浮时显示大图预览的组件
 ///
 /// 将缩略图包装在此组件中，鼠标悬浮时会在附近显示放大后的图片
 class HoverImagePreview extends StatefulWidget {
   /// 图片数据
-  final Uint8List imageBytes;
+  final Uint8List? imageBytes;
+
+  /// 本地图片路径
+  final String? imagePath;
 
   /// 缩略图组件
   final Widget child;
 
-  /// 预览图最大尺寸
+  /// 预览图最长边的最大尺寸
   final double previewMaxSize;
+
+  /// 预览图宽高比
+  final double previewAspectRatio;
+
+  /// 本地缩略图水平偏移 (-1.0 ~ 1.0)
+  final double imageOffsetX;
+
+  /// 本地缩略图垂直偏移 (-1.0 ~ 1.0)
+  final double imageOffsetY;
+
+  /// 本地缩略图缩放比例 (1.0 ~ 3.0)
+  final double imageScale;
+
+  /// 悬浮延迟；内存图片默认保持即时预览。
+  final Duration hoverDelay;
 
   const HoverImagePreview({
     super.key,
-    required this.imageBytes,
+    required Uint8List this.imageBytes,
     required this.child,
     this.previewMaxSize = 300,
-  });
+    this.hoverDelay = Duration.zero,
+  }) : imagePath = null,
+       previewAspectRatio = 1,
+       imageOffsetX = 0,
+       imageOffsetY = 0,
+       imageScale = 1;
+
+  const HoverImagePreview.file({
+    super.key,
+    required String imagePath,
+    required this.child,
+    this.previewMaxSize = 300,
+    this.previewAspectRatio = 16 / 9,
+    this.imageOffsetX = 0,
+    this.imageOffsetY = 0,
+    this.imageScale = 1,
+    this.hoverDelay = Duration.zero,
+  }) : assert(imagePath.length > 0),
+       assert(previewAspectRatio > 0),
+       imagePath = imagePath,
+       imageBytes = null;
 
   @override
   State<HoverImagePreview> createState() => _HoverImagePreviewState();
@@ -35,12 +75,38 @@ class _HoverImagePreviewState extends State<HoverImagePreview> {
 
   final _layerLink = LayerLink();
   OverlayEntry? _overlayEntry;
+  Timer? _hoverTimer;
   Rect? _targetRect;
 
   @override
+  void didUpdateWidget(HoverImagePreview oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imageBytes != widget.imageBytes ||
+        oldWidget.imagePath != widget.imagePath ||
+        oldWidget.previewAspectRatio != widget.previewAspectRatio ||
+        oldWidget.imageOffsetX != widget.imageOffsetX ||
+        oldWidget.imageOffsetY != widget.imageOffsetY ||
+        oldWidget.imageScale != widget.imageScale) {
+      _overlayEntry?.markNeedsBuild();
+    }
+  }
+
+  @override
   void dispose() {
+    _hoverTimer?.cancel();
     _removeOverlay();
     super.dispose();
+  }
+
+  void _scheduleOverlay() {
+    _hoverTimer?.cancel();
+    if (widget.hoverDelay == Duration.zero) {
+      _showOverlay();
+      return;
+    }
+    _hoverTimer = Timer(widget.hoverDelay, () {
+      if (mounted) _showOverlay();
+    });
   }
 
   void _showOverlay() {
@@ -55,6 +121,8 @@ class _HoverImagePreviewState extends State<HoverImagePreview> {
   }
 
   void _removeOverlay() {
+    _hoverTimer?.cancel();
+    _hoverTimer = null;
     _overlayEntry?.remove();
     _overlayEntry = null;
     _targetRect = null;
@@ -70,22 +138,36 @@ class _HoverImagePreviewState extends State<HoverImagePreview> {
     final leftSpace = targetRect.left - _viewportMargin - _targetGap;
     final horizontalSpace = math.max(rightSpace, leftSpace);
     final verticalSpace = viewport.height - (_viewportMargin * 2);
-    final previewSize = math.min(
-      widget.previewMaxSize,
-      math.min(horizontalSpace, verticalSpace),
-    );
-    if (previewSize <= 0) return const SizedBox.shrink();
+    final aspectRatio = widget.previewAspectRatio;
+    final (previewWidth, previewHeight) = aspectRatio >= 1
+        ? (() {
+            final width = math.min(
+              widget.previewMaxSize,
+              math.min(horizontalSpace, verticalSpace * aspectRatio),
+            );
+            return (width, width / aspectRatio);
+          })()
+        : (() {
+            final height = math.min(
+              widget.previewMaxSize,
+              math.min(verticalSpace, horizontalSpace / aspectRatio),
+            );
+            return (height * aspectRatio, height);
+          })();
+    if (previewWidth <= 0 || previewHeight <= 0) {
+      return const SizedBox.shrink();
+    }
 
-    final showOnRight = rightSpace >= previewSize || rightSpace >= leftSpace;
-    final previewTop = (targetRect.center.dy - previewSize / 2).clamp(
+    final showOnRight = rightSpace >= previewWidth || rightSpace >= leftSpace;
+    final previewTop = (targetRect.center.dy - previewHeight / 2).clamp(
       _viewportMargin,
-      viewport.height - _viewportMargin - previewSize,
+      viewport.height - _viewportMargin - previewHeight,
     );
     final verticalOffset = previewTop - targetRect.top;
 
     return Positioned(
-      width: previewSize,
-      height: previewSize,
+      width: previewWidth,
+      height: previewHeight,
       child: CompositedTransformFollower(
         link: _layerLink,
         showWhenUnlinked: false,
@@ -99,27 +181,51 @@ class _HoverImagePreviewState extends State<HoverImagePreview> {
           clipBehavior: Clip.antiAlias,
           child: ColoredBox(
             color: Theme.of(context).colorScheme.surface,
-            child: DecodedMemoryImage(
-              bytes: widget.imageBytes,
-              fit: BoxFit.contain,
-              maxLogicalWidth: previewSize,
-              maxLogicalHeight: previewSize,
-              errorBuilder: (context, error, stackTrace) {
-                return Container(
-                  width: 100,
-                  height: 100,
-                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                  child: Icon(
-                    Icons.broken_image_outlined,
-                    size: 32,
-                    color: Theme.of(context).colorScheme.outline,
-                  ),
-                );
-              },
+            child: _buildPreviewContent(
+              context,
+              previewWidth: previewWidth,
+              previewHeight: previewHeight,
             ),
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildPreviewContent(
+    BuildContext context, {
+    required double previewWidth,
+    required double previewHeight,
+  }) {
+    final imagePath = widget.imagePath;
+    if (imagePath != null) {
+      return ThumbnailDisplay(
+        imagePath: imagePath,
+        offsetX: widget.imageOffsetX,
+        offsetY: widget.imageOffsetY,
+        scale: widget.imageScale,
+        width: previewWidth,
+        height: previewHeight,
+      );
+    }
+
+    return DecodedMemoryImage(
+      bytes: widget.imageBytes!,
+      fit: BoxFit.contain,
+      maxLogicalWidth: previewWidth,
+      maxLogicalHeight: previewHeight,
+      errorBuilder: (context, error, stackTrace) {
+        return Container(
+          width: 100,
+          height: 100,
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          child: Icon(
+            Icons.broken_image_outlined,
+            size: 32,
+            color: Theme.of(context).colorScheme.outline,
+          ),
+        );
+      },
     );
   }
 
@@ -128,12 +234,8 @@ class _HoverImagePreviewState extends State<HoverImagePreview> {
     return CompositedTransformTarget(
       link: _layerLink,
       child: MouseRegion(
-        onEnter: (_) {
-          _showOverlay();
-        },
-        onExit: (_) {
-          _removeOverlay();
-        },
+        onEnter: (_) => _scheduleOverlay(),
+        onExit: (_) => _removeOverlay(),
         child: widget.child,
       ),
     );

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
@@ -21,6 +21,7 @@ import 'package:nai_launcher/presentation/screens/generation/generation_screen.d
 import 'package:nai_launcher/presentation/screens/generation/widgets/fixed_tags_sidebar.dart';
 import 'package:nai_launcher/presentation/screens/generation/widgets/sidebar_entry_tile.dart';
 import 'package:nai_launcher/presentation/screens/generation/widgets/sidebar_link_painter.dart';
+import 'package:nai_launcher/presentation/widgets/common/hover_image_preview.dart';
 import 'package:nai_launcher/presentation/widgets/common/thumbnail_display.dart';
 import 'package:nai_launcher/presentation/widgets/prompt/fixed_tags_button.dart';
 
@@ -788,6 +789,131 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets(
+    'SidebarEntryTile shows a linked preview image after the hover delay',
+    (tester) async {
+      tester.view.physicalSize = const Size(1000, 600);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final entry = FixedTagEntry.create(name: 'tile', content: 'tag');
+      final libraryEntry = TagLibraryEntry.create(
+        name: 'tile',
+        content: 'tag',
+        thumbnail: 'missing-preview.png',
+        thumbnailOffsetX: 0.25,
+        thumbnailOffsetY: -0.5,
+        thumbnailScale: 1.4,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.centerRight,
+              child: SizedBox(
+                width: 280,
+                child: SidebarEntryTile(
+                  entry: entry,
+                  libraryEntry: libraryEntry,
+                  categoryColor: Colors.blue,
+                  isListMode: true,
+                  onToggle: () {},
+                  onEdit: () {},
+                  onDelete: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer();
+      addTearDown(mouse.removePointer);
+      await mouse.moveTo(tester.getCenter(find.byType(SidebarEntryTile)));
+      await tester.pump(const Duration(milliseconds: 299));
+
+      const previewKey = ValueKey('hover-image-preview-overlay');
+      expect(find.byKey(previewKey), findsNothing);
+
+      await tester.pump(const Duration(milliseconds: 1));
+
+      expect(find.byKey(previewKey), findsOneWidget);
+      final previewThumbnail = tester.widget<ThumbnailDisplay>(
+        find.descendant(
+          of: find.byKey(previewKey),
+          matching: find.byType(ThumbnailDisplay),
+        ),
+      );
+      expect(previewThumbnail.imagePath, libraryEntry.thumbnail);
+      expect(previewThumbnail.offsetX, libraryEntry.thumbnailOffsetX);
+      expect(previewThumbnail.offsetY, libraryEntry.thumbnailOffsetY);
+      expect(previewThumbnail.scale, libraryEntry.thumbnailScale);
+
+      final previewRect = tester.getRect(find.byKey(previewKey));
+      expect(previewRect.width, 320);
+      expect(previewRect.height, 180);
+      expect(previewRect.left, greaterThanOrEqualTo(16));
+      expect(previewRect.right, lessThanOrEqualTo(984));
+      expect(previewRect.top, greaterThanOrEqualTo(16));
+      expect(previewRect.bottom, lessThanOrEqualTo(584));
+
+      await mouse.moveTo(const Offset(16, 16));
+      await tester.pump();
+
+      expect(find.byKey(previewKey), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('SidebarEntryTile skips hover preview without an image', (
+    tester,
+  ) async {
+    final entry = FixedTagEntry.create(name: 'tile', content: 'tag');
+    final libraryEntry = TagLibraryEntry.create(name: 'tile', content: 'tag');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 280,
+              child: SidebarEntryTile(
+                entry: entry,
+                libraryEntry: libraryEntry,
+                categoryColor: Colors.blue,
+                isListMode: true,
+                onToggle: () {},
+                onEdit: () {},
+                onDelete: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(HoverImagePreview), findsNothing);
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer();
+    addTearDown(mouse.removePointer);
+    await mouse.moveTo(tester.getCenter(find.byType(SidebarEntryTile)));
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(
+      find.byKey(const ValueKey('hover-image-preview-overlay')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets('SidebarEntryTile triggers edit action after hover', (
     tester,


### PR DESCRIPTION
## Problem
固定词侧边栏条目悬浮时无法查看关联缩略图。

## Solution
为有缩略图的固定词条目添加延迟悬浮预览，并支持本地图片的比例、偏移和缩放设置；无缩略图时不显示预览。

## Testing
- Added widget tests for delayed preview rendering and image settings.
- Added coverage confirming entries without images skip the preview.