### PR TITLE
持久化画廊浏览会话与滚动位置

### DIFF
--- a/lib/core/constants/storage_keys.dart
+++ b/lib/core/constants/storage_keys.dart
@@ -291,6 +291,8 @@ class StorageKeys {
       'online_gallery_prompt_tag_categories';
   static const String onlineGalleryOutputFilterTags =
       'online_gallery_output_filter_tags';
+  static const String onlineGalleryBrowsingSessionV1 =
+      'online_gallery_browsing_session_v1';
 
   // ComfyUI 设置
   static const String comfyuiEnabled = 'comfyui_enabled';

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
 import 'dart:collection';
+import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../core/cache/online_gallery_detail_coordinator.dart';
+import '../../core/constants/storage_keys.dart';
 import '../../core/network/online_gallery_retry_interceptor.dart';
+import '../../core/storage/local_storage_service.dart';
 import '../../core/utils/app_logger.dart';
 import '../../data/datasources/remote/danbooru_api_service.dart';
 import '../../data/datasources/remote/gelbooru_api_service.dart';
@@ -562,6 +565,202 @@ class OnlineGalleryState {
   }
 }
 
+/// Encodes only browsing intent and lightweight location metadata. Remote
+/// gallery rows are deliberately refreshed after restart so stale URLs and
+/// source-side favorite/ranking changes are not treated as durable data.
+String encodeOnlineGalleryBrowsingSession(OnlineGalleryState state) {
+  final positions = <String, dynamic>{};
+  for (final entry in state.caches.entries) {
+    positions[entry.key] = _encodeGalleryPosition(entry.value);
+  }
+  positions
+    ..remove(state.currentCacheKey)
+    ..[state.currentCacheKey] = _encodeGalleryPosition(state.currentCache);
+  while (positions.length > 12) {
+    positions.remove(positions.keys.first);
+  }
+
+  return jsonEncode({
+    'version': 1,
+    'viewMode': state.viewMode.name,
+    'sourceId': state.sourceId.key,
+    'popularSourceId': state.popularSourceId.key,
+    'favoritesSourceId': state.favoritesSourceId.key,
+    'searchQuery': state.searchQuery,
+    'promptQuery': state.promptQuery,
+    'popularQuery': state.popularQuery,
+    'popularPromptQuery': state.popularPromptQuery,
+    'fuzzySearchEnabled': state.fuzzySearchEnabled,
+    'selectedRatings': (state.selectedRatings.toList()..sort()),
+    'popularScale': state.popularScale.name,
+    'popularDate': state.popularDate?.toIso8601String(),
+    'aiTagTimeRange': state.aiTagTimeRange,
+    'aiTagPopularPeriod': state.aiTagPopularPeriod,
+    'dateRangeStart': state.dateRangeStart?.toIso8601String(),
+    'dateRangeEnd': state.dateRangeEnd?.toIso8601String(),
+    'randomEnabled': state.randomEnabled,
+    'randomPosition': _encodeGalleryPosition(state.randomSession.cache),
+    'artistHuntEnabled': state.artistHuntEnabled,
+    'positions': positions,
+  });
+}
+
+OnlineGalleryState decodeOnlineGalleryBrowsingSession(String? encoded) {
+  if (encoded == null || encoded.trim().isEmpty) {
+    return const OnlineGalleryState();
+  }
+  try {
+    final decoded = jsonDecode(encoded);
+    if (decoded is! Map || decoded['version'] != 1) {
+      return const OnlineGalleryState();
+    }
+    final json = Map<String, dynamic>.from(decoded);
+    final sourceId = _decodeGallerySource(json['sourceId']);
+    final popularSourceCandidate = _decodeGallerySource(
+      json['popularSourceId'],
+    );
+    final popularSourceId = popularSourceCandidate.capabilities.supportsRanking
+        ? popularSourceCandidate
+        : GallerySourceId.danbooru;
+    final favoritesSourceCandidate = _decodeGallerySource(
+      json['favoritesSourceId'],
+    );
+    final favoritesSourceId =
+        favoritesSourceCandidate == GallerySourceId.gelbooru
+        ? GallerySourceId.gelbooru
+        : GallerySourceId.danbooru;
+    final viewMode = _decodeEnumByName(
+      GalleryViewMode.values,
+      json['viewMode'],
+      GalleryViewMode.search,
+    );
+    final selectedRatings = _decodeRatings(json['selectedRatings']);
+    final base = OnlineGalleryState(
+      searchQuery: _decodeBoundedString(json['searchQuery']),
+      promptQuery: _decodeBoundedString(json['promptQuery']),
+      popularQuery: _decodeBoundedString(json['popularQuery']),
+      popularPromptQuery: _decodeBoundedString(json['popularPromptQuery']),
+      fuzzySearchEnabled: json['fuzzySearchEnabled'] == true,
+      sourceId: sourceId,
+      popularSourceId: popularSourceId,
+      favoritesSourceId: favoritesSourceId,
+      selectedRatings: selectedRatings,
+      viewMode: viewMode,
+      popularScale: _decodeEnumByName(
+        PopularScale.values,
+        json['popularScale'],
+        PopularScale.day,
+      ),
+      popularDate: _decodeDate(json['popularDate']),
+      aiTagTimeRange: _decodeBoundedString(
+        json['aiTagTimeRange'],
+        fallback: 'all',
+        maxLength: 100,
+      ),
+      aiTagPopularPeriod: _decodeBoundedString(
+        json['aiTagPopularPeriod'],
+        fallback: 'current',
+        maxLength: 100,
+      ),
+      dateRangeStart: _decodeDate(json['dateRangeStart']),
+      dateRangeEnd: _decodeDate(json['dateRangeEnd']),
+      artistHuntEnabled: json['artistHuntEnabled'] == true,
+    );
+
+    final caches = <String, ModeCache>{};
+    final rawPositions = json['positions'];
+    if (rawPositions is Map) {
+      for (final entry in rawPositions.entries.take(12)) {
+        final key = entry.key;
+        if (key is! String || key.isEmpty || key.length > 4096) continue;
+        final position = _decodeGalleryPosition(entry.value);
+        if (position != null) caches[key] = position;
+      }
+    }
+    var restored = base.copyWith(caches: caches);
+    final randomPosition =
+        _decodeGalleryPosition(json['randomPosition']) ?? const ModeCache();
+    final randomEnabled =
+        json['randomEnabled'] == true && restored.supportsRandom;
+    restored = restored.copyWith(
+      randomEnabled: randomEnabled,
+      randomSession: RandomGallerySession(cache: randomPosition),
+    );
+    return restored;
+  } catch (error, stack) {
+    AppLogger.w(
+      'Ignored invalid online gallery browsing session',
+      'OnlineGallery',
+    );
+    AppLogger.d('$error\n$stack', 'OnlineGallery');
+    return const OnlineGalleryState();
+  }
+}
+
+Map<String, dynamic> _encodeGalleryPosition(ModeCache cache) => {
+  'page': cache.page,
+  'scrollOffset': cache.scrollOffset,
+  if (cache.anchorStableKey != null) 'anchorStableKey': cache.anchorStableKey,
+  'anchorLocalOffset': cache.anchorLocalOffset,
+};
+
+ModeCache? _decodeGalleryPosition(Object? raw) {
+  if (raw is! Map) return null;
+  final pageValue = raw['page'];
+  final offsetValue = raw['scrollOffset'];
+  final localOffsetValue = raw['anchorLocalOffset'];
+  final page = pageValue is num
+      ? pageValue.toInt().clamp(1, 1000000).toInt()
+      : 1;
+  final offset = offsetValue is num && offsetValue.isFinite
+      ? offsetValue.toDouble().clamp(0, double.maxFinite).toDouble()
+      : 0.0;
+  final localOffset = localOffsetValue is num && localOffsetValue.isFinite
+      ? localOffsetValue.toDouble().clamp(0, double.maxFinite).toDouble()
+      : 0.0;
+  final anchor = raw['anchorStableKey'];
+  return ModeCache(
+    page: page,
+    nextCursor: '$page',
+    scrollOffset: offset,
+    anchorStableKey: anchor is String && anchor.length <= 256 ? anchor : null,
+    anchorLocalOffset: localOffset,
+  );
+}
+
+GallerySourceId _decodeGallerySource(Object? value) {
+  if (value is! String) return GallerySourceId.danbooru;
+  return GallerySourceId.fromKey(value);
+}
+
+T _decodeEnumByName<T extends Enum>(List<T> values, Object? value, T fallback) {
+  if (value is! String) return fallback;
+  return values.firstWhere(
+    (candidate) => candidate.name == value,
+    orElse: () => fallback,
+  );
+}
+
+Set<String> _decodeRatings(Object? value) {
+  if (value is! List) return kAllRatings;
+  final ratings = value.whereType<String>().where(kAllRatings.contains).toSet();
+  return ratings.isEmpty ? kAllRatings : ratings;
+}
+
+String _decodeBoundedString(
+  Object? value, {
+  String fallback = '',
+  int maxLength = 10000,
+}) {
+  if (value is! String || value.length > maxLength) return fallback;
+  return value;
+}
+
+DateTime? _decodeDate(Object? value) {
+  if (value is! String) return null;
+  return DateTime.tryParse(value);
+}
+
 @riverpod
 class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   static const int _pageSize = 40;
