### PR TITLE
统一生成与取消按钮样式并保持尺寸一致

### DIFF
--- a/lib/presentation/screens/generation/mobile_layout.dart
+++ b/lib/presentation/screens/generation/mobile_layout.dart
@@ -275,60 +275,89 @@ class _MobileGenerateButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (showCancel) {
-      return Row(
-        children: [
-          if (_canSkipCurrentBatch) ...[
-            Expanded(
-              child: ThemedButton(
-                onPressed: onSkipCurrent,
-                icon: const Icon(Icons.skip_next),
-                label: Text(
-                  '${context.l10n.generation_skipCurrentBatch} ${_progressText()}',
+    final theme = Theme.of(context);
+    final cancelTheme = theme.copyWith(
+      colorScheme: theme.colorScheme.copyWith(
+        primary: theme.colorScheme.errorContainer,
+        onPrimary: theme.colorScheme.onErrorContainer,
+        primaryContainer: theme.colorScheme.error,
+        onPrimaryContainer: theme.colorScheme.onError,
+      ),
+    );
+    final isLoading = isGenerating && !showCancel;
+    final primaryButton = AnimatedTheme(
+      data: showCancel ? cancelTheme : theme,
+      duration: const Duration(milliseconds: 160),
+      curve: Curves.easeOut,
+      child: ThemedButton(
+        onPressed: showCancel
+            ? onCancel
+            : isGenerating || cooldownRemainingSeconds > 0
+            ? null
+            : onGenerate,
+        isLoading: isLoading,
+        label: IndexedStack(
+          index: showCancel ? 1 : 0,
+          alignment: Alignment.center,
+          children: [
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (!isLoading) ...[
+                  Icon(
+                    cooldownRemainingSeconds > 0
+                        ? Icons.hourglass_bottom_outlined
+                        : Icons.auto_awesome,
+                  ),
+                  const SizedBox(width: 8),
+                ],
+                Text(
+                  showCancel
+                      ? context.l10n.generation_generate
+                      : isGenerating
+                      ? context.l10n.generation_generating
+                      : cooldownRemainingSeconds > 0
+                      ? context.l10n.generation_cooldownRemaining(
+                          cooldownRemainingSeconds,
+                        )
+                      : context.l10n.generation_generate,
                 ),
-                style: ThemedButtonStyle.outlined,
-              ),
+                AnlasCostBadge(isGenerating: isLoading),
+              ],
             ),
-            const SizedBox(width: 8),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.stop_circle_outlined),
+                const SizedBox(width: 8),
+                Text(context.l10n.common_cancel),
+              ],
+            ),
           ],
-          Expanded(
-            child: ThemedButton(
-              onPressed: onCancel,
-              icon: const Icon(Icons.stop_circle_outlined),
-              label: Text(context.l10n.generation_stopAllGeneration),
-              style: ThemedButtonStyle.outlined,
-            ),
-          ),
-        ],
-      );
+        ),
+        style: ThemedButtonStyle.filled,
+      ),
+    );
+
+    if (!_canSkipCurrentBatch) {
+      return primaryButton;
     }
 
-    return ThemedButton(
-      onPressed: isGenerating || cooldownRemainingSeconds > 0
-          ? null
-          : onGenerate,
-      icon: isGenerating
-          ? null
-          : cooldownRemainingSeconds > 0
-          ? const Icon(Icons.hourglass_bottom_outlined)
-          : const Icon(Icons.auto_awesome),
-      isLoading: isGenerating,
-      label: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            isGenerating
-                ? context.l10n.generation_generating
-                : cooldownRemainingSeconds > 0
-                ? context.l10n.generation_cooldownRemaining(
-                    cooldownRemainingSeconds,
-                  )
-                : context.l10n.generation_generate,
+    return Row(
+      children: [
+        Expanded(
+          child: ThemedButton(
+            onPressed: onSkipCurrent,
+            icon: const Icon(Icons.skip_next),
+            label: Text(
+              '${context.l10n.generation_skipCurrentBatch} ${_progressText()}',
+            ),
+            style: ThemedButtonStyle.outlined,
           ),
-          AnlasCostBadge(isGenerating: isGenerating),
-        ],
-      ),
-      style: ThemedButtonStyle.filled,
+        ),
+        const SizedBox(width: 8),
+        Expanded(child: primaryButton),
+      ],
     );
   }
 }

