### PR TITLE
优化启动流程并支持失败重试

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -48,18 +48,21 @@ class _AppBootstrapEffectsState extends ConsumerState<AppBootstrapEffects> {
   @override
   void initState() {
     super.initState();
-    _anlasWatcherSubscription = ref.listenManual(
-      widget.anlasWatcher ?? anlasBalanceWatcherProvider,
-      (_, __) {},
-    );
-    _backgroundRefreshSubscription = ref.listenManual(
-      widget.backgroundRefresh ?? backgroundRefreshNotifierProvider,
-      (_, __) {},
-    );
-    _kritaBridgeSubscription = ref.listenManual(
-      widget.kritaBridge ?? kritaBridgeNotifierProvider,
-      (_, __) {},
-    );
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _anlasWatcherSubscription = ref.listenManual(
+        widget.anlasWatcher ?? anlasBalanceWatcherProvider,
+        (_, __) {},
+      );
+      _backgroundRefreshSubscription = ref.listenManual(
+        widget.backgroundRefresh ?? backgroundRefreshNotifierProvider,
+        (_, __) {},
+      );
+      _kritaBridgeSubscription = ref.listenManual(
+        widget.kritaBridge ?? kritaBridgeNotifierProvider,
+        (_, __) {},
+      );
+    });
   }
 
   @override
@@ -161,7 +164,6 @@ class NAILauncherApp extends ConsumerWidget {
             fontConfig: fontType.fontFamily.isEmpty ? null : fontType,
           ),
           themeMode: ThemeMode.dark, // 默认深色模式
-
           // 国际化
           locale: locale,
           supportedLocales: AppLocalizations.supportedLocales,
@@ -173,9 +175,9 @@ class NAILauncherApp extends ConsumerWidget {
           // 字体缩放全局应用
           builder: (context, child) {
             return MediaQuery(
-              data: MediaQuery.of(context).copyWith(
-                textScaler: TextScaler.linear(fontScale),
-              ),
+              data: MediaQuery.of(
+                context,
+              ).copyWith(textScaler: TextScaler.linear(fontScale)),
               child: child!,
             );
           },

--- a/lib/core/database/asset_database_manager.dart
+++ b/lib/core/database/asset_database_manager.dart
@@ -69,7 +69,6 @@ class AssetDatabaseManager {
         'tag_search': {'term', 'search_key', 'tag_id', 'kind'},
       },
     );
-    _instance._tagCatalogDbPath = catalogPath;
     await _migrateLegacyAutocompleteData(appDir, assetDbDir);
 
     final cooccurrencePath = p.join(assetDbDir.path, cooccurrenceDb);
@@ -81,9 +80,10 @@ class AssetDatabaseManager {
         'cooccurrences': {'tag1', 'tag2', 'count'},
       },
     );
-    _instance._cooccurrenceDbPath = cooccurrencePath;
-
     await _removeLegacyTranslationDatabase(assetDbDir);
+    _instance
+      .._tagCatalogDbPath = catalogPath
+      .._cooccurrenceDbPath = cooccurrencePath;
     AppLogger.i('Asset databases initialized', 'AssetDatabaseManager');
   }
 

