### PR TITLE
优化图库详情页提示词复制与操作交互

### DIFF
--- a/lib/data/models/gallery/nai_image_metadata.dart
+++ b/lib/data/models/gallery/nai_image_metadata.dart
@@ -1394,6 +1394,15 @@ class NaiImageMetadata with _$NaiImageMetadata {
       vibeReferences.isNotEmpty ||
       preciseReferenceImages.isNotEmpty;
 
+  /// 是否记录了透明背景自动提示词。
+  bool get hasRecordedTransparentBackgroundTag =>
+      transparentBackground == true &&
+      prompt.split(',').any(
+            (tag) =>
+                tag.trim().toLowerCase() ==
+                QualityTags.transparentBackgroundTag.toLowerCase(),
+          );
+
   /// 是否有角色提示词
   bool get hasCharacters => characterPrompts.isNotEmpty;
 
@@ -1444,57 +1453,100 @@ class NaiImageMetadata with _$NaiImageMetadata {
 
   /// 获取主提示词（不含固定词和质量词）
   String get mainPrompt {
-    if (!hasSeparatedFields) {
-      // 旧数据：返回原始prompt
-      return prompt;
+    if (!hasSeparatedFields) return prompt;
+
+    final mainTags = _splitPromptSegments(prompt);
+    _removeLeadingSegments(mainTags, _splitPromptEntries(fixedPrefixTags));
+    _removeTrailingSegments(mainTags, _splitPromptEntries(qualityTags));
+    if (hasRecordedTransparentBackgroundTag) {
+      _removeTrailingSegments(mainTags, const [
+        QualityTags.transparentBackgroundTag,
+      ]);
     }
-
-    final allTags = prompt
-        .split(',')
-        .map((t) => t.trim())
-        .where((t) => t.isNotEmpty)
-        .toList();
-    final mainTags = <String>[];
-
-    // 跳过前缀词
-    var startIndex = fixedPrefixTags.length;
-
-    // 跳过后缀词和质量词
-    var endIndex = allTags.length - fixedSuffixTags.length - qualityTags.length;
-
-    // 确保索引有效
-    startIndex = startIndex.clamp(0, allTags.length);
-    endIndex = endIndex.clamp(startIndex, allTags.length);
-
-    if (startIndex < endIndex) {
-      mainTags.addAll(allTags.sublist(startIndex, endIndex));
-    }
-
-    // 官网把透明背景词包装进质量预设。只剥离主提示词末尾的自动词，避免
-    // 删除用户在正文其他位置主动写入的同名描述。
-    if (transparentBackground == true &&
-        mainTags.isNotEmpty &&
-        mainTags.last.toLowerCase() ==
-            QualityTags.transparentBackgroundTag.toLowerCase()) {
-      mainTags.removeLast();
-    }
-
+    _removeTrailingSegments(mainTags, _splitPromptEntries(fixedSuffixTags));
     return mainTags.join(', ');
+  }
+
+  /// 获取不含固定词、但保留质量词和用户正文的正向提示词。
+  String get promptWithoutFixedTags => buildPositivePromptSelection(
+        includeMainPrompt: true,
+        includeCharacterPrompts: false,
+        includeQualityTags: true,
+        includeFixedTags: false,
+      );
+
+  /// 获取不含固定词的负向提示词。
+  String get negativePromptWithoutFixedTags {
+    var result = negativePrompt.trim();
+    for (final tag in fixedNegativePrefixTags) {
+      result = _stripLeadingPromptSegment(result, tag);
+    }
+    for (final tag in fixedNegativeSuffixTags.reversed) {
+      result = _stripTrailingPromptSegment(result, tag);
+    }
+    return result;
   }
 
   /// 获取完整的提示词（包含角色提示词）
   /// 格式：主提示词\n\n| 角色1提示词\n\n| 角色2提示词
-  String get fullPrompt {
-    if (!hasCharacters) return prompt;
+  String get fullPrompt => _appendCharacterPrompts(prompt);
 
-    final buffer = StringBuffer(prompt);
-    for (var i = 0; i < characterPrompts.length; i++) {
-      if (characterPrompts[i].isNotEmpty) {
-        buffer.writeln();
-        buffer.writeln();
-        buffer.write('| ');
-        buffer.write(characterPrompts[i]);
+  /// 获取不含固定词、但保留角色提示词的完整正向提示词。
+  String get fullPromptWithoutFixedTags => buildPositivePromptSelection(
+        includeMainPrompt: true,
+        includeCharacterPrompts: true,
+        includeQualityTags: true,
+        includeFixedTags: false,
+      );
+
+  /// 按详情页复制对话框选择的类别重新组合正向提示词。
+  String buildPositivePromptSelection({
+    required bool includeMainPrompt,
+    required bool includeCharacterPrompts,
+    required bool includeQualityTags,
+    required bool includeFixedTags,
+  }) {
+    final tags = <String>[];
+    if (includeFixedTags) tags.addAll(fixedPrefixTags);
+
+    final body = hasSeparatedFields ? mainPrompt : prompt.trim();
+    if (includeMainPrompt && body.isNotEmpty) tags.add(body);
+
+    if (includeFixedTags) tags.addAll(fixedSuffixTags);
+    if (includeQualityTags) {
+      if (hasRecordedTransparentBackgroundTag &&
+          !qualityTags.any(
+            (tag) =>
+                tag.trim().toLowerCase() ==
+                QualityTags.transparentBackgroundTag.toLowerCase(),
+          )) {
+        tags.add(QualityTags.transparentBackgroundTag);
       }
+      tags.addAll(qualityTags);
+    }
+
+    var result = tags
+        .map((tag) => tag.trim())
+        .where((tag) => tag.isNotEmpty)
+        .join(', ');
+    if (includeCharacterPrompts) {
+      result = _appendCharacterPrompts(result);
+    }
+    return result;
+  }
+
+  String _appendCharacterPrompts(String basePrompt) {
+    if (!hasCharacters) return basePrompt;
+
+    final buffer = StringBuffer(basePrompt);
+    for (final characterPrompt in characterPrompts) {
+      if (characterPrompt.isEmpty) continue;
+      if (buffer.isNotEmpty) {
+        buffer.writeln();
+        buffer.writeln();
+      }
+      buffer.write('| ');
+      buffer.write(characterPrompt);
     }
     return buffer.toString();
   }
@@ -1527,6 +1579,74 @@ class NaiImageMetadata with _$NaiImageMetadata {
         .map((word) => '${word[0].toUpperCase()}${word.substring(1)}')
         .join(' ');
   }
+}
+
+List<String> _splitPromptSegments(String text) => text
+    .split(',')
+    .map((tag) => tag.trim())
+    .where((tag) => tag.isNotEmpty)
+    .toList();
+
+List<String> _splitPromptEntries(List<String> entries) => entries
+    .expand(_splitPromptSegments)
+    .toList();
+
+void _removeLeadingSegments(List<String> source, List<String> expected) {
+  if (expected.isEmpty || source.length < expected.length) return;
+  for (var i = 0; i < expected.length; i++) {
+    if (source[i].toLowerCase() != expected[i].toLowerCase()) return;
+  }
+  source.removeRange(0, expected.length);
+}
+
+void _removeTrailingSegments(List<String> source, List<String> expected) {
+  if (expected.isEmpty || source.length < expected.length) return;
+  final offset = source.length - expected.length;
+  for (var i = 0; i < expected.length; i++) {
+    if (source[offset + i].toLowerCase() != expected[i].toLowerCase()) return;
+  }
+  source.removeRange(offset, source.length);
+}
+
+bool _hasTrailingPromptSegment(String text, String segment) {
+  final trimmedText = text.trim();
+  final trimmedSegment = segment.trim();
+  if (trimmedText == trimmedSegment) return true;
+  if (!trimmedText.endsWith(trimmedSegment)) return false;
+  final prefix = trimmedText.substring(
+    0,
+    trimmedText.length - trimmedSegment.length,
+  );
+  return prefix.trimRight().endsWith(',');
+}
+
+String _stripLeadingPromptSegment(String text, String segment) {
+  final trimmedText = text.trim();
+  final trimmedSegment = segment.trim();
+  if (trimmedText.isEmpty || trimmedSegment.isEmpty) return trimmedText;
+  if (trimmedText == trimmedSegment) return '';
+  if (!trimmedText.startsWith(trimmedSegment)) return trimmedText;
+
+  final rest = trimmedText.substring(trimmedSegment.length).trimLeft();
+  if (!rest.startsWith(',')) return trimmedText;
+  return rest.substring(1).trimLeft();
+}
+
+String _stripTrailingPromptSegment(String text, String segment) {
+  final trimmedText = text.trim();
+  final trimmedSegment = segment.trim();
+  if (trimmedText.isEmpty || trimmedSegment.isEmpty) return trimmedText;
+  if (trimmedText == trimmedSegment) return '';
+  if (!_hasTrailingPromptSegment(trimmedText, trimmedSegment)) {
+    return trimmedText;
+  }
+
+  final rest = trimmedText.substring(
+    0,
+    trimmedText.length - trimmedSegment.length,
+  );
+  final trimmedRest = rest.trimRight();
+  return trimmedRest.substring(0, trimmedRest.length - 1).trimRight();
 }
 
 class _PreciseReferenceMetadata {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5154,6 +5154,18 @@
       "label": {}
     }
   },
+  "detail_copyPromptTitle": "Copy Positive Prompt",
+  "detail_copyPromptDescription": "Select the prompt categories to copy. Fixed tags may contain private strings or personal markers, so review them before sharing.",
+  "detail_promptCategoryMain": "Subject prompt",
+  "detail_promptCategoryMainHint": "Subject, scene, and general descriptions",
+  "detail_promptCategoryCharacters": "Character prompts",
+  "detail_promptCategoryCharactersHint": "Prompts assigned to individual characters",
+  "detail_promptCategoryQuality": "Quality tags",
+  "detail_promptCategoryQualityHint": "Official quality preset and automatic transparent-background tag",
+  "detail_promptCategoryFixed": "Fixed tags",
+  "detail_promptCategoryFixedHint": "Fixed prefixes and suffixes that may contain private content",
+  "detail_promptCategoryUnavailable": "This category is not stored in the image",
+  "detail_copyPromptDefaultHint": "Subject and character prompts are selected by default; quality and fixed tags are excluded.",
   "detail_copyCharacterPrompt": "Copy Character Prompt",
   "detail_copyAllVibeData": "Copy all Vibe data",
   "detail_saveToVibeLibrary": "Save to Vibe Library",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -5170,6 +5170,18 @@
       "label": {}
     }
   },
+  "detail_copyPromptTitle": "ポジティブプロンプトをコピー",
+  "detail_copyPromptDescription": "コピーするプロンプトのカテゴリを選択してください。固定タグには非公開文字列や個人用マーカーが含まれる場合があります。共有前に確認してください。",
+  "detail_promptCategoryMain": "主体プロンプト",
+  "detail_promptCategoryMainHint": "主体、シーン、一般的な説明",
+  "detail_promptCategoryCharacters": "キャラクタープロンプト",
+  "detail_promptCategoryCharactersHint": "各キャラクターに割り当てられたプロンプト",
+  "detail_promptCategoryQuality": "品質タグ",
+  "detail_promptCategoryQualityHint": "公式品質プリセットと透明背景の自動タグ",
+  "detail_promptCategoryFixed": "固定タグ",
+  "detail_promptCategoryFixedHint": "非公開内容を含む可能性がある固定の接頭・接尾タグ",
+  "detail_promptCategoryUnavailable": "このカテゴリは画像に記録されていません",
+  "detail_copyPromptDefaultHint": "主体とキャラクターは既定で選択され、品質タグと固定タグは除外されます。",
   "detail_copyCharacterPrompt": "キャラクタープロンプトをコピー",
   "detail_copyAllVibeData": "すべての Vibe データをコピーします",
   "detail_saveToVibeLibrary": "バイブライブラリに保存",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17933,6 +17933,78 @@ abstract class AppLocalizations {
   /// **'Copy {label}'**
   String detail_copyLabel(Object label);
 
+  /// No description provided for @detail_copyPromptTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy Positive Prompt'**
+  String get detail_copyPromptTitle;
+
+  /// No description provided for @detail_copyPromptDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Select the prompt categories to copy. Fixed tags may contain private strings or personal markers, so review them before sharing.'**
+  String get detail_copyPromptDescription;
+
+  /// No description provided for @detail_promptCategoryMain.
+  ///
+  /// In en, this message translates to:
+  /// **'Subject prompt'**
+  String get detail_promptCategoryMain;
+
+  /// No description provided for @detail_promptCategoryMainHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Subject, scene, and general descriptions'**
+  String get detail_promptCategoryMainHint;
+
+  /// No description provided for @detail_promptCategoryCharacters.
+  ///
+  /// In en, this message translates to:
+  /// **'Character prompts'**
+  String get detail_promptCategoryCharacters;
+
+  /// No description provided for @detail_promptCategoryCharactersHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Prompts assigned to individual characters'**
+  String get detail_promptCategoryCharactersHint;
+
+  /// No description provided for @detail_promptCategoryQuality.
+  ///
+  /// In en, this message translates to:
+  /// **'Quality tags'**
+  String get detail_promptCategoryQuality;
+
+  /// No description provided for @detail_promptCategoryQualityHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Official quality preset and automatic transparent-background tag'**
+  String get detail_promptCategoryQualityHint;
+
+  /// No description provided for @detail_promptCategoryFixed.
+  ///
+  /// In en, this message translates to:
+  /// **'Fixed tags'**
+  String get detail_promptCategoryFixed;
+
+  /// No description provided for @detail_promptCategoryFixedHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Fixed prefixes and suffixes that may contain private content'**
+  String get detail_promptCategoryFixedHint;
+
+  /// No description provided for @detail_promptCategoryUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'This category is not stored in the image'**
+  String get detail_promptCategoryUnavailable;
+
+  /// No description provided for @detail_copyPromptDefaultHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Subject and character prompts are selected by default; quality and fixed tags are excluded.'**
+  String get detail_copyPromptDefaultHint;
+
   /// No description provided for @detail_copyCharacterPrompt.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10236,6 +10236,49 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get detail_copyPromptTitle => 'Copy Positive Prompt';
+
+  @override
+  String get detail_copyPromptDescription =>
+      'Select the prompt categories to copy. Fixed tags may contain private strings or personal markers, so review them before sharing.';
+
+  @override
+  String get detail_promptCategoryMain => 'Subject prompt';
+
+  @override
+  String get detail_promptCategoryMainHint =>
+      'Subject, scene, and general descriptions';
+
+  @override
+  String get detail_promptCategoryCharacters => 'Character prompts';
+
+  @override
+  String get detail_promptCategoryCharactersHint =>
+      'Prompts assigned to individual characters';
+
+  @override
+  String get detail_promptCategoryQuality => 'Quality tags';
+
+  @override
+  String get detail_promptCategoryQualityHint =>
+      'Official quality preset and automatic transparent-background tag';
+
+  @override
+  String get detail_promptCategoryFixed => 'Fixed tags';
+
+  @override
+  String get detail_promptCategoryFixedHint =>
+      'Fixed prefixes and suffixes that may contain private content';
+
+  @override
+  String get detail_promptCategoryUnavailable =>
+      'This category is not stored in the image';
+
+  @override
+  String get detail_copyPromptDefaultHint =>
+      'Subject and character prompts are selected by default; quality and fixed tags are excluded.';
+
+  @override
   String get detail_copyCharacterPrompt => 'Copy Character Prompt';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -10012,6 +10012,44 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get detail_copyPromptTitle => 'ポジティブプロンプトをコピー';
+
+  @override
+  String get detail_copyPromptDescription =>
+      'コピーするプロンプトのカテゴリを選択してください。固定タグには非公開文字列や個人用マーカーが含まれる場合があります。共有前に確認してください。';
+
+  @override
+  String get detail_promptCategoryMain => '主体プロンプト';
+
+  @override
+  String get detail_promptCategoryMainHint => '主体、シーン、一般的な説明';
+
+  @override
+  String get detail_promptCategoryCharacters => 'キャラクタープロンプト';
+
+  @override
+  String get detail_promptCategoryCharactersHint => '各キャラクターに割り当てられたプロンプト';
+
+  @override
+  String get detail_promptCategoryQuality => '品質タグ';
+
+  @override
+  String get detail_promptCategoryQualityHint => '公式品質プリセットと透明背景の自動タグ';
+
+  @override
+  String get detail_promptCategoryFixed => '固定タグ';
+
+  @override
+  String get detail_promptCategoryFixedHint => '非公開内容を含む可能性がある固定の接頭・接尾タグ';
+
+  @override
+  String get detail_promptCategoryUnavailable => 'このカテゴリは画像に記録されていません';
+
+  @override
+  String get detail_copyPromptDefaultHint =>
+      '主体とキャラクターは既定で選択され、品質タグと固定タグは除外されます。';
+
+  @override
   String get detail_copyCharacterPrompt => 'キャラクタープロンプトをコピー';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9860,6 +9860,43 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get detail_copyPromptTitle => '复制正面提示词';
+
+  @override
+  String get detail_copyPromptDescription =>
+      '勾选需要复制的提示词类别。固定词可能包含私密串或个人标记，请确认后再分享。';
+
+  @override
+  String get detail_promptCategoryMain => '主体提示词';
+
+  @override
+  String get detail_promptCategoryMainHint => '画面主体、场景和常规描述';
+
+  @override
+  String get detail_promptCategoryCharacters => '角色提示词';
+
+  @override
+  String get detail_promptCategoryCharactersHint => '多角色专用提示词';
+
+  @override
+  String get detail_promptCategoryQuality => '质量提示词';
+
+  @override
+  String get detail_promptCategoryQualityHint => '官方质量预设与透明背景自动词';
+
+  @override
+  String get detail_promptCategoryFixed => '固定词';
+
+  @override
+  String get detail_promptCategoryFixedHint => '固定前缀和后缀，可能包含私密内容';
+
+  @override
+  String get detail_promptCategoryUnavailable => '此图片未记录该类别';
+
+  @override
+  String get detail_copyPromptDefaultHint => '默认复制主体和角色提示词，不包含质量词与固定词。';
+
+  @override
   String get detail_copyCharacterPrompt => '复制角色提示词';
 
   @override
@@ -21487,6 +21524,43 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String detail_copyLabel(Object label) {
     return '複製$label';
   }
+
+  @override
+  String get detail_copyPromptTitle => '複製正面提示詞';
+
+  @override
+  String get detail_copyPromptDescription =>
+      '勾選需要複製的提示詞類別。固定詞可能包含私密字串或個人標記，請確認後再分享。';
+
+  @override
+  String get detail_promptCategoryMain => '主體提示詞';
+
+  @override
+  String get detail_promptCategoryMainHint => '畫面主體、場景和一般描述';
+
+  @override
+  String get detail_promptCategoryCharacters => '角色提示詞';
+
+  @override
+  String get detail_promptCategoryCharactersHint => '多角色專用提示詞';
+
+  @override
+  String get detail_promptCategoryQuality => '品質提示詞';
+
+  @override
+  String get detail_promptCategoryQualityHint => '官方品質預設與透明背景自動詞';
+
+  @override
+  String get detail_promptCategoryFixed => '固定詞';
+
+  @override
+  String get detail_promptCategoryFixedHint => '固定前綴和後綴，可能包含私密內容';
+
+  @override
+  String get detail_promptCategoryUnavailable => '此圖片未記錄該類別';
+
+  @override
+  String get detail_copyPromptDefaultHint => '預設複製主體和角色提示詞，不包含品質詞與固定詞。';
 
   @override
   String get detail_copyCharacterPrompt => '複製角色提示詞';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -4937,6 +4937,18 @@
       "label": {}
     }
   },
+  "detail_copyPromptTitle": "复制正面提示词",
+  "detail_copyPromptDescription": "勾选需要复制的提示词类别。固定词可能包含私密串或个人标记，请确认后再分享。",
+  "detail_promptCategoryMain": "主体提示词",
+  "detail_promptCategoryMainHint": "画面主体、场景和常规描述",
+  "detail_promptCategoryCharacters": "角色提示词",
+  "detail_promptCategoryCharactersHint": "多角色专用提示词",
+  "detail_promptCategoryQuality": "质量提示词",
+  "detail_promptCategoryQualityHint": "官方质量预设与透明背景自动词",
+  "detail_promptCategoryFixed": "固定词",
+  "detail_promptCategoryFixedHint": "固定前缀和后缀，可能包含私密内容",
+  "detail_promptCategoryUnavailable": "此图片未记录该类别",
+  "detail_copyPromptDefaultHint": "默认复制主体和角色提示词，不包含质量词与固定词。",
   "detail_copyCharacterPrompt": "复制角色提示词",
   "detail_copyAllVibeData": "复制全部 Vibe 数据",
   "detail_saveToVibeLibrary": "保存到 Vibe 库",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -5044,6 +5044,18 @@
       "label": {}
     }
   },
