### PR TITLE
添加在线画廊输出过滤标签功能

### DIFF
--- a/lib/core/constants/storage_keys.dart
+++ b/lib/core/constants/storage_keys.dart
@@ -287,6 +287,8 @@ class StorageKeys {
       'online_gallery_blacklist_last_sync_error';
   static const String onlineGalleryPromptTagCategories =
       'online_gallery_prompt_tag_categories';
+  static const String onlineGalleryOutputFilterTags =
+      'online_gallery_output_filter_tags';
 
   // ComfyUI 设置
   static const String comfyuiEnabled = 'comfyui_enabled';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1222,6 +1222,36 @@
   "onlineGallery_fuzzySearch": "Fuzzy Match",
   "onlineGallery_fuzzySearchTooltip": "Use *tag* matching for related tags when enabled; search exact Danbooru tags when disabled",
   "onlineGallery_blacklistTags": "Blacklist Tags",
+  "onlineGallery_outputFilter": "Output Filter",
+  "onlineGallery_outputFilterTooltip": "Manage tags removed automatically when copying, sending, or adding to the queue",
+  "onlineGallery_outputFilterTitle": "Output filter tags",
+  "onlineGallery_outputFilterSubtitle": "Images remain visible. Exact matching tags are removed only from copied, sent, and queued prompts.",
+  "onlineGallery_outputFilterAddHint": "Add a tag to remove from output",
+  "onlineGallery_outputFilterInputHint": "Separate multiple tags with commas or line breaks",
+  "onlineGallery_outputFilterEmpty": "No output filter tags configured",
+  "onlineGallery_outputFilterRestoreDefaults": "Restore defaults",
+  "onlineGallery_outputFilterClearTitle": "Clear the output filter?",
+  "onlineGallery_outputFilterClearConfirm": "Watermark and mosaic tags will appear in copied and sent prompts again.",
+  "onlineGallery_addTagToOutputFilter": "Add to output filter",
+  "onlineGallery_outputFilterAlreadyAdded": "Already in output filter",
+  "onlineGallery_outputFilterMenuHint": "Keep the image visible and remove only this output tag",
+  "onlineGallery_addTagToBlacklist": "Add to blacklist",
+  "onlineGallery_blacklistAlreadyAdded": "Already in blacklist",
+  "onlineGallery_blacklistMenuHint": "Hide gallery images containing this tag",
+  "onlineGallery_outputFilteredTagTooltip": "Removed when copying, sending, or adding to queue; right-click to manage",
+  "onlineGallery_tagContextMenuTooltip": "Right-click to add to the blacklist or output filter",
+  "onlineGallery_outputFilterTagAdded": "Added {tag} to the output filter",
+  "@onlineGallery_outputFilterTagAdded": {
+    "placeholders": {
+      "tag": {}
+    }
+  },
+  "onlineGallery_blacklistTagAdded": "Added {tag} to the blacklist",
+  "@onlineGallery_blacklistTagAdded": {
+    "placeholders": {
+      "tag": {}
+    }
+  },
   "onlineGallery_blacklistTitle": "Online Gallery Blacklist",
   "onlineGallery_blacklistSubtitle": "Images containing blacklisted tags will be hidden directly in the online gallery.",
   "onlineGallery_addBlacklistTagHint": "Add blacklist tag",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1210,6 +1210,36 @@
   "onlineGallery_fuzzySearch": "ファジーマッチ",
   "onlineGallery_fuzzySearchTooltip": "有効な場合は、関連タグに *tag* マッチングを使用します。無効になっている場合は、正確な Danbooru タグを検索します",
   "onlineGallery_blacklistTags": "ブラックリスト タグ",
+  "onlineGallery_outputFilter": "出力フィルター",
+  "onlineGallery_outputFilterTooltip": "コピー、送信、キュー追加時に自動で除外するタグを管理します",
+  "onlineGallery_outputFilterTitle": "出力フィルタータグ",
+  "onlineGallery_outputFilterSubtitle": "画像は表示されたまま、完全一致するタグだけをコピー・送信・キューのプロンプトから除外します。",
+  "onlineGallery_outputFilterAddHint": "出力から除外するタグを追加",
+  "onlineGallery_outputFilterInputHint": "複数のタグはカンマまたは改行で区切ります",
+  "onlineGallery_outputFilterEmpty": "出力フィルタータグは設定されていません",
+  "onlineGallery_outputFilterRestoreDefaults": "デフォルトに戻す",
+  "onlineGallery_outputFilterClearTitle": "出力フィルターをクリアしますか？",
+  "onlineGallery_outputFilterClearConfirm": "透かしやモザイクのタグがコピー・送信するプロンプトに再び含まれます。",
+  "onlineGallery_addTagToOutputFilter": "出力フィルターに追加",
+  "onlineGallery_outputFilterAlreadyAdded": "出力フィルターに追加済み",
+  "onlineGallery_outputFilterMenuHint": "画像は表示したまま、このタグだけを出力から除外します",
+  "onlineGallery_addTagToBlacklist": "ブラックリストに追加",
+  "onlineGallery_blacklistAlreadyAdded": "ブラックリストに追加済み",
+  "onlineGallery_blacklistMenuHint": "このタグを含むギャラリー画像を非表示にします",
+  "onlineGallery_outputFilteredTagTooltip": "コピー、送信、キュー追加時に除外されます。右クリックで管理できます",
+  "onlineGallery_tagContextMenuTooltip": "右クリックでブラックリストまたは出力フィルターに追加",
+  "onlineGallery_outputFilterTagAdded": "{tag} を出力フィルターに追加しました",
+  "@onlineGallery_outputFilterTagAdded": {
+    "placeholders": {
+      "tag": {}
+    }
+  },
+  "onlineGallery_blacklistTagAdded": "{tag} をブラックリストに追加しました",
+  "@onlineGallery_blacklistTagAdded": {
+    "placeholders": {
+      "tag": {}
+    }
+  },
   "onlineGallery_blacklistTitle": "オンライン ギャラリー ブラックリスト",
   "onlineGallery_blacklistSubtitle": "ブラックリストに登録されたタグを含む画像は、オンライン ギャラリーで直接非表示になります。",
   "onlineGallery_addBlacklistTagHint": "ブラックリスト タグを追加",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -63,7 +63,8 @@ import 'app_localizations_zh.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -71,7 +72,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -83,18 +85,19 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
     Locale('ja'),
-    Locale('zh')
+    Locale('zh'),
   ];
 
   /// No description provided for @app_title.
@@ -3701,13 +3704,23 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Work {workWidth}×{workHeight} → output {targetWidth}×{targetHeight}'**
-  String editor_compressionSizeSummary(int workWidth, int workHeight, int targetWidth, int targetHeight);
+  String editor_compressionSizeSummary(
+    int workWidth,
+    int workHeight,
+    int targetWidth,
+    int targetHeight,
+  );
 
   /// No description provided for @editor_compressionNormalSummary.
   ///
   /// In en, this message translates to:
   /// **'Normal (about 1 MP): {normalWidth}×{normalHeight}. Lowest: {minimumWidth}×{minimumHeight}.'**
-  String editor_compressionNormalSummary(int normalWidth, int normalHeight, int minimumWidth, int minimumHeight);
+  String editor_compressionNormalSummary(
+    int normalWidth,
+    int normalHeight,
+    int minimumWidth,
+    int minimumHeight,
+  );
 
   /// No description provided for @editor_compressionUnavailable.
   ///
@@ -3725,7 +3738,13 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Outer crop {outerWidth}×{outerHeight}, request {requestWidth}×{requestHeight}, estimated {cost} Anlas.'**
-  String editor_focusRequestSummary(int outerWidth, int outerHeight, int requestWidth, int requestHeight, int cost);
+  String editor_focusRequestSummary(
+    int outerWidth,
+    int outerHeight,
+    int requestWidth,
+    int requestHeight,
+    int cost,
+  );
 
   /// No description provided for @editor_unsupportedImageFormat.
   ///
@@ -4866,6 +4885,126 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Blacklist Tags'**
   String get onlineGallery_blacklistTags;
