### PR TITLE
优化画廊滚动预载策略

### DIFF
--- a/lib/core/cache/online_gallery_preload_policy.dart
+++ b/lib/core/cache/online_gallery_preload_policy.dart
@@ -1,0 +1,28 @@
+import 'dart:math';
+
+abstract final class OnlineGalleryPreloadPolicy {
+  static const double _minimumLoadAheadDistance = 900;
+  static const double _loadAheadScreens = 1.25;
+  static const double _cacheExtentScreens = 0.75;
+
+  static double loadAheadDistance(double viewportHeight) => max(
+    _minimumLoadAheadDistance,
+    viewportHeight * _loadAheadScreens,
+  ).toDouble();
+
+  static double cacheExtent(double viewportHeight) =>
+      max(0, viewportHeight * _cacheExtentScreens).toDouble();
+
+  static int lookaheadItemCount({
+    required double viewportHeight,
+    required double itemWidth,
+    required int columnCount,
+  }) {
+    if (viewportHeight <= 0 || itemWidth <= 0 || columnCount <= 0) return 12;
+    final rowsPerScreen = (viewportHeight / itemWidth).ceil();
+    return (rowsPerScreen * columnCount * _cacheExtentScreens)
+        .ceil()
+        .clamp(12, 48)
+        .toInt();
+  }
+}

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -564,7 +564,7 @@ class OnlineGalleryState {
 
 @riverpod
 class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
-  static const int _pageSize = 40;
+  static const int _pageSize = 60;
   static const int _maxFilteredEmptyPagesPerLoad = 5;
 
   CancelToken? _cancelToken;

--- a/lib/presentation/screens/online_gallery/online_gallery_screen.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen.dart
@@ -13,6 +13,7 @@ import '../../../core/cache/gallery_image_request.dart';
 import '../../../core/cache/online_gallery_image_cache_manager.dart';
 import '../../../core/cache/online_gallery_detail_coordinator.dart';
 import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
+import '../../../core/cache/online_gallery_preload_policy.dart';
 import '../../../core/services/date_formatting_service.dart';
 import '../../../core/utils/file_picker_utils.dart';
 import '../../../data/datasources/remote/danbooru_api_service.dart';
@@ -83,6 +84,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
   double _pendingAnchorLocalOffset = 0;
   double _lastScrollOffset = 0;
   int _scrollDirection = 1;
+  int _lookaheadItemCount = 12;
   bool _isScrolling = false;
   bool _isEditingPage = false;
   GalleryViewMode? _lastViewMode;
@@ -178,11 +180,14 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         _scheduleVisiblePrefetch();
       });
     }
-    if (_scrollController.position.pixels >=
-        _scrollController.position.maxScrollExtent - 200) {
+    if (_isWithinLoadAhead(_scrollController.position)) {
       _galleryNotifier.loadMore();
     }
   }
+
+  bool _isWithinLoadAhead(ScrollMetrics metrics) =>
+      metrics.extentAfter <=
+      OnlineGalleryPreloadPolicy.loadAheadDistance(metrics.viewportDimension);
 
   void _scheduleAutoLoadIfUnderfilled(OnlineGalleryState state) {
     final activeCache = state.randomEnabled
@@ -220,8 +225,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
       final needsMore =
           latest.posts.isEmpty ||
           (_scrollController.hasClients &&
-              _scrollController.position.pixels >=
-                  _scrollController.position.maxScrollExtent - 200);
+              _isWithinLoadAhead(_scrollController.position));
       if (needsMore) {
         unawaited(_galleryNotifier.loadMore());
       }
@@ -1993,6 +1997,14 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
     final screenWidth = MediaQuery.of(context).size.width - 60;
     final columnCount = (screenWidth / 200).floor().clamp(2, 8);
     final itemWidth = (screenWidth - 24 - (columnCount - 1) * 6) / columnCount;
+    final viewportHeight = _scrollController.hasClients
+        ? _scrollController.position.viewportDimension
+        : MediaQuery.sizeOf(context).height;
+    _lookaheadItemCount = OnlineGalleryPreloadPolicy.lookaheadItemCount(
+      viewportHeight: viewportHeight,
+      itemWidth: itemWidth,
+      columnCount: columnCount,
+    );
 
     final storageScope = state.randomEnabled
         ? 'random:${state.randomSession.scopeKey}'
@@ -2002,6 +2014,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         'online_gallery_$storageScope:${state.currentCacheKey}',
       ),
       controller: _scrollController,
+      cacheExtent: OnlineGalleryPreloadPolicy.cacheExtent(viewportHeight),
       padding: const EdgeInsets.all(12),
       crossAxisCount: columnCount,
       mainAxisSpacing: 6,
@@ -2410,28 +2423,13 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
     final state = ref.read(onlineGalleryNotifierProvider);
     final visible = _visibleItems.entries.toList()
       ..sort((left, right) => left.key.compareTo(right.key));
