### PR TITLE
Fix character position canvas sizing

### DIFF
--- a/lib/presentation/providers/generation/generation_settings_notifiers.g.dart
+++ b/lib/presentation/providers/generation/generation_settings_notifiers.g.dart
@@ -7,7 +7,7 @@ part of 'generation_settings_notifiers.dart';
 // **************************************************************************
 
 String _$autocompleteSettingsHash() =>
-    r'0ca3c153a47c4babddbcfe874c4142a211bc5a01';
+    r'4c9452cec36b8369553769ecf16dde884bd2c9b4';
 
 /// 自动补全设置 Notifier
 ///

--- a/lib/presentation/widgets/character/character_position_canvas.dart
+++ b/lib/presentation/widgets/character/character_position_canvas.dart
@@ -159,9 +159,8 @@ class _CharacterPositionCanvasViewState
     final backgroundImage = generationState.displayImages.isNotEmpty
         ? generationState.displayImages.first
         : null;
-    final aspectRatio =
-        backgroundImage?.aspectRatio ??
-        previewDimensions.width / previewDimensions.height;
+    // 锚点坐标用于下一次请求；历史预览只作背景，不能决定画布尺寸。
+    final aspectRatio = previewDimensions.width / previewDimensions.height;
 
     return AspectRatio(
       aspectRatio: aspectRatio,

--- a/test/presentation/widgets/character/character_position_canvas_test.dart
+++ b/test/presentation/widgets/character/character_position_canvas_test.dart
@@ -36,6 +36,25 @@ class _WidePreviewImageGenerationNotifier extends ImageGenerationNotifier {
   }
 }
 
+class _PortraitPreviewImageGenerationNotifier extends ImageGenerationNotifier {
+  @override
+  ImageGenerationState build() {
+    return ImageGenerationState(
+      displayImages: [
+        GeneratedImage(
+          id: 'portrait-preview',
+          bytes: base64Decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0l'
+            'EQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+          ),
+          width: 832,
+          height: 1216,
+        ),
+      ],
+    );
+  }
+}
+
 class _MemoryCharacterPromptRepository extends CharacterPromptRepository {
   CharacterPromptConfig config = const CharacterPromptConfig();
 
@@ -216,6 +235,24 @@ void main() {
       );
     }
 
+    Widget buildPortraitPreviewTestApp() {
+      return ProviderScope(
+        overrides: [
+          characterPromptRepositoryProvider.overrideWith(
+            (ref) => _MemoryCharacterPromptRepository(),
+          ),
+          imageGenerationNotifierProvider.overrideWith(
+            _PortraitPreviewImageGenerationNotifier.new,
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: CharacterPositionCanvasView()),
+        ),
+      );
+    }
+
     test('replaceAll 和重新启用会在自定义模式补齐全部坐标', () async {
       final container = ProviderContainer(
         overrides: [
@@ -301,6 +338,9 @@ void main() {
       final container = ProviderScope.containerOf(
         tester.element(find.byType(CharacterPositionCanvasView)),
       );
+      container
+          .read(generationParamsNotifierProvider.notifier)
+          .updateSize(1000, 10, persist: false);
       final notifier = container.read(characterPromptNotifierProvider.notifier);
       notifier.addCharacter(CharacterGender.female, name: 'Alice');
       notifier.setGlobalAiChoice(false);
@@ -333,6 +373,22 @@ void main() {
             .customPosition,
         isNotNull,
       );
+    });
+
+    testWidgets('已有纵向预览图时切换横向分辨率会更新画布宽高比', (tester) async {
+      await tester.pumpWidget(buildPortraitPreviewTestApp());
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(CharacterPositionCanvasView)),
+      );
+
+      container
+          .read(generationParamsNotifierProvider.notifier)
+          .updateSize(1216, 832, persist: false);
+      await tester.pump();
+
+      final canvas = tester.widget<AspectRatio>(find.byType(AspectRatio));
+      expect(canvas.aspectRatio, closeTo(1216 / 832, 0.0001));
+      expect(find.byType(DecodedMemoryImage), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Keep the character position canvas aligned with the currently selected generation dimensions, even when the retained history preview has a different aspect ratio.
- Continue using the retained preview image as the canvas background without letting it override the next request's coordinate space.
- Refresh the generated Riverpod provider hash required by the autocomplete provider now present on `main`.

## Validation

- `flutter gen-l10n`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze`
- `flutter test --reporter expanded test/presentation/widgets/character/character_position_canvas_test.dart` (14 passed)
- `flutter test --reporter compact` (2129 passed, 1 skipped)
- `flutter build windows --debug`
- GitHub Actions `Pull Request Validation` run `32560645716` passed generate/validate/analyze, tests, and Windows debug build.

## Scope Notes

- The two follow-up commits were rebased onto `main` after PR #81 merged. `main` later advanced to `f5ec12a0` with file-disjoint tag-library changes; `git merge-tree` is clean and GitHub reports `MERGEABLE / CLEAN`.
- No assets, Git LFS databases, build outputs, logs, credentials, or local workflow files are included.
- No screenshot is attached because the regression depends on changing generation dimensions while retaining a history preview; the widget regression test covers that state transition directly.