+
+  /// No description provided for @onlineGallery_outputFilter.
+  ///
+  /// In en, this message translates to:
+  /// **'Output Filter'**
+  String get onlineGallery_outputFilter;
+
+  /// No description provided for @onlineGallery_outputFilterTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Manage tags removed automatically when copying, sending, or adding to the queue'**
+  String get onlineGallery_outputFilterTooltip;
+
+  /// No description provided for @onlineGallery_outputFilterTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Output filter tags'**
+  String get onlineGallery_outputFilterTitle;
+
+  /// No description provided for @onlineGallery_outputFilterSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Images remain visible. Exact matching tags are removed only from copied, sent, and queued prompts.'**
+  String get onlineGallery_outputFilterSubtitle;
+
+  /// No description provided for @onlineGallery_outputFilterAddHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Add a tag to remove from output'**
+  String get onlineGallery_outputFilterAddHint;
+
+  /// No description provided for @onlineGallery_outputFilterInputHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate multiple tags with commas or line breaks'**
+  String get onlineGallery_outputFilterInputHint;
+
+  /// No description provided for @onlineGallery_outputFilterEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No output filter tags configured'**
+  String get onlineGallery_outputFilterEmpty;
+
+  /// No description provided for @onlineGallery_outputFilterRestoreDefaults.
+  ///
+  /// In en, this message translates to:
+  /// **'Restore defaults'**
+  String get onlineGallery_outputFilterRestoreDefaults;
+
+  /// No description provided for @onlineGallery_outputFilterClearTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear the output filter?'**
+  String get onlineGallery_outputFilterClearTitle;
+
+  /// No description provided for @onlineGallery_outputFilterClearConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Watermark and mosaic tags will appear in copied and sent prompts again.'**
+  String get onlineGallery_outputFilterClearConfirm;
+
+  /// No description provided for @onlineGallery_addTagToOutputFilter.
+  ///
+  /// In en, this message translates to:
+  /// **'Add to output filter'**
+  String get onlineGallery_addTagToOutputFilter;
+
+  /// No description provided for @onlineGallery_outputFilterAlreadyAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'Already in output filter'**
+  String get onlineGallery_outputFilterAlreadyAdded;
+
+  /// No description provided for @onlineGallery_outputFilterMenuHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep the image visible and remove only this output tag'**
+  String get onlineGallery_outputFilterMenuHint;
+
+  /// No description provided for @onlineGallery_addTagToBlacklist.
+  ///
+  /// In en, this message translates to:
+  /// **'Add to blacklist'**
+  String get onlineGallery_addTagToBlacklist;
+
+  /// No description provided for @onlineGallery_blacklistAlreadyAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'Already in blacklist'**
+  String get onlineGallery_blacklistAlreadyAdded;
+
+  /// No description provided for @onlineGallery_blacklistMenuHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide gallery images containing this tag'**
+  String get onlineGallery_blacklistMenuHint;
+
+  /// No description provided for @onlineGallery_outputFilteredTagTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Removed when copying, sending, or adding to queue; right-click to manage'**
+  String get onlineGallery_outputFilteredTagTooltip;
+
+  /// No description provided for @onlineGallery_tagContextMenuTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Right-click to add to the blacklist or output filter'**
+  String get onlineGallery_tagContextMenuTooltip;
+
+  /// No description provided for @onlineGallery_outputFilterTagAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'Added {tag} to the output filter'**
+  String onlineGallery_outputFilterTagAdded(Object tag);
+
+  /// No description provided for @onlineGallery_blacklistTagAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'Added {tag} to the blacklist'**
+  String onlineGallery_blacklistTagAdded(Object tag);
 
   /// No description provided for @onlineGallery_blacklistTitle.
   ///
@@ -10259,7 +10398,11 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{enabled}/{total} · showing {shown}'**
-  String fixedTags_columnFilteredCount(Object enabled, Object total, Object shown);
+  String fixedTags_columnFilteredCount(
+    Object enabled,
+    Object total,
+    Object shown,
+  );
 
   /// No description provided for @fixedTags_new.
   ///
@@ -13097,7 +13240,12 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Reference {index}: {type} (strength {strength}%, fidelity {fidelity}%)'**
-  String metadataImport_preciseReferenceDetail(int index, Object type, Object strength, Object fidelity);
+  String metadataImport_preciseReferenceDetail(
+    int index,
+    Object type,
+    Object strength,
+    Object fidelity,
+  );
 
   /// No description provided for @metadataImport_noData.
   ///
@@ -19979,7 +20127,13 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{name} ({startMonth}/{startDay} - {endMonth}/{endDay})'**
-  String diy_timeRangeSummary(String name, int startMonth, int startDay, int endMonth, int endDay);
+  String diy_timeRangeSummary(
+    String name,
+    int startMonth,
+    int startDay,
+    int endMonth,
+    int endDay,
+  );
 
   /// No description provided for @diy_activeBadge.
   ///
@@ -20804,7 +20958,8 @@ abstract class AppLocalizations {
   String get autocomplete_openSettings;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -20813,26 +20968,28 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en', 'ja', 'zh'].contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      <String>['en', 'ja', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
-
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'en': return AppLocalizationsEn();
-    case 'ja': return AppLocalizationsJa();
-    case 'zh': return AppLocalizationsZh();
+    case 'en':
+      return AppLocalizationsEn();
+    case 'ja':
+      return AppLocalizationsJa();
+    case 'zh':
+      return AppLocalizationsZh();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
+    'that was used.',
   );
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2688,6 +2688,81 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onlineGallery_blacklistTags => 'Blacklist Tags';
 
   @override