--- a/lib/presentation/screens/generation/widgets/generation_controls/generate_button.dart
+++ b/lib/presentation/screens/generation/widgets/generation_controls/generate_button.dart
@@ -55,51 +55,84 @@ class GenerateButtonWithCost extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (showCancel) {
-      return SizedBox(
-        height: height,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (_canSkipCurrentBatch) ...[
-              ThemedButton(
-                onPressed: onSkipCurrent,
-                icon: const Icon(Icons.skip_next),
-                label: Text(
-                  '${context.l10n.generation_skipCurrentBatch} ${_progressText()}',
-                ),
-                style: ThemedButtonStyle.outlined,
-              ),
-              const SizedBox(width: 8),
-            ],
-            ThemedButton(
-              onPressed: onCancel,
-              icon: const Icon(Icons.stop_circle_outlined),
-              label: Text(context.l10n.generation_stopAllGeneration),
-              style: ThemedButtonStyle.outlined,
-            ),
-          ],
-        ),
-      );
-    }
+    final primaryButton = _buildPrimaryButton(context);
 
     return SizedBox(
       height: height,
+      child: _canSkipCurrentBatch
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ThemedButton(
+                  onPressed: onSkipCurrent,
+                  icon: const Icon(Icons.skip_next),
+                  label: Text(
+                    '${context.l10n.generation_skipCurrentBatch} ${_progressText()}',
+                  ),
+                  style: ThemedButtonStyle.outlined,
+                ),
+                const SizedBox(width: 8),
+                primaryButton,
+              ],
+            )
+          : primaryButton,
+    );
+  }
+
+  Widget _buildPrimaryButton(BuildContext context) {
+    final theme = Theme.of(context);
+    final cancelTheme = theme.copyWith(
+      colorScheme: theme.colorScheme.copyWith(
+        primary: theme.colorScheme.errorContainer,
+        onPrimary: theme.colorScheme.onErrorContainer,
+        primaryContainer: theme.colorScheme.error,
+        onPrimaryContainer: theme.colorScheme.onError,
+      ),
+    );
+    final isLoading = isGenerating && !showCancel;
+
+    return AnimatedTheme(
+      data: showCancel ? cancelTheme : theme,
+      duration: const Duration(milliseconds: 160),
+      curve: Curves.easeOut,
       child: ThemedButton(
-        onPressed: isGenerating || cooldownRemainingSeconds > 0
+        onPressed: showCancel
+            ? onCancel
+            : isGenerating || cooldownRemainingSeconds > 0
             ? null
             : onGenerate,
-        icon: isGenerating
-            ? null
-            : cooldownRemainingSeconds > 0
-            ? const Icon(Icons.hourglass_bottom_outlined)
-            : const Icon(Icons.auto_awesome),
-        isLoading: isGenerating,
-        label: Row(
-          mainAxisSize: MainAxisSize.min,
+        isLoading: isLoading,
+        label: IndexedStack(
+          index: showCancel ? 1 : 0,
+          alignment: Alignment.center,
           children: [
-            Text(_generateLabelText(context)),
-            AnlasCostBadge(isGenerating: isGenerating),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (!isLoading) ...[
+                  Icon(
+                    cooldownRemainingSeconds > 0
+                        ? Icons.hourglass_bottom_outlined
+                        : Icons.auto_awesome,
+                  ),
+                  const SizedBox(width: 8),
+                ],
+                Text(
+                  showCancel
+                      ? context.l10n.generation_generate
+                      : _generateLabelText(context),
+                ),
+                AnlasCostBadge(isGenerating: isLoading),
+              ],
+            ),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.stop_circle_outlined),
+                const SizedBox(width: 8),
+                Text(context.l10n.common_cancel),
+              ],
+            ),
           ],
         ),
         style: ThemedButtonStyle.filled,

--- a/test/presentation/screens/generation/widgets/generation_controls/generate_button_test.dart
+++ b/test/presentation/screens/generation/widgets/generation_controls/generate_button_test.dart
@@ -51,8 +51,9 @@ void main() {
     );
   }
 
