### PR TITLE
fix(discord): 完善分享限速反馈与并发保护

### DIFF
--- a/lib/data/services/discord_share_service.dart
+++ b/lib/data/services/discord_share_service.dart
@@ -113,12 +113,14 @@ class DiscordShareException implements Exception {
     required this.message,
     this.status,
     this.communityUrl,
+    this.retryAfter,
   });
 
   final String code;
   final String message;
   final int? status;
   final String? communityUrl;
+  final Duration? retryAfter;
 
   bool get isUnauthorized => status == 401 || code == 'unauthorized';
   bool get isNotMember => code == 'not_member';
@@ -146,6 +148,7 @@ class DiscordShareService {
   final LocalStorageService _localStorage;
   final Dio _dio;
   final DiscordExternalUrlLauncher _externalUrlLauncher;
+  Future<DiscordShareResult>? _shareInFlight;
 
   Future<DiscordShareSession?> loadSession() async {
     final raw = await _secureStorage.read(StorageKeys.discordShareSession);
@@ -344,6 +347,45 @@ class DiscordShareService {
     required int? width,
     required int? height,
     required bool longPromptAsFile,
+  }) {
+    if (_shareInFlight != null) {
+      return Future<DiscordShareResult>.error(
+        const DiscordShareException(
+          code: 'share_in_progress',
+          message: 'A Discord share is already in progress.',
+        ),
+      );
+    }
+
+    late final Future<DiscordShareResult> operation;
+    operation =
+        _performShare(
+          session: session,
+          image: image,
+          targetIds: targetIds,
+          prompt: prompt,
+          caption: caption,
+          width: width,
+          height: height,
+          longPromptAsFile: longPromptAsFile,
+        ).whenComplete(() {
+          if (identical(_shareInFlight, operation)) {
+            _shareInFlight = null;
+          }
+        });
+    _shareInFlight = operation;
+    return operation;
+  }
+
+  Future<DiscordShareResult> _performShare({
+    required DiscordShareSession session,
+    required SanitizedShareImage image,
+    required Set<String> targetIds,
+    required String prompt,
+    required String caption,
+    required int? width,
+    required int? height,
+    required bool longPromptAsFile,
   }) async {
     final formData = FormData();
     formData.files.add(
@@ -420,7 +462,11 @@ class DiscordShareService {
         if (clearSessionOnAuthFailure && (status == 401 || status == 403)) {
           await clearSession();
         }
-        throw _exceptionFromPayload(payload, status);
+        throw _exceptionFromPayload(
+          payload,
+          status,
+          retryAfterHeader: response.headers.value('retry-after'),
+        );
       }
       return response.data as T;
     } on DiscordShareException {
@@ -438,6 +484,7 @@ class DiscordShareService {
         payload,
         status,
         fallback: error.message ?? 'Discord sharing failed.',
+        retryAfterHeader: response?.headers.value('retry-after'),
       );
     }
   }
@@ -446,6 +493,7 @@ class DiscordShareService {
     Map<String, dynamic> payload,
     int? status, {
     String fallback = 'Discord sharing failed.',
+    String? retryAfterHeader,
   }) {
     return DiscordShareException(
       code: '${payload['code'] ?? 'request_failed'}',
@@ -454,7 +502,18 @@ class DiscordShareService {
       communityUrl:
           payload['community_url']?.toString() ??
           (payload['code'] == 'not_member' ? discordCommunityUrl : null),
+      retryAfter: _retryAfter(
+        retryAfterHeader ??
+            payload['retry_after_seconds'] ??
+            payload['retry_after'],
+      ),
     );
+  }
+
+  Duration? _retryAfter(Object? raw) {
+    final seconds = raw is num ? raw.toDouble() : double.tryParse('$raw');
+    if (seconds == null || !seconds.isFinite || seconds <= 0) return null;
+    return Duration(milliseconds: (seconds * 1000).ceil());
   }
 
   String _randomBase64Url(int byteCount) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4735,6 +4735,8 @@
   "discordShare_errorBrowser": "Could not open your browser. Check the system default browser setting.",
   "discordShare_errorTimeout": "Discord verification timed out. Please verify again.",
   "discordShare_errorRateLimited": "You are sharing too quickly. Please try again shortly.",
+  "discordShare_errorRateLimitedRetry": "You are sharing too quickly. Try again in {seconds} seconds.",
+  "@discordShare_errorRateLimitedRetry": {"placeholders": {"seconds": {"type": "int"}}},
   "discordShare_errorNoChannels": "No Discord share channels are currently available.",
   "discordShare_errorSession": "Your Discord verification expired. Please verify again.",
   "discordShare_errorRelay": "The Discord share service is temporarily unavailable. Please try again later.",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -4763,6 +4763,8 @@
   "discordShare_errorBrowser": "ブラウザーを開けません。システムの既定のブラウザー設定を確認してください。",
   "discordShare_errorTimeout": "Discord の確認がタイムアウトしました。もう一度確認してください。",
   "discordShare_errorRateLimited": "共有回数が多すぎます。しばらくしてから再試行してください。",
+  "discordShare_errorRateLimitedRetry": "共有回数が多すぎます。{seconds} 秒後に再試行してください。",
+  "@discordShare_errorRateLimitedRetry": {"placeholders": {"seconds": {"type": "int"}}},
   "discordShare_errorNoChannels": "現在利用できる Discord 共有チャンネルがありません。",
   "discordShare_errorSession": "Discord の確認が期限切れです。もう一度確認してください。",
   "discordShare_errorRelay": "Discord 共有サービスは一時的に利用できません。後でもう一度お試しください。",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -16861,6 +16861,12 @@ abstract class AppLocalizations {
   /// **'You are sharing too quickly. Please try again shortly.'**
   String get discordShare_errorRateLimited;
 
+  /// No description provided for @discordShare_errorRateLimitedRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'You are sharing too quickly. Try again in {seconds} seconds.'**
+  String discordShare_errorRateLimitedRetry(int seconds);
+
   /// No description provided for @discordShare_errorNoChannels.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -9584,6 +9584,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'You are sharing too quickly. Please try again shortly.';
 
   @override
+  String discordShare_errorRateLimitedRetry(int seconds) {
+    return 'You are sharing too quickly. Try again in $seconds seconds.';
+  }
+
+  @override
   String get discordShare_errorNoChannels =>
       'No Discord share channels are currently available.';
 

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -9372,6 +9372,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get discordShare_errorRateLimited => '共有回数が多すぎます。しばらくしてから再試行してください。';
 
   @override
+  String discordShare_errorRateLimitedRetry(int seconds) {
+    return '共有回数が多すぎます。$seconds 秒後に再試行してください。';
+  }
+
+  @override
   String get discordShare_errorNoChannels => '現在利用できる Discord 共有チャンネルがありません。';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9226,6 +9226,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get discordShare_errorRateLimited => '分享过于频繁，请稍后再试';
 
   @override
+  String discordShare_errorRateLimitedRetry(int seconds) {
+    return '分享过于频繁，请在 $seconds 秒后重试';
+  }
+
+  @override
   String get discordShare_errorNoChannels => '当前没有可用的 Discord 分享频道';
 
   @override
@@ -21300,6 +21305,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get discordShare_errorRateLimited => '分享過於頻繁，請稍後再試';
+
+  @override
+  String discordShare_errorRateLimitedRetry(int seconds) {
+    return '分享過於頻繁，請在 $seconds 秒後重試';
+  }
 
   @override
   String get discordShare_errorNoChannels => '目前沒有可用的 Discord 分享頻道';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -4518,6 +4518,8 @@
   "discordShare_errorBrowser": "无法打开浏览器，请检查系统的默认浏览器设置",
   "discordShare_errorTimeout": "Discord 验证已超时，请重新验证",
   "discordShare_errorRateLimited": "分享过于频繁，请稍后再试",
+  "discordShare_errorRateLimitedRetry": "分享过于频繁，请在 {seconds} 秒后重试",
+  "@discordShare_errorRateLimitedRetry": {"placeholders": {"seconds": {"type": "int"}}},
   "discordShare_errorNoChannels": "当前没有可用的 Discord 分享频道",
   "discordShare_errorSession": "Discord 验证已失效，请重新验证",
   "discordShare_errorRelay": "Discord 分享服务暂时不可用，请稍后再试",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -4639,6 +4639,8 @@
   "discordShare_errorBrowser": "無法開啟瀏覽器，請檢查系統的預設瀏覽器設定",
   "discordShare_errorTimeout": "Discord 驗證已逾時，請重新驗證",
   "discordShare_errorRateLimited": "分享過於頻繁，請稍後再試",
+  "discordShare_errorRateLimitedRetry": "分享過於頻繁，請在 {seconds} 秒後重試",
+  "@discordShare_errorRateLimitedRetry": {"placeholders": {"seconds": {"type": "int"}}},
   "discordShare_errorNoChannels": "目前沒有可用的 Discord 分享頻道",
   "discordShare_errorSession": "Discord 驗證已失效，請重新驗證",
   "discordShare_errorRelay": "Discord 分享服務暫時無法使用，請稍後再試",

--- a/lib/presentation/widgets/discord_share/discord_share_dialog.dart
+++ b/lib/presentation/widgets/discord_share/discord_share_dialog.dart
@@ -72,6 +72,9 @@ class _DiscordShareDialogState extends ConsumerState<DiscordShareDialog> {
   Object? _error;
   CancelToken? _authenticationCancelToken;
   Future<void> _preferenceWrite = Future<void>.value();
+  Timer? _rateLimitTimer;
+  Stopwatch? _rateLimitStopwatch;
+  Duration? _rateLimitDuration;
 
   late final Map<_PromptCategory, String> _categoryContent;
   late final Set<_PromptCategory> _preferredCategories;
@@ -99,6 +102,7 @@ class _DiscordShareDialogState extends ConsumerState<DiscordShareDialog> {
   @override
   void dispose() {
     _authenticationCancelToken?.cancel('Discord share dialog closed');
+    _rateLimitTimer?.cancel();
     _captionController.dispose();
     _promptController.dispose();
     super.dispose();
@@ -270,20 +274,25 @@ class _DiscordShareDialogState extends ConsumerState<DiscordShareDialog> {
 
   Future<void> _send() async {
     final session = _session;
-    if (session == null || _selectedTargets.isEmpty || _sending) return;
-    final confirmed = await AssetProtectionGuard.confirmExternalImageSend(
-      context: context,
-      ref: ref,
-      targetName: 'Discord',
-    );
-    if (!confirmed || !mounted) return;
-
+    if (session == null ||
+        _selectedTargets.isEmpty ||
+        _sending ||
+        _rateLimitSecondsRemaining > 0) {
+      return;
+    }
     setState(() {
       _sending = true;
       _error = null;
     });
     final service = ref.read(discordShareServiceProvider);
     try {
+      final confirmed = await AssetProtectionGuard.confirmExternalImageSend(
+        context: context,
+        ref: ref,
+        targetName: 'Discord',
+      );
+      if (!confirmed || !mounted) return;
+
       final image = await ImageShareSanitizer.prepareForCopyOrDragInBackground(
         widget.imageBytes,
         fileName: widget.fileName,
@@ -318,6 +327,8 @@ class _DiscordShareDialogState extends ConsumerState<DiscordShareDialog> {
           _joinRequired = error.isNotMember;
           _error = error.isNotMember ? null : error;
         });
+      } else if (error.code == 'rate_limited' && error.retryAfter != null) {
+        _startRateLimitCooldown(error);
       } else {
         setState(() => _error = error);
       }
@@ -326,6 +337,41 @@ class _DiscordShareDialogState extends ConsumerState<DiscordShareDialog> {
     } finally {
       if (mounted) setState(() => _sending = false);
     }
+  }
+
+  int get _rateLimitSecondsRemaining {
+    final duration = _rateLimitDuration;
+    final stopwatch = _rateLimitStopwatch;
+    if (duration == null || stopwatch == null) return 0;
+    final remaining = duration - stopwatch.elapsed;
+    if (remaining <= Duration.zero) return 0;
+    return (remaining.inMilliseconds / 1000).ceil();
+  }
+
+  void _startRateLimitCooldown(DiscordShareException error) {
+    _rateLimitTimer?.cancel();
+    _rateLimitDuration = error.retryAfter;
+    _rateLimitStopwatch = Stopwatch()..start();
+    setState(() => _error = error);
+    _rateLimitTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (!mounted) {
+        timer.cancel();
+        return;
+      }
+      if (_rateLimitSecondsRemaining <= 0) {
+        timer.cancel();
+        _rateLimitDuration = null;
+        _rateLimitStopwatch = null;
+        setState(() {
+          if (_error is DiscordShareException &&
+              (_error! as DiscordShareException).code == 'rate_limited') {
+            _error = null;
+          }
+        });
+        return;
+      }
+      setState(() {});
+    });
   }
 
   @override
@@ -758,7 +804,12 @@ class _DiscordShareDialogState extends ConsumerState<DiscordShareDialog> {
           ),
           const SizedBox(width: 8),
           FilledButton.icon(
-            onPressed: _sending || _selectedTargets.isEmpty ? null : _send,
+            onPressed:
+                _sending ||
+                    _selectedTargets.isEmpty ||
+                    _rateLimitSecondsRemaining > 0
+                ? null
+                : _send,
             icon: _sending
                 ? const SizedBox.square(
                     dimension: 16,
@@ -781,7 +832,13 @@ class _DiscordShareDialogState extends ConsumerState<DiscordShareDialog> {
     return switch (error.code) {
       'browser_unavailable' => context.l10n.discordShare_errorBrowser,
       'timeout' => context.l10n.discordShare_errorTimeout,
-      'rate_limited' => context.l10n.discordShare_errorRateLimited,
+      'share_in_progress' => context.l10n.discordShare_sending,
+      'rate_limited' =>
+        _rateLimitSecondsRemaining > 0
+            ? context.l10n.discordShare_errorRateLimitedRetry(
+                _rateLimitSecondsRemaining,
+              )
+            : context.l10n.discordShare_errorRateLimited,
       'no_targets' ||
       'invalid_targets' => context.l10n.discordShare_errorNoChannels,
       'unauthorized' ||

--- a/test/data/services/discord_share_service_test.dart
+++ b/test/data/services/discord_share_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
@@ -252,6 +253,138 @@ void main() {
       expect(result.deliveredTargets, ['Art', 'Showcase']);
       expect(result.isPartial, isFalse);
     },
+  );
+
+  test('uses Retry-After from a relay 429 response', () async {
+    when(
+      () => dio.post<Map<String, dynamic>>(
+        '/v1/share',
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+      ),
+    ).thenAnswer(
+      (_) async => Response(
+        requestOptions: RequestOptions(path: '/v1/share'),
+        statusCode: 429,
+        headers: Headers.fromMap({
+          'retry-after': ['12.5'],
+        }),
+        data: const {
+          'code': 'rate_limited',
+          'message': 'Wait before sharing again.',
+          'retry_after_seconds': 60,
+        },
+      ),
+    );
+
+    await expectLater(
+      _share(service),
+      throwsA(
+        isA<DiscordShareException>()
+            .having((error) => error.status, 'status', 429)
+            .having(
+              (error) => error.retryAfter,
+              'retryAfter',
+              const Duration(milliseconds: 12500),
+            ),
+      ),
+    );
+  });
+
+  test(
+    'rejects a concurrent share without a duplicate relay request',
+    () async {
+      final response = Completer<Response<Map<String, dynamic>>>();
+      when(
+        () => dio.post<Map<String, dynamic>>(
+          '/v1/share',
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => response.future);
+
+      final first = _share(service);
+      final duplicate = _share(service);
+      await expectLater(
+        duplicate,
+        throwsA(
+          isA<DiscordShareException>().having(
+            (error) => error.code,
+            'code',
+            'share_in_progress',
+          ),
+        ),
+      );
+
+      response.complete(
+        Response(
+          requestOptions: RequestOptions(path: '/v1/share'),
+          statusCode: 200,
+          data: const {
+            'delivered_targets': <Map<String, dynamic>>[],
+            'failed_targets': <Map<String, dynamic>>[],
+          },
+        ),
+      );
+      await first;
+
+      verify(
+        () => dio.post<Map<String, dynamic>>(
+          '/v1/share',
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        ),
+      ).called(1);
+    },
+  );
+
+  test('releases the concurrent-share guard after a failed request', () async {
+    var attempts = 0;
+    when(
+      () => dio.post<Map<String, dynamic>>(
+        '/v1/share',
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+      ),
+    ).thenAnswer((invocation) async {
+      attempts++;
+      if (attempts == 1) {
+        throw DioException(
+          requestOptions: RequestOptions(path: '/v1/share'),
+          type: DioExceptionType.connectionError,
+          error: 'offline',
+        );
+      }
+      return Response(
+        requestOptions: RequestOptions(path: '/v1/share'),
+        statusCode: 200,
+        data: const {
+          'delivered_targets': <Map<String, dynamic>>[],
+          'failed_targets': <Map<String, dynamic>>[],
+        },
+      );
+    });
+
+    await expectLater(_share(service), throwsA(isA<DiscordShareException>()));
+    await expectLater(_share(service), completes);
+    expect(attempts, 2);
+  });
+}
+
+Future<DiscordShareResult> _share(DiscordShareService service) {
+  return service.share(
+    session: _session,
+    image: SanitizedShareImage(
+      bytes: Uint8List.fromList([1, 2, 3]),
+      fileName: 'result.png',
+      mimeType: 'image/png',
+    ),
+    targetIds: const {'showcase'},
+    prompt: 'scene',
+    caption: '',
+    width: 832,
+    height: 1216,
+    longPromptAsFile: true,
   );
 }
 


### PR DESCRIPTION
## 用户可见变化
- Discord 分享被限速时显示准确倒计时，并在可重试前禁用重复发送
- 阻止并发重复分享，失败后正常恢复可操作状态
- 同步中、英、日、繁中文案

## 服务端配套
- 对应 `ComfyUI-Aaalice-Nodes` 分支 `Aaalice/relax-discord-share-rate-limit` 将共享 Worker 额度从每用户 5 次/60 秒调整为 8 次/60 秒
- Discord webhook 官方 429 限制仍按 `retry_after` 处理

## 验证
- Launcher 受影响测试 9/9 通过
- 限定 `dart analyze` 通过
- `git diff --check origin/main...HEAD` 通过