+  "detail_copyPromptTitle": "複製正面提示詞",
+  "detail_copyPromptDescription": "勾選需要複製的提示詞類別。固定詞可能包含私密字串或個人標記，請確認後再分享。",
+  "detail_promptCategoryMain": "主體提示詞",
+  "detail_promptCategoryMainHint": "畫面主體、場景和一般描述",
+  "detail_promptCategoryCharacters": "角色提示詞",
+  "detail_promptCategoryCharactersHint": "多角色專用提示詞",
+  "detail_promptCategoryQuality": "品質提示詞",
+  "detail_promptCategoryQualityHint": "官方品質預設與透明背景自動詞",
+  "detail_promptCategoryFixed": "固定詞",
+  "detail_promptCategoryFixedHint": "固定前綴和後綴，可能包含私密內容",
+  "detail_promptCategoryUnavailable": "此圖片未記錄該類別",
+  "detail_copyPromptDefaultHint": "預設複製主體和角色提示詞，不包含品質詞與固定詞。",
   "detail_copyCharacterPrompt": "複製角色提示詞",
   "detail_copyAllVibeData": "複製全部 Vibe 資料",
   "detail_saveToVibeLibrary": "儲存到 Vibe 庫",

--- a/lib/presentation/screens/local_gallery/local_gallery_screen.dart
+++ b/lib/presentation/screens/local_gallery/local_gallery_screen.dart
@@ -41,6 +41,7 @@ import '../../providers/selection_mode_provider.dart';
 import '../../widgets/bulk_metadata_edit_dialog.dart';
 import '../../widgets/collection_select_dialog.dart';
 import '../../widgets/common/app_toast.dart';