+  String get onlineGallery_outputFilter => 'Output Filter';
+
+  @override
+  String get onlineGallery_outputFilterTooltip =>
+      'Manage tags removed automatically when copying, sending, or adding to the queue';
+
+  @override
+  String get onlineGallery_outputFilterTitle => 'Output filter tags';
+
+  @override
+  String get onlineGallery_outputFilterSubtitle =>
+      'Images remain visible. Exact matching tags are removed only from copied, sent, and queued prompts.';
+
+  @override
+  String get onlineGallery_outputFilterAddHint =>
+      'Add a tag to remove from output';
+
+  @override
+  String get onlineGallery_outputFilterInputHint =>
+      'Separate multiple tags with commas or line breaks';
+
+  @override
+  String get onlineGallery_outputFilterEmpty =>
+      'No output filter tags configured';
+
+  @override
+  String get onlineGallery_outputFilterRestoreDefaults => 'Restore defaults';
+
+  @override
+  String get onlineGallery_outputFilterClearTitle => 'Clear the output filter?';
+
+  @override
+  String get onlineGallery_outputFilterClearConfirm =>
+      'Watermark and mosaic tags will appear in copied and sent prompts again.';
+
+  @override
+  String get onlineGallery_addTagToOutputFilter => 'Add to output filter';
+
+  @override
+  String get onlineGallery_outputFilterAlreadyAdded =>
+      'Already in output filter';
+
+  @override
+  String get onlineGallery_outputFilterMenuHint =>
+      'Keep the image visible and remove only this output tag';
+
+  @override
+  String get onlineGallery_addTagToBlacklist => 'Add to blacklist';
+
+  @override
+  String get onlineGallery_blacklistAlreadyAdded => 'Already in blacklist';
+
+  @override
+  String get onlineGallery_blacklistMenuHint =>
+      'Hide gallery images containing this tag';
+
+  @override
+  String get onlineGallery_outputFilteredTagTooltip =>
+      'Removed when copying, sending, or adding to queue; right-click to manage';
+
+  @override
+  String get onlineGallery_tagContextMenuTooltip =>
+      'Right-click to add to the blacklist or output filter';
+
+  @override
+  String onlineGallery_outputFilterTagAdded(Object tag) {
+    return 'Added $tag to the output filter';
+  }
+
+  @override
+  String onlineGallery_blacklistTagAdded(Object tag) {
+    return 'Added $tag to the blacklist';
+  }
+
+  @override
   String get onlineGallery_blacklistTitle => 'Online Gallery Blacklist';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2632,6 +2632,75 @@ class AppLocalizationsJa extends AppLocalizations {
   String get onlineGallery_blacklistTags => 'ブラックリスト タグ';
 
   @override
+  String get onlineGallery_outputFilter => '出力フィルター';
+
+  @override
+  String get onlineGallery_outputFilterTooltip =>
+      'コピー、送信、キュー追加時に自動で除外するタグを管理します';
+
+  @override
+  String get onlineGallery_outputFilterTitle => '出力フィルタータグ';
+
+  @override
+  String get onlineGallery_outputFilterSubtitle =>
+      '画像は表示されたまま、完全一致するタグだけをコピー・送信・キューのプロンプトから除外します。';
+
+  @override
+  String get onlineGallery_outputFilterAddHint => '出力から除外するタグを追加';
+
+  @override
+  String get onlineGallery_outputFilterInputHint => '複数のタグはカンマまたは改行で区切ります';
+
+  @override
+  String get onlineGallery_outputFilterEmpty => '出力フィルタータグは設定されていません';
+
+  @override
+  String get onlineGallery_outputFilterRestoreDefaults => 'デフォルトに戻す';
+
+  @override
+  String get onlineGallery_outputFilterClearTitle => '出力フィルターをクリアしますか？';
+
+  @override
+  String get onlineGallery_outputFilterClearConfirm =>
+      '透かしやモザイクのタグがコピー・送信するプロンプトに再び含まれます。';
+
+  @override
+  String get onlineGallery_addTagToOutputFilter => '出力フィルターに追加';
+
+  @override
+  String get onlineGallery_outputFilterAlreadyAdded => '出力フィルターに追加済み';
+
+  @override
+  String get onlineGallery_outputFilterMenuHint => '画像は表示したまま、このタグだけを出力から除外します';
+
+  @override
+  String get onlineGallery_addTagToBlacklist => 'ブラックリストに追加';
+
+  @override
+  String get onlineGallery_blacklistAlreadyAdded => 'ブラックリストに追加済み';
+
+  @override
+  String get onlineGallery_blacklistMenuHint => 'このタグを含むギャラリー画像を非表示にします';
+
+  @override
+  String get onlineGallery_outputFilteredTagTooltip =>
+      'コピー、送信、キュー追加時に除外されます。右クリックで管理できます';
+
+  @override
+  String get onlineGallery_tagContextMenuTooltip =>
+      '右クリックでブラックリストまたは出力フィルターに追加';
+
+  @override
+  String onlineGallery_outputFilterTagAdded(Object tag) {
+    return '$tag を出力フィルターに追加しました';
+  }
+
+  @override
+  String onlineGallery_blacklistTagAdded(Object tag) {
+    return '$tag をブラックリストに追加しました';
+  }
+
+  @override
   String get onlineGallery_blacklistTitle => 'オンライン ギャラリー ブラックリスト';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2596,6 +2596,73 @@ class AppLocalizationsZh extends AppLocalizations {
   String get onlineGallery_blacklistTags => '黑名单标签';
 
   @override
+  String get onlineGallery_outputFilter => '输出过滤';
+
+  @override
+  String get onlineGallery_outputFilterTooltip => '管理复制、发送和加入队列时自动剔除的标签';
+
+  @override
+  String get onlineGallery_outputFilterTitle => '输出过滤标签';
+
+  @override
+  String get onlineGallery_outputFilterSubtitle =>
+      '图片仍会正常显示；这些标签只会从复制、发送和队列提示词中精确剔除。';
+
+  @override
+  String get onlineGallery_outputFilterAddHint => '添加需要从输出中剔除的标签';
+
+  @override
+  String get onlineGallery_outputFilterInputHint => '支持逗号、中文逗号、顿号或换行分隔';
+
+  @override
+  String get onlineGallery_outputFilterEmpty => '暂未设置输出过滤标签';
+
+  @override
+  String get onlineGallery_outputFilterRestoreDefaults => '恢复默认过滤词';
+
+  @override
+  String get onlineGallery_outputFilterClearTitle => '清空输出过滤？';
+
+  @override
+  String get onlineGallery_outputFilterClearConfirm =>
+      '清空后，水印和马赛克等标签也会重新出现在复制与发送的提示词中。';
+
+  @override
+  String get onlineGallery_addTagToOutputFilter => '加入输出过滤';
+
+  @override
+  String get onlineGallery_outputFilterAlreadyAdded => '已在输出过滤中';
+
+  @override
+  String get onlineGallery_outputFilterMenuHint => '保留图片，只从输出提示词中剔除此标签';
+
+  @override
+  String get onlineGallery_addTagToBlacklist => '加入黑名单';
+
+  @override
+  String get onlineGallery_blacklistAlreadyAdded => '已在黑名单中';
+
+  @override
+  String get onlineGallery_blacklistMenuHint => '隐藏包含此标签的画廊图片';
+
+  @override
+  String get onlineGallery_outputFilteredTagTooltip =>
+      '此标签会在复制、发送和加入队列时被剔除；右键可管理';
+
+  @override
+  String get onlineGallery_tagContextMenuTooltip => '右键可加入黑名单或输出过滤';
+
+  @override
+  String onlineGallery_outputFilterTagAdded(Object tag) {
+    return '已将 $tag 加入输出过滤';
+  }
+
+  @override
+  String onlineGallery_blacklistTagAdded(Object tag) {
+    return '已将 $tag 加入黑名单';
+  }
+
+  @override
   String get onlineGallery_blacklistTitle => '在线画廊黑名单';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1124,6 +1124,36 @@
   "onlineGallery_fuzzySearch": "模糊匹配",
   "onlineGallery_fuzzySearchTooltip": "开启后使用 *tag* 匹配相近标签；关闭时按 Danbooru 精确标签搜索",
   "onlineGallery_blacklistTags": "黑名单标签",
+  "onlineGallery_outputFilter": "输出过滤",
+  "onlineGallery_outputFilterTooltip": "管理复制、发送和加入队列时自动剔除的标签",
+  "onlineGallery_outputFilterTitle": "输出过滤标签",
+  "onlineGallery_outputFilterSubtitle": "图片仍会正常显示；这些标签只会从复制、发送和队列提示词中精确剔除。",
+  "onlineGallery_outputFilterAddHint": "添加需要从输出中剔除的标签",
+  "onlineGallery_outputFilterInputHint": "支持逗号、中文逗号、顿号或换行分隔",
+  "onlineGallery_outputFilterEmpty": "暂未设置输出过滤标签",
+  "onlineGallery_outputFilterRestoreDefaults": "恢复默认过滤词",
+  "onlineGallery_outputFilterClearTitle": "清空输出过滤？",
+  "onlineGallery_outputFilterClearConfirm": "清空后，水印和马赛克等标签也会重新出现在复制与发送的提示词中。",
+  "onlineGallery_addTagToOutputFilter": "加入输出过滤",
+  "onlineGallery_outputFilterAlreadyAdded": "已在输出过滤中",
+  "onlineGallery_outputFilterMenuHint": "保留图片，只从输出提示词中剔除此标签",
+  "onlineGallery_addTagToBlacklist": "加入黑名单",
+  "onlineGallery_blacklistAlreadyAdded": "已在黑名单中",
+  "onlineGallery_blacklistMenuHint": "隐藏包含此标签的画廊图片",
+  "onlineGallery_outputFilteredTagTooltip": "此标签会在复制、发送和加入队列时被剔除；右键可管理",
+  "onlineGallery_tagContextMenuTooltip": "右键可加入黑名单或输出过滤",
+  "onlineGallery_outputFilterTagAdded": "已将 {tag} 加入输出过滤",
+  "@onlineGallery_outputFilterTagAdded": {
+    "placeholders": {
+      "tag": {}
+    }
+  },
+  "onlineGallery_blacklistTagAdded": "已将 {tag} 加入黑名单",
+  "@onlineGallery_blacklistTagAdded": {
+    "placeholders": {
+      "tag": {}
+    }
+  },
   "onlineGallery_blacklistTitle": "在线画廊黑名单",
   "onlineGallery_blacklistSubtitle": "包含黑名单标签的图片会在在线画廊中直接隐藏。",
   "onlineGallery_addBlacklistTagHint": "添加黑名单标签",

--- a/lib/presentation/providers/online_gallery_output_filter_provider.dart
+++ b/lib/presentation/providers/online_gallery_output_filter_provider.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/constants/storage_keys.dart';
+import '../../core/storage/local_storage_service.dart';
+
+class OnlineGalleryOutputFilterSettings {
+  const OnlineGalleryOutputFilterSettings({required this.tags});
+
+  /// Tags that describe source-side censoring or watermarks but are generally
+  /// undesirable when recreating an image. A persisted empty list remains
+  /// empty; these defaults are only used before the user saves this setting.
+  static const defaultTags = <String>{
+    '3rd_party_watermark',
+    'artist_watermark',
+    'bar_censor',
+    'blur_censor',
+    'blur_censorship',
+    'censor_bar',
+    'censored',
+    'censored_version_at_source',
+    'character_watermark',
+    'distracting_watermark',
+    'extremely_distracting_watermark',
+    'miyoushe_watermark',
+    'mosaic',
+    'mosaic_censoring',
+    'mosaic_censorship',
+    'photo_date_watermark',
+    'pixelated',
+    'sample_watermark',
+    'third-party_watermark',
+    'too_many_watermarks',
+    'unobtrusive_watermark',
+    'watermark',
+    'watermark_grid',
+    'watermarked_at_source',
+    'weibo_watermark',
+  };
+
+  final Set<String> tags;
+
+  bool contains(String tag) {
+    final normalized = normalizeTag(tag);
+    if (normalized == null) return false;
+    if (tags.contains(normalized)) return true;
+
+    // Artist tags are rendered as `artist:name` in output, while the detail
+    // menu adds the source tag (`name`). Treat both forms as the same tag.
+    const artistPrefix = 'artist:';
+    return normalized.startsWith(artistPrefix) &&
+        tags.contains(normalized.substring(artistPrefix.length));
+  }
+
+  Iterable<String> filterTags(Iterable<String> values) sync* {
+    for (final value in values) {
+      if (!contains(value)) yield value;
+    }
+  }
+
+  /// Filters comma-separated prompt tags by exact normalized tag identity.
+  /// It deliberately never performs substring replacement, so filtering
+  /// `watermark` cannot damage unrelated tags or free-form prompt text.
+  String filterPrompt(String prompt) {
+    if (prompt.trim().isEmpty || tags.isEmpty) return prompt.trim();
+    return prompt
+        .split(',')
+        .map((part) => part.trim())
+        .where((part) => part.isNotEmpty && !contains(part))
+        .join(', ');
+  }
+
+  static String? normalizeTag(String value) {
+    var normalized = value.trim().toLowerCase();
+    if (normalized.isEmpty) return null;
+
+    while (normalized.startsWith('-')) {
+      normalized = normalized.substring(1).trimLeft();
+    }
+
+    // Common NovelAI emphasis wrappers and numeric emphasis syntax should not
+    // prevent an otherwise exact configured tag from matching.
+    var changed = true;
+    while (changed && normalized.length > 1) {
+      changed = false;
+      for (final wrapper in const [('(', ')'), ('[', ']'), ('{', '}')]) {
+        if (normalized.startsWith(wrapper.$1) &&
+            normalized.endsWith(wrapper.$2)) {
+          normalized = normalized.substring(1, normalized.length - 1).trim();
+          changed = true;
+        }
+      }
+    }
+    final weighted = RegExp(r'^\d+(?:\.\d+)?::(.+)::$').firstMatch(normalized);
+    if (weighted != null) normalized = weighted.group(1)!.trim();
+
+    normalized = normalized.replaceAll(RegExp(r'\s+'), '_');
+    return normalized.isEmpty ? null : normalized;
+  }
+}
+
+final onlineGalleryOutputFilterProvider =
+    NotifierProvider<
+      OnlineGalleryOutputFilterNotifier,
+      OnlineGalleryOutputFilterSettings
+    >(OnlineGalleryOutputFilterNotifier.new);
+
+class OnlineGalleryOutputFilterNotifier
+    extends Notifier<OnlineGalleryOutputFilterSettings> {
+  LocalStorageService get _storage => ref.read(localStorageServiceProvider);
+
+  @override
+  OnlineGalleryOutputFilterSettings build() {
+    final stored = _storage.getSetting<List<dynamic>>(
+      StorageKeys.onlineGalleryOutputFilterTags,
+    );
+    final tags = stored == null
+        ? OnlineGalleryOutputFilterSettings.defaultTags
+        : _normalizeTags(stored.whereType<String>());
+    return OnlineGalleryOutputFilterSettings(tags: Set.unmodifiable(tags));
+  }
+
+  Future<bool> addTag(String input) async {
+    final normalized = OnlineGalleryOutputFilterSettings.normalizeTag(input);
+    if (normalized == null || state.tags.contains(normalized)) return false;
+    await _save({...state.tags, normalized});
+    return true;
+  }
+
+  Future<int> addTags(Iterable<String> inputs) async {
+    final next = {...state.tags};
+    for (final input in inputs) {
+      final normalized = OnlineGalleryOutputFilterSettings.normalizeTag(input);
+      if (normalized != null) next.add(normalized);
+    }
+    final added = next.length - state.tags.length;
+    if (added > 0) await _save(next);
+    return added;
+  }
+
+  Future<void> removeTag(String input) async {
+    final normalized = OnlineGalleryOutputFilterSettings.normalizeTag(input);
+    if (normalized == null || !state.tags.contains(normalized)) return;
+    await _save({...state.tags}..remove(normalized));
+  }
+
+  Future<void> clear() => _save(const <String>{});
+
+  Future<void> resetToDefaults() =>
+      _save(OnlineGalleryOutputFilterSettings.defaultTags);
+
+  Set<String> _normalizeTags(Iterable<String> values) => values
+      .map(OnlineGalleryOutputFilterSettings.normalizeTag)
+      .whereType<String>()
+      .toSet();
+
+  Future<void> _save(Set<String> tags) async {
+    final normalized = _normalizeTags(tags);
+    await _storage.setSetting<List<String>>(
+      StorageKeys.onlineGalleryOutputFilterTags,
+      normalized.toList()..sort(),
+    );
+    state = OnlineGalleryOutputFilterSettings(
+      tags: Set.unmodifiable(normalized),
+    );
+  }
+}

--- a/lib/presentation/providers/online_gallery_prompt_tag_settings_provider.dart
+++ b/lib/presentation/providers/online_gallery_prompt_tag_settings_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/constants/storage_keys.dart';
 import '../../core/storage/local_storage_service.dart';
 import '../../data/models/online_gallery/gallery_item.dart';
+import 'online_gallery_output_filter_provider.dart';
 
 enum OnlineGalleryPromptTagCategory {
   general,
@@ -39,7 +40,10 @@ class OnlineGalleryPromptTagSettings {
     );
   }
 
-  String promptFor(GalleryItem item) {
+  String promptFor(
+    GalleryItem item, {
+    OnlineGalleryOutputFilterSettings? outputFilter,
+  }) {
     final categoryTags = <OnlineGalleryPromptTagCategory, List<String>>{
       OnlineGalleryPromptTagCategory.general: item.generalTags,
       OnlineGalleryPromptTagCategory.character: item.characterTags,
@@ -53,17 +57,22 @@ class OnlineGalleryPromptTagSettings {
 
     // Gelbooru and AI TAG do not always expose per-category fields. Keeping the
     // source-provided tag list prevents the selector from erasing their prompt.
-    if (!hasCategorizedTags) return item.tags.join(', ');
+    if (!hasCategorizedTags) {
+      return (outputFilter?.filterTags(item.tags) ?? item.tags).join(', ');
+    }
 
     final selectedTags = <String>{};
     for (final category in _promptCategoryOrder) {
       if (!categories.contains(category)) continue;
       for (final tag in categoryTags[category]!) {
-        selectedTags.add(
-          category == OnlineGalleryPromptTagCategory.artist
-              ? _formatArtistTag(tag)
-              : tag,
-        );
+        final rendered = category == OnlineGalleryPromptTagCategory.artist
+            ? _formatArtistTag(tag)
+            : tag;
+        if (outputFilter?.contains(tag) == true ||
+            outputFilter?.contains(rendered) == true) {
+          continue;
+        }
+        selectedTags.add(rendered);
       }
     }
     return selectedTags.join(', ');

--- a/lib/presentation/screens/online_gallery/online_gallery_screen.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen.dart
@@ -21,6 +21,7 @@ import '../../../data/models/queue/replication_task.dart';
 import '../../../data/services/danbooru_auth_service.dart';
 import '../../../data/services/gelbooru_auth_service.dart';
 
+import '../../providers/online_gallery_output_filter_provider.dart';
 import '../../providers/online_gallery_prompt_tag_settings_provider.dart';
 import '../../providers/online_gallery_provider.dart';
 import '../../providers/replication_queue_provider.dart';
@@ -33,6 +34,7 @@ import '../../widgets/online_gallery/post_detail_dialog.dart';
 import '../../widgets/online_gallery/ai_tag_detail_dialog.dart';
 import '../../widgets/online_gallery/blacklist_settings_panel.dart';
 import '../../widgets/online_gallery/online_gallery_hover_controller.dart';
+import '../../widgets/online_gallery/output_filter_settings_panel.dart';
 
 import '../../widgets/common/app_toast.dart';
 import '../../widgets/bulk_action_bar.dart';
@@ -1203,6 +1205,34 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
             ),
           ),
         ),
+        Consumer(
+          builder: (context, filterRef, _) {
+            final count = filterRef.watch(
+              onlineGalleryOutputFilterProvider.select(
+                (settings) => settings.tags.length,
+              ),
+            );
+            return Tooltip(
+              message: context.l10n.onlineGallery_outputFilterTooltip,
+              child: OutlinedButton.icon(
+                key: const ValueKey('online-gallery-output-filter'),
+                onPressed: () => showOnlineGalleryOutputFilterDialog(context),
+                icon: const Icon(Icons.filter_alt_off_outlined, size: 17),
+                label: Text(
+                  '${context.l10n.onlineGallery_outputFilter} · $count',
+                ),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: theme.colorScheme.onSurfaceVariant,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 7,
+                  ),
+                  visualDensity: VisualDensity.compact,
+                ),
+              ),
+            );
+          },
+        ),
         _buildPromptTagCategorySelector(theme),
         if (state.viewMode == GalleryViewMode.popular && includePopularOptions)
           _buildPopularOptions(theme, state),
@@ -2111,11 +2141,20 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
                 (value.isActive, value.selectedIds.contains(post.stableKey)),
           ),
         );
