### PR TITLE
Fix Windows clipboard history paste key sequence

### DIFF
--- a/lib/core/utils/windows_clipboard_history_key_fix.dart
+++ b/lib/core/utils/windows_clipboard_history_key_fix.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:ui';
+
+/// 修正 Windows 剪贴板历史粘贴生成的异常按键序列。
+///
+/// Windows 11 从 Win+V 面板选择内容后，会用扫描码为 0 的消息模拟
+/// Ctrl+V。Flutter Windows Engine 会把这组消息错误地映射成同一个物理键，
+/// 导致文本框无法处理粘贴。上游问题：
+/// https://github.com/flutter/flutter/issues/143997
+class WindowsClipboardHistoryKeyFix {
+  WindowsClipboardHistoryKeyFix._();
+
+  static final WindowsClipboardHistoryKeyFix instance =
+      WindowsClipboardHistoryKeyFix._();
+
+  final WindowsClipboardHistoryKeyEventNormalizer _normalizer =
+      WindowsClipboardHistoryKeyEventNormalizer();
+
+  Timer? _installTimer;
+  bool _installed = false;
+
+  void install() {
+    if (!Platform.isWindows || _installed || _installTimer != null) return;
+
+    // ServicesBinding 异步同步键盘状态后才注册 onKeyData，因此需要延后包装。
+    _installTimer = Timer(const Duration(seconds: 1), () {
+      _installTimer = null;
+      final callback = PlatformDispatcher.instance.onKeyData;
+      if (callback == null || _installed) return;
+
+      PlatformDispatcher.instance.onKeyData = (data) {
+        final normalized = _normalizer.normalize(data);
+        if (normalized == null) return true;
+        return callback(normalized);
+      };
+      _installed = true;
+    });
+  }
+}
+
+/// 将 Flutter Engine 误报的 Win+V 模拟按键还原为 Ctrl+V。
+///
+/// 返回 `null` 表示该条无效中间事件应被消费。
+class WindowsClipboardHistoryKeyEventNormalizer {
+  static const int _invalidPhysicalKey = 0x1600000000;
+  static const int _controlLeftPhysicalKey = 0x700e0;
+  static const int _controlLeftLogicalKey = 0x200000100;
+  static const int _keyVPhysicalKey = 0x70019;
+  static const int _keyVLogicalKey = 0x76;
+
+  bool _normalizingClipboardPaste = false;
+
+  KeyData? normalize(KeyData data) {
+    if (!_normalizingClipboardPaste &&
+        data.physical == _invalidPhysicalKey &&
+        data.logical == _controlLeftLogicalKey &&
+        data.type == KeyEventType.down &&
+        !data.synthesized) {
+      _normalizingClipboardPaste = true;
+      return _copyAs(
+        data,
+        type: KeyEventType.down,
+        physical: _controlLeftPhysicalKey,
+        logical: _controlLeftLogicalKey,
+      );
+    }
+
+    if (_normalizingClipboardPaste &&
+        data.physical == 0 &&
+        data.logical == 0 &&
+        data.type == KeyEventType.down &&
+        !data.synthesized) {
+      return null;
+    }
+
+    if (_normalizingClipboardPaste &&
+        data.physical == _invalidPhysicalKey &&
+        data.logical == _controlLeftLogicalKey &&
+        data.type == KeyEventType.up &&
+        !data.synthesized) {
+      return _copyAs(
+        data,
+        type: KeyEventType.down,
+        physical: _keyVPhysicalKey,
+        logical: _keyVLogicalKey,
+      );
+    }
+
+    if (_normalizingClipboardPaste &&
+        data.physical == _invalidPhysicalKey &&
+        data.logical == _controlLeftLogicalKey &&
+        data.type == KeyEventType.down &&
+        data.synthesized) {
+      return _copyAs(
+        data,
+        type: KeyEventType.up,
+        physical: _keyVPhysicalKey,
+        logical: _keyVLogicalKey,
+      );
+    }
+
+    if (_normalizingClipboardPaste &&
+        data.physical == _invalidPhysicalKey &&
+        data.logical == _controlLeftLogicalKey &&
+        data.type == KeyEventType.up &&
+        data.synthesized) {
+      _normalizingClipboardPaste = false;
+      return _copyAs(
+        data,
+        type: KeyEventType.up,
+        physical: _controlLeftPhysicalKey,
+        logical: _controlLeftLogicalKey,
+      );
+    }
+
+    _normalizingClipboardPaste = false;
+    return data;
+  }
+
+  KeyData _copyAs(
+    KeyData source, {
+    required KeyEventType type,
+    required int physical,
+    required int logical,
+  }) {
+    return KeyData(
+      timeStamp: source.timeStamp,
+      type: type,
+      physical: physical,
+      logical: logical,
+      character: null,
+      synthesized: false,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'core/utils/app_logger.dart';
 import 'core/utils/hive_startup_box_opener.dart';
 import 'core/utils/hive_storage_helper.dart';
 import 'core/utils/window_focus_tracker.dart';
+import 'core/utils/windows_clipboard_history_key_fix.dart';
 import 'core/utils/window_state_coercion.dart';
 import 'core/utils/window_state_persistence.dart';
 import 'data/datasources/local/nai_tags_data_source.dart';
@@ -298,6 +299,7 @@ void main() {
 
 Future<void> _bootstrapApplication() async {
   WidgetsFlutterBinding.ensureInitialized();
+  WindowsClipboardHistoryKeyFix.instance.install();
   AppErrorReporter.installGlobalHandlers();
 
   // 先初始化控制台日志；文件日志稍后读取设置后按需开启，默认关闭。

--- a/test/core/utils/windows_clipboard_history_key_fix_test.dart
+++ b/test/core/utils/windows_clipboard_history_key_fix_test.dart
@@ -1,0 +1,119 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/utils/windows_clipboard_history_key_fix.dart';
+
+void main() {
+  group('WindowsClipboardHistoryKeyEventNormalizer', () {
+    test('restores the malformed Win+V sequence as Ctrl+V', () {
+      final normalizer = WindowsClipboardHistoryKeyEventNormalizer();
+
+      final normalized = <KeyData?>[
+        normalizer.normalize(
+          _keyData(
+            type: KeyEventType.down,
+            physical: 0x1600000000,
+            logical: 0x200000100,
+          ),
+        ),
+        normalizer.normalize(
+          _keyData(type: KeyEventType.down, physical: 0, logical: 0),
+        ),
+        normalizer.normalize(
+          _keyData(
+            type: KeyEventType.up,
+            physical: 0x1600000000,
+            logical: 0x200000100,
+          ),
+        ),
+        normalizer.normalize(
+          _keyData(
+            type: KeyEventType.down,
+            physical: 0x1600000000,
+            logical: 0x200000100,
+            synthesized: true,
+          ),
+        ),
+        normalizer.normalize(
+          _keyData(
+            type: KeyEventType.up,
+            physical: 0x1600000000,
+            logical: 0x200000100,
+            synthesized: true,
+          ),
+        ),
+      ];
+
+      expect(
+        normalized[0],
+        _matchesKey(KeyEventType.down, 0x700e0, 0x200000100),
+      );
+      expect(normalized[1], isNull);
+      expect(normalized[2], _matchesKey(KeyEventType.down, 0x70019, 0x76));
+      expect(normalized[3], _matchesKey(KeyEventType.up, 0x70019, 0x76));
+      expect(normalized[4], _matchesKey(KeyEventType.up, 0x700e0, 0x200000100));
+    });
+
+    test('leaves unrelated events unchanged', () {
+      final normalizer = WindowsClipboardHistoryKeyEventNormalizer();
+      final event = _keyData(
+        type: KeyEventType.down,
+        physical: 0x70004,
+        logical: 0x61,
+      );
+
+      expect(normalizer.normalize(event), same(event));
+    });
+
+    test('abandons normalization when the sequence is interrupted', () {
+      final normalizer = WindowsClipboardHistoryKeyEventNormalizer();
+      normalizer.normalize(
+        _keyData(
+          type: KeyEventType.down,
+          physical: 0x1600000000,
+          logical: 0x200000100,
+        ),
+      );
+      final interruption = _keyData(
+        type: KeyEventType.down,
+        physical: 0x70004,
+        logical: 0x61,
+      );
+      final laterMalformedEvent = _keyData(
+        type: KeyEventType.up,
+        physical: 0x1600000000,
+        logical: 0x200000100,
+      );
+
+      expect(normalizer.normalize(interruption), same(interruption));
+      expect(
+        normalizer.normalize(laterMalformedEvent),
+        same(laterMalformedEvent),
+      );
+    });
+  });
+}
+
+KeyData _keyData({
+  required KeyEventType type,
+  required int physical,
+  required int logical,
+  bool synthesized = false,
+}) {
+  return KeyData(
+    timeStamp: const Duration(milliseconds: 1),
+    type: type,
+    physical: physical,
+    logical: logical,
+    character: null,
+    synthesized: synthesized,
+  );
+}
+
+Matcher _matchesKey(KeyEventType type, int physical, int logical) {
+  return isA<KeyData>()
+      .having((event) => event.type, 'type', type)
+      .having((event) => event.physical, 'physical', physical)
+      .having((event) => event.logical, 'logical', logical)
+      .having((event) => event.synthesized, 'synthesized', isFalse);
+}


### PR DESCRIPTION
## Problem
On Windows 11, pasting from the Win+V clipboard history can produce malformed keyboard events, so Flutter text fields fail to paste.

## Solution
Normalize the malformed events into a standard Ctrl+V sequence and ignore invalid intermediate events. Install the fix during application startup and add tests for valid, unrelated, and interrupted sequences.