-  testWidgets('idle: shows generate label and triggers onGenerate on tap',
-      (tester) async {
+  testWidgets('idle: shows generate label and triggers onGenerate on tap', (
+    tester,
+  ) async {
     var generateCalled = false;
     var cancelCalled = false;
     await pumpButton(
@@ -72,8 +73,9 @@ void main() {
     expect(cancelCalled, isFalse);
   });
 
-  testWidgets('generating: shows stop-all label and triggers onCancel on tap',
-      (tester) async {
+  testWidgets('generating: keeps filled style and triggers onCancel on tap', (
+    tester,
+  ) async {
     var generateCalled = false;
     var cancelCalled = false;
     await pumpButton(
@@ -84,16 +86,32 @@ void main() {
       onCancel: () => cancelCalled = true,
     );
 
-    expect(find.text(l10n.generation_stopAllGeneration), findsOneWidget);
+    expect(find.text(l10n.common_cancel), findsOneWidget);
     expect(find.byIcon(Icons.stop_circle_outlined), findsOneWidget);
+    expect(find.byType(FilledButton), findsOneWidget);
+    expect(find.byType(OutlinedButton), findsNothing);
 
-    await tester.tap(find.byType(OutlinedButton));
+    await tester.tap(find.byType(FilledButton));
     expect(cancelCalled, isTrue);
     expect(generateCalled, isFalse);
   });
 
-  testWidgets('cooldown: shows countdown and disables generation',
-      (tester) async {
+  testWidgets('idle and cancel states keep the same button size', (
+    tester,
+  ) async {
+    await pumpButton(tester, isGenerating: false, showCancel: false);
+    final idleSize = tester.getSize(find.byType(FilledButton));
+
+    await pumpButton(tester, isGenerating: true, showCancel: true);
+    await tester.pumpAndSettle();
+    final cancelSize = tester.getSize(find.byType(FilledButton));
+
+    expect(cancelSize, idleSize);
+  });
+
+  testWidgets('cooldown: shows countdown and disables generation', (
+    tester,
+  ) async {
     var generateCalled = false;
     await pumpButton(
       tester,
@@ -112,65 +130,71 @@ void main() {
     expect(generateCalled, isFalse);
   });
 
-  testWidgets('generating multiple images: shows skip-current progress and stop-all',
-      (tester) async {
-    await pumpButton(
-      tester,
-      isGenerating: true,
-      showCancel: true,
-      generationState: const ImageGenerationState(
-        currentImage: 2,
-        totalImages: 4,
-      ),
-    );
+  testWidgets(
+    'generating multiple images: shows skip-current progress and cancel',
+    (tester) async {
+      await pumpButton(
+        tester,
+        isGenerating: true,
+        showCancel: true,
+        generationState: const ImageGenerationState(
+          currentImage: 2,
+          totalImages: 4,
+        ),
+      );
 
-    expect(find.text('${l10n.generation_skipCurrentBatch} 2/4'), findsOneWidget);
-    expect(find.text(l10n.generation_stopAllGeneration), findsOneWidget);
-    expect(find.byIcon(Icons.skip_next), findsOneWidget);
-    expect(find.byIcon(Icons.stop_circle_outlined), findsOneWidget);
-  });
+      expect(
+        find.text('${l10n.generation_skipCurrentBatch} 2/4'),
+        findsOneWidget,
+      );
+      expect(find.text(l10n.common_cancel), findsOneWidget);
+      expect(find.byIcon(Icons.skip_next), findsOneWidget);
+      expect(find.byIcon(Icons.stop_circle_outlined), findsOneWidget);
+    },
+  );
 
-  testWidgets('generating multiple images: skip button triggers onSkipCurrent',
-      (tester) async {
-    var skipCalled = false;
-    var cancelCalled = false;
-    await pumpButton(
-      tester,
-      isGenerating: true,
-      showCancel: true,
-      generationState: const ImageGenerationState(
-        currentImage: 2,
-        totalImages: 4,
-      ),
-      onSkipCurrent: () => skipCalled = true,
-      onCancel: () => cancelCalled = true,
-    );
+  testWidgets(
+    'generating multiple images: skip button triggers onSkipCurrent',
+    (tester) async {
+      var skipCalled = false;
+      var cancelCalled = false;
+      await pumpButton(
+        tester,
+        isGenerating: true,
+        showCancel: true,
+        generationState: const ImageGenerationState(
+          currentImage: 2,
+          totalImages: 4,
+        ),
+        onSkipCurrent: () => skipCalled = true,
+        onCancel: () => cancelCalled = true,
+      );
 
-    await tester.tap(
-      find.widgetWithText(
-        OutlinedButton,
-        '${l10n.generation_skipCurrentBatch} 2/4',
-      ),
-    );
+      await tester.tap(
+        find.widgetWithText(
+          OutlinedButton,
+          '${l10n.generation_skipCurrentBatch} 2/4',
+        ),
+      );
 
-    expect(skipCalled, isTrue);
-    expect(cancelCalled, isFalse);
-  });
+      expect(skipCalled, isTrue);
+      expect(cancelCalled, isFalse);
+    },
+  );
 
-  testWidgets('generating without cancel (bridge busy): keeps generating label',
-      (tester) async {
-    await pumpButton(
-      tester,
-      isGenerating: true,
-      showCancel: false,
-    );
+  testWidgets(
+    'generating without cancel (bridge busy): keeps generating label',
+    (tester) async {
+      await pumpButton(tester, isGenerating: true, showCancel: false);
 
-    expect(find.text(l10n.generation_generating), findsOneWidget);
-    expect(find.byIcon(Icons.stop_circle_outlined), findsNothing);
-  });
+      expect(find.text(l10n.generation_generating), findsOneWidget);
+      expect(find.byIcon(Icons.stop_circle_outlined), findsNothing);
+    },
+  );
 
-  testWidgets('generating without cancel does not trigger onCancel on tap',
-      (tester) async {
+  testWidgets('generating without cancel does not trigger onCancel on tap', (
+    tester,
+  ) async {
     var generateCalled = false;
     var cancelCalled = false;
     await pumpButton(


### PR DESCRIPTION
## Problem
生成和取消按钮样式不同，切换状态时按钮尺寸也可能变化，影响界面一致性。

## Solution
统一生成与取消按钮为填充样式，并通过固定内容布局保持尺寸一致；多图生成时保留跳过当前批次按钮。新增测试覆盖样式、尺寸、文案和交互行为。