### PR TITLE
修复词库预览图按容器比例铺满

### DIFF
--- a/lib/presentation/screens/tag_library_page/widgets/entry_card.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_card.dart
@@ -319,17 +319,20 @@ class _EntryCardState extends State<EntryCard>
   }
 
   /// 构建背景图片
-  /// 使用固定尺寸 200x80，与裁剪对话框的比例一致
   Widget _buildBackgroundImage(TagLibraryEntry entry) {
     if (entry.hasThumbnail && entry.thumbnail != null) {
-      return ThumbnailDisplay(
-        imagePath: entry.thumbnail!,
-        offsetX: entry.thumbnailOffsetX,
-        offsetY: entry.thumbnailOffsetY,
-        scale: entry.thumbnailScale,
-        width: 200,
-        height: 80,
-        borderRadius: BorderRadius.circular(12),
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          return ThumbnailDisplay(
+            imagePath: entry.thumbnail!,
+            offsetX: entry.thumbnailOffsetX,
+            offsetY: entry.thumbnailOffsetY,
+            scale: entry.thumbnailScale,
+            width: constraints.maxWidth,
+            height: constraints.maxHeight,
+            borderRadius: BorderRadius.circular(12),
+          );
+        },
       );
     }
     return _buildPlaceholder();

--- a/lib/presentation/widgets/common/thumbnail_display.dart
+++ b/lib/presentation/widgets/common/thumbnail_display.dart
@@ -98,9 +98,10 @@ class _ThumbnailDisplayState extends State<ThumbnailDisplay> {
     // 容器尺寸
     final containerWidth = widget.width;
     final containerHeight = widget.height;
-    const containerAspectRatio = 2.5; // 与 EntryCard 一致
+    final containerAspectRatio = containerWidth / containerHeight;
 
-    // 计算图像相对于容器的缩放（模拟 BoxFit.cover 或类似效果）
+    // 按当前显示区域的实际比例铺满，避免组件用于非 200x80
+    // 区域时出现未被图像覆盖的边带。
     final imageAspectRatio = _imageSize!.width / _imageSize!.height;
 
     // 使用与裁剪对话框相同的逻辑计算"虚拟图像"尺寸

--- a/test/presentation/screens/tag_library_page/widgets/entry_card_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/entry_card_test.dart
@@ -83,7 +83,12 @@ void main() {
 
     await pumpCard(isSelectionMode: false);
     await tester.pump();
-    final thumbnailState = tester.state(find.byType(ThumbnailDisplay));
+    final thumbnailFinder = find.byType(ThumbnailDisplay);
+    final thumbnailState = tester.state(thumbnailFinder);
+    final thumbnail = tester.widget<ThumbnailDisplay>(thumbnailFinder);
+
+    expect(thumbnail.width, 240);
+    expect(thumbnail.height, 80);
 
     await pumpCard(isSelectionMode: true);
 

--- a/test/presentation/widgets/common/thumbnail_display_test.dart
+++ b/test/presentation/widgets/common/thumbnail_display_test.dart
@@ -63,6 +63,45 @@ void main() {
     expect(resized.width, 400);
     expect(resized.height, 400);
   });
+
+  testWidgets('uses the actual viewport ratio when covering the thumbnail', (
+    tester,
+  ) async {
+    final directory = Directory.systemTemp.createTempSync(
+      'thumbnail_display_ratio_test_',
+    );
+    addTearDown(() {
+      if (directory.existsSync()) {
+        directory.deleteSync(recursive: true);
+      }
+    });
+
+    final imageFile = File('${directory.path}/landscape.png');
+    imageFile.writeAsBytesSync(
+      img.encodePng(img.Image(width: 200, height: 100)),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(devicePixelRatio: 2),
+          child: ThumbnailDisplay(
+            imagePath: imageFile.path,
+            width: 64,
+            height: 64,
+          ),
+        ),
+      ),
+    );
+
+    final resized = await _pumpUntilResizeWidth(tester, 256);
+    final image = tester.widget<Image>(find.byType(Image));
+
+    expect(resized.width, 256);
+    expect(resized.height, 128);
+    expect(image.width, 128);
+    expect(image.height, 64);
+  });
 }
 
 Future<ResizeImage> _pumpUntilResizeWidth(


### PR DESCRIPTION
## Problem
词库卡片预览图使用固定的 200×80 尺寸，容器宽度变化时可能无法完整铺满，出现空白边带。

## Solution
根据实际容器尺寸计算预览图比例，并补充不同尺寸下的测试，确保图片正确铺满显示区域。

## Testing
- Added widget coverage for actual viewport ratio handling
- Updated entry card assertions for dynamic thumbnail dimensions