--- a/lib/core/database/connection_pool_holder.dart
+++ b/lib/core/database/connection_pool_holder.dart
@@ -26,6 +26,7 @@ class WarmupResult {
 /// ConnectionPool 全局持有者
 class ConnectionPoolHolder {
   static ConnectionPool? _instance;
+  static Future<ConnectionPool>? _initialization;
 
   /// 连接池版本号，每次重置时递增
   /// 用于检测连接池是否在操作期间被重置
@@ -63,20 +64,55 @@ class ConnectionPoolHolder {
       );
     }
 
-    _version++;
-    final currentVersion = _version;
+    final inFlight = _initialization;
+    if (inFlight != null) return inFlight;
 
-    _instance = ConnectionPool(
+    final attempt = _initializeNew(
       dbPath: dbPath,
       maxConnections: maxConnections,
     );
-    await _instance!.initialize();
+    _initialization = attempt;
+    try {
+      return await attempt;
+    } finally {
+      if (identical(_initialization, attempt)) {
+        _initialization = null;
+      }
+    }
+  }
+
+  static Future<ConnectionPool> _initializeNew({
+    required String dbPath,
+    required int maxConnections,
+  }) async {
+    _version++;
+    final currentVersion = _version;
+    final candidate = ConnectionPool(
+      dbPath: dbPath,
+      maxConnections: maxConnections,
+    );
+    try {
+      await candidate.initialize();
+      _instance = candidate;
+    } catch (error, stackTrace) {
+      try {
+        await candidate.dispose();
+      } catch (cleanupError, cleanupStackTrace) {
+        AppLogger.e(
+          'Failed to clean up an unsuccessful connection pool',
+          cleanupError,
+          cleanupStackTrace,
+          'ConnectionPoolHolder',
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
 
     AppLogger.i(
       'ConnectionPool initialized (version: $currentVersion)',
       'ConnectionPoolHolder',
     );
-    return _instance!;
+    return candidate;
   }
 
   static Future<ConnectionPool> reset({
@@ -214,17 +250,11 @@ class ConnectionPoolHolder {
     int warmupConnections = 3,
     Duration warmupTimeout = const Duration(seconds: 5),
   }) async {
-    await reset(
-      dbPath: dbPath,
-      maxConnections: maxConnections,
-    );
+    await reset(dbPath: dbPath, maxConnections: maxConnections);
 
     // 小延迟确保连接池完全就绪
     await Future.delayed(const Duration(milliseconds: 100));
 
-    return await warmup(
-      connections: warmupConnections,
-      timeout: warmupTimeout,
-    );
+    return await warmup(connections: warmupConnections, timeout: warmupTimeout);
   }
 }

--- a/lib/core/database/database_manager.dart
+++ b/lib/core/database/database_manager.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -25,6 +24,7 @@ class DatabaseManager {
   DatabaseManager._();
 
   static DatabaseManager? _instance;
+  static Future<DatabaseManager>? _initialization;
 
   /// 获取单例实例
   static DatabaseManager get instance {
@@ -36,34 +36,65 @@ class DatabaseManager {
     return _instance!;
   }
 
-  /// 初始化数据库管理器
+  /// 初始化数据库管理器。并发调用共享同一次初始化，成功后才发布单例。
   static Future<DatabaseManager> initialize({int maxConnections = 20}) async {
-    if (_instance != null) {
-      // 检查是否可用
-      try {
-        final pool = ConnectionPoolHolder.getInstanceOrNull();
-        if (pool != null && !pool.isDisposed) {
-          AppLogger.d('DatabaseManager already initialized', 'DatabaseManager');
-          return _instance!;
-        }
+    final existing = _instance;
+    final pool = ConnectionPoolHolder.getInstanceOrNull();
+    if (existing != null &&
+        existing.isInitialized &&
+        pool != null &&
+        !pool.isDisposed) {
+      AppLogger.d('DatabaseManager already initialized', 'DatabaseManager');
+      return existing;
+    }
 
-        // 不可用，需要重置
-        AppLogger.i(
-          'DatabaseManager exists but ConnectionPool disposed, resetting...',
-          'DatabaseManager',
-        );
-        _instance = null;
-      } catch (e) {
-        _instance = null;
+    final inFlight = _initialization;
+    if (inFlight != null) return inFlight;
+
+    final attempt = _initializeNew(maxConnections: maxConnections);
+    _initialization = attempt;
+    try {
+      return await attempt;
+    } finally {
+      if (identical(_initialization, attempt)) {
+        _initialization = null;
       }
+    }
+  }
+
+  static Future<DatabaseManager> _initializeNew({
+    required int maxConnections,
+  }) async {
+    final stale = _instance;
+    if (stale != null) {
+      AppLogger.w(
+        'Discarding unusable DatabaseManager instance',
+        'DatabaseManager',
+      );
+      await stale.dispose();
+    } else if (ConnectionPoolHolder.getInstanceOrNull() != null) {
+      await ConnectionPoolHolder.dispose();
     }
 
     AppLogger.i('Initializing DatabaseManager...', 'DatabaseManager');
-
-    _instance = DatabaseManager._();
-    await _instance!._doInitialize(maxConnections: maxConnections);
-
-    return _instance!;
+    final candidate = DatabaseManager._();
+    try {
+      await candidate._doInitialize(maxConnections: maxConnections);
+      _instance = candidate;
+      return candidate;
+    } catch (error, stackTrace) {
+      try {
+        await candidate.dispose();
+      } catch (cleanupError, cleanupStackTrace) {
+        AppLogger.e(
+          'Failed to clean up an unsuccessful DatabaseManager',
+          cleanupError,
+          cleanupStackTrace,
+          'DatabaseManager',
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
   }
 
   static const int _maxConnections = 20;
@@ -72,9 +103,6 @@ class DatabaseManager {
   DatabaseInitState _state = DatabaseInitState.uninitialized;
   String? _dbPath;
   String? _errorMessage;
-
-  // 初始化完成标记
-  final _initCompleter = Completer<void>();
 
   // 数据源
   TranslationDataSource? _translationDataSource;
@@ -141,8 +169,14 @@ class DatabaseManager {
   /// 是否有错误
   bool get hasError => _state == DatabaseInitState.error;
 
-  /// 初始化完成Future
-  Future<void> get initialized => _initCompleter.future;
+  /// [initialize] 仅在完成后返回；保留此 Future 作为调用方兼容契约。
+  Future<void> get initialized {
+    if (_state == DatabaseInitState.initialized) return Future.value();
+    if (_state == DatabaseInitState.error) {
+      return Future.error(StateError(_errorMessage ?? 'Database init failed'));
+    }
+    return Future.error(StateError('Database initialization is not complete'));
+  }
 
   /// 执行初始化
   Future<void> _doInitialize({required int maxConnections}) async {
@@ -169,16 +203,11 @@ class DatabaseManager {
       _startMetricsReporting();
 
       _state = DatabaseInitState.initialized;
-      _initCompleter.complete();
 
       AppLogger.i('DatabaseManager initialized', 'DatabaseManager');
     } catch (e, stack) {
       _state = DatabaseInitState.error;
       _errorMessage = e.toString();
-
-      if (!_initCompleter.isCompleted) {
-        _initCompleter.completeError(e, stack);
-      }
 
       AppLogger.e(
         'DatabaseManager initialization failed',
@@ -368,35 +397,19 @@ class DatabaseManager {
     await ConnectionPoolHolder.dispose();
 
     _state = DatabaseInitState.uninitialized;
-    _instance = null;
+    if (identical(_instance, this)) {
+      _instance = null;
+    }
 
     AppLogger.i('DatabaseManager disposed', 'DatabaseManager');
   }
 
   Future<void> _registerRuntimeDataSources() async {
     _danbooruTagDataSource = DanbooruTagDataSource();
-    try {
-      await _danbooruTagDataSource!.initialize();
-    } catch (e, stack) {
-      AppLogger.e(
-        'Failed to initialize DanbooruTagDataSource',
-        e,
-        stack,
-        'DatabaseManager',
-      );
-    }
+    await _danbooruTagDataSource!.initialize();
 
     _galleryDataSource = GalleryDataSource();
-    try {
-      await _galleryDataSource!.initialize();
-    } catch (e, stack) {
-      AppLogger.e(
-        'Failed to initialize GalleryDataSource',
-        e,
-        stack,
-        'DatabaseManager',
-      );
-    }
+    await _galleryDataSource!.initialize();
 
     await _warmupConnectionPool();
   }

--- a/lib/core/database/database_providers.dart
+++ b/lib/core/database/database_providers.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -13,9 +11,6 @@ part 'database_providers.g.dart';
 @Riverpod(keepAlive: true)
 Future<DatabaseManager> databaseManager(Ref ref) async {
   final manager = await DatabaseManager.initialize();
-  ref.onDispose(() {
-    unawaited(manager.dispose());
-  });
   await manager.initialized;
   return manager;
 }

--- a/lib/core/services/data_migration_service.dart
+++ b/lib/core/services/data_migration_service.dart
@@ -79,8 +79,9 @@ class DataMigrationService {
       AppLogger.e('数据迁移失败: $e', 'DataMigration', stackTrace);
       result.error = e.toString();
 
-      _migratedThisSession = true;
-      _lastResult = result;
+      // 失败结果不能标记为本次进程已迁移，否则 Splash 的重试只会复用失败。
+      _migratedThisSession = false;
+      _lastResult = null;
 
       return result;
     }

--- a/lib/core/utils/hive_storage_helper.dart
+++ b/lib/core/utils/hive_storage_helper.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -22,7 +23,6 @@ class HiveStorageHelper {
 
   /// 默认子目录名称
   static const String _defaultSubDir = 'hive';
-
 
   /// Settings box 中的自定义路径键名
   static const String _customHivePathKey = 'hive_storage_path';
@@ -61,7 +61,10 @@ class HiveStorageHelper {
     try {
       // 检查旧位置的 settings.hive 文件
       final appDir = await getApplicationDocumentsDirectory();
-      final oldSettingsPath = p.join(appDir.path, '${StorageKeys.settingsBox}.hive');
+      final oldSettingsPath = p.join(
+        appDir.path,
+        '${StorageKeys.settingsBox}.hive',
+      );
       final oldSettingsFile = File(oldSettingsPath);
 
       // 如果旧位置存在 settings.hive，说明还没有迁移，返回 null 使用默认路径
@@ -73,7 +76,10 @@ class HiveStorageHelper {
       // 注意：getApplicationSupportDirectory() 已经包含应用包名，不需要再加 NAI_Launcher
       final appSupportDir = await getApplicationSupportDirectory();
       final newPath = p.join(appSupportDir.path, _defaultSubDir);
-      final newSettingsPath = p.join(newPath, '${StorageKeys.settingsBox}.hive');
+      final newSettingsPath = p.join(
+        newPath,
+        '${StorageKeys.settingsBox}.hive',
+      );
       final newSettingsFile = File(newSettingsPath);
 
       if (await newSettingsFile.exists()) {
@@ -148,15 +154,29 @@ class HiveStorageHelper {
     }
   }
 
-  /// 从旧位置迁移数据
-  ///
+  /// 在首帧前只迁移启动设置，避免打开 settings box 后被 Windows 文件锁阻止覆盖。
+  Future<void> migrateSettingsFromOldLocation(String newPath) {
+    return _migrateFromOldLocation(
+      newPath,
+      includedHiveFileNames: {'${StorageKeys.settingsBox}.hive'},
+      failOnError: false,
+    );
+  }
+
+  /// 从旧位置迁移全部数据，由 [DataMigrationService] 在预热阶段调用。
+  Future<void> migrateFromOldLocation(String newPath) {
+    return _migrateFromOldLocation(newPath);
+  }
+
   /// 旧位置 1：Documents 根目录下的 .hive 文件（最早的版本）
   /// 旧位置 2：Documents/NAI_Launcher/hive/（中间版本）
   /// 旧位置 3：%APPDATA%/NAI_Launcher/hive/（beta2.1版本）
   /// 新位置：%APPDATA%/com.example/nai_launcher/hive/（当前版本）
-  ///
-  /// 由 [DataMigrationService] 在预热阶段调用
-  Future<void> migrateFromOldLocation(String newPath) async {
+  Future<void> _migrateFromOldLocation(
+    String newPath, {
+    Set<String>? includedHiveFileNames,
+    bool failOnError = true,
+  }) async {
     try {
       final appDir = await getApplicationDocumentsDirectory();
       final appSupportDir = await getApplicationSupportDirectory();
@@ -179,7 +199,9 @@ class HiveStorageHelper {
       for (final oldLocation in oldLocations) {
         if (oldLocation == newPath) continue; // 跳过新位置
 
-        final oldFiles = await _findOldHiveFiles(oldLocation);
+        final oldFiles = includedHiveFileNames == null
+            ? await _findOldHiveFiles(oldLocation)
+            : await _findNamedOldHiveFiles(oldLocation, includedHiveFileNames);
         for (final oldFile in oldFiles) {
           final fileName = p.basename(oldFile.path);
           // 如果同名文件已存在，保留修改时间更新的
@@ -207,8 +229,11 @@ class HiveStorageHelper {
       // 确保新目录存在
       await FileSystemUtils.ensureDirectory(newPath, logTag: 'HiveStorage');
 
-      // 迁移文件
+      // 只清理已成功复制，或确认新位置版本更新的旧文件。
       var migratedCount = 0;
+      final safeToCleanup = <String>{};
+      Object? firstMigrationError;
+      StackTrace? firstMigrationStackTrace;
       for (final entry in filesToMigrate.entries) {
         final fileName = entry.key;
         final oldFile = entry.value;
@@ -224,12 +249,21 @@ class HiveStorageHelper {
 
           final newSize = newFileStat.size;
           final oldSize = oldFileStat.size;
-          final shouldPreferOldBySize = oldSize > 0 &&
+          final shouldPreferOldBySize =
+              oldSize > 0 &&
               (newSize == 0 || (newSize <= 1024 && oldSize >= newSize * 4));
 
           if (!shouldPreferOldBySize &&
               newFileStat.modified.isAfter(oldFileStat.modified)) {
-            AppLogger.d('新位置已存在更新的 $fileName，跳过迁移', 'HiveStorage');
+            final contentsMatch =
+                newSize == oldSize &&
+                await _filesHaveSameContent(newFile, oldFile);
+            if (contentsMatch) {
+              safeToCleanup.add(fileName);
+              AppLogger.d('新位置已有相同的 $fileName，跳过迁移', 'HiveStorage');
+            } else {
+              AppLogger.w('新旧 $fileName 内容不同，保留旧文件且不覆盖较新的目标文件', 'HiveStorage');
+            }
             continue;
           }
 
@@ -241,15 +275,37 @@ class HiveStorageHelper {
           }
         }
 
+        final temporaryPath = '$newFilePath.migrating';
+        final temporaryFile = File(temporaryPath);
         try {
+          if (await temporaryFile.exists()) {
+            await temporaryFile.delete();
+          }
+          await oldFile.copy(temporaryPath);
+          if (await temporaryFile.length() != await oldFile.length()) {
+            throw FileSystemException('迁移临时文件大小校验失败', temporaryPath);
+          }
           if (await newFile.exists()) {
             await newFile.delete();
           }
-          await oldFile.copy(newFilePath);
+          await temporaryFile.rename(newFilePath);
           migratedCount++;
+          safeToCleanup.add(fileName);
           AppLogger.i('已迁移: $fileName', 'HiveStorage');
-        } catch (e) {
-          AppLogger.e('迁移失败 $fileName: $e', 'HiveStorage');
+        } catch (e, stackTrace) {
+          firstMigrationError ??= e;
+          firstMigrationStackTrace ??= stackTrace;
+          AppLogger.e('迁移失败 $fileName: $e', 'HiveStorage', stackTrace);
+          try {
+            if (await temporaryFile.exists()) {
+              await temporaryFile.delete();
+            }
+          } catch (cleanupError) {
+            AppLogger.w(
+              '清理迁移临时文件失败 $temporaryPath: $cleanupError',
+              'HiveStorage',
+            );
+          }
         }
       }
 
@@ -261,13 +317,22 @@ class HiveStorageHelper {
       final cleanedCount = await _cleanupMigratedOldFiles(
         oldLocations: oldLocations,
         newPath: newPath,
-        migratedHiveFileNames: filesToMigrate.keys.toSet(),
+        migratedHiveFileNames: safeToCleanup,
       );
       if (cleanedCount > 0) {
         AppLogger.i('旧位置清理完成: $cleanedCount 个文件', 'HiveStorage');
       }
+      if (firstMigrationError != null) {
+        Error.throwWithStackTrace(
+          firstMigrationError,
+          firstMigrationStackTrace ?? StackTrace.current,
+        );
+      }
     } catch (e, stackTrace) {
       AppLogger.e('迁移过程出错: $e', 'HiveStorage', stackTrace);
+      if (failOnError) {
+        Error.throwWithStackTrace(e, stackTrace);
+      }
     }
   }
 
@@ -292,8 +357,8 @@ class HiveStorageHelper {
         final shouldDelete = switch (ext) {
           '.hive' => migratedHiveFileNames.contains(fileName),
           '.lock' || '.crc' => migratedHiveFileNames.contains(
-              '${p.basenameWithoutExtension(fileName)}.hive',
-            ),
+            '${p.basenameWithoutExtension(fileName)}.hive',
+          ),
           _ => false,
         };
 
@@ -319,6 +384,24 @@ class HiveStorageHelper {
     }
 
     return deletedCount;
+  }
+
+  Future<bool> _filesHaveSameContent(File first, File second) async {
+    final firstDigest = await sha256.bind(first.openRead()).first;
+    final secondDigest = await sha256.bind(second.openRead()).first;
+    return firstDigest.toString() == secondDigest.toString();
+  }
+
+  Future<List<File>> _findNamedOldHiveFiles(
+    String appDirPath,
+    Set<String> fileNames,
+  ) async {
+    final files = <File>[];
+    for (final fileName in fileNames) {
+      final file = File(p.join(appDirPath, fileName));
+      if (await file.exists()) files.add(file);
+    }
+    return files;
   }
 
   /// 查找旧位置的 Hive 文件

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:tray_manager/tray_manager.dart';
-import 'package:video_player_media_kit/video_player_media_kit.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:screen_retriever/screen_retriever.dart';
 
@@ -18,13 +17,7 @@ import 'l10n/app_localizations.dart';
 import 'l10n/app_localizations_en.dart';
 import 'l10n/app_localizations_ja.dart';
 import 'l10n/app_localizations_zh.dart';
-import 'core/network/proxy_service.dart';
-import 'core/network/system_proxy_http_overrides.dart';
-import 'core/shortcuts/shortcut_storage.dart';
-import 'core/database/database_manager.dart';
-import 'core/services/data_migration_service.dart';
 import 'core/services/desktop_app_shutdown_service.dart';
-import 'core/services/sqflite_bootstrap_service.dart';
 import 'core/utils/app_error_reporter.dart';
 import 'core/utils/fatal_diagnostics.dart';
 import 'core/utils/app_logger.dart';
@@ -35,13 +28,11 @@ import 'core/utils/window_state_coercion.dart';
 import 'core/utils/window_state_persistence.dart';
 import 'data/datasources/local/nai_tags_data_source.dart';
 import 'data/models/gallery/nai_image_metadata.dart';
-import 'data/repositories/collection_repository.dart';
 import 'data/repositories/gallery_folder_repository.dart';
 import 'core/cache/gallery_cache_manager.dart';
 
 import 'core/cache/tag_cache_service.dart';
-import 'data/services/gallery/index.dart';
-import 'data/services/image_metadata_service.dart';
+import 'core/services/sqflite_bootstrap_service.dart';
 import 'data/services/metadata/isolate_metadata_service.dart';
 import 'data/services/search_index_service.dart';
 import 'data/services/temp_image_service.dart';
@@ -91,12 +82,6 @@ Future<void> _runNonFatalStartupStep(
     '$name completed in ${stopwatch.elapsedMilliseconds}ms',
     'Startup',
   );
-}
-
-void _runDeferredStartupStep(String name, Future<void> Function() action) {
-  WidgetsBinding.instance.addPostFrameCallback((_) {
-    unawaited(_runNonFatalStartupStep(name, action));
-  });
 }
 
 Future<WindowStateSnapshot> _saveCurrentWindowState() async {
@@ -279,6 +264,216 @@ void setupWindowsWakeUpChannel() {
   });
 }
 
+class _DesktopWindowConfiguration {
+  const _DesktopWindowConfiguration({
+    required this.options,
+    required this.width,
+    required this.height,
+    required this.savedX,
+    required this.savedY,
+    required this.fillBounds,
+  });
+
+  final WindowOptions options;
+  final double width;
+  final double height;
+  final double? savedX;
+  final double? savedY;
+  final Rect? fillBounds;
+
+  Future<void> show() async {
+    await windowManager.waitUntilReadyToShow(options, () async {
+      if (fillBounds != null) {
+        await windowManager.setBounds(fillBounds!);
+        AppLogger.d('Window filled to work area: ${width}x$height', 'Main');
+      } else if (savedX != null && savedY != null) {
+        await windowManager.setPosition(Offset(savedX!, savedY!));
+        AppLogger.d(
+          'Window state restored: ${width}x$height at ($savedX, $savedY)',
+          'Main',
+        );
+      }
+      await windowManager.show();
+      await windowManager.focus();
+      AppLogger.i('Desktop window showing rendered Splash', 'Main');
+    });
+    final trayReady = await _initializeSystemTray();
+    if (trayReady) {
+      await windowManager.setPreventClose(true);
+      windowManager.addListener(AppWindowListener());
+    }
+  }
+}
+
+Future<_DesktopWindowConfiguration?> _prepareDesktopWindow() async {
+  if (!(Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+    return null;
+  }
+
+  try {
+    await windowManager.ensureInitialized();
+    if (Platform.isWindows) setupWindowsWakeUpChannel();
+
+    final box = Hive.box(StorageKeys.settingsBox);
+    final savedWidth = coerceWindowDimension(
+      box.get(StorageKeys.windowWidth, defaultValue: 1600.0),
+      fallback: 1600.0,
+    );
+    final savedHeight = coerceWindowDimension(
+      box.get(StorageKeys.windowHeight, defaultValue: 900.0),
+      fallback: 900.0,
+    );
+    final savedX = coerceWindowPosition(box.get(StorageKeys.windowX));
+    final savedY = coerceWindowPosition(box.get(StorageKeys.windowY));
+
+    var width = savedWidth;
+    var height = savedHeight;
+    Rect? fillBounds;
+    try {
+      final display = await screenRetriever.getPrimaryDisplay();
+      final work = display.visibleSize ?? display.size;
+      final workPosition = display.visiblePosition ?? Offset.zero;
+      if (Platform.isMacOS) {
+        width = work.width;
+        height = work.height;
+        fillBounds = Rect.fromLTWH(
+          workPosition.dx,
+          workPosition.dy,
+          work.width,
+          work.height,
+        );
+      } else {
+        final maxWidth = (work.width - 40)
+            .clamp(800.0, double.infinity)
+            .toDouble();
+        final maxHeight = (work.height - 40)
+            .clamp(600.0, double.infinity)
+            .toDouble();
+        width = savedWidth.clamp(800.0, maxWidth).toDouble();
+        height = savedHeight.clamp(600.0, maxHeight).toDouble();
+      }
+    } catch (e) {
+      AppLogger.w('获取屏幕工作区失败，使用默认窗口尺寸: $e', 'Main');
+    }
+
+    await windowManager.setMinimumSize(const Size(800, 600));
+    if (fillBounds != null) {
+      await windowManager.setBounds(fillBounds);
+    } else {
+      await windowManager.setSize(Size(width, height));
+      if (savedX != null && savedY != null) {
+        await windowManager.setPosition(Offset(savedX, savedY));
+      } else {
+        await windowManager.center();
+      }
+    }
+
+    WidgetsBinding.instance.addObserver(WindowStateObserver());
+    AppLogger.d('Desktop window configured before first frame', 'Main');
+
+    return _DesktopWindowConfiguration(
+      options: WindowOptions(
+        size: Size(width, height),
+        minimumSize: const Size(800, 600),
+        center: fillBounds == null && (savedX == null || savedY == null),
+        backgroundColor: const Color(0xFF121212),
+        skipTaskbar: false,
+        titleBarStyle: TitleBarStyle.normal,
+        title: 'NAI Launcher',
+      ),
+      width: width,
+      height: height,
+      savedX: savedX,
+      savedY: savedY,
+      fillBounds: fillBounds,
+    );
+  } catch (e, stackTrace) {
+    AppLogger.e(
+      'Desktop window preparation failed; continuing startup',
+      e,
+      stackTrace,
+      'Main',
+    );
+    return null;
+  }
+}
+
+Future<bool> _initializeSystemTray() async {
+  if (!(Platform.isWindows || Platform.isMacOS)) return false;
+  try {
+    await trayManager.setIcon(
+      Platform.isWindows
+          ? 'assets/icons/app_icon.ico'
+          : 'assets/icons/tray_icon.png',
+    );
+    await trayManager.setToolTip('NAI Launcher');
+    final l10n = _getLocalizedStrings();
+    await trayManager.setContextMenu(
+      Menu(
+        items: [
+          MenuItem(key: 'show', label: l10n.tray_show),
+          MenuItem.separator(),
+          MenuItem(key: 'exit', label: l10n.tray_exit),
+        ],
+      ),
+    );
+    trayManager.addListener(AppTrayListener());
+    return true;
+  } catch (error, stackTrace) {
+    AppLogger.e(
+      'System tray initialization failed; normal window close remains enabled',
+      error,
+      stackTrace,
+      'Main',
+    );
+    return false;
+  }
+}
+
+Future<void> _runDeferredStartup(ProviderContainer container) async {
+  final thumbnailService = ThumbnailService.instance;
+  await Future.wait([
+    _runNonFatalStartupStep('L2 cache cleanup', () async {
+      await L2CacheCleaner().checkAndClean();
+    }),
+    _runNonFatalStartupStep(
+      'Isolate metadata service initialization',
+      () async {
+        await IsolateMetadataService.instance.initialize();
+      },
+    ),
+    _runNonFatalStartupStep('Temp files cleanup', () async {
+      await TempImageService().cleanupOldTempFiles();
+    }),
+    _runNonFatalStartupStep('NAI tags preload', () async {
+      await container.read(naiTagsDataSourceProvider).loadData();
+    }),
+    _runNonFatalStartupStep('Search index service initialization', () async {
+      await SearchIndexService().init();
+    }),
+    _runNonFatalStartupStep('Tag cache service initialization', () async {
+      await TagCacheService().init();
+    }),
+  ]);
+
+  await _runNonFatalStartupStep('Nested thumbnail cleanup', () async {
+    final rootPath = await GalleryFolderRepository.instance.getRootPath();
+    if (rootPath == null) return;
+    final cleanedCount = await thumbnailService.cleanupNestedThumbs(rootPath);
+    if (cleanedCount > 0) {
+      AppLogger.i('启动清理完成: 删除了 $cleanedCount 个嵌套缩略图目录', 'Main');
+    }
+  });
+
+  Future.delayed(const Duration(seconds: 8), () async {
+    await _runNonFatalStartupStep('Online gallery blacklist sync', () async {
+      await container
+          .read(onlineGalleryBlacklistNotifierProvider.notifier)
+          .syncOnStartup();
+    });
+  });
+}
+
 void main() {
   final bootstrap = runZonedGuarded<Future<void>>(_bootstrapApplication, (
     error,
@@ -321,24 +516,7 @@ Future<void> _bootstrapApplication() async {
   PaintingBinding.instance.imageCache.maximumSize = 500; // 最大缓存 500 张图片
   PaintingBinding.instance.imageCache.maximumSizeBytes = 200 << 20; // 200MB
 
-  try {
-    // 初始化桌面端视频播放支持 (media_kit: Windows + macOS)
-    VideoPlayerMediaKit.ensureInitialized(
-      windows: Platform.isWindows,
-      macOS: Platform.isMacOS,
-    );
-  } catch (e, stackTrace) {
-    AppLogger.e(
-      'Video player initialization failed; continuing startup',
-      e,
-      stackTrace,
-      'Main',
-    );
-  }
-
-  // 日志系统已自动初始化，无需显式调用
-
-  // 初始化 SQLite FFI（Windows/Linux 桌面端必需）
+  // FFI 注册本身不打开数据库，需在数据库调用方出现前完成。
   await SqfliteBootstrapService.instance.ensureInitialized();
 
   // 初始化 Hive（使用子目录存储，支持迁移旧数据）
@@ -353,394 +531,36 @@ Future<void> _bootstrapApplication() async {
     Hive.registerAdapter(CharacterPromptInfoAdapter());
   }
 
-  // 先迁移 Hive 文件，再打开 box，避免 Windows 文件锁阻止旧数据覆盖占位文件。
-  await HiveStorageHelper.instance.migrateFromOldLocation(hivePath);
+  // settings 是 Splash 首帧唯一必需 box，先单独迁移，避免 Windows 文件锁阻止覆盖。
+  // 其余 Hive 文件由 Splash Warmup 迁移。
+  await HiveStorageHelper.instance.migrateSettingsFromOldLocation(hivePath);
 
   await _openHiveBoxIfNeeded(StorageKeys.settingsBox, hivePath: hivePath);
-  final settingsBox = Hive.box(StorageKeys.settingsBox);
-  final fileLoggingEnabled =
-      settingsBox.get(StorageKeys.fileLoggingEnabled, defaultValue: false) ==
-      true;
-  await AppLogger.setFileLoggingEnabled(fileLoggingEnabled);
-
-  // 在 Hive 初始化之后执行文件迁移
-  try {
-    final migrationResult = await DataMigrationService.instance.migrateAll();
-    AppLogger.i('Startup migration result: $migrationResult', 'Main');
-  } catch (e) {
-    AppLogger.w('Startup migration failed (will continue): $e', 'Main');
-  }
-
-  // ===== V2 架构：数据库初始化和恢复（在 runApp 之前完成）====
-  AppLogger.i('等待数据库初始化...', 'Main');
-  final container = ProviderContainer();
-
-  try {
-    // V2 架构：DatabaseManagerV2 自动处理热重启检测
-    final manager = await DatabaseManager.initialize();
-    await manager.initialized;
-
-    // 检查核心资产库完整性。翻译和共现数据已迁移到独立资产数据库，
-    // 不应再从 danbooru.db 的运行时表统计里判断。
-    final coreAssetStats = await manager.getCoreAssetStatistics();
-    final translationCount = coreAssetStats['translations'] ?? 0;
-    final cooccurrenceCount = coreAssetStats['cooccurrences'] ?? 0;
-
-    AppLogger.i(
-      '核心资产数据库状态: translations=$translationCount, cooccurrences=$cooccurrenceCount',
-      'Main',
-    );
-
-    if (translationCount == 0 || cooccurrenceCount == 0) {
-      AppLogger.w('核心资产数据为空，请检查打包数据库', 'Main');
-    }
-
-    AppLogger.i('数据库初始化完成', 'Main');
-  } catch (e, stack) {
-    AppLogger.e('数据库初始化失败', e, stack, 'Main');
-    // 继续启动，应用内会显示错误',
-  }
-
-  // 预先打开 Hive boxes (确保 LocalStorageService 可用)
-  await _openHiveBoxIfNeeded(StorageKeys.settingsBox, hivePath: hivePath);
-  await _openHiveBoxIfNeeded(StorageKeys.historyBox, hivePath: hivePath);
-  await _openHiveBoxIfNeeded(StorageKeys.tagCacheBox, hivePath: hivePath);
-  await _openHiveBoxIfNeeded(StorageKeys.galleryBox, hivePath: hivePath);
-  // Local Gallery 新功能所需的 Hive boxes
-  await _openHiveBoxIfNeeded(StorageKeys.localFavoritesBox, hivePath: hivePath);
-  await _openHiveBoxIfNeeded(StorageKeys.tagsBox, hivePath: hivePath);
-  await _openHiveBoxIfNeeded(StorageKeys.searchIndexBox, hivePath: hivePath);
-  // 统计数据缓存 Box
-  await _openHiveBoxIfNeeded(
-    StorageKeys.statisticsCacheBox,
-    hivePath: hivePath,
-  );
-  // 收藏集合 Box
-  await _openHiveBoxIfNeeded(StorageKeys.collectionsBox, hivePath: hivePath);
-  // 队列相关 Box（预加载以避免首次打开队列管理页面时的延迟）
-  await _openHiveBoxIfNeeded<String>(
-    StorageKeys.replicationQueueBox,
-    hivePath: hivePath,
-  );
-  await _openHiveBoxIfNeeded<String>(
-    StorageKeys.queueExecutionStateBox,
-    hivePath: hivePath,
-  );
-
-  // 初始化图像元数据服务（包含持久化缓存，用于详情页快速加载）
-  await _runNonFatalStartupStep(
-    'Image metadata service initialization',
-    () async {
-      await ImageMetadataService().initialize();
-      AppLogger.i('图像元数据服务初始化完成', 'Main');
-    },
-  );
-
-  // 后台执行 L2 Hive 缓存清理（不阻塞启动）
-  Future.microtask(() async {
-    try {
-      await L2CacheCleaner().checkAndClean();
-    } catch (e) {
-      AppLogger.w('L2 cache cleanup failed: $e', 'Main');
-    }
-  });
-
-  // 初始化统一缩略图服务
-  final thumbnailService = ThumbnailService.instance;
-  await _runNonFatalStartupStep('Thumbnail service initialization', () async {
-    await thumbnailService.initialize();
-    AppLogger.i('缩略图服务初始化完成', 'Main');
-  });
-
-  // 【修复】初始化收藏集合仓库
-  await _runNonFatalStartupStep(
-    'Collection repository initialization',
-    () async {
-      await CollectionRepository.instance.initialize();
-      AppLogger.i('收藏集合仓库初始化完成', 'Main');
-    },
-  );
-
-  // 【修复】初始化扫描状态管理器（确保检查点功能正常工作）
-  await _runNonFatalStartupStep('Scan state manager initialization', () async {
-    await ScanStateManager.instance.initialize();
-    AppLogger.i('扫描状态管理器初始化完成', 'Main');
-  });
-
-  // 【修复】初始化 Isolate 元数据服务（详情页快速解析）
-  await _runNonFatalStartupStep(
-    'Isolate metadata service initialization',
-    () async {
-      await IsolateMetadataService.instance.initialize();
-      AppLogger.i('Isolate 元数据服务初始化完成', 'Main');
-    },
-  );
-
-  // 【修复】启动时清理嵌套缩略图（修复递归生成bug遗留问题）
-  Future.microtask(() async {
-    try {
-      final rootPath = await GalleryFolderRepository.instance.getRootPath();
-      if (rootPath != null) {
-        final cleanedCount = await thumbnailService.cleanupNestedThumbs(
-          rootPath,
-        );
-        if (cleanedCount > 0) {
-          AppLogger.i('启动清理完成: 删除了 $cleanedCount 个嵌套缩略图目录', 'Main');
-        }
-      }
-    } catch (e) {
-      AppLogger.w('清理嵌套缩略图失败: $e', 'Main');
-    }
-  });
-
-  // 扫描已由 UnifiedGalleryService 处理，在打开本地画廊时自动执行
-
-  // 初始化快捷键存储
-  final shortcutStorage = ShortcutStorage();
-  await _runNonFatalStartupStep('Shortcut storage initialization', () async {
-    await shortcutStorage.init();
-    AppLogger.d('Shortcut storage initialized', 'Main');
-  });
+  final desktopWindowFuture = _prepareDesktopWindow();
 
   // Timeago 本地化配置
   timeago.setLocaleMessages('zh', timeago.ZhCnMessages());
   timeago.setLocaleMessages('zh_CN', timeago.ZhCnMessages());
   timeago.setLocaleMessages('ja', timeago.JaMessages());
 
-  // 清理过期临时文件（不阻塞启动）
-  Future.microtask(() async {
-    try {
-      await TempImageService().cleanupOldTempFiles();
-    } catch (e) {
-      AppLogger.w('Temp files cleanup failed: $e', 'Main');
-    }
-  });
-
-  // 后台预加载 NAI 标签数据（不阻塞启动）
-  // 使用已创建的 container
-  Future.microtask(() async {
-    try {
-      await container.read(naiTagsDataSourceProvider).loadData();
-      AppLogger.d('NAI tags preloaded successfully', 'Main');
-    } catch (e) {
-      AppLogger.w('NAI tags preload failed: $e', 'Main');
-      // 预加载失败不影响应用启动
-    }
-  });
-
-  // 启动时自动同步在线画廊黑名单（不阻塞启动）
-  Future.delayed(const Duration(seconds: 8), () async {
-    try {
-      await container
-          .read(onlineGalleryBlacklistNotifierProvider.notifier)
-          .syncOnStartup();
-    } catch (e) {
-      AppLogger.w('Online gallery blacklist auto-sync failed: $e', 'Main');
-    }
-  });
-
-  // 桌面端窗口配置
-  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
-    try {
-      await windowManager.ensureInitialized();
-
-      // 设置 Windows 唤醒消息处理（单实例唤醒）
-      if (Platform.isWindows) {
-        setupWindowsWakeUpChannel();
-      }
-
-      // 从 Hive 读取保存的窗口状态
-      final box = Hive.box(StorageKeys.settingsBox);
-      final savedWidth = coerceWindowDimension(
-        box.get(StorageKeys.windowWidth, defaultValue: 1600.0),
-        fallback: 1600.0,
-      );
-      final savedHeight = coerceWindowDimension(
-        box.get(StorageKeys.windowHeight, defaultValue: 900.0),
-        fallback: 900.0,
-      );
-      final savedX = coerceWindowPosition(box.get(StorageKeys.windowX));
-      final savedY = coerceWindowPosition(box.get(StorageKeys.windowY));
-
-      // 读取屏幕可用工作区
-      double effWidth = savedWidth;
-      double effHeight = savedHeight;
-      Rect? fillBounds; // macOS 首次启动：铺满工作区时使用
-      try {
-        final display = await screenRetriever.getPrimaryDisplay();
-        final work = display.visibleSize ?? display.size;
-        final workPos = display.visiblePosition ?? Offset.zero;
-
-        if (Platform.isMacOS) {
-          // macOS：启动时自适应屏幕，铺满可用工作区（紧贴屏幕，保留菜单栏/Dock）
-          effWidth = work.width;
-          effHeight = work.height;
-          fillBounds = Rect.fromLTWH(
-            workPos.dx,
-            workPos.dy,
-            work.width,
-            work.height,
-          );
-        } else {
-          // 其它情况：clamp 到工作区，避免窗口超出屏幕
-          final maxW = (work.width - 40)
-              .clamp(800.0, double.infinity)
-              .toDouble();
-          final maxH = (work.height - 40)
-              .clamp(600.0, double.infinity)
-              .toDouble();
-          effWidth = savedWidth.clamp(800.0, maxW).toDouble();
-          effHeight = savedHeight.clamp(600.0, maxH).toDouble();
-        }
-      } catch (e) {
-        AppLogger.w('获取屏幕工作区失败，使用默认窗口尺寸: $e', 'Main');
-      }
-
-      final windowOptions = WindowOptions(
-        size: Size(effWidth, effHeight),
-        minimumSize: const Size(800, 600),
-        center: fillBounds == null && (savedX == null || savedY == null),
-        backgroundColor: const Color(0xFF121212), // 深色背景，避免窗口透明
-        skipTaskbar: false,
-        titleBarStyle: TitleBarStyle.normal,
-        title: 'NAI Launcher',
-      );
-
-      await windowManager.waitUntilReadyToShow(windowOptions, () async {
-        if (fillBounds != null) {
-          // macOS 首次启动：精确铺满屏幕工作区
-          await windowManager.setBounds(fillBounds);
-          AppLogger.d(
-            'Window filled to work area: ${effWidth}x$effHeight',
-            'Main',
-          );
-        } else if (savedX != null && savedY != null) {
-          await windowManager.setPosition(Offset(savedX, savedY));
-          AppLogger.d(
-            'Window state restored: ${effWidth}x$effHeight at ($savedX, $savedY)',
-            'Main',
-          );
-        } else {
-          AppLogger.d(
-            'Window initialized with default state: ${effWidth}x$effHeight (centered)',
-            'Main',
-          );
-        }
-
-        await windowManager.show();
-        await windowManager.focus();
-      });
-
-      // 初始化系统托盘（Windows + macOS）
-      if (Platform.isWindows || Platform.isMacOS) {
-        try {
-          // 设置托盘图标和提示
-          // tray_manager 使用 Flutter 资源路径格式（相对于 data/flutter_assets/）
-          // macOS 菜单栏不支持 .ico，使用 png
-          await trayManager.setIcon(
-            Platform.isWindows
-                ? 'assets/icons/app_icon.ico'
-                : 'assets/icons/tray_icon.png',
-          );
-          await trayManager.setToolTip('NAI Launcher');
-
-          // 获取本地化字符串
-          final l10n = _getLocalizedStrings();
-
-          final menu = Menu(
-            items: [
-              MenuItem(key: 'show', label: l10n.tray_show),
-              MenuItem.separator(),
-              MenuItem(key: 'exit', label: l10n.tray_exit),
-            ],
-          );
-          await trayManager.setContextMenu(menu);
-
-          // 设置阻止关闭（关闭时隐藏到托盘）
-          await windowManager.setPreventClose(true);
-
-          trayManager.addListener(AppTrayListener());
-          windowManager.addListener(AppWindowListener());
-
-          AppLogger.d('System tray initialized', 'Main');
-        } catch (e) {
-          AppLogger.e('Failed to initialize system tray: $e', 'Main');
-        }
-      }
-    } catch (e, stackTrace) {
-      AppLogger.e(
-        'Desktop window initialization failed; continuing startup',
-        e,
-        stackTrace,
-        'Main',
-      );
-    }
-  }
-
-  // 系统代理配置（根据用户设置）
-  if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
-    final settingsBox = Hive.box(StorageKeys.settingsBox);
-    final proxyEnabled =
-        settingsBox.get(StorageKeys.proxyEnabled, defaultValue: true) as bool;
-
-    if (proxyEnabled) {
-      final proxyMode =
-          settingsBox.get(StorageKeys.proxyMode, defaultValue: 'auto')
-              as String;
-
-      String? proxyAddress;
-
-      if (proxyMode == 'manual') {
-        // 手动模式：从设置读取
-        final host = settingsBox.get(StorageKeys.proxyManualHost) as String?;
-        final port = settingsBox.get(StorageKeys.proxyManualPort) as int?;
-        if (host != null && host.isNotEmpty && port != null && port > 0) {
-          proxyAddress = '$host:$port';
-        }
-      } else {
-        // 自动模式：从系统获取
-        proxyAddress = ProxyService.getSystemProxyAddress();
-      }
-
-      if (proxyAddress != null && proxyAddress.isNotEmpty) {
-        HttpOverrides.global = SystemProxyHttpOverrides('PROXY $proxyAddress');
-        AppLogger.i(
-          'Applied proxy: $proxyAddress (mode: $proxyMode)',
-          'NETWORK',
-        );
-      } else {
-        AppLogger.w(
-          'Proxy enabled but no proxy address available (mode: $proxyMode)',
-          'NETWORK',
-        );
-      }
-    } else {
-      AppLogger.d('Proxy disabled by user settings', 'NETWORK');
-    }
-  }
-
-  // 注册窗口状态观察者（桌面端）
-  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
-    WidgetsBinding.instance.addObserver(WindowStateObserver());
-    AppLogger.d('Window state observer registered', 'Main');
-  }
-
-  final searchIndexService = SearchIndexService();
-  _runDeferredStartupStep('Search index service initialization', () async {
-    await searchIndexService.init();
-    AppLogger.i('搜索索引服务初始化完成', 'Main');
-  });
-
-  final tagCacheService = TagCacheService();
-  _runDeferredStartupStep('Tag cache service initialization', () async {
-    await tagCacheService.init();
-    AppLogger.i('Tag 缓存服务初始化完成', 'Main');
-  });
-
+  final desktopWindow = await desktopWindowFuture;
+  final container = ProviderContainer();
+  AppLogger.i('Calling runApp; database warmup has not started', 'Main');
   runApp(
     UncontrolledProviderScope(
       container: container,
-      child: const AppBootstrap(),
+      child: AppBootstrap(
+        onWarmupComplete: () {
+          unawaited(_runDeferredStartup(container));
+        },
+      ),
     ),
   );
+
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    AppLogger.i('Flutter first frame completed', 'Main');
+    if (desktopWindow != null) {
+      unawaited(desktopWindow.show());
+    }
+  });
 }

--- a/lib/presentation/providers/startup_initialization_provider.dart
+++ b/lib/presentation/providers/startup_initialization_provider.dart
@@ -1,0 +1,201 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:video_player_media_kit/video_player_media_kit.dart';
+
+import '../../core/constants/storage_keys.dart';
+import '../../core/database/database_providers.dart';
+import '../../core/network/proxy_service.dart';
+import '../../core/network/system_proxy_http_overrides.dart';
+import '../../core/services/data_migration_service.dart';
+import '../../core/shortcuts/shortcut_storage.dart';
+import '../../core/utils/app_logger.dart';
+import '../../core/utils/hive_startup_box_opener.dart';
+import '../../core/utils/hive_storage_helper.dart';
+import '../../data/repositories/collection_repository.dart';
+import '../../data/services/gallery/scan_state_manager.dart';
+import '../../data/services/image_metadata_service.dart';
+import '../../data/services/thumbnail_service.dart';
+import '../../data/services/vibe_library_migration_service.dart';
+
+/// 可替换的启动关键任务边界，便于验证 Splash 与真实初始化的时序。
+class StartupInitializationTasks {
+  const StartupInitializationTasks({
+    required this.initializeRuntimeConfiguration,
+    required this.runDataMigration,
+    required this.initializeDatabase,
+    required this.initializeCriticalServices,
+    this.enablePostWarmupTasks = true,
+  });
+
+  final Future<void> Function() initializeRuntimeConfiguration;
+  final Future<MigrationResult> Function(
+    void Function(String stage, double progress) onProgress,
+  )
+  runDataMigration;
+  final Future<void> Function() initializeDatabase;
+  final Future<void> Function() initializeCriticalServices;
+  final bool enablePostWarmupTasks;
+}
+
+final startupInitializationTasksProvider = Provider<StartupInitializationTasks>(
+  (ref) {
+    MigrationResult? completedMigration;
+    return StartupInitializationTasks(
+      initializeRuntimeConfiguration: () async {
+        final settingsBox = Hive.box(StorageKeys.settingsBox);
+        final fileLoggingEnabled =
+            settingsBox.get(
+              StorageKeys.fileLoggingEnabled,
+              defaultValue: false,
+            ) ==
+            true;
+        await AppLogger.setFileLoggingEnabled(fileLoggingEnabled);
+
+        try {
+          VideoPlayerMediaKit.ensureInitialized(
+            windows: Platform.isWindows,
+            macOS: Platform.isMacOS,
+          );
+        } catch (error, stackTrace) {
+          AppLogger.e(
+            'Video player initialization failed; continuing startup',
+            error,
+            stackTrace,
+            'Warmup',
+          );
+        }
+
+        _configureSystemProxy(settingsBox);
+      },
+      runDataMigration: (onProgress) async {
+        final cached = completedMigration;
+        if (cached != null) return cached;
+
+        final migrationService = DataMigrationService.instance;
+        migrationService.onProgress = onProgress;
+        try {
+          final result = await migrationService.migrateAll();
+          final vibeResult = await VibeLibraryMigrationService()
+              .migrateIfNeeded();
+          if (!vibeResult.success) {
+            throw StateError('Vibe 库迁移失败: ${vibeResult.error ?? '未知错误'}');
+          }
+          if (result.isSuccess) {
+            completedMigration = result;
+          }
+          return result;
+        } finally {
+          migrationService.onProgress = null;
+        }
+      },
+      initializeDatabase: () async {
+        final manager = await ref.read(databaseManagerProvider.future);
+        await manager.initialized;
+
+        try {
+          final stats = await manager.getCoreAssetStatistics();
+          final translationCount = stats['translations'] ?? 0;
+          final cooccurrenceCount = stats['cooccurrences'] ?? 0;
+          AppLogger.i(
+            '核心资产数据库状态: translations=$translationCount, '
+                'cooccurrences=$cooccurrenceCount',
+            'Warmup',
+          );
+          if (translationCount == 0 || cooccurrenceCount == 0) {
+            AppLogger.w('核心资产数据为空，请检查打包数据库', 'Warmup');
+          }
+        } catch (error, stackTrace) {
+          // 资产验证属于数据库初始化契约；失败时不能把健康标记的半成品留给重试。
+          try {
+            await manager.dispose();
+          } catch (cleanupError, cleanupStackTrace) {
+            AppLogger.e(
+              '数据库验证失败后的清理也失败',
+              cleanupError,
+              cleanupStackTrace,
+              'Warmup',
+            );
+          }
+          Error.throwWithStackTrace(error, stackTrace);
+        }
+      },
+      initializeCriticalServices: () async {
+        final hivePath = await HiveStorageHelper.instance.getPath();
+        await Future.wait([
+          _openHiveBoxIfNeeded(StorageKeys.historyBox, hivePath: hivePath),
+          _openHiveBoxIfNeeded(StorageKeys.tagCacheBox, hivePath: hivePath),
+          _openHiveBoxIfNeeded(StorageKeys.galleryBox, hivePath: hivePath),
+          _openHiveBoxIfNeeded(
+            StorageKeys.localFavoritesBox,
+            hivePath: hivePath,
+          ),
+          _openHiveBoxIfNeeded(StorageKeys.tagsBox, hivePath: hivePath),
+          _openHiveBoxIfNeeded(StorageKeys.searchIndexBox, hivePath: hivePath),
+          _openHiveBoxIfNeeded(
+            StorageKeys.statisticsCacheBox,
+            hivePath: hivePath,
+          ),
+          _openHiveBoxIfNeeded(StorageKeys.collectionsBox, hivePath: hivePath),
+          _openHiveBoxIfNeeded<String>(
+            StorageKeys.replicationQueueBox,
+            hivePath: hivePath,
+          ),
+          _openHiveBoxIfNeeded<String>(
+            StorageKeys.queueExecutionStateBox,
+            hivePath: hivePath,
+          ),
+          ImageMetadataService().initialize(),
+          ThumbnailService.instance.initialize(),
+          ScanStateManager.instance.initialize(),
+          ShortcutStorage().init(),
+        ]);
+        await CollectionRepository.instance.initialize();
+      },
+    );
+  },
+);
+
+void _configureSystemProxy(Box<dynamic> settingsBox) {
+  if (!(Platform.isWindows || Platform.isMacOS || Platform.isLinux)) return;
+
+  final proxyEnabled =
+      settingsBox.get(StorageKeys.proxyEnabled, defaultValue: true) as bool;
+  if (!proxyEnabled) {
+    AppLogger.d('Proxy disabled by user settings', 'NETWORK');
+    return;
+  }
+
+  final proxyMode =
+      settingsBox.get(StorageKeys.proxyMode, defaultValue: 'auto') as String;
+  String? proxyAddress;
+  if (proxyMode == 'manual') {
+    final host = settingsBox.get(StorageKeys.proxyManualHost) as String?;
+    final port = settingsBox.get(StorageKeys.proxyManualPort) as int?;
+    if (host != null && host.isNotEmpty && port != null && port > 0) {
+      proxyAddress = '$host:$port';
+    }
+  } else {
+    proxyAddress = ProxyService.getSystemProxyAddress();
+  }
+
+  if (proxyAddress != null && proxyAddress.isNotEmpty) {
+    HttpOverrides.global = SystemProxyHttpOverrides('PROXY $proxyAddress');
+    AppLogger.i('Applied proxy: $proxyAddress (mode: $proxyMode)', 'NETWORK');
+  } else {
+    AppLogger.w(
+      'Proxy enabled but no proxy address available (mode: $proxyMode)',
+      'NETWORK',
+    );
+  }
+}
+
+Future<void> _openHiveBoxIfNeeded<E>(
+  String name, {
+  required String hivePath,
+}) async {
+  if (!Hive.isBoxOpen(name)) {
+    await HiveStartupBoxOpener.openBox<E>(name, hivePath: hivePath);
+  }
+}

--- a/lib/presentation/providers/warmup_provider.dart
+++ b/lib/presentation/providers/warmup_provider.dart
@@ -7,9 +7,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../core/network/proxy_service.dart';
 import '../../core/enums/warmup_phase.dart';
 import '../../core/database/database.dart';
-import '../../core/database/datasources/gallery_data_source.dart';
 import '../../core/services/danbooru_tags_lazy_service.dart';
-import '../../core/services/data_migration_service.dart';
 import '../../core/services/warmup_task_scheduler.dart';
 
 import 'data_source_cache_provider.dart';
@@ -20,7 +18,7 @@ import 'auth_provider.dart';
 import 'font_provider.dart';
 import 'prompt_config_provider.dart';
 import 'subscription_provider.dart';
-import '../../data/services/vibe_library_migration_service.dart';
+import 'startup_initialization_provider.dart';
 
 part 'warmup_provider.g.dart';
 
@@ -85,12 +83,13 @@ class WarmupState {
     bool? isComplete,
     String? error,
     String? subTaskMessage,
+    bool clearError = false,
     bool clearSubTaskMessage = false,
   }) {
     return WarmupState(
       progress: progress ?? this.progress,
       isComplete: isComplete ?? this.isComplete,
-      error: error ?? this.error,
+      error: clearError ? null : error ?? this.error,
       subTaskMessage: clearSubTaskMessage
           ? null
           : subTaskMessage ?? this.subTaskMessage,
@@ -102,65 +101,65 @@ class WarmupState {
 @riverpod
 class WarmupNotifier extends _$WarmupNotifier {
   late WarmupTaskScheduler _scheduler;
-  StreamSubscription<PhaseProgress>? _phaseSubscription;
-  final _completer = Completer<void>();
+  Completer<void> _completer = Completer<void>();
+  bool _isRunning = false;
+  bool _postWarmupStarted = false;
 
   @override
   WarmupState build() {
-    ref.onDispose(() {
-      _phaseSubscription?.cancel();
-    });
-
     _scheduler = WarmupTaskScheduler();
     _registerTasks();
-
-    // 延迟后台任务注册到 build 完成后，避免修改其他 provider
-    Future.microtask(_registerBackgroundPhaseTasks);
-
-    _startWarmup();
-
     return WarmupState.initial();
   }
 
-  /// 等待预热完成
+  /// 等待当前预热尝试结束，结果通过 [state] 判断。
   Future<void> get whenComplete => _completer.future;
+
+  /// Splash 首帧完成后才开始关键初始化。
+  void start() {
+    if (_isRunning || state.isComplete) return;
+    unawaited(_startWarmup());
+  }
 
   // ===== 任务实现方法 =====
 
+  Future<void> _initializeRuntimeConfiguration() async {
+    AppLogger.i('开始运行时配置...', 'Warmup');
+    await ref
+        .read(startupInitializationTasksProvider)
+        .initializeRuntimeConfiguration();
+    AppLogger.i('运行时配置完成', 'Warmup');
+  }
+
   Future<void> _runDataMigration() async {
     AppLogger.i('开始数据迁移阶段...', 'Warmup');
-    final migrationService = DataMigrationService.instance;
-
-    migrationService.onProgress = (stage, progress) {
+    final tasks = ref.read(startupInitializationTasksProvider);
+    final result = await tasks.runDataMigration((stage, progress) {
       state = state.copyWith(
         subTaskMessage: '$stage (${(progress * 100).toInt()}%)',
       );
-    };
+    });
 
-    final result = await migrationService.migrateAll();
-    migrationService.onProgress = null;
-
-    await _runVibeLibraryMigration();
     state = state.copyWith(clearSubTaskMessage: true);
 
-    if (result.isSuccess) {
-      AppLogger.i('数据迁移完成: $result', 'Warmup');
-    } else {
-      AppLogger.w('数据迁移部分失败: ${result.error}', 'Warmup');
+    if (!result.isSuccess) {
+      throw StateError('数据迁移失败: ${result.error ?? result}');
     }
+    AppLogger.i('数据迁移完成: $result', 'Warmup');
   }
 
-  Future<void> _runVibeLibraryMigration() async {
-    try {
-      final vibeResult = await VibeLibraryMigrationService().migrateIfNeeded();
-      if (vibeResult.success) {
-        AppLogger.i('Vibe 库迁移完成，导出 ${vibeResult.exportedCount} 条', 'Warmup');
-      } else {
-        AppLogger.w('Vibe 库迁移失败: ${vibeResult.error}', 'Warmup');
-      }
-    } catch (e) {
-      AppLogger.w('Vibe 库迁移异常: $e', 'Warmup');
-    }
+  Future<void> _initializeDatabase() async {
+    AppLogger.i('开始数据库初始化...', 'Warmup');
+    await ref.read(startupInitializationTasksProvider).initializeDatabase();
+    AppLogger.i('数据库初始化完成', 'Warmup');
+  }
+
+  Future<void> _initializeCriticalServices() async {
+    AppLogger.i('开始关键服务初始化...', 'Warmup');
+    await ref
+        .read(startupInitializationTasksProvider)
+        .initializeCriticalServices();
+    AppLogger.i('关键服务初始化完成', 'Warmup');
   }
 
   // 【修复】移除了 _configureImageCache 方法
@@ -200,13 +199,15 @@ class WarmupNotifier extends _$WarmupNotifier {
     }
   }
 
-  /// 重试预加载
+  /// 重试预加载。失败的数据库 FutureProvider 必须失效后重新创建实例。
   void retry() {
-    _phaseSubscription?.cancel();
-    _scheduler.clear();
+    if (_isRunning) return;
+    ref.invalidate(databaseManagerProvider);
+    _scheduler = WarmupTaskScheduler();
+    _completer = Completer<void>();
     state = WarmupState.initial();
     _registerTasks();
-    _startWarmup();
+    start();
   }
 
   /// 检查网络环境（最多尝试2次，失败不阻塞启动）
@@ -266,149 +267,48 @@ class WarmupNotifier extends _$WarmupNotifier {
   // 三阶段预热架构
   // ===========================================================================
 
-  /// 注册所有预热任务
+  /// 注册进入主界面前必须成功的任务。它们严格串行，确保迁移早于数据库打开。
   void _registerTasks() {
-    // ==== 阶段 1: Critical ====
-    _registerCriticalPhaseTasks();
-
-    // ==== 阶段 2: Quick ====
-    _registerQuickPhaseTasks();
-
-    // 注意: 阶段 3 (Background) 在 build() 完成后通过 Future.microtask 注册
-    // 避免在 build() 中修改其他 provider
-  }
-
-  void _registerCriticalPhaseTasks() {
-    // 1. 数据迁移
+    _scheduler.registerTask(
+      PhasedWarmupTask(
+        name: 'warmup_runtimeConfiguration',
+        displayName: 'warmup_group_basicUI',
+        phase: WarmupPhase.critical,
+        weight: 1,
+        timeout: Duration.zero,
+        task: _initializeRuntimeConfiguration,
+      ),
+    );
     _scheduler.registerTask(
       PhasedWarmupTask(
         name: 'warmup_dataMigration',
         displayName: 'warmup_dataMigration',
         phase: WarmupPhase.critical,
         weight: 2,
-        timeout: const Duration(seconds: 60),
+        timeout: Duration.zero,
         task: _runDataMigration,
       ),
     );
-
-    // 2. 基础UI服务（并行）- 移除了数据库初始化，让它在 Quick 阶段异步执行
-    _scheduler.registerGroup(
-      PhasedTaskGroup(
-        name: 'basicUI',
-        displayName: 'warmup_group_basicUI',
-        phase: WarmupPhase.critical,
-        parallel: true,
-        tasks: [
-          // 【修复】移除 warmup_imageCache 任务，因为 main.dart 已配置（200MB）
-          // 避免重复配置和参数不一致问题
-          PhasedWarmupTask(
-            name: 'warmup_fonts',
-            displayName: 'warmup_fonts',
-            phase: WarmupPhase.critical,
-            weight: 1,
-            task: _preloadFonts,
-          ),
-          PhasedWarmupTask(
-            name: 'warmup_imageEditor',
-            displayName: 'warmup_imageEditor',
-            phase: WarmupPhase.critical,
-            weight: 1,
-            task: _warmupImageEditor,
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _registerQuickPhaseTasks() {
-    // 1. 数据库初始化
     _scheduler.registerTask(
       PhasedWarmupTask(
         name: 'warmup_unifiedDbInit',
         displayName: 'warmup_initUnifiedDatabase',
-        phase: WarmupPhase.quick,
+        phase: WarmupPhase.critical,
+        weight: 4,
+        timeout: Duration.zero,
+        task: _initializeDatabase,
+      ),
+    );
+    _scheduler.registerTask(
+      PhasedWarmupTask(
+        name: 'warmup_criticalServices',
+        displayName: 'warmup_group_basicUI',
+        phase: WarmupPhase.critical,
         weight: 2,
-        task: _initUnifiedDatabaseLightweight,
+        timeout: Duration.zero,
+        task: _initializeCriticalServices,
       ),
     );
-
-    // 2. 共现数据初始化（轻量级检查，依赖数据库）
-    _scheduler.registerTask(
-      PhasedWarmupTask(
-        name: 'warmup_cooccurrenceInit',
-        displayName: 'warmup_cooccurrenceInit',
-        phase: WarmupPhase.quick,
-        weight: 1,
-        task: () async {
-          // 只执行轻量级检查，实际导入在 background 阶段
-          await _initCooccurrenceData();
-        },
-      ),
-    );
-
-    // 4. 网络检测（8秒超时，防止无限等待）
-    _scheduler.registerTask(
-      PhasedWarmupTask(
-        name: 'warmup_networkCheck',
-        displayName: 'warmup_networkCheck',
-        phase: WarmupPhase.quick,
-        weight: 1,
-        timeout: const Duration(seconds: 8),
-        task: _checkNetworkEnvironment,
-      ),
-    );
-
-    // 5. 提示词配置
-    _scheduler.registerTask(
-      PhasedWarmupTask(
-        name: 'warmup_loadingPromptConfig',
-        displayName: 'warmup_loadingPromptConfig',
-        phase: WarmupPhase.quick,
-        weight: 1,
-        task: _loadPromptConfig,
-      ),
-    );
-
-    // 6. 画廊数据源初始化
-    _scheduler.registerTask(
-      PhasedWarmupTask(
-        name: 'warmup_galleryDataSource',
-        displayName: 'warmup_galleryDataSource',
-        phase: WarmupPhase.quick,
-        weight: 3,
-        timeout: const Duration(seconds: 30),
-        task: _initGalleryDataSource,
-      ),
-    );
-
-    // 7. 画廊计数
-    _scheduler.registerTask(
-      PhasedWarmupTask(
-        name: 'warmup_galleryFileCount',
-        displayName: 'warmup_galleryFileCount',
-        phase: WarmupPhase.quick,
-        weight: 1,
-        task: _countGalleryFiles,
-      ),
-    );
-
-    // 7. 订阅信息（仅缓存，不强制网络）
-    _scheduler.registerTask(
-      PhasedWarmupTask(
-        name: 'warmup_subscription',
-        displayName: 'warmup_subscription',
-        phase: WarmupPhase.quick,
-        weight: 1,
-        task: _loadSubscriptionCached,
-      ),
-    );
-
-    // 标签 catalog 随应用提供并按需只读查询；启动阶段不再下载全量标签。
-  }
-
-  void _registerBackgroundPhaseTasks() {
-    // 注意：共现数据是预打包的数据库，在 _initCooccurrenceData() 中已完成初始化
-    // 不需要额外的后台导入任务
   }
 
   /// 启动全局画廊扫描（预热结束后自动调用，不绑定页面）
@@ -446,74 +346,72 @@ class WarmupNotifier extends _$WarmupNotifier {
     });
   }
 
-  /// 开始预热流程
+  /// 开始预热流程。
   Future<void> _startWarmup() async {
+    if (_isRunning) return;
+    _isRunning = true;
     try {
-      // 阶段 1: Critical
       await for (final progress in _scheduler.runPhase(WarmupPhase.critical)) {
         state = state.copyWith(
           progress: WarmupProgress(
-            progress: progress.progress * 0.3, // critical 占 30%
+            progress: progress.progress,
             currentTask: progress.currentTask,
           ),
+          clearError: true,
           clearSubTaskMessage: true,
         );
       }
 
-      // 阶段 2: Quick
-      await for (final progress in _scheduler.runPhase(WarmupPhase.quick)) {
-        state = state.copyWith(
-          progress: WarmupProgress(
-            progress: 0.3 + progress.progress * 0.7, // quick 占 70%
-            currentTask: progress.currentTask,
-          ),
-          clearSubTaskMessage: true,
-        );
-      }
-
-      // 完成，进入主界面
       state = WarmupState.complete();
-      _completer.complete();
-
-      // 【关键】预热完成后，自动启动全局画廊扫描（不绑定页面）
-      _startGlobalGalleryScan();
+      AppLogger.i('Warmup completed; entering main application', 'Warmup');
     } catch (e, stack) {
       AppLogger.e('Warmup failed', e, stack, 'Warmup');
       state = state.copyWith(
         error: e.toString(),
         progress: WarmupProgress.error(e.toString()),
       );
-      _completer.completeError(e);
+    } finally {
+      _isRunning = false;
+      if (!_completer.isCompleted) {
+        _completer.complete();
+      }
     }
   }
 
-  /// 轻量级初始化统一数据库（带进度反馈、错误处理和损坏检测）
-  Future<void> _initUnifiedDatabaseLightweight() async {
-    AppLogger.i('等待数据库准备就绪...', 'Warmup');
+  /// 主应用首帧完成后再启动非关键任务，避免争用页面切换帧。
+  void startPostWarmupTasks() {
+    if (_postWarmupStarted || !state.isComplete) return;
+    _postWarmupStarted = true;
+    if (!ref.read(startupInitializationTasksProvider).enablePostWarmupTasks) {
+      return;
+    }
+    _startNonCriticalWarmup();
+    _startGlobalGalleryScan();
+  }
 
+  void _startNonCriticalWarmup() {
+    final tasks = <(String, Future<void> Function())>[
+      ('Font preload', _preloadFonts),
+      ('Image editor warmup', _warmupImageEditor),
+      ('Network check', _checkNetworkEnvironment),
+      ('Prompt config load', _loadPromptConfig),
+      ('Gallery file count', _countGalleryFiles),
+      ('Subscription cache load', _loadSubscriptionCached),
+    ];
+    for (final task in tasks) {
+      unawaited(_runNonCriticalTask(task.$1, task.$2));
+    }
+  }
+
+  Future<void> _runNonCriticalTask(
+    String name,
+    Future<void> Function() task,
+  ) async {
     try {
-      // 数据库已在 main() 中初始化和恢复，这里只需等待就绪
-      final manager = await ref.watch(databaseManagerProvider.future);
-      await manager.initialized.timeout(
-        const Duration(seconds: 60),
-        onTimeout: () {
-          AppLogger.w('Database initialization timeout', 'Warmup');
-          throw TimeoutException(
-            'Database initialization timed out. Check disk space.',
-          );
-        },
-      );
-
-      AppLogger.i('数据库已就绪', 'Warmup');
-    } on TimeoutException {
-      rethrow;
+      await task();
+      AppLogger.d('$name completed', 'Warmup');
     } catch (e, stack) {
-      AppLogger.e('Database initialization failed', e, stack, 'Warmup');
-      // 数据库初始化失败不应阻塞启动，记录错误但继续
-      AppLogger.w(
-        'Continuing without database - will retry on first use',
-        'Warmup',
-      );
+      AppLogger.e('$name failed', e, stack, 'Warmup');
     }
   }
 
@@ -521,24 +419,6 @@ class WarmupNotifier extends _$WarmupNotifier {
   Future<void> _loadPromptConfig() async {
     final notifier = ref.read(promptConfigNotifierProvider.notifier);
     await notifier.whenLoaded.timeout(const Duration(seconds: 8));
-  }
-
-  /// 初始化画廊数据源
-  Future<void> _initGalleryDataSource() async {
-    try {
-      // 获取 DatabaseManager 并等待初始化
-      final dbManager = await ref.read(databaseManagerProvider.future);
-
-      // 获取 GalleryDataSource
-      final galleryDs = dbManager.getDataSource<GalleryDataSource>('gallery');
-      if (galleryDs != null) {
-        // 数据源已初始化（DatabaseManager 中已完成）
-        AppLogger.i('GalleryDataSource initialized in warmup phase', 'Warmup');
-      }
-    } catch (e) {
-      AppLogger.w('GalleryDataSource warmup failed: $e', 'Warmup');
-      // 不抛出异常，避免阻塞启动
-    }
   }
 
   /// 统计画廊文件数
@@ -574,36 +454,6 @@ class WarmupNotifier extends _$WarmupNotifier {
   }
 
   // ==== 后台任务方法 ====
-
-  Future<void> _initCooccurrenceData() async {
-    AppLogger.i('开始初始化共现数据...', 'Warmup');
-
-    try {
-      final cooccurrenceService = await ref.watch(
-        cooccurrenceServiceProvider.future,
-      );
-
-      // 初始化共现服务
-      final isReady = await cooccurrenceService.initialize();
-
-      if (isReady) {
-        final count = await cooccurrenceService.getCount();
-        AppLogger.i('共现数据已就绪（$count 条记录）', 'Warmup');
-      } else {
-        final count = await cooccurrenceService.getCount();
-        if (count > 0) {
-          AppLogger.w('共现数据不完整（$count 条记录），将在后台继续导入', 'Warmup');
-        } else {
-          AppLogger.i('共现数据为空，将在后台导入', 'Warmup');
-        }
-      }
-    } on StateError catch (e) {
-      // 数据库正在恢复中，不阻塞启动
-      AppLogger.w('共现数据初始化时数据库正在恢复，将在后台重试: $e', 'Warmup');
-    } catch (e, stack) {
-      AppLogger.e('共现数据初始化失败', e, stack, 'Warmup');
-    }
-  }
 
   // TODO: Remove with the retired dynamic tag-cache implementation.
   // ignore: unused_element

--- a/lib/presentation/screens/splash/app_bootstrap.dart
+++ b/lib/presentation/screens/splash/app_bootstrap.dart
@@ -16,7 +16,11 @@ import 'splash_screen.dart';
 /// 应用启动引导器
 /// 管理预加载流程和页面切换
 class AppBootstrap extends ConsumerStatefulWidget {
-  const AppBootstrap({super.key});
+  const AppBootstrap({super.key, this.mainAppBuilder, this.onWarmupComplete});
+
+  @visibleForTesting
+  final WidgetBuilder? mainAppBuilder;
+  final VoidCallback? onWarmupComplete;
 
   @override
   ConsumerState<AppBootstrap> createState() => _AppBootstrapState();
@@ -25,6 +29,20 @@ class AppBootstrap extends ConsumerStatefulWidget {
 class _AppBootstrapState extends ConsumerState<AppBootstrap> {
   bool _showMainApp = false;
   bool _hasCheckedFirstLaunch = false;
+  bool _warmupCompletionNotified = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      AppLogger.i(
+        'Splash first frame rendered; starting warmup',
+        'AppBootstrap',
+      );
+      ref.read(warmupNotifierProvider.notifier).start();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -34,16 +52,25 @@ class _AppBootstrapState extends ConsumerState<AppBootstrap> {
     if (warmupState.isComplete && !_showMainApp) {
       // 延迟一帧后切换，确保动画流畅
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          setState(() {
-            _showMainApp = true;
-          });
-        }
+        if (!mounted || _showMainApp) return;
+        setState(() {
+          _showMainApp = true;
+        });
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted || _warmupCompletionNotified) return;
+          _warmupCompletionNotified = true;
+          ref.read(warmupNotifierProvider.notifier).startPostWarmupTasks();
+          widget.onWarmupComplete?.call();
+        });
       });
     }
 
     // 如果显示主应用，直接返回（NAILauncherApp 自带 MaterialApp）
     if (_showMainApp) {
+      final mainAppBuilder = widget.mainAppBuilder;
+      if (mainAppBuilder != null) {
+        return mainAppBuilder(context);
+      }
       return _MainAppWrapper(
         hasCheckedFirstLaunch: _hasCheckedFirstLaunch,
         onFirstLaunchChecked: () {

--- a/lib/presentation/screens/splash/splash_screen.dart
+++ b/lib/presentation/screens/splash/splash_screen.dart
@@ -84,6 +84,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
                   primaryColor,
                   progress,
                   warmupState.subTaskMessage,
+                  warmupState.error,
                 ),
 
                 const SizedBox(height: 48),
@@ -203,6 +204,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     Color primaryColor,
     WarmupProgress progress,
     String? subTaskMessage,
+    String? error,
   ) {
     final l10n = context.l10n;
     final translatedTask = WarmupMessageLocalizer.localizeTask(
@@ -215,80 +217,109 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
       padding: const EdgeInsets.symmetric(horizontal: 48),
       child: Column(
         children: [
-          // 进度条 + 百分比
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Flexible(
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 260),
-                  child: _buildProgressBar(
-                    theme,
-                    primaryColor,
-                    progress.progress,
-                  ),
+          if (error != null) ...[
+            Icon(Icons.error_outline, color: theme.colorScheme.error, size: 28),
+            const SizedBox(height: 12),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 520),
+              child: Text(
+                error,
+                textAlign: TextAlign.center,
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.75),
                 ),
               ),
-              const SizedBox(width: 12),
-              // 百分比文字（使用等宽数字特性）
-              SizedBox(
-                width: 42,
-                child: Text(
-                  '$percentage%',
-                  textAlign: TextAlign.right,
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                    color: primaryColor,
-                    fontFeatures: const [FontFeature.tabularFigures()],
-                  ),
-                ),
-              ),
-            ],
-          ),
-
-          const SizedBox(height: 16),
-
-          // 当前任务（带加载指示器）
-          AnimatedSwitcher(
-            duration: const Duration(milliseconds: 200),
-            child: Row(
-              key: ValueKey(progress.currentTask),
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              key: const ValueKey('warmup_retry'),
+              onPressed: () {
+                ref.read(warmupNotifierProvider.notifier).retry();
+              },
+              icon: const Icon(Icons.refresh),
+              label: Text(l10n.common_retry),
+            ),
+          ] else ...[
+            // 进度条 + 百分比
+            Row(
               mainAxisAlignment: MainAxisAlignment.center,
-              mainAxisSize: MainAxisSize.min,
               children: [
-                if (!progress.isComplete) ...[
-                  SizedBox(
-                    width: 14,
-                    height: 14,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+                Flexible(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 260),
+                    child: _buildProgressBar(
+                      theme,
+                      primaryColor,
+                      progress.progress,
                     ),
                   ),
-                  const SizedBox(width: 8),
-                ],
-                Text(
-                  translatedTask,
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+                const SizedBox(width: 12),
+                // 百分比文字（使用等宽数字特性）
+                SizedBox(
+                  width: 42,
+                  child: Text(
+                    '$percentage%',
+                    textAlign: TextAlign.right,
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: primaryColor,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
                   ),
                 ),
               ],
             ),
-          ),
 
-          // 子任务进度（如"下载中... 50%"）
-          if (subTaskMessage != null && !progress.isComplete) ...[
-            const SizedBox(height: 8),
-            Text(
-              WarmupMessageLocalizer.localizeSubTask(l10n, subTaskMessage),
-              style: TextStyle(
-                fontSize: 11,
-                color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+            const SizedBox(height: 16),
+
+            // 当前任务（带加载指示器）
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 200),
+              child: Row(
+                key: ValueKey(progress.currentTask),
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (!progress.isComplete) ...[
+                    SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.4,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                  ],
+                  Text(
+                    translatedTask,
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                    ),
+                  ),
+                ],
               ),
             ),
+
+            // 子任务进度（如"下载中... 50%"）
+            if (subTaskMessage != null && !progress.isComplete) ...[
+              const SizedBox(height: 8),
+              Text(
+                WarmupMessageLocalizer.localizeSubTask(l10n, subTaskMessage),
+                style: TextStyle(
+                  fontSize: 11,
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+                ),
+              ),
+            ],
           ],
         ],
       ),

--- a/test/core/database/database_providers_test.dart
+++ b/test/core/database/database_providers_test.dart
@@ -96,7 +96,7 @@ void main() {
   );
 
   test(
-    'disposing provider container closes manager owned asset sources',
+    'provider container does not own the global database lifecycle',
     () async {
       final container = ProviderContainer();
 
@@ -108,7 +108,46 @@ void main() {
       container.dispose();
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
-      expect((await cooccurrence.checkHealth()).status, HealthStatus.corrupted);
+      expect((await cooccurrence.checkHealth()).status, HealthStatus.healthy);
+    },
+  );
+
+  test(
+    'concurrent DatabaseManager initialization shares one instance',
+    () async {
+      final results = await Future.wait([
+        DatabaseManager.initialize(),
+        DatabaseManager.initialize(),
+        DatabaseManager.initialize(),
+      ]);
+
+      expect(identical(results[0], results[1]), isTrue);
+      expect(identical(results[1], results[2]), isTrue);
+    },
+  );
+
+  test(
+    'failed DatabaseManager initialization can retry with a fresh instance',
+    () async {
+      final blockedPath = p.join(tempDir.path, 'not_a_directory');
+      await File(blockedPath).writeAsString('blocked');
+      PathProviderPlatform.instance = _TestPathProviderPlatform(
+        appSupportPath: blockedPath,
+      );
+
+      await expectLater(
+        DatabaseManager.initialize(),
+        throwsA(isA<FileSystemException>()),
+      );
+      expect(() => DatabaseManager.instance, throwsStateError);
+
+      PathProviderPlatform.instance = _TestPathProviderPlatform(
+        appSupportPath: appSupportDir.path,
+      );
+      final manager = await DatabaseManager.initialize();
+
+      expect(manager.isInitialized, isTrue);
+      expect(identical(DatabaseManager.instance, manager), isTrue);
     },
   );
 }

--- a/test/core/utils/hive_storage_helper_test.dart
+++ b/test/core/utils/hive_storage_helper_test.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/utils/hive_storage_helper.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late Directory documentsDir;
+  late Directory supportDir;
+  late Directory targetDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_startup_migration_');
+    documentsDir = await Directory(
+      p.join(tempDir.path, 'documents'),
+    ).create(recursive: true);
+    supportDir = await Directory(
+      p.join(tempDir.path, 'app_data', 'publisher', 'app'),
+    ).create(recursive: true);
+    targetDir = await Directory(
+      p.join(tempDir.path, 'target'),
+    ).create(recursive: true);
+    PathProviderPlatform.instance = _TestPathProviderPlatform(
+      documentsPath: documentsDir.path,
+      supportPath: supportDir.path,
+    );
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('首帧前只迁移 settings，其他 Hive 文件留给 Warmup', () async {
+    final oldSettings = File(p.join(documentsDir.path, 'settings.hive'));
+    final oldTagCache = File(p.join(documentsDir.path, 'tag_cache.hive'));
+    await oldSettings.writeAsString('settings data');
+    await oldTagCache.writeAsString('tag cache data');
+
+    await HiveStorageHelper.instance.migrateSettingsFromOldLocation(
+      targetDir.path,
+    );
+
+    expect(
+      await File(p.join(targetDir.path, 'settings.hive')).readAsString(),
+      'settings data',
+    );
+    expect(await oldSettings.exists(), isFalse);
+    expect(await oldTagCache.exists(), isTrue);
+    expect(
+      await File(p.join(targetDir.path, 'tag_cache.hive')).exists(),
+      isFalse,
+    );
+  });
+
+  test('较新的目标文件内容不同时保留旧文件', () async {
+    final oldSettings = File(p.join(documentsDir.path, 'settings.hive'));
+    final targetSettings = File(p.join(targetDir.path, 'settings.hive'));
+    await oldSettings.writeAsString('old settings');
+    await targetSettings.writeAsString('new settings');
+    await oldSettings.setLastModified(DateTime.utc(2020));
+    await targetSettings.setLastModified(DateTime.utc(2021));
+
+    await HiveStorageHelper.instance.migrateSettingsFromOldLocation(
+      targetDir.path,
+    );
+
+    expect(await oldSettings.readAsString(), 'old settings');
+    expect(await targetSettings.readAsString(), 'new settings');
+  });
+}
+
+class _TestPathProviderPlatform extends PathProviderPlatform {
+  _TestPathProviderPlatform({
+    required this.documentsPath,
+    required this.supportPath,
+  });
+
+  final String documentsPath;
+  final String supportPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => supportPath;
+}

--- a/test/presentation/screens/splash/app_bootstrap_test.dart
+++ b/test/presentation/screens/splash/app_bootstrap_test.dart
@@ -1,0 +1,154 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/constants/app_version.dart';
+import 'package:nai_launcher/core/services/data_migration_service.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/presentation/providers/startup_initialization_provider.dart';
+import 'package:nai_launcher/presentation/screens/splash/app_bootstrap.dart';
+import 'package:nai_launcher/presentation/screens/splash/splash_screen.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    PackageInfo.setMockInitialValues(
+      appName: 'NAI Launcher',
+      packageName: 'nai_launcher',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+    await AppVersion.initialize();
+  });
+
+  testWidgets('Splash 先渲染，再按迁移、数据库、关键服务顺序进入主应用', (tester) async {
+    final migration = Completer<void>();
+    final database = Completer<void>();
+    final criticalServices = Completer<void>();
+    final calls = <String>[];
+
+    await tester.pumpWidget(
+      _buildApp(
+        tasks: StartupInitializationTasks(
+          enablePostWarmupTasks: false,
+          initializeRuntimeConfiguration: () async {
+            calls.add('runtimeConfiguration');
+          },
+          runDataMigration: (_) async {
+            calls.add('migration');
+            await migration.future;
+            return _successfulMigration();
+          },
+          initializeDatabase: () async {
+            calls.add('database');
+            await database.future;
+          },
+          initializeCriticalServices: () async {
+            calls.add('criticalServices');
+            await criticalServices.future;
+          },
+        ),
+      ),
+    );
+
+    expect(find.byType(SplashScreen), findsOneWidget);
+    expect(find.byKey(const ValueKey('main_app')), findsNothing);
+    expect(calls, ['runtimeConfiguration', 'migration']);
+
+    migration.complete();
+    await _pumpAsync(tester);
+    expect(calls, ['runtimeConfiguration', 'migration', 'database']);
+    expect(find.byType(SplashScreen), findsOneWidget);
+
+    database.complete();
+    await _pumpAsync(tester);
+    expect(calls, [
+      'runtimeConfiguration',
+      'migration',
+      'database',
+      'criticalServices',
+    ]);
+    expect(find.byType(SplashScreen), findsOneWidget);
+
+    criticalServices.complete();
+    await _pumpAsync(tester);
+    expect(find.byKey(const ValueKey('main_app')), findsOneWidget);
+    expect(calls.where((call) => call == 'migration'), hasLength(1));
+    expect(calls.where((call) => call == 'database'), hasLength(1));
+  });
+
+  testWidgets('数据库失败保留 Splash，点击重试后才进入主应用', (tester) async {
+    var databaseAttempts = 0;
+    var criticalServiceCalls = 0;
+
+    await tester.pumpWidget(
+      _buildApp(
+        tasks: StartupInitializationTasks(
+          enablePostWarmupTasks: false,
+          initializeRuntimeConfiguration: () async {},
+          runDataMigration: (_) async => _successfulMigration(),
+          initializeDatabase: () async {
+            databaseAttempts++;
+            if (databaseAttempts == 1) {
+              throw StateError('database failed');
+            }
+          },
+          initializeCriticalServices: () async {
+            criticalServiceCalls++;
+          },
+        ),
+      ),
+    );
+    await _pumpAsync(tester);
+
+    expect(find.byType(SplashScreen), findsOneWidget);
+    expect(find.byKey(const ValueKey('main_app')), findsNothing);
+    expect(find.byKey(const ValueKey('warmup_retry')), findsOneWidget);
+    expect(databaseAttempts, 1);
+    expect(criticalServiceCalls, 0);
+
+    await tester.tap(find.byKey(const ValueKey('warmup_retry')));
+    await _pumpAsync(tester);
+
+    expect(databaseAttempts, 2);
+    expect(criticalServiceCalls, 1);
+    expect(find.byKey(const ValueKey('main_app')), findsOneWidget);
+  });
+}
+
+Widget _buildApp({required StartupInitializationTasks tasks}) {
+  return ProviderScope(
+    overrides: [
+      localStorageServiceProvider.overrideWith((ref) => _MemoryStorage()),
+      startupInitializationTasksProvider.overrideWithValue(tasks),
+    ],
+    child: AppBootstrap(
+      mainAppBuilder: (_) => const Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(key: ValueKey('main_app')),
+      ),
+    ),
+  );
+}
+
+MigrationResult _successfulMigration() {
+  return MigrationResult()
+    ..hiveMigrated = true
+    ..vibeMigrated = true
+    ..imageMigrated = true;
+}
+
+Future<void> _pumpAsync(WidgetTester tester) async {
+  for (var i = 0; i < 8; i++) {
+    await tester.pump();
+  }
+}
+
+class _MemoryStorage extends LocalStorageService {
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) => defaultValue;
+}


### PR DESCRIPTION
## Problem
应用启动时会同步执行许多非关键任务，导致首帧显示变慢；初始化失败后，重试可能复用不完整状态。

## Solution
先显示 Splash，再按顺序执行关键迁移、数据库和服务初始化，将其他任务延后到后台，并确保失败初始化可清理后重新尝试。

### Details
- 延迟非关键启动任务、窗口显示和全局监听器初始化
- 为数据库管理器和连接池增加并发初始化复用与失败清理
- 将启动初始化任务集中管理，并支持 Splash 内重试
- 改进 Hive 数据迁移的校验、临时文件处理和失败清理
- 增加数据库初始化、Hive 迁移和 Splash 启动流程测试

### Testing
- Added tests for concurrent database initialization and retry after failure
- Added tests for Hive settings migration safety
- Added widget tests for Splash initialization order and retry flow