-    for (final entry in visible.take(12)) {
-      final item = entry.value.item;
-      if (item.isVideo || item.isAnimated) continue;
-      final sampleUrl =
-          item.sampleUrl ?? item.largeFileUrl ?? item.cover.displayUrl;
-      if (sampleUrl.isEmpty) continue;
-      unawaited(
-        _prefetchCoordinator.submit(
-          _imageRequest(
-            item,
-            sampleUrl,
-            GalleryImageTier.sample,
-            entry.value.itemWidth,
-          ),
-          priority: GalleryImagePriority.visible,
-        ),
-      );
-    }
-
+    final itemWidth = visible.first.value.itemWidth;
     final edge = _scrollDirection >= 0 ? visible.last.key : visible.first.key;
     var aiDetailsQueued = 0;
-    for (var step = 1; step <= 8; step++) {
+
+    // 先把下一段网格缩略图放入队列，避免悬浮大图占满并发槽后，
+    // 用户滚到下一屏时仍要等待缩略图下载和解码。
+    for (var step = 1; step <= _lookaheadItemCount; step++) {
       final index = edge + step * _scrollDirection;
       if (index < 0 || index >= state.posts.length) continue;
       final item = state.posts[index];
@@ -2442,7 +2440,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
               item,
               item.previewUrl,
               GalleryImageTier.thumbnail,
-              visible.first.value.itemWidth,
+              itemWidth,
             ),
             priority: GalleryImagePriority.lookahead,
           ),
@@ -2457,6 +2455,34 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
               .catchError((_) {}),
         );
       }
+    }
+
+    // 与 ComfyUI 画廊一致，只预取真正独立的 Sample。AI TAG 的预览通常
+    // 就是原图；重复以更大尺寸解码只会挤占滚动所需的 IO 和解码时间。
+    for (final entry in visible.take(12)) {
+      final item = entry.value.item;
+      if (item.isVideo ||
+          item.isAnimated ||
+          item.sourceId == GallerySourceId.aiTag) {
+        continue;
+      }
+      final sampleUrl = item.sampleUrl ?? item.largeFileUrl;
+      if (sampleUrl == null ||
+          sampleUrl.isEmpty ||
+          sampleUrl == item.previewUrl) {
+        continue;
+      }
+      unawaited(
+        _prefetchCoordinator.submit(
+          _imageRequest(
+            item,
+            sampleUrl,
+            GalleryImageTier.sample,
+            entry.value.itemWidth,
+          ),
+          priority: GalleryImagePriority.lookahead,
+        ),
+      );
     }
   }
 

--- a/test/presentation/providers/online_gallery_pagination_test.dart
+++ b/test/presentation/providers/online_gallery_pagination_test.dart
@@ -35,6 +35,7 @@ void main() {
 
       final state = container.read(onlineGalleryNotifierProvider);
       expect(adapter.searchCursors, ['1', '2']);
+      expect(adapter.searchPageSizes, [60, 60]);
       expect(state.posts.map((item) => item.id), [1, 2, 3]);
       expect(state.page, 2);
       expect(state.currentCache.nextCursor, '3');
@@ -448,6 +449,7 @@ class _FakeGalleryAdapter implements GallerySourceAdapter {
   )
   onSearch;
   final List<String> searchCursors = [];
+  final List<int> searchPageSizes = [];
 
   @override
   Random get randomGenerator => Random(1);
@@ -462,6 +464,7 @@ class _FakeGalleryAdapter implements GallerySourceAdapter {
     CancelToken? cancelToken,
   }) {
     searchCursors.add(request.cursor);
+    searchPageSizes.add(request.pageSize);
     return onSearch(request, cancelToken);
   }
 

--- a/test/presentation/screens/online_gallery/online_gallery_preload_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_preload_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/cache/online_gallery_preload_policy.dart';
+
+void main() {
+  group('online gallery preload window', () {
+    test('starts pagination before reaching the end of the current page', () {
+      expect(OnlineGalleryPreloadPolicy.loadAheadDistance(600), 900);
+      expect(OnlineGalleryPreloadPolicy.loadAheadDistance(800), 1000);
+    });
+
+    test('keeps three quarters of a viewport built ahead', () {
+      expect(OnlineGalleryPreloadPolicy.cacheExtent(800), 600);
+      expect(OnlineGalleryPreloadPolicy.cacheExtent(-1), 0);
+    });
+
+    test('scales thumbnail lookahead with viewport and column count', () {
+      expect(
+        OnlineGalleryPreloadPolicy.lookaheadItemCount(
+          viewportHeight: 800,
+          itemWidth: 200,
+          columnCount: 4,
+        ),
+        12,
+      );
+      expect(
+        OnlineGalleryPreloadPolicy.lookaheadItemCount(
+          viewportHeight: 1600,
+          itemWidth: 100,
+          columnCount: 8,
+        ),
+        48,
+      );
+      expect(
+        OnlineGalleryPreloadPolicy.lookaheadItemCount(
+          viewportHeight: 0,
+          itemWidth: 200,
+          columnCount: 4,
+        ),
+        12,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem
画廊接近当前页面末尾才加载下一页，滚动时可能等待图片加载；过度预取大图也会占用资源。

## Solution
提前触发分页加载，并根据视口动态预载缩略图和缓存内容；减少重复的 Sample 预取，同时将分页大小调整为 60。

### Testing
- Added preload policy tests for load-ahead distance, cache extent, and lookahead count.
- Updated pagination tests to verify page size 60.