@@ -571,6 +770,8 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   int _requestGeneration = 0;
   OnlineGalleryState? _normalRestorePoint;
   OnlineGalleryDetailCoordinator? _detailCoordinator;
+  String? _lastPersistedBrowsingSession;
+  Future<void> _persistenceQueue = Future<void>.value();
 
   OnlineGalleryDetailCoordinator get _details =>
       _detailCoordinator ??= OnlineGalleryDetailCoordinator(
@@ -582,6 +783,17 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   OnlineGalleryState build() {
     ref.keepAlive();
     ref.onDispose(() => _detailCoordinator?.clear());
+    final storage = ref.read(localStorageServiceProvider);
+    final restored = decodeOnlineGalleryBrowsingSession(
+      storage.getSetting<String>(StorageKeys.onlineGalleryBrowsingSessionV1),
+    );
+    _lastPersistedBrowsingSession = encodeOnlineGalleryBrowsingSession(
+      restored,
+    );
+    if (restored.randomEnabled) {
+      _normalRestorePoint = restored.copyWith(randomEnabled: false);
+    }
+    listenSelf((_, next) => _persistBrowsingSession(storage, next));
     ref.listen<String?>(
       danbooruAuthProvider.select((value) => value.user?.name),
       (_, _) => _handleRandomAccountIdentityChanged(GallerySourceId.danbooru),
@@ -599,7 +811,31 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       }),
       (_, _) => _handleRandomScopeInputChanged(),
     );