+import '../../widgets/common/image_detail/components/prompt_copy_dialog.dart';
 import '../../widgets/common/pagination_bar.dart';
 import '../../utils/precise_ref_library_import_helper.dart';
 import '../../widgets/common/precise_reference_type_dialog.dart';
@@ -1269,12 +1270,17 @@ class _LocalGalleryScreenState extends ConsumerState<LocalGalleryScreen> {
         await _importImageMetadata(record);
       case LocalImageContextAction.copyPrompt:
         if (availableMetadata?.fullPrompt.isNotEmpty == true) {
-          await Clipboard.setData(
-            ClipboardData(text: availableMetadata!.fullPrompt),
+          final prompt = await PromptCopyDialog.show(
+            context,
+            metadata: availableMetadata!,
           );
+          if (prompt == null || !mounted) return;
+          await Clipboard.setData(ClipboardData(text: prompt));
           if (mounted) {
             AppToast.success(context, context.l10n.localGallery_promptCopied);
           }
+        } else if (mounted) {
+          AppToast.info(context, context.l10n.toast_imageHasNoMetadata);
         }
       case LocalImageContextAction.copySeed:
         if (availableMetadata?.seed != null) {
@@ -1306,33 +1312,19 @@ class _LocalGalleryScreenState extends ConsumerState<LocalGalleryScreen> {
   }
 
   Future<void> _confirmDeleteImage(LocalImageRecord record) async {
-    final confirmed = await showDialog<bool>(
+    final confirmed = await ThemedConfirmDialog.show(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Text(context.l10n.common_confirmDelete),
-        content: Text(
-          context.l10n.localGallery_confirmDeleteImageContent(
-            path.basename(record.path),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(context.l10n.common_cancel),
-          ),
-          ElevatedButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-              foregroundColor: Theme.of(context).colorScheme.onError,
-            ),
-            child: Text(context.l10n.common_delete),
-          ),
-        ],
+      title: context.l10n.common_confirmDelete,
+      content: context.l10n.localGallery_confirmDeleteImageContent(
+        path.basename(record.path),
       ),
+      confirmText: context.l10n.common_delete,
+      cancelText: context.l10n.common_cancel,
+      type: ThemedConfirmDialogType.danger,
+      icon: Icons.delete_forever_outlined,
     );
 
-    if (confirmed == true && mounted) {
+    if (confirmed && mounted) {
       final protected = await AssetProtectionGuard.confirmDangerousAction(
         context: context,
         ref: ref,

--- a/lib/presentation/widgets/common/floating_action_buttons.dart
+++ b/lib/presentation/widgets/common/floating_action_buttons.dart
@@ -39,6 +39,9 @@ class FloatingActionButtons extends StatelessWidget {
   /// 动画持续时间
   final Duration duration;
 
+  /// 按钮排列方向
+  final Axis axis;
+
   /// 按钮位置（默认右上角）
   final Alignment alignment;
 
@@ -51,6 +54,7 @@ class FloatingActionButtons extends StatelessWidget {
     required this.buttons,
     this.spacing = 8.0,
     this.duration = const Duration(milliseconds: 150),
+    this.axis = Axis.vertical,
     this.alignment = Alignment.topRight,
     this.padding = const EdgeInsets.all(8.0),
   });
@@ -68,7 +72,8 @@ class FloatingActionButtons extends StatelessWidget {
       alwaysIncludeSemantics: true,
       child: Container(
         padding: padding,
-        child: Column(
+        child: Flex(
+          direction: axis,
           mainAxisSize: MainAxisSize.min,
           children: _buildButtonList(visibleButtons),
         ),
@@ -88,8 +93,11 @@ class FloatingActionButtons extends StatelessWidget {
           icon: button.icon,
           onTap: button.onTap,
           iconColor: button.iconColor,
+          hoverIconColor: button.hoverIconColor,
           backgroundColor: button.backgroundColor,
           hoverBackgroundColor: button.hoverBackgroundColor,
+          tooltip: button.tooltip,
+          isLoading: button.isLoading,
           size: button.size,
           duration: duration,
         ),
@@ -97,7 +105,12 @@ class FloatingActionButtons extends StatelessWidget {
 
       // 添加间距（最后一个按钮后不加）
       if (i < buttons.length - 1) {
-        result.add(SizedBox(height: spacing));
+        result.add(
+          SizedBox(
+            width: axis == Axis.horizontal ? spacing : 0,
+            height: axis == Axis.vertical ? spacing : 0,
+          ),
+        );
       }
     }
 
@@ -116,11 +129,20 @@ class FloatingActionButtonData {
   /// 图标颜色
   final Color? iconColor;
 
+  /// 悬浮时的图标颜色
+  final Color? hoverIconColor;
+
   /// 背景颜色（默认半透明黑）
   final Color? backgroundColor;
 
   /// 悬浮时的背景颜色
   final Color? hoverBackgroundColor;
+
+  /// 悬浮提示
+  final String? tooltip;
+
+  /// 是否显示加载状态并禁用点击
+  final bool isLoading;
 
   /// 按钮大小
   final double size;
@@ -132,8 +154,11 @@ class FloatingActionButtonData {
     required this.icon,
     this.onTap,
     this.iconColor,
+    this.hoverIconColor,
     this.backgroundColor,
     this.hoverBackgroundColor,
+    this.tooltip,
+    this.isLoading = false,
     this.size = 28.0,
     this.visible = true,
   });
@@ -144,8 +169,11 @@ class _FloatingActionButtonItem extends StatefulWidget {
   final IconData icon;
   final VoidCallback? onTap;
   final Color? iconColor;
+  final Color? hoverIconColor;
   final Color? backgroundColor;
   final Color? hoverBackgroundColor;
+  final String? tooltip;
+  final bool isLoading;
   final double size;
   final Duration duration;
 
@@ -153,8 +181,11 @@ class _FloatingActionButtonItem extends StatefulWidget {
     required this.icon,
     this.onTap,
     this.iconColor,
+    this.hoverIconColor,
     this.backgroundColor,
     this.hoverBackgroundColor,
+    this.tooltip,
+    required this.isLoading,
     required this.size,
     required this.duration,
   });
@@ -174,12 +205,15 @@ class _FloatingActionButtonItemState extends State<_FloatingActionButtonItem> {
     final hoverBgColor =
         widget.hoverBackgroundColor ?? Colors.black.withValues(alpha: 0.85);
 
-    return MouseRegion(
+    final button = MouseRegion(
       onEnter: (_) => setState(() => _isHovering = true),
       onExit: (_) => setState(() => _isHovering = false),
+      cursor: widget.isLoading
+          ? SystemMouseCursors.progress
+          : SystemMouseCursors.click,
       child: GestureDetector(
         // 执行回调，同时通过 opaque 行为阻止事件冒泡
-        onTap: widget.onTap,
+        onTap: widget.isLoading ? null : widget.onTap,
         behavior: HitTestBehavior.opaque,
         child: AnimatedScale(
           duration: widget.duration,
@@ -202,16 +236,33 @@ class _FloatingActionButtonItemState extends State<_FloatingActionButtonItem> {
                   : null,
             ),
             child: Center(
-              child: Icon(
-                widget.icon,
-                size: widget.size * 0.57, // 图标大小约为按钮的 57%
-                color: widget.iconColor ?? Colors.white,
-              ),
+              child: widget.isLoading
+                  ? SizedBox.square(
+                      dimension: widget.size * 0.48,
+                      child: const CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : Icon(
+                      widget.icon,
+                      size: widget.size * 0.57,
+                      color: _isHovering
+                          ? widget.hoverIconColor ??
+                                widget.iconColor ??
+                                Colors.white
+                          : widget.iconColor ?? Colors.white,
+                    ),
             ),
           ),
         ),
       ),
     );
+
+    final tooltip = widget.tooltip;
+    return tooltip == null || tooltip.isEmpty
+        ? button
+        : Tooltip(message: tooltip, child: button);
   }
 }
 

--- a/lib/presentation/widgets/common/image_detail/components/detail_metadata_panel.dart
+++ b/lib/presentation/widgets/common/image_detail/components/detail_metadata_panel.dart
@@ -17,6 +17,7 @@ import '../../save_vibe_dialog.dart';
 import '../../themed_divider.dart';
 import '../file_image_detail_data.dart';
 import '../image_detail_data.dart';
+import 'prompt_copy_dialog.dart';
 import 'prompt_section.dart';
 import 'selection_copy_shortcuts.dart';
 import 'vibe_section.dart';
@@ -583,6 +584,7 @@ class _MetadataContent extends StatelessWidget {
               content: fixedTags.join(', '),
               tags: fixedTags,
               initiallyExpanded: false,
+              allTagsAreFixed: true,
             ),
           ],
           // 负向固定词（前缀+后缀合并）
@@ -594,9 +596,8 @@ class _MetadataContent extends StatelessWidget {
               content: fixedNegativeTags.join(', '),
               tags: fixedNegativeTags,
               initiallyExpanded: false,
-              contentColor: Theme.of(
-                context,
-              ).colorScheme.error.withValues(alpha: 0.8),
+              allTagsAreFixed: true,
+              isNegative: true,
               borderColor: Theme.of(context).colorScheme.error,
             ),
           ],
@@ -639,9 +640,8 @@ class _MetadataContent extends StatelessWidget {
               content: negativePrompt,
               tags: negativeTags,
               initiallyExpanded: false,
-              contentColor: Theme.of(
-                context,
-              ).colorScheme.error.withValues(alpha: 0.8),
+              fixedTags: fixedNegativeTags,
+              isNegative: true,
               borderColor: Theme.of(context).colorScheme.error,
             ),
           ],
@@ -679,9 +679,7 @@ class _MetadataContent extends StatelessWidget {
             content: negativePrompt,
             tags: negativeTags,
             initiallyExpanded: false,
-            contentColor: Theme.of(
-              context,
-            ).colorScheme.error.withValues(alpha: 0.8),
+            isNegative: true,
             borderColor: Theme.of(context).colorScheme.error,
           ),
         ],
@@ -898,6 +896,16 @@ class _ActionButtons extends StatelessWidget {
 
   const _ActionButtons({required this.metadata});
 
+  Future<void> _copyPositivePrompt(BuildContext context) async {
+    final prompt = await PromptCopyDialog.show(context, metadata: metadata);
+    if (prompt == null || !context.mounted) return;
+
+    await Clipboard.setData(ClipboardData(text: prompt));
+    if (context.mounted) {
+      AppToast.success(context, context.l10n.gallery_promptCopied);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -914,13 +922,7 @@ class _ActionButtons extends StatelessWidget {
                   label: context.l10n.detail_copyLabel(
                     context.l10n.prompt_positivePrompt,
                   ),
-                  onPressed: () {
-                    Clipboard.setData(ClipboardData(text: metadata.fullPrompt));
-                    AppToast.success(
-                      context,
-                      context.l10n.gallery_promptCopied,
-                    );
-                  },
+                  onPressed: () => _copyPositivePrompt(context),
                 ),
               ),
               const SizedBox(width: 8),

--- a/lib/presentation/widgets/common/image_detail/components/prompt_copy_dialog.dart
+++ b/lib/presentation/widgets/common/image_detail/components/prompt_copy_dialog.dart
@@ -1,0 +1,272 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/utils/localization_extension.dart';
+import '../../../../../data/models/gallery/nai_image_metadata.dart';
+
+/// 按提示词类别选择复制范围，默认排除容易泄露私密串的固定词和自动质量词。
+class PromptCopyDialog extends StatefulWidget {
+  const PromptCopyDialog({super.key, required this.metadata});
+
+  final NaiImageMetadata metadata;
+
+  static Future<String?> show(
+    BuildContext context, {
+    required NaiImageMetadata metadata,
+  }) {
+    return showDialog<String>(
+      context: context,
+      builder: (_) => PromptCopyDialog(metadata: metadata),
+    );
+  }
+
+  @override
+  State<PromptCopyDialog> createState() => _PromptCopyDialogState();
+}
+
+class _PromptCopyDialogState extends State<PromptCopyDialog> {
+  late bool _includeMainPrompt;
+  late bool _includeCharacterPrompts;
+  bool _includeQualityTags = false;
+  bool _includeFixedTags = false;
+
+  NaiImageMetadata get _metadata => widget.metadata;
+
+  bool get _hasMainPrompt {
+    final body = _metadata.hasSeparatedFields
+        ? _metadata.mainPrompt
+        : _metadata.prompt;
+    return body.trim().isNotEmpty;
+  }
+
+  bool get _hasCharacterPrompts =>
+      _metadata.characterPrompts.any((prompt) => prompt.trim().isNotEmpty);
+
+  bool get _hasQualityTags =>
+      _metadata.qualityTags.isNotEmpty ||
+      _metadata.hasRecordedTransparentBackgroundTag;
+
+  bool get _hasFixedTags =>
+      _metadata.fixedPrefixTags.isNotEmpty ||
+      _metadata.fixedSuffixTags.isNotEmpty;
+
+  String get _selectedPrompt => _metadata.buildPositivePromptSelection(
+    includeMainPrompt: _includeMainPrompt,
+    includeCharacterPrompts: _includeCharacterPrompts,
+    includeQualityTags: _includeQualityTags,
+    includeFixedTags: _includeFixedTags,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _includeMainPrompt = _hasMainPrompt;
+    _includeCharacterPrompts = _hasCharacterPrompts;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final fixedCount =
+        _metadata.fixedPrefixTags.length + _metadata.fixedSuffixTags.length;
+    final qualityCount =
+        _metadata.qualityTags.length +
+        (_metadata.hasRecordedTransparentBackgroundTag ? 1 : 0);
+
+    return AlertDialog(
+      icon: Icon(Icons.privacy_tip_outlined, color: colorScheme.primary),
+      title: Text(context.l10n.detail_copyPromptTitle),
+      content: SizedBox(
+        width: 440,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                context.l10n.detail_copyPromptDescription,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  height: 1.45,
+                ),
+              ),
+              const SizedBox(height: 14),
+              Material(
+                color: colorScheme.surfaceContainerHighest.withValues(
+                  alpha: 0.45,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  side: BorderSide(
+                    color: colorScheme.outlineVariant.withValues(alpha: 0.55),
+                  ),
+                ),
+                clipBehavior: Clip.antiAlias,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _PromptCategoryTile(
+                      icon: Icons.subject,
+                      title: context.l10n.detail_promptCategoryMain,
+                      subtitle: context.l10n.detail_promptCategoryMainHint,
+                      value: _includeMainPrompt,
+                      enabled: _hasMainPrompt,
+                      onChanged: (value) =>
+                          setState(() => _includeMainPrompt = value),
+                    ),
+                    const Divider(height: 1),
+                    _PromptCategoryTile(
+                      icon: Icons.people_outline,
+                      title: context.l10n.detail_promptCategoryCharacters,
+                      subtitle:
+                          context.l10n.detail_promptCategoryCharactersHint,
+                      count: _metadata.characterPrompts.length,
+                      value: _includeCharacterPrompts,
+                      enabled: _hasCharacterPrompts,
+                      onChanged: (value) =>
+                          setState(() => _includeCharacterPrompts = value),
+                    ),
+                    const Divider(height: 1),
+                    _PromptCategoryTile(
+                      icon: Icons.auto_awesome_outlined,
+                      title: context.l10n.detail_promptCategoryQuality,
+                      subtitle: context.l10n.detail_promptCategoryQualityHint,
+                      count: qualityCount,
+                      value: _includeQualityTags,
+                      enabled: _hasQualityTags,
+                      onChanged: (value) =>
+                          setState(() => _includeQualityTags = value),
+                    ),
+                    const Divider(height: 1),
+                    _PromptCategoryTile(
+                      icon: Icons.push_pin_outlined,
+                      title: context.l10n.detail_promptCategoryFixed,
+                      subtitle: context.l10n.detail_promptCategoryFixedHint,
+                      count: fixedCount,
+                      value: _includeFixedTags,
+                      enabled: _hasFixedTags,
+                      warning: true,
+                      onChanged: (value) =>
+                          setState(() => _includeFixedTags = value),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 10),
+              Row(
+                children: [
+                  Icon(
+                    Icons.info_outline,
+                    size: 15,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      context.l10n.detail_copyPromptDefaultHint,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(context.l10n.common_cancel),
+        ),
+        FilledButton.icon(
+          onPressed: _selectedPrompt.isEmpty
+              ? null
+              : () => Navigator.of(context).pop(_selectedPrompt),
+          icon: const Icon(Icons.copy, size: 17),
+          label: Text(context.l10n.common_copy),
+        ),
+      ],
+    );
+  }
+}
+
+class _PromptCategoryTile extends StatelessWidget {
+  const _PromptCategoryTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.enabled,
+    required this.onChanged,
+    this.count,
+    this.warning = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final int? count;
+  final bool value;
+  final bool enabled;
+  final bool warning;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final accent = warning ? colorScheme.tertiary : colorScheme.primary;
+
+    return CheckboxListTile(
+      value: enabled && value,
+      onChanged: enabled ? (value) => onChanged(value ?? false) : null,
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: Icon(
+        icon,
+        size: 20,
+        color: enabled ? accent : colorScheme.onSurface.withValues(alpha: 0.3),
+      ),
+      title: Row(
+        children: [
+          Flexible(
+            child: Text(
+              title,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          if (count != null && count! > 0) ...[
+            const SizedBox(width: 7),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+              decoration: BoxDecoration(
+                color: accent.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                '$count',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: accent,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+      subtitle: Text(
+        enabled ? subtitle : context.l10n.detail_promptCategoryUnavailable,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: colorScheme.onSurfaceVariant,
+          height: 1.3,
+        ),
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 3),
+      activeColor: accent,
+      dense: true,
+    );
+  }
+}

--- a/lib/presentation/widgets/common/image_detail/components/prompt_section.dart
+++ b/lib/presentation/widgets/common/image_detail/components/prompt_section.dart
@@ -19,10 +19,12 @@ class PromptSection extends StatefulWidget {
   final bool initiallyExpanded;
   final bool showAddToLibrary;
   final VoidCallback? onAddToLibrary;
-  final Color? contentColor;
   final Color? borderColor;
   final bool showTranslation;
   final Widget? customContent;
+  final List<String> fixedTags;
+  final bool allTagsAreFixed;
+  final bool isNegative;
 
   const PromptSection({
     super.key,
@@ -33,10 +35,12 @@ class PromptSection extends StatefulWidget {
     this.initiallyExpanded = false,
     this.showAddToLibrary = false,
     this.onAddToLibrary,
-    this.contentColor,
     this.borderColor,
     this.showTranslation = true,
     this.customContent,
+    this.fixedTags = const [],
+    this.allTagsAreFixed = false,
+    this.isNegative = false,
   });
 
   @override
@@ -52,10 +56,13 @@ class _PromptSectionState extends State<PromptSection> {
     _isExpanded = widget.initiallyExpanded;
   }
 
-  void _copyContent() {
+  Future<void> _copyContent() async {
     if (widget.content.isEmpty) return;
-    Clipboard.setData(ClipboardData(text: widget.content));
-    AppToast.success(context, context.l10n.toast_copiedTitle(widget.title));
+
+    await Clipboard.setData(ClipboardData(text: widget.content));
+    if (mounted) {
+      AppToast.success(context, context.l10n.toast_copiedTitle(widget.title));
+    }
   }
 
   void _copyTag(String tag) {
@@ -110,8 +117,15 @@ class _PromptSectionState extends State<PromptSection> {
     ThemeData theme,
     bool hasContent,
   ) {
-    final primaryColor = hasContent
-        ? colorScheme.primary
+    final accentColor = widget.allTagsAreFixed
+        ? colorScheme.tertiary
+        : widget.isNegative
+        ? colorScheme.error
+        : colorScheme.primary;
+    final titleColor = hasContent
+        ? widget.isNegative
+              ? colorScheme.onSurface
+              : accentColor
         : colorScheme.onSurfaceVariant;
 
     return Row(
@@ -127,12 +141,16 @@ class _PromptSectionState extends State<PromptSection> {
                   : SystemMouseCursors.basic,
               child: Row(
                 children: [
-                  Icon(widget.icon, size: 16, color: primaryColor),
+                  Icon(
+                    widget.icon,
+                    size: 16,
+                    color: hasContent ? accentColor : titleColor,
+                  ),
                   const SizedBox(width: 6),
                   Text(
                     widget.title,
                     style: theme.textTheme.titleSmall?.copyWith(
-                      color: primaryColor,
+                      color: titleColor,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
@@ -144,16 +162,15 @@ class _PromptSectionState extends State<PromptSection> {
                         vertical: 2,
                       ),
                       decoration: BoxDecoration(
-                        color: colorScheme.primaryContainer.withValues(
-                          alpha: 0.5,
-                        ),
+                        color: accentColor.withValues(alpha: 0.12),
                         borderRadius: BorderRadius.circular(10),
                       ),
                       child: Text(
                         '$_tagCount',
                         style: theme.textTheme.labelSmall?.copyWith(
-                          color: colorScheme.onPrimaryContainer,
+                          color: accentColor,
                           fontSize: 10,
+                          fontWeight: FontWeight.w700,
                         ),
                       ),
                     ),
@@ -209,14 +226,16 @@ class _PromptSectionState extends State<PromptSection> {
     List<String> tags,
   ) {
     final borderColor =
-        widget.borderColor?.withValues(alpha: 0.2) ??
+        widget.borderColor?.withValues(alpha: widget.isNegative ? 0.28 : 0.2) ??
         colorScheme.outline.withValues(alpha: 0.1);
 
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        color: widget.isNegative
+            ? colorScheme.errorContainer.withValues(alpha: 0.10)
+            : colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: borderColor),
       ),
@@ -226,8 +245,10 @@ class _PromptSectionState extends State<PromptSection> {
               ? _TagChipGrid(
                   tags: tags,
                   onTagTap: _copyTag,
-                  contentColor: widget.contentColor,
                   showTranslation: widget.showTranslation,
+                  fixedTags: widget.fixedTags,
+                  allTagsAreFixed: widget.allTagsAreFixed,
+                  isNegative: widget.isNegative,
                 )
               : Text(
                   context.l10n.detail_noContent,
@@ -244,18 +265,28 @@ class _PromptSectionState extends State<PromptSection> {
 class _TagChipGrid extends StatelessWidget {
   final List<String> tags;
   final void Function(String) onTagTap;
-  final Color? contentColor;
   final bool showTranslation;
+  final List<String> fixedTags;
+  final bool allTagsAreFixed;
+  final bool isNegative;
 
   const _TagChipGrid({
     required this.tags,
     required this.onTagTap,
-    this.contentColor,
+    required this.fixedTags,
+    required this.allTagsAreFixed,
+    required this.isNegative,
     this.showTranslation = true,
   });
 
   @override
   Widget build(BuildContext context) {
+    final normalizedFixedTags = fixedTags
+        .expand((entry) => entry.split(','))
+        .map((tag) => tag.trim().toLowerCase())
+        .where((tag) => tag.isNotEmpty)
+        .toSet();
+
     return Wrap(
       spacing: 6,
       runSpacing: 6,
@@ -264,8 +295,11 @@ class _TagChipGrid extends StatelessWidget {
             (tag) => _TranslatedTagChip(
               tag: tag,
               onTap: () => onTagTap(tag),
-              contentColor: contentColor,
               showTranslation: showTranslation,
+              isFixed:
+                  allTagsAreFixed ||
+                  normalizedFixedTags.contains(tag.trim().toLowerCase()),
+              isNegative: isNegative,
             ),
           )
           .toList(),
@@ -277,13 +311,15 @@ class _TagChipGrid extends StatelessWidget {
 class _TranslatedTagChip extends ConsumerStatefulWidget {
   final String tag;
   final VoidCallback onTap;
-  final Color? contentColor;
   final bool showTranslation;
+  final bool isFixed;
+  final bool isNegative;
 
   const _TranslatedTagChip({
     required this.tag,
     required this.onTap,
-    this.contentColor,
+    required this.isFixed,
+    required this.isNegative,
     this.showTranslation = true,
   });
 
@@ -357,12 +393,25 @@ class _TranslatedTagChipState extends ConsumerState<_TranslatedTagChip> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final bgColor = _isHovered
-        ? colorScheme.primary.withValues(alpha: 0.15)
+    final accent = widget.isFixed
+        ? colorScheme.tertiary
+        : widget.isNegative
+        ? colorScheme.error
+        : colorScheme.primary;
+    final bgColor = widget.isFixed
+        ? accent.withValues(alpha: _isHovered ? 0.24 : 0.16)
+        : widget.isNegative
+        ? colorScheme.onSurface.withValues(alpha: _isHovered ? 0.12 : 0.07)
+        : _isHovered
+        ? accent.withValues(alpha: 0.15)
         : colorScheme.surfaceContainerHighest;
-    final borderColor = _isHovered
-        ? colorScheme.primary.withValues(alpha: 0.3)
-        : colorScheme.outline.withValues(alpha: 0.15);
+    final borderColor = accent.withValues(
+      alpha: _isHovered
+          ? 0.42
+          : widget.isFixed
+          ? 0.30
+          : 0.18,
+    );
 
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
@@ -378,13 +427,27 @@ class _TranslatedTagChipState extends ConsumerState<_TranslatedTagChip> {
             borderRadius: BorderRadius.circular(6),
             border: Border.all(color: borderColor),
           ),
-          child: Text(
-            _displayText,
-            style: theme.textTheme.bodySmall?.copyWith(
-              fontSize: 11,
-              color: widget.contentColor ?? colorScheme.onSurface,
-              height: 1.3,
-            ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (widget.isFixed) ...[
+                Icon(Icons.push_pin, size: 11, color: accent),
+                const SizedBox(width: 4),
+              ],
+              Flexible(
+                child: Text(
+                  _displayText,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontSize: 11,
+                    color: colorScheme.onSurface,
+                    fontWeight: widget.isFixed
+                        ? FontWeight.w600
+                        : FontWeight.w500,
+                    height: 1.35,
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),
@@ -512,31 +575,49 @@ class CharacterPromptCard extends StatelessWidget {
         const SizedBox(height: 8),
         Divider(color: colorScheme.outline.withValues(alpha: 0.2), height: 1),
         const SizedBox(height: 8),
-        Row(
-          children: [
-            Icon(
-              Icons.block_outlined,
-              size: 12,
-              color: colorScheme.error.withValues(alpha: 0.7),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: colorScheme.errorContainer.withValues(alpha: 0.18),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: colorScheme.error.withValues(alpha: 0.22),
             ),
-            const SizedBox(width: 4),
-            Text(
-              '${context.l10n.prompt_negativePrompt}:',
-              style: theme.textTheme.labelSmall?.copyWith(
-                color: colorScheme.error.withValues(alpha: 0.7),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Icons.block_outlined,
+                    size: 13,
+                    color: colorScheme.error,
+                  ),
+                  const SizedBox(width: 5),
+                  Text(
+                    '${context.l10n.prompt_negativePrompt}:',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 4),
-        SelectionCopyShortcuts(
-          child: SelectableText(
-            negativePrompt!,
-            style: theme.textTheme.bodySmall?.copyWith(
-              fontFamily: 'monospace',
-              height: 1.5,
-              color: colorScheme.error.withValues(alpha: 0.8),
-            ),
+              const SizedBox(height: 6),
+              SelectionCopyShortcuts(
+                child: SelectableText(
+                  negativePrompt!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
+                    height: 1.55,
+                    color: colorScheme.onSurface,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ],

--- a/lib/presentation/widgets/common/image_detail/image_detail_viewer.dart
+++ b/lib/presentation/widgets/common/image_detail/image_detail_viewer.dart
@@ -17,6 +17,7 @@ import '../app_toast.dart';
 import '../../metadata/metadata_import_dialog.dart';
 import 'components/detail_image_page.dart';
 import 'components/detail_metadata_panel.dart';
+import 'components/prompt_copy_dialog.dart';
 import 'components/detail_thumbnail_bar.dart';
 import 'components/detail_top_bar.dart';
 import 'image_detail_data.dart';
@@ -397,18 +398,21 @@ class _ImageDetailViewerState extends ConsumerState<ImageDetailViewer> {
   }
 
   /// 复制 Prompt
-  void _copyPrompt() {
+  Future<void> _copyPrompt() async {
     final metadata = _currentImage.metadata;
-    final prompt = metadata?.prompt;
-    if (prompt != null && prompt.isNotEmpty) {
-      Clipboard.setData(ClipboardData(text: prompt));
-      if (context.mounted) {
-        AppToast.success(context, context.l10n.toast_imagePromptCopied);
-      }
-    } else {
+    if (metadata == null || metadata.fullPrompt.isEmpty) {
       if (context.mounted) {
         AppToast.warning(context, context.l10n.toast_imageHasNoPrompt);
       }
+      return;
+    }
+
+    final prompt = await PromptCopyDialog.show(context, metadata: metadata);
+    if (prompt == null || !mounted) return;
+
+    await Clipboard.setData(ClipboardData(text: prompt));
+    if (mounted) {
+      AppToast.success(context, context.l10n.toast_imagePromptCopied);
     }
   }
 

--- a/lib/presentation/widgets/gallery/local_image_card_3d.dart
+++ b/lib/presentation/widgets/gallery/local_image_card_3d.dart
@@ -75,6 +75,8 @@ class _LocalImageCard3DState extends ConsumerState<LocalImageCard3D>
   ThumbnailCacheService? _thumbnailService;
   _ImageLoadState _loadState = _ImageLoadState.idle;
   bool _isLoadingThumbnail = false;
+  bool _isCopyingImage = false;
+  bool _suppressCardTap = false;
 
   @override
   void initState() {
@@ -195,6 +197,9 @@ class _LocalImageCard3DState extends ConsumerState<LocalImageCard3D>
   }
 
   Future<void> _copyImageToClipboard() async {
+    if (_isCopyingImage) return;
+    setState(() => _isCopyingImage = true);
+
     try {
       final sourceFile = File(widget.record.path);
       if (!await sourceFile.exists()) {
@@ -209,7 +214,8 @@ class _LocalImageCard3DState extends ConsumerState<LocalImageCard3D>
       final sourceName =
           sourceParts.isNotEmpty ? sourceParts.last : 'shared.png';
       final originalBytes = await sourceFile.readAsBytes();
-      final shareImage = await ImageShareSanitizer.prepareForCopyOrDrag(
+      final shareImage =
+          await ImageShareSanitizer.prepareForCopyOrDragInBackground(
         originalBytes,
         fileName: sourceName,
         stripMetadata: stripMetadata,
@@ -227,7 +233,20 @@ class _LocalImageCard3DState extends ConsumerState<LocalImageCard3D>
       if (mounted) {
         AppToast.error(context, context.l10n.gallery_copyFailed('$e'));
       }
+    } finally {
+      if (mounted) setState(() => _isCopyingImage = false);
     }
+  }
+
+  void _handleCardTap() {
+    if (_suppressCardTap || _isCopyingImage) return;
+    widget.onTap?.call();
+  }
+
+  void _releaseActionPointerAfterGesture() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _suppressCardTap = false;
+    });
   }
 
   (_EffectIntensity, Color) _getEffectConfig(BuildContext context) {
@@ -256,7 +275,7 @@ class _LocalImageCard3DState extends ConsumerState<LocalImageCard3D>
     final (intensity, glowColor) = _getEffectConfig(context);
 
     Widget cardContent = GestureDetector(
-      onTap: widget.onTap,
+      onTap: widget.onTap == null ? null : _handleCardTap,
       onDoubleTap: widget.onDoubleTap,
       onLongPress: widget.onLongPress,
       onSecondaryTapDown: widget.onSecondaryTapDown,
@@ -503,26 +522,57 @@ class _LocalImageCard3DState extends ConsumerState<LocalImageCard3D>
   }
 
   Widget _buildActionButtons() {
-    return FloatingActionButtons(
-      isVisible: _isHovered,
-      buttons: [
-        FloatingActionButtonData(
-          icon:
-              widget.record.isFavorite ? Icons.favorite : Icons.favorite_border,
-          onTap: widget.onFavoriteToggle,
-          iconColor: widget.record.isFavorite ? Colors.red : Colors.white,
-          visible: widget.onFavoriteToggle != null,
-        ),
-        FloatingActionButtonData(
-          icon: Icons.copy,
-          onTap: _copyImageToClipboard,
-        ),
-        FloatingActionButtonData(
-          icon: Icons.send,
-          onTap: () => unawaited(_showSendMenu(context)),
-          visible: widget.onSendAction != null,
-        ),
-      ],
+    return Listener(
+      behavior: HitTestBehavior.opaque,
+      onPointerDown: (_) => _suppressCardTap = true,
+      onPointerUp: (_) => _releaseActionPointerAfterGesture(),
+      onPointerCancel: (_) => _releaseActionPointerAfterGesture(),
+      child: FloatingActionButtons(
+        isVisible: _isHovered,
+        axis: Axis.horizontal,
+        spacing: 6,
+        padding: const EdgeInsets.all(4),
+        buttons: [
+          FloatingActionButtonData(
+            icon: widget.record.isFavorite
+                ? Icons.favorite
+                : Icons.favorite_border,
+            onTap: widget.onFavoriteToggle,
+            iconColor: widget.record.isFavorite ? Colors.red : Colors.white,
+            visible: widget.onFavoriteToggle != null,
+          ),
+          FloatingActionButtonData(
+            icon: Icons.copy,
+            onTap: _copyImageToClipboard,
+            isLoading: _isCopyingImage,
+            tooltip: context.l10n.shortcut_action_copy_image,
+          ),
+          FloatingActionButtonData(
+            icon: Icons.text_snippet_outlined,
+            onTap: () => unawaited(
+              widget.onSendAction?.call(LocalImageContextAction.copyPrompt),
+            ),
+            tooltip: context.l10n.localGallery_copyPrompt,
+            visible: widget.onSendAction != null,
+          ),
+          FloatingActionButtonData(
+            icon: Icons.delete_outline,
+            onTap: () => unawaited(
+              widget.onSendAction?.call(LocalImageContextAction.delete),
+            ),
+            hoverIconColor: Colors.white,
+            hoverBackgroundColor: Colors.red.shade700,
+            tooltip: context.l10n.common_delete,
+            visible: widget.onSendAction != null,
+          ),
+          FloatingActionButtonData(
+            icon: Icons.send,
+            onTap: () => unawaited(_showSendMenu(context)),
+            tooltip: context.l10n.detail_sendToImg2Img,
+            visible: widget.onSendAction != null,
+          ),
+        ],
+      ),
     );
   }
 

--- a/test/data/models/gallery/nai_image_metadata_test.dart
+++ b/test/data/models/gallery/nai_image_metadata_test.dart
@@ -56,7 +56,88 @@ void main() {
         metadata.displayNegativePrompt,
         equals('bad anatomy, plain_negative, text'),
       );
+      expect(metadata.negativePromptWithoutFixedTags, equals('plain_negative'));
     });
+
+    test('copy-safe prompt should remove only fixed tags', () {
+      const metadata = NaiImageMetadata(
+        prompt:
+            'private-prefix, 1girl, blue hair, private-suffix, very aesthetic, no text',
+        fixedPrefixTags: ['private-prefix'],
+        fixedSuffixTags: ['private-suffix'],
+        qualityTags: ['very aesthetic', 'no text'],
+        characterPrompts: ['cat ears, green eyes'],
+      );
+
+      expect(
+        metadata.promptWithoutFixedTags,
+        equals('1girl, blue hair, very aesthetic, no text'),
+      );
+      expect(
+        metadata.fullPromptWithoutFixedTags,
+        equals(
+          '1girl, blue hair, very aesthetic, no text\n\n| cat ears, green eyes',
+        ),
+      );
+      expect(
+        metadata.buildPositivePromptSelection(
+          includeMainPrompt: true,
+          includeCharacterPrompts: true,
+          includeQualityTags: false,
+          includeFixedTags: false,
+        ),
+        equals('1girl, blue hair\n\n| cat ears, green eyes'),
+      );
+      expect(
+        metadata.buildPositivePromptSelection(
+          includeMainPrompt: true,
+          includeCharacterPrompts: false,
+          includeQualityTags: true,
+          includeFixedTags: true,
+        ),
+        equals(
+          'private-prefix, 1girl, blue hair, private-suffix, very aesthetic, no text',
+        ),
+      );
+    });
+
+    test('copy categories preserve a recorded transparent background tag', () {
+      const metadata = NaiImageMetadata(
+        prompt:
+            'private-prefix, 1girl, private-suffix, transparent background, very aesthetic',
+        fixedPrefixTags: ['private-prefix'],
+        fixedSuffixTags: ['private-suffix'],
+        qualityTags: ['very aesthetic'],
+        transparentBackground: true,
+      );
+
+      expect(
+        metadata.buildPositivePromptSelection(
+          includeMainPrompt: true,
+          includeCharacterPrompts: false,
+          includeQualityTags: true,
+          includeFixedTags: false,
+        ),
+        equals('1girl, transparent background, very aesthetic'),
+      );
+    });
+
+    test(
+      'copy-safe prompt preserves matching text outside fixed boundaries',
+      () {
+        const metadata = NaiImageMetadata(
+          prompt: 'private, subject, private, quality',
+          fixedPrefixTags: ['private'],
+          fixedSuffixTags: ['missing'],
+          qualityTags: ['quality'],
+        );
+
+        expect(
+          metadata.promptWithoutFixedTags,
+          equals('subject, private, quality'),
+        );
+      },
+    );
 
     test(
       'fromNaiComment should map known V4.5 source fingerprint without inferring uc preset',

--- a/test/presentation/widgets/common/image_detail/components/prompt_copy_dialog_test.dart
+++ b/test/presentation/widgets/common/image_detail/components/prompt_copy_dialog_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/widgets/common/image_detail/components/prompt_copy_dialog.dart';
+
+void main() {
+  testWidgets(
+    'defaults to subject and characters while excluding quality and fixed tags',
+    (tester) async {
+      const metadata = NaiImageMetadata(
+        prompt:
+            'private-prefix, 1girl, blue hair, private-suffix, very aesthetic',
+        negativePrompt: '',
+        fixedPrefixTags: ['private-prefix'],
+        fixedSuffixTags: ['private-suffix'],
+        qualityTags: ['very aesthetic'],
+        characterPrompts: ['cat ears, green eyes'],
+      );
+      String? copiedPrompt;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                copiedPrompt = await PromptCopyDialog.show(
+                  context,
+                  metadata: metadata,
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      final values = tester
+          .widgetList<Checkbox>(find.byType(Checkbox))
+          .map((checkbox) => checkbox.value)
+          .toList();
+      expect(values, [true, true, false, false]);
+
+      await tester.tap(find.text('复制'));
+      await tester.pumpAndSettle();
+      expect(copiedPrompt, '1girl, blue hair\n\n| cat ears, green eyes');
+    },
+  );
+}

--- a/test/presentation/widgets/gallery/gallery_content_view_context_menu_test.dart
+++ b/test/presentation/widgets/gallery/gallery_content_view_context_menu_test.dart
@@ -106,6 +106,16 @@ void main() {
 
     expect(selectedRecord, same(record));
     expect(selectedAction, LocalImageContextAction.sendToReversePrompt);
+
+    selectedAction = null;
+    await tester.tap(find.byIcon(Icons.text_snippet_outlined));
+    await tester.pump();
+    expect(selectedAction, LocalImageContextAction.copyPrompt);
+
+    selectedAction = null;
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pump();
+    expect(selectedAction, LocalImageContextAction.delete);
   });
 }
 


### PR DESCRIPTION
## Problem
复制图片提示词时会直接包含可能泄露隐私的固定词和质量词，用户无法选择复制内容。图库卡片操作也缺少清晰的状态反馈和快捷操作区分。

## Solution
新增按类别选择提示词的复制对话框，默认只复制主体和角色提示词，并支持多语言显示。固定词、质量词和透明背景标签会被安全识别和处理，同时详情页和本地图库统一使用该流程。

此外，优化提示词区块的固定词与负向提示词视觉标识，增强图库卡片复制中的加载状态、防止误触，并增加复制提示词、删除和发送等快捷按钮。

## Testing
- 新增提示词安全拆分、固定词过滤和透明背景标签测试
- 新增提示词复制对话框默认选项测试
- 更新图库卡片快捷操作测试