-        final tagPrompt = cardRef.watch(
-          onlineGalleryPromptTagSettingsProvider.select(
-            (value) => value.promptFor(post),
-          ),
+        final promptTagSettings = cardRef.watch(
+          onlineGalleryPromptTagSettingsProvider,
         );
+        final outputFilter = cardRef.watch(onlineGalleryOutputFilterProvider);
+        final tagPrompt = promptTagSettings.promptFor(
+          post,
+          outputFilter: outputFilter,
+        );
+        final filteredPromptOverride = promptOverride == null
+            ? null
+            : outputFilter.filterPrompt(promptOverride);
+        final filteredCopyText = post.artistChain == null
+            ? null
+            : outputFilter.filterPrompt(post.artistChain!.formattedText);
         return DanbooruPostCard(
           key: ValueKey(post.stableKey),
           post: post,
@@ -2126,12 +2165,12 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
           favoriteReadOnly: favoriteReadOnly,
           selectionMode: selectionState.$1,
           isSelected: selectionState.$2,
-          canSelect: (promptOverride ?? tagPrompt).isNotEmpty,
+          canSelect: (filteredPromptOverride ?? tagPrompt).isNotEmpty,
           tagPrompt: tagPrompt,
-          promptOverride: promptOverride,
+          promptOverride: filteredPromptOverride,
           negativePromptOverride:
               targetMedia?.negativePrompt ?? detail?.negativePrompt,
-          copyTextOverride: post.artistChain?.formattedText,
+          copyTextOverride: filteredCopyText,
           copyTooltip: post.artistChain != null
               ? context.l10n.onlineGallery_copyArtistChain
               : null,
@@ -2458,6 +2497,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
     final selectionState = ref.read(onlineGallerySelectionNotifierProvider);
     final galleryState = ref.read(onlineGalleryNotifierProvider);
     final promptTagSettings = ref.read(onlineGalleryPromptTagSettingsProvider);
+    final outputFilter = ref.read(onlineGalleryOutputFilterProvider);
 
     final selectedPosts = galleryState.posts
         .where((p) => selectionState.selectedIds.contains(p.stableKey))
@@ -2475,7 +2515,10 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
       final resolved = await Future.wait(
         batch.map((post) async {
           if (post.sourceId != GallerySourceId.aiTag) {
-            final prompt = promptTagSettings.promptFor(post);
+            final prompt = promptTagSettings.promptFor(
+              post,
+              outputFilter: outputFilter,
+            );
             return prompt.isEmpty
                 ? null
                 : ReplicationTask.create(
@@ -2494,10 +2537,11 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
             final media = focusedIndex >= 0
                 ? detail.media[focusedIndex]
                 : detail.media.first;
-            final prompt =
+            final rawPrompt =
                 media.prompt ??
                 detail.prompt ??
-                promptTagSettings.promptFor(post);
+                promptTagSettings.promptFor(post, outputFilter: outputFilter);
+            final prompt = outputFilter.filterPrompt(rawPrompt);
             if (prompt.isEmpty) return null;
             return ReplicationTask.create(
               prompt: prompt,

--- a/lib/presentation/widgets/danbooru_post_card.dart
+++ b/lib/presentation/widgets/danbooru_post_card.dart
@@ -853,14 +853,17 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
                                       ? context.l10n.localGallery_copyPrompt
                                       : context.l10n.onlineGallery_copyTags),
                               onPressed: () async {
-                                final prompt =
-                                    widget.copyTextOverride
-                                            ?.trim()
-                                            .isNotEmpty ==
-                                        true
-                                    ? widget.copyTextOverride!.trim()
-                                    : _promptForAction();
+                                final prompt = widget.copyTextOverride == null
+                                    ? _promptForAction()
+                                    : widget.copyTextOverride!.trim();
                                 if (prompt == null) return;
+                                if (prompt.isEmpty) {
+                                  AppToast.info(
+                                    context,
+                                    context.l10n.onlineGallery_noTagInfo,
+                                  );
+                                  return;
+                                }
                                 try {
                                   await Clipboard.setData(
                                     ClipboardData(text: prompt),

--- a/lib/presentation/widgets/online_gallery/ai_tag_detail_dialog.dart
+++ b/lib/presentation/widgets/online_gallery/ai_tag_detail_dialog.dart
@@ -20,11 +20,14 @@ import '../../../data/models/online_gallery/gallery_source.dart';
 import '../../../data/models/queue/replication_task.dart';
 import '../../../data/services/online_gallery/artist_chain_parser.dart';
 import '../../providers/character_prompt_provider.dart';
+import '../../providers/online_gallery_output_filter_provider.dart';
 import '../../providers/online_gallery_provider.dart';
 import '../../providers/pending_prompt_provider.dart';
 import '../../providers/replication_queue_provider.dart';
 import '../../providers/reverse_prompt_provider.dart';
 import '../common/app_toast.dart';
+import '../tag_chip.dart';
+import 'gallery_tag_context_menu.dart';
 
 Future<void> showAiTagDetailDialog(
   BuildContext context, {
@@ -426,7 +429,14 @@ class _AiTagDetailDialogState extends ConsumerState<_AiTagDetailDialog> {
     GalleryMedia media,
   ) {
     final item = detail.item;
+    final outputFilter = ref.watch(onlineGalleryOutputFilterProvider);
     final artistChain = ArtistChainParser.parse(media.prompt);
+    final filteredArtistChain = outputFilter.filterPrompt(
+      artistChain.formattedText,
+    );
+    final filteredMediaPrompt = media.prompt == null
+        ? null
+        : outputFilter.filterPrompt(media.prompt!);
     final artistHuntMode = widget.item.focusedMediaId != null;
     return ListView(
       padding: const EdgeInsets.all(16),
@@ -473,12 +483,19 @@ class _AiTagDetailDialogState extends ConsumerState<_AiTagDetailDialog> {
           spacing: 6,
           runSpacing: 6,
           children: item.tags
-              .map(
-                (tag) => Chip(
-                  label: Text(tag),
-                  visualDensity: VisualDensity.compact,
-                ),
-              )
+              .map((tag) {
+                final filtered = outputFilter.contains(tag);
+                return SimpleTagChip(
+                  tag: tag,
+                  autoTranslate: false,
+                  isOutputFiltered: filtered,
+                  tooltip: filtered
+                      ? context.l10n.onlineGallery_outputFilteredTagTooltip
+                      : context.l10n.onlineGallery_tagContextMenuTooltip,
+                  onSecondaryTapDown: (details) =>
+                      _showTagContextMenu(tag, details),
+                );
+              })
               .toList(growable: false),
         ),
         const SizedBox(height: 16),
@@ -507,8 +524,8 @@ class _AiTagDetailDialogState extends ConsumerState<_AiTagDetailDialog> {
           children: [
             if (artistHuntMode) ...[
               FilledButton.tonalIcon(
-                onPressed: artistChain.isNotEmpty
-                    ? () => _copy(artistChain.formattedText)
+                onPressed: filteredArtistChain.isNotEmpty
+                    ? () => _copy(filteredArtistChain)
                     : null,
                 icon: const Icon(Icons.brush_outlined, size: 16),
                 label: Text(
@@ -518,8 +535,8 @@ class _AiTagDetailDialogState extends ConsumerState<_AiTagDetailDialog> {
                 ),
               ),
               OutlinedButton.icon(
-                onPressed: media.prompt?.isNotEmpty == true
-                    ? () => _copy(media.prompt!)
+                onPressed: filteredMediaPrompt?.isNotEmpty == true
+                    ? () => _copy(filteredMediaPrompt!)
                     : null,
                 icon: const Icon(Icons.copy_all, size: 16),
                 label: Text(context.l10n.onlineGallery_copyFullPrompt),
@@ -533,8 +550,8 @@ class _AiTagDetailDialogState extends ConsumerState<_AiTagDetailDialog> {
               ),
             ] else
               OutlinedButton.icon(
-                onPressed: media.prompt?.isNotEmpty == true
-                    ? () => _copy(media.prompt!)
+                onPressed: filteredMediaPrompt?.isNotEmpty == true
+                    ? () => _copy(filteredMediaPrompt!)
                     : null,
                 icon: const Icon(Icons.copy, size: 16),
                 label: Text(context.l10n.localGallery_copyPrompt),
@@ -636,13 +653,27 @@ class _AiTagDetailDialogState extends ConsumerState<_AiTagDetailDialog> {
     }
   }
 
+  Future<void> _showTagContextMenu(String tag, TapDownDetails details) async {
+    final action = await showOnlineGalleryTagContextMenu(
+      context: context,
+      ref: ref,
+      tag: tag,
+      globalPosition: details.globalPosition,
+    );
+    if (!mounted || action != OnlineGalleryTagContextAction.blacklist) return;
+    final notifier = ref.read(onlineGalleryNotifierProvider.notifier);
+    Navigator.pop(context);
+    notifier.refresh();
+  }
+
   void _copy(String value) {
     Clipboard.setData(ClipboardData(text: value));
     AppToast.success(context, context.l10n.onlineGallery_copied);
   }
 
   String _promptFor(GalleryDetail detail, GalleryMedia media) {
-    return media.prompt ?? detail.prompt ?? detail.item.tags.join(', ');
+    final raw = media.prompt ?? detail.prompt ?? detail.item.tags.join(', ');
+    return ref.read(onlineGalleryOutputFilterProvider).filterPrompt(raw);
   }
 
   String _fullMetadata(GalleryMedia media) {

--- a/lib/presentation/widgets/online_gallery/gallery_tag_context_menu.dart
+++ b/lib/presentation/widgets/online_gallery/gallery_tag_context_menu.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/utils/localization_extension.dart';
+import '../../providers/online_gallery_blacklist_provider.dart';
+import '../../providers/online_gallery_output_filter_provider.dart';
+import '../common/app_toast.dart';
+
+enum OnlineGalleryTagContextAction { outputFilter, blacklist }
+
+Future<OnlineGalleryTagContextAction?> showOnlineGalleryTagContextMenu({
+  required BuildContext context,
+  required WidgetRef ref,
+  required String tag,
+  required Offset globalPosition,
+}) async {
+  final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+  final outputFilter = ref.read(onlineGalleryOutputFilterProvider);
+  final blacklist = ref.read(onlineGalleryBlacklistNotifierProvider);
+  final normalized = OnlineGalleryOutputFilterSettings.normalizeTag(tag);
+  final isOutputFiltered = outputFilter.contains(tag);
+  final isBlacklisted =
+      normalized != null && blacklist.effectiveTags.contains(normalized);
+
+  final action = await showMenu<OnlineGalleryTagContextAction>(
+    context: context,
+    position: RelativeRect.fromRect(
+      Rect.fromLTWH(globalPosition.dx, globalPosition.dy, 0, 0),
+      Offset.zero & overlay.size,
+    ),
+    items: [
+      PopupMenuItem(
+        value: OnlineGalleryTagContextAction.outputFilter,
+        enabled: !isOutputFiltered,
+        child: ListTile(
+          contentPadding: EdgeInsets.zero,
+          dense: true,
+          leading: Icon(
+            isOutputFiltered
+                ? Icons.check_circle_outline
+                : Icons.filter_alt_off_outlined,
+            size: 20,
+          ),
+          title: Text(
+            isOutputFiltered
+                ? context.l10n.onlineGallery_outputFilterAlreadyAdded
+                : context.l10n.onlineGallery_addTagToOutputFilter,
+          ),
+          subtitle: Text(context.l10n.onlineGallery_outputFilterMenuHint),
+        ),
+      ),
+      PopupMenuItem(
+        value: OnlineGalleryTagContextAction.blacklist,
+        enabled: !isBlacklisted,
+        child: ListTile(
+          contentPadding: EdgeInsets.zero,
+          dense: true,
+          leading: Icon(
+            isBlacklisted ? Icons.check_circle_outline : Icons.block,
+            size: 20,
+          ),
+          title: Text(
+            isBlacklisted
+                ? context.l10n.onlineGallery_blacklistAlreadyAdded
+                : context.l10n.onlineGallery_addTagToBlacklist,
+          ),
+          subtitle: Text(context.l10n.onlineGallery_blacklistMenuHint),
+        ),
+      ),
+    ],
+  );
+
+  if (action == OnlineGalleryTagContextAction.outputFilter) {
+    final added = await ref
+        .read(onlineGalleryOutputFilterProvider.notifier)
+        .addTag(tag);
+    if (added && context.mounted) {
+      AppToast.success(
+        context,
+        context.l10n.onlineGallery_outputFilterTagAdded(tag),
+      );
+    }
+  } else if (action == OnlineGalleryTagContextAction.blacklist) {
+    await ref
+        .read(onlineGalleryBlacklistNotifierProvider.notifier)
+        .addLocalTag(tag);
+    if (context.mounted) {
+      AppToast.success(
+        context,
+        context.l10n.onlineGallery_blacklistTagAdded(tag),
+      );
+    }
+  }
+  return action;
+}

--- a/lib/presentation/widgets/online_gallery/output_filter_settings_panel.dart
+++ b/lib/presentation/widgets/online_gallery/output_filter_settings_panel.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/utils/localization_extension.dart';
+import '../../providers/online_gallery_output_filter_provider.dart';
+import '../autocomplete/autocomplete_config.dart';
+import '../autocomplete/autocomplete_wrapper.dart';
+
+class OnlineGalleryOutputFilterSettingsPanel extends ConsumerStatefulWidget {
+  const OnlineGalleryOutputFilterSettingsPanel({super.key});
+
+  @override
+  ConsumerState<OnlineGalleryOutputFilterSettingsPanel> createState() =>
+      _OnlineGalleryOutputFilterSettingsPanelState();
+}
+
+class _OnlineGalleryOutputFilterSettingsPanelState
+    extends ConsumerState<OnlineGalleryOutputFilterSettingsPanel> {
+  final TextEditingController _tagController = TextEditingController();
+  final FocusNode _tagFocusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _tagController.dispose();
+    _tagFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final settings = ref.watch(onlineGalleryOutputFilterProvider);
+    final tags = settings.tags.toList()..sort();
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(
+              Icons.filter_alt_off_outlined,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    context.l10n.onlineGallery_outputFilterTitle,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    context.l10n.onlineGallery_outputFilterSubtitle,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primaryContainer,
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: Text(
+                '${tags.length}',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onPrimaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Row(
+          children: [
+            Expanded(
+              child: AutocompleteWrapper(
+                controller: _tagController,
+                focusNode: _tagFocusNode,
+                config: const AutocompleteConfig(
+                  minQueryLength: 1,
+                  autoInsertComma: false,
+                ),
+                onSuggestionSelected: (_) => _addTags(),
+                child: TextField(
+                  controller: _tagController,
+                  focusNode: _tagFocusNode,
+                  decoration: InputDecoration(
+                    isDense: true,
+                    border: const OutlineInputBorder(),
+                    hintText: context.l10n.onlineGallery_outputFilterAddHint,
+                    helperText:
+                        context.l10n.onlineGallery_outputFilterInputHint,
+                  ),
+                  onSubmitted: (_) => _addTags(),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            IconButton.filledTonal(
+              tooltip: context.l10n.common_add,
+              onPressed: _addTags,
+              icon: const Icon(Icons.add),
+            ),
+          ],
+        ),
+        const SizedBox(height: 14),
+        Container(
+          width: double.infinity,
+          constraints: const BoxConstraints(maxHeight: 280),
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerLow,
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(color: theme.colorScheme.outlineVariant),
+          ),
+          child: tags.isEmpty
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 24),
+                    child: Text(
+                      context.l10n.onlineGallery_outputFilterEmpty,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                )
+              : SingleChildScrollView(
+                  child: Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: [
+                      for (final tag in tags)
+                        InputChip(
+                          label: Text(tag.replaceAll('_', ' ')),
+                          avatar: const Icon(
+                            Icons.filter_alt_off_outlined,
+                            size: 15,
+                          ),
+                          tooltip: tag,
+                          onDeleted: () => ref
+                              .read(onlineGalleryOutputFilterProvider.notifier)
+                              .removeTag(tag),
+                          visualDensity: VisualDensity.compact,
+                        ),
+                    ],
+                  ),
+                ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            TextButton.icon(
+              onPressed: _resetDefaults,
+              icon: const Icon(Icons.restore, size: 18),
+              label: Text(
+                context.l10n.onlineGallery_outputFilterRestoreDefaults,
+              ),
+            ),
+            const Spacer(),
+            TextButton.icon(
+              onPressed: tags.isEmpty ? null : _clearAll,
+              icon: const Icon(Icons.delete_outline, size: 18),
+              label: Text(context.l10n.common_clear),
+              style: TextButton.styleFrom(
+                foregroundColor: theme.colorScheme.error,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Future<void> _addTags() async {
+    final values = _tagController.text
+        .split(RegExp(r'[,\n，、]+'))
+        .map((value) => value.trim())
+        .where((value) => value.isNotEmpty);
+    if (values.isEmpty) return;
+    await ref.read(onlineGalleryOutputFilterProvider.notifier).addTags(values);
+    if (!mounted) return;
+    _tagController.clear();
+    _tagFocusNode.requestFocus();
+  }
+
+  Future<void> _resetDefaults() async {
+    await ref
+        .read(onlineGalleryOutputFilterProvider.notifier)
+        .resetToDefaults();
+  }
+
+  Future<void> _clearAll() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(context.l10n.onlineGallery_outputFilterClearTitle),
+        content: Text(context.l10n.onlineGallery_outputFilterClearConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(context.l10n.common_cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(context.l10n.common_clear),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await ref.read(onlineGalleryOutputFilterProvider.notifier).clear();
+    }
+  }
+}
+
+Future<void> showOnlineGalleryOutputFilterDialog(BuildContext context) async {
+  await showDialog<void>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(context.l10n.onlineGallery_outputFilter),
+      content: const SizedBox(
+        width: 720,
+        child: OnlineGalleryOutputFilterSettingsPanel(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(context.l10n.common_close),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/presentation/widgets/online_gallery/post_detail_dialog.dart
+++ b/lib/presentation/widgets/online_gallery/post_detail_dialog.dart
@@ -14,6 +14,7 @@ import '../../../data/models/queue/replication_task.dart';
 import '../../../data/services/danbooru_auth_service.dart';
 import '../../../core/autocomplete/tag_translation_lookup.dart';
 import '../../providers/character_prompt_provider.dart';
+import '../../providers/online_gallery_output_filter_provider.dart';
 import '../../providers/online_gallery_prompt_tag_settings_provider.dart';
 import '../../providers/online_gallery_provider.dart';
 import '../../providers/pending_prompt_provider.dart';
@@ -22,6 +23,7 @@ import '../../providers/reverse_prompt_provider.dart';
 import '../tag_chip.dart';
 import '../../widgets/common/themed_divider.dart';
 import '../../widgets/common/app_toast.dart';
+import 'gallery_tag_context_menu.dart';
 import 'video_player_widget.dart';
 
 /// 在线画廊帖子详情弹窗
@@ -466,6 +468,7 @@ class _PostDetailDialogState extends ConsumerState<PostDetailDialog>
   /// 标签区域
   Widget _buildTagsSection(ThemeData theme) {
     final translationService = ref.watch(tagTranslationLookupProvider);
+    final outputFilter = ref.watch(onlineGalleryOutputFilterProvider);
     final generalTags = _generalDisplayTags(widget.post);
 
     return SingleChildScrollView(
@@ -487,7 +490,9 @@ class _PostDetailDialogState extends ConsumerState<PostDetailDialog>
               tags: widget.post.artistTags,
               color: TagColors.artist,
               translationService: translationService,
+              outputFilter: outputFilter,
               onTagTap: _handleTagTap,
+              onTagSecondaryTapDown: _handleTagSecondaryTapDown,
             ),
           // 角色标签
           if (widget.post.characterTags.isNotEmpty)
@@ -496,7 +501,9 @@ class _PostDetailDialogState extends ConsumerState<PostDetailDialog>
               tags: widget.post.characterTags,
               color: TagColors.character,
               translationService: translationService,
+              outputFilter: outputFilter,
               onTagTap: _handleTagTap,
+              onTagSecondaryTapDown: _handleTagSecondaryTapDown,
             ),
           // 版权标签
           if (widget.post.copyrightTags.isNotEmpty)
@@ -505,7 +512,9 @@ class _PostDetailDialogState extends ConsumerState<PostDetailDialog>
               tags: widget.post.copyrightTags,
               color: TagColors.copyright,
               translationService: translationService,
+              outputFilter: outputFilter,
               onTagTap: _handleTagTap,
+              onTagSecondaryTapDown: _handleTagSecondaryTapDown,
             ),
           // 通用标签
           if (generalTags.isNotEmpty)
@@ -514,7 +523,9 @@ class _PostDetailDialogState extends ConsumerState<PostDetailDialog>
               tags: generalTags,
               color: TagColors.general,
               translationService: translationService,
+              outputFilter: outputFilter,
               onTagTap: _handleTagTap,
+              onTagSecondaryTapDown: _handleTagSecondaryTapDown,
             ),
           // 元标签
           if (widget.post.metaTags.isNotEmpty)
@@ -523,7 +534,9 @@ class _PostDetailDialogState extends ConsumerState<PostDetailDialog>
               tags: widget.post.metaTags,
               color: TagColors.meta,
               translationService: translationService,
+              outputFilter: outputFilter,
               onTagTap: _handleTagTap,
+              onTagSecondaryTapDown: _handleTagSecondaryTapDown,
             ),
         ],
       ),
@@ -533,6 +546,24 @@ class _PostDetailDialogState extends ConsumerState<PostDetailDialog>
   void _handleTagTap(String tag) {
     _close();
     widget.onTagTap?.call(tag);
+  }
+
+  Future<void> _handleTagSecondaryTapDown(
+    String tag,
+    TapDownDetails details,
+  ) async {
+    final action = await showOnlineGalleryTagContextMenu(
+      context: context,
+      ref: ref,
+      tag: tag,
+      globalPosition: details.globalPosition,
+    );
+    if (!mounted || action != OnlineGalleryTagContextAction.blacklist) return;
+
+    // The current post may no longer belong in the visible result set.
+    final notifier = ref.read(onlineGalleryNotifierProvider.notifier);
+    await _close();
+    notifier.refresh();
   }
 
   /// 操作按钮区域
@@ -610,8 +641,12 @@ class _PostDetailDialogState extends ConsumerState<PostDetailDialog>
     );
   }
 
-  String get _actionPrompt =>
-      ref.read(onlineGalleryPromptTagSettingsProvider).promptFor(widget.post);
+  String get _actionPrompt {
+    final outputFilter = ref.read(onlineGalleryOutputFilterProvider);
+    return ref
+        .read(onlineGalleryPromptTagSettingsProvider)
+        .promptFor(widget.post, outputFilter: outputFilter);
+  }
 
   /// 复制标签
   void _copyTags() {
@@ -793,14 +828,18 @@ class _TagSection extends StatelessWidget {
   final List<String> tags;
   final Color color;
   final TagTranslationLookup translationService;
+  final OnlineGalleryOutputFilterSettings outputFilter;
   final Function(String) onTagTap;
+  final void Function(String, TapDownDetails) onTagSecondaryTapDown;
 
   const _TagSection({
     required this.title,
     required this.tags,
     required this.color,
     required this.translationService,
+    required this.outputFilter,
     required this.onTagTap,
+    required this.onTagSecondaryTapDown,
   });
 
   @override
@@ -839,11 +878,18 @@ class _TagSection extends StatelessWidget {
               return FutureBuilder<String?>(
                 future: translationService.translate(tag),
                 builder: (context, snapshot) {
+                  final filtered = outputFilter.contains(tag);
                   return SimpleTagChip(
                     tag: tag,
                     color: color,
                     translation: snapshot.data,
                     onTap: () => onTagTap(tag),
+                    onSecondaryTapDown: (details) =>
+                        onTagSecondaryTapDown(tag, details),
+                    isOutputFiltered: filtered,
+                    tooltip: filtered
+                        ? context.l10n.onlineGallery_outputFilteredTagTooltip
+                        : context.l10n.onlineGallery_tagContextMenuTooltip,
                   );
                 },
               );

--- a/lib/presentation/widgets/tag_chip.dart
+++ b/lib/presentation/widgets/tag_chip.dart
@@ -11,18 +11,24 @@ class SimpleTagChip extends ConsumerStatefulWidget {
   final String tag;
   final Color? color;
   final VoidCallback? onTap;
+  final GestureTapDownCallback? onSecondaryTapDown;
   final String? translation;
   final bool autoTranslate;
   final int? category;
+  final bool isOutputFiltered;
+  final String? tooltip;
 
   const SimpleTagChip({
     super.key,
     required this.tag,
     this.color,
     this.onTap,
+    this.onSecondaryTapDown,
     this.translation,
     this.autoTranslate = true,
     this.category,
+    this.isOutputFiltered = false,
+    this.tooltip,
   });
 
   @override
@@ -69,22 +75,28 @@ class _SimpleTagChipState extends ConsumerState<SimpleTagChip> {
             ? TagColors.fromCategory(widget.category!)
             : theme.colorScheme.primary);
     final translationText = widget.translation ?? _autoTranslation;
+    final stateColor = widget.isOutputFiltered
+        ? theme.colorScheme.error
+        : chipColor;
 
-    return MouseRegion(
+    final chip = MouseRegion(
       onEnter: (_) => setState(() => _isHovering = true),
       onExit: (_) => setState(() => _isHovering = false),
       child: GestureDetector(
         onTap: widget.onTap,
+        onSecondaryTapDown: widget.onSecondaryTapDown,
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 150),
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           decoration: BoxDecoration(
             color: _isHovering
-                ? chipColor.withValues(alpha: 0.3)
-                : chipColor.withValues(alpha: 0.1),
+                ? stateColor.withValues(alpha: 0.22)
+                : stateColor.withValues(
+                    alpha: widget.isOutputFiltered ? 0.08 : 0.1,
+                  ),
             borderRadius: BorderRadius.circular(4),
             border: Border.all(
-              color: chipColor.withValues(alpha: _isHovering ? 0.8 : 0.3),
+              color: stateColor.withValues(alpha: _isHovering ? 0.8 : 0.35),
             ),
           ),
           child: Row(
@@ -95,13 +107,24 @@ class _SimpleTagChipState extends ConsumerState<SimpleTagChip> {
                   displayText,
                   style: TextStyle(
                     fontSize: 11,
-                    color: chipColor,
+                    color: stateColor,
                     fontWeight: FontWeight.w500,
+                    decoration: widget.isOutputFiltered
+                        ? TextDecoration.lineThrough
+                        : null,
                   ),
                   overflow: TextOverflow.ellipsis,
                   softWrap: false,
                 ),
               ),
+              if (widget.isOutputFiltered) ...[
+                const SizedBox(width: 4),
+                Icon(
+                  Icons.filter_alt_off_outlined,
+                  size: 12,
+                  color: theme.colorScheme.error,
+                ),
+              ],
               if (translationText != null) ...[
                 const SizedBox(width: 4),
                 Flexible(
@@ -121,6 +144,9 @@ class _SimpleTagChipState extends ConsumerState<SimpleTagChip> {
         ),
       ),
     );
+    return widget.tooltip == null
+        ? chip
+        : Tooltip(message: widget.tooltip!, child: chip);
   }
 }
 

--- a/test/presentation/providers/online_gallery_output_filter_provider_test.dart
+++ b/test/presentation/providers/online_gallery_output_filter_provider_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_item.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_source.dart';
+import 'package:nai_launcher/presentation/providers/online_gallery_output_filter_provider.dart';
+import 'package:nai_launcher/presentation/providers/online_gallery_prompt_tag_settings_provider.dart';
+
+void main() {
+  group('OnlineGalleryOutputFilterSettings', () {
+    test('filters only exact normalized prompt tags', () {
+      const settings = OnlineGalleryOutputFilterSettings(
+        tags: {'watermark', 'mosaic_censoring'},
+      );
+
+      expect(
+        settings.filterPrompt(
+          'best_quality, watermark, watermark_background, {mosaic censoring}',
+        ),
+        'best_quality, watermark_background',
+      );
+    });
+
+    test('matches artist output syntax against the source artist tag', () {
+      const settings = OnlineGalleryOutputFilterSettings(
+        tags: {'example_artist'},
+      );
+
+      expect(settings.contains('artist:example_artist'), isTrue);
+      expect(settings.contains('another_example_artist'), isFalse);
+    });
+
+    test('filters categorized tags before formatting the output', () {
+      const item = GalleryItem(
+        id: 1,
+        sourceId: GallerySourceId.danbooru,
+        tags: ['solo', 'watermark', 'example_artist'],
+        tagStringGeneral: 'solo watermark',
+        tagStringArtist: 'example_artist',
+      );
+      const promptSettings = OnlineGalleryPromptTagSettings(
+        categories: {
+          OnlineGalleryPromptTagCategory.general,
+          OnlineGalleryPromptTagCategory.artist,
+        },
+      );
+      const filter = OnlineGalleryOutputFilterSettings(
+        tags: {'watermark', 'example_artist'},
+      );
+
+      expect(promptSettings.promptFor(item, outputFilter: filter), 'solo');
+    });
+  });
+
+  group('OnlineGalleryOutputFilterNotifier', () {
+    test('uses curated defaults only when no saved value exists', () {
+      final storage = _FakeStorage();
+      final container = ProviderContainer(
+        overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+      );
+      addTearDown(container.dispose);
+
+      final tags = container.read(onlineGalleryOutputFilterProvider).tags;
+      expect(tags, containsAll(['watermark', 'mosaic_censoring']));
+    });
+
+    test('preserves an explicitly saved empty list', () {
+      final storage = _FakeStorage()
+        ..values[StorageKeys.onlineGalleryOutputFilterTags] = <String>[];
+      final container = ProviderContainer(
+        overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(onlineGalleryOutputFilterProvider).tags, isEmpty);
+    });
+
+    test('normalizes, deduplicates, and persists added tags', () async {
+      final storage = _FakeStorage()
+        ..values[StorageKeys.onlineGalleryOutputFilterTags] = <String>[];
+      final container = ProviderContainer(
+        overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+      );
+      addTearDown(container.dispose);
+
+      final added = await container
+          .read(onlineGalleryOutputFilterProvider.notifier)
+          .addTags([' Watermark ', 'watermark', '-mosaic censoring']);
+
+      expect(added, 2);
+      expect(container.read(onlineGalleryOutputFilterProvider).tags, {
+        'watermark',
+        'mosaic_censoring',
+      });
+      expect(storage.values[StorageKeys.onlineGalleryOutputFilterTags], [
+        'mosaic_censoring',
+        'watermark',
+      ]);
+    });
+  });
+}
+
+class _FakeStorage extends LocalStorageService {
+  final Map<String, Object?> values = {};
+
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) {
+    return (values[key] ?? defaultValue) as T?;
+  }
+
+  @override
+  Future<void> setSetting<T>(String key, T value) async {
+    values[key] = value;
+  }
+}

--- a/test/presentation/widgets/online_gallery/output_filter_settings_panel_test.dart
+++ b/test/presentation/widgets/online_gallery/output_filter_settings_panel_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/providers/online_gallery_output_filter_provider.dart';
+import 'package:nai_launcher/presentation/widgets/online_gallery/output_filter_settings_panel.dart';
+
+void main() {
+  testWidgets('adds multiple output filter tags from one input', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final storage = _FakeStorage()
+      ..values[StorageKeys.onlineGalleryOutputFilterTags] = <String>[];
+    late ProviderContainer container;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+        child: Consumer(
+          builder: (context, ref, _) {
+            container = ProviderScope.containerOf(context);
+            return const MaterialApp(
+              locale: Locale('en'),
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: Center(
+                  child: SizedBox(
+                    width: 720,
+                    child: OnlineGalleryOutputFilterSettingsPanel(),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'Custom Tag，watermark');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+
+    expect(container.read(onlineGalleryOutputFilterProvider).tags, {
+      'custom_tag',
+      'watermark',
+    });
+    expect(find.text('Custom Tag', skipOffstage: false), findsNothing);
+    expect(find.text('custom tag'), findsOneWidget);
+    expect(find.text('watermark'), findsOneWidget);
+  });
+}
+
+class _FakeStorage extends LocalStorageService {
+  final Map<String, Object?> values = {};
+
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) {
+    return (values[key] ?? defaultValue) as T?;
+  }
+
+  @override
+  Future<void> setSetting<T>(String key, T value) async {
+    values[key] = value;
+  }
+}

--- a/test/presentation/widgets/online_gallery/post_detail_dialog_test.dart
+++ b/test/presentation/widgets/online_gallery/post_detail_dialog_test.dart
@@ -1,4 +1,5 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/online_gallery/danbooru_post.dart';
 import 'package:nai_launcher/data/services/danbooru_auth_service.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/providers/online_gallery_output_filter_provider.dart';
 import 'package:nai_launcher/presentation/providers/online_gallery_prompt_tag_settings_provider.dart';
 import 'package:nai_launcher/presentation/providers/online_gallery_provider.dart';
 import 'package:nai_launcher/presentation/widgets/online_gallery/post_detail_dialog.dart';
@@ -190,6 +192,111 @@ void main() {
     await tester.pump(const Duration(milliseconds: 400));
   });
 
+  testWidgets('filtered tags are styled and omitted from copied output', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    String? copiedText;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copiedText = (call.arguments as Map)['text'] as String?;
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
+    const post = DanbooruPost(
+      id: 206,
+      site: 'danbooru',
+      previewFileUrl: 'https://cdn.donmai.us/preview/206.jpg',
+      tagString: 'solo watermark',
+      tagStringGeneral: 'solo watermark',
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          danbooruAuthProvider.overrideWith(_LoggedOutDanbooruAuth.new),
+          onlineGalleryOutputFilterProvider.overrideWith(
+            _WatermarkOutputFilterNotifier.new,
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: PostDetailDialog(post: post),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(
+      find.byTooltip(
+        'Removed when copying, sending, or adding to queue; '
+        'right-click to manage',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Copy Tags'));
+    await tester.pump();
+    expect(copiedText, 'solo');
+
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pump(const Duration(milliseconds: 400));
+  });
+
+  testWidgets('right-clicking a detail tag opens quick-list actions', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const post = DanbooruPost(
+      id: 207,
+      site: 'danbooru',
+      previewFileUrl: 'https://cdn.donmai.us/preview/207.jpg',
+      tagString: 'solo',
+      tagStringGeneral: 'solo',
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          danbooruAuthProvider.overrideWith(_LoggedOutDanbooruAuth.new),
+        ],
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: PostDetailDialog(post: post),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('solo'), buttons: kSecondaryMouseButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Add to output filter'), findsOneWidget);
+    expect(find.text('Add to blacklist'), findsOneWidget);
+  });
+
   testWidgets('Danbooru detail retains its writable favorite action', (
     tester,
   ) async {
@@ -234,6 +341,13 @@ class _GelbooruFavoriteGalleryNotifier extends OnlineGalleryNotifier {
       gelbooruFavoritesCache: ModeCache(posts: [post]),
       favoritedPostKeys: {'gelbooru:203'},
     );
+  }
+}
+
+class _WatermarkOutputFilterNotifier extends OnlineGalleryOutputFilterNotifier {
+  @override
+  OnlineGalleryOutputFilterSettings build() {
+    return const OnlineGalleryOutputFilterSettings(tags: {'watermark'});
   }
 }
 


### PR DESCRIPTION
## Problem
在线画廊中的水印、马赛克等标签会被复制、发送或加入队列，影响生成结果。

## Solution
新增输出过滤标签设置，在保留图片显示的同时，从输出提示词中精确移除指定标签。

- 支持默认过滤标签、添加/删除、自定义恢复和清空
- 应用于复制、发送、队列提示词及艺术家链输出
- 标签支持右键快速加入输出过滤或黑名单
- 使用多语言界面提示，并为过滤逻辑和设置面板添加测试