-    return const OnlineGalleryState();
+    return restored;
+  }
+
+  void _persistBrowsingSession(
+    LocalStorageService storage,
+    OnlineGalleryState next,
+  ) {
+    final encoded = encodeOnlineGalleryBrowsingSession(next);
+    if (encoded == _lastPersistedBrowsingSession) return;
+    _lastPersistedBrowsingSession = encoded;
+    _persistenceQueue = _persistenceQueue.then((_) async {
+      try {
+        await storage.setSetting(
+          StorageKeys.onlineGalleryBrowsingSessionV1,
+          encoded,
+        );
+      } catch (error, stack) {
+        AppLogger.e(
+          'Failed to persist online gallery browsing session',
+          error,
+          stack,
+          'OnlineGallery',
+        );
+      }
+    });
   }
 
   void _handleRandomScopeInputChanged() {
@@ -942,7 +1178,13 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       final scopeKey = _randomScopeKey(blacklist);
       var session = state.randomSession;
       if (restart || session.scopeKey != scopeKey) {
-        session = RandomGallerySession(scopeKey: scopeKey);
+        final restoredPosition = !restart && session.cache.posts.isEmpty
+            ? session.cache
+            : const ModeCache();
+        session = RandomGallerySession(
+          scopeKey: scopeKey,
+          cache: restoredPosition,
+        );
       }
       if (session.seenStableKeys.length >= 20000) {
         state = state.copyWith(
@@ -1181,13 +1423,19 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       return;
     }
     if (!refresh && (state.isLoading || state.isLoadingMore)) return;
+    final restoredPage = !refresh && state.currentCache.posts.isEmpty
+        ? state.currentCache.page
+        : null;
     switch (state.viewMode) {
       case GalleryViewMode.search:
       case GalleryViewMode.popular:
-        await _loadAdapterPage(refresh: refresh);
+        await _loadAdapterPage(
+          refresh: refresh,
+          initialCursor: restoredPage == null ? null : '$restoredPage',
+        );
         return;
       case GalleryViewMode.favorites:
-        await _loadFavorites(refresh: refresh);
+        await _loadFavorites(refresh: refresh, targetPage: restoredPage);
         return;
     }
   }

--- a/lib/presentation/screens/online_gallery/online_gallery_screen.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen.dart
@@ -91,6 +91,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
   bool? _lastRandomEnabled;
   int? _lastRandomDrawRevision;
   String? _scheduledAutoLoadCacheKey;
+  bool _restoreInitialPositionPending = false;
   bool _branchVisible = true;
 
   @override
@@ -129,6 +130,17 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
       if (_promptSearchController.text != state.promptQuery) {
         _promptSearchController.text = state.promptQuery;
       }
+      if (_popularSearchController.text != state.popularQuery) {
+        _popularSearchController.text = state.popularQuery;
+      }
+      if (_popularPromptSearchController.text != state.popularPromptQuery) {
+        _popularPromptSearchController.text = state.popularPromptQuery;
+      }
+      final initialCache = state.randomEnabled
+          ? state.randomSession.cache
+          : state.currentCache;
+      _restoreInitialPositionPending =
+          initialCache.scrollOffset > 0 || initialCache.anchorStableKey != null;
       // 首次加载
       if (state.posts.isEmpty && !state.isLoading) {
         _galleryNotifier.loadPosts();
@@ -271,6 +283,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
 
   @override
   void dispose() {
+    _saveScrollOffset();
     _searchDebounceTimer?.cancel();
     _scrollStopTimer?.cancel();
     _idlePrefetchTimer?.cancel();
@@ -400,14 +413,19 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         state.randomEnabled &&
         _lastRandomDrawRevision != null &&
         _lastRandomDrawRevision != state.randomSession.drawRevision;
-    if (browsingContextChanged || randomDrawChanged) {
+    final initialPositionReady =
+        _restoreInitialPositionPending &&
+        state.posts.isNotEmpty &&
+        !state.isLoading;
+    if (browsingContextChanged || randomDrawChanged || initialPositionReady) {
       _hoverController.dismiss();
       _visibleItems.clear();
       _prefetchCoordinator.rotateGeneration();
-      if (browsingContextChanged) {
+      if (browsingContextChanged || initialPositionReady) {
         _restoreScrollOffset(
           state.randomEnabled ? state.randomSession.cache : state.currentCache,
         );
+        _restoreInitialPositionPending = false;
       }
     }
     _lastViewMode = state.viewMode;

--- a/test/presentation/providers/online_gallery_browsing_session_test.dart
+++ b/test/presentation/providers/online_gallery_browsing_session_test.dart
@@ -1,0 +1,190 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/data/datasources/remote/danbooru_api_service.dart';
+import 'package:nai_launcher/data/datasources/remote/online_gallery/gallery_source_adapter.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_item.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_source.dart';
+import 'package:nai_launcher/presentation/providers/online_gallery_provider.dart';
+
+void main() {
+  test('browsing session round-trips choices and per-query position', () {
+    const base = OnlineGalleryState(
+      viewMode: GalleryViewMode.popular,
+      sourceId: GallerySourceId.gelbooru,
+      popularSourceId: GallerySourceId.aiTag,
+      favoritesSourceId: GallerySourceId.gelbooru,
+      searchQuery: '1girl sky',
+      promptQuery: 'artist:foo',
+      popularQuery: 'landscape',
+      popularPromptQuery: 'cinematic',
+      fuzzySearchEnabled: true,
+      selectedRatings: {'g', 's'},
+      popularScale: PopularScale.month,
+      aiTagTimeRange: 'month',
+      aiTagPopularPeriod: '2026-02',
+      randomEnabled: true,
+      randomSession: RandomGallerySession(
+        cache: ModeCache(
+          scrollOffset: 512,
+          anchorStableKey: 'ai_tag:88',
+          anchorLocalOffset: 12,
+        ),
+      ),
+      artistHuntEnabled: true,
+    );
+    final state = base.updateCurrentCache(
+      const ModeCache(
+        page: 7,
+        scrollOffset: 2048,
+        anchorStableKey: 'ai_tag:42',
+        anchorLocalOffset: 16,
+      ),
+    );
+
+    final restored = decodeOnlineGalleryBrowsingSession(
+      encodeOnlineGalleryBrowsingSession(state),
+    );
+
+    expect(restored.viewMode, GalleryViewMode.popular);
+    expect(restored.sourceId, GallerySourceId.gelbooru);
+    expect(restored.popularSourceId, GallerySourceId.aiTag);
+    expect(restored.favoritesSourceId, GallerySourceId.gelbooru);
+    expect(restored.searchQuery, '1girl sky');
+    expect(restored.promptQuery, 'artist:foo');
+    expect(restored.popularQuery, 'landscape');
+    expect(restored.popularPromptQuery, 'cinematic');
+    expect(restored.fuzzySearchEnabled, isTrue);
+    expect(restored.selectedRatings, {'g', 's'});
+    expect(restored.popularScale, PopularScale.month);
+    expect(restored.aiTagTimeRange, 'month');
+    expect(restored.aiTagPopularPeriod, '2026-02');
+    expect(restored.randomEnabled, isTrue);
+    expect(restored.artistHuntEnabled, isTrue);
+    expect(restored.currentCache.page, 7);
+    expect(restored.currentCache.nextCursor, '7');
+    expect(restored.currentCache.scrollOffset, 2048);
+    expect(restored.currentCache.anchorStableKey, 'ai_tag:42');
+    expect(restored.randomSession.cache.scrollOffset, 512);
+  });
+
+  test('invalid or obsolete session safely falls back to defaults', () {
+    expect(
+      decodeOnlineGalleryBrowsingSession('{"version":99}').viewMode,
+      GalleryViewMode.search,
+    );
+    expect(
+      decodeOnlineGalleryBrowsingSession('not json').sourceId,
+      GallerySourceId.danbooru,
+    );
+  });
+
+  test('restored page is re-fetched without losing its position', () async {
+    final storage = _MemoryStorage();
+    final initial = const OnlineGalleryState(
+      searchQuery: 'restored',
+    ).updateCurrentCache(const ModeCache(page: 3, scrollOffset: 120));
+    await storage.setSetting(
+      StorageKeys.onlineGalleryBrowsingSessionV1,
+      encodeOnlineGalleryBrowsingSession(initial),
+    );
+    final adapter = _CursorAdapter(GallerySourceId.danbooru);
+    final container = ProviderContainer(
+      overrides: [
+        localStorageServiceProvider.overrideWithValue(storage),
+        onlineGallerySourceAdaptersProvider.overrideWithValue({
+          for (final source in GallerySourceId.values)
+            source: source == GallerySourceId.danbooru
+                ? adapter
+                : _CursorAdapter(source),
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(onlineGalleryNotifierProvider.notifier).loadPosts();
+
+    final restored = container.read(onlineGalleryNotifierProvider);
+    expect(adapter.lastSearchCursor, '3');
+    expect(restored.currentCache.page, 3);
+    expect(restored.currentCache.scrollOffset, 120);
+  });
+
+  test('notifier restores and persists location changes', () async {
+    final storage = _MemoryStorage();
+    final initial = const OnlineGalleryState(
+      searchQuery: 'restored',
+    ).updateCurrentCache(const ModeCache(page: 3, scrollOffset: 120));
+    await storage.setSetting(
+      StorageKeys.onlineGalleryBrowsingSessionV1,
+      encodeOnlineGalleryBrowsingSession(initial),
+    );
+    final container = ProviderContainer(
+      overrides: [localStorageServiceProvider.overrideWithValue(storage)],
+    );
+    addTearDown(container.dispose);
+
+    final restored = container.read(onlineGalleryNotifierProvider);
+    expect(restored.searchQuery, 'restored');
+    expect(restored.currentCache.page, 3);
+
+    container
+        .read(onlineGalleryNotifierProvider.notifier)
+        .saveScrollOffset(
+          456,
+          anchorStableKey: 'danbooru:9',
+          anchorLocalOffset: 8,
+        );
+    await Future<void>.delayed(Duration.zero);
+
+    final persisted = decodeOnlineGalleryBrowsingSession(
+      storage.getSetting<String>(StorageKeys.onlineGalleryBrowsingSessionV1),
+    );
+    expect(persisted.currentCache.scrollOffset, 456);
+    expect(persisted.currentCache.anchorStableKey, 'danbooru:9');
+    expect(persisted.currentCache.anchorLocalOffset, 8);
+  });
+}
+
+class _CursorAdapter extends GallerySourceAdapter {
+  _CursorAdapter(this.sourceId);
+
+  @override
+  final GallerySourceId sourceId;
+
+  String? lastSearchCursor;
+
+  @override
+  Future<GalleryPage> search(
+    GallerySearchRequest request, {
+    CancelToken? cancelToken,
+  }) async {
+    lastSearchCursor = request.cursor;
+    return GalleryPage(
+      items: const [],
+      cursor: request.cursor,
+      nextCursor: null,
+      hasMore: false,
+    );
+  }
+}
+
+class _MemoryStorage extends LocalStorageService {
+  final Map<String, Object?> _values = {};
+
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) =>
+      (_values[key] ?? defaultValue) as T?;
+
+  @override
+  Future<void> setSetting<T>(String key, T value) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> deleteSetting(String key) async {
+    _values.remove(key);
+  }
+}


### PR DESCRIPTION
## Problem
重启应用后，画廊的筛选条件、浏览位置和滚动位置会丢失，用户需要重新查找内容。

## Solution
保存画廊浏览会话和每个查询的轻量位置数据，并在恢复后重新加载对应页面、还原滚动位置。

### Details
- 持久化搜索条件、数据源、筛选项、视图模式及随机浏览状态
- 最多保存 12 个查询缓存的位置和锚点信息
- 恢复时重新请求远程内容，避免使用过期数据
- 页面销毁时保存滚动位置
- 增加序列化、异常回退、页面恢复和持久化测试