### PR TITLE
fix(metadata): 支持识别 WebP 生成元数据

### DIFF
--- a/lib/data/services/image_metadata_service.dart
+++ b/lib/data/services/image_metadata_service.dart
@@ -580,18 +580,10 @@ class ImageMetadataService {
 
       _checkCancelled(cancelToken);
 
-      // 检查是否是PNG文件
-      // 检查是否是PNG文件
-      if (!path.toLowerCase().endsWith('.png')) {
-        AppLogger.w('[MetadataFlow] Not a PNG file: $path', 'ImageMetadataService');
-        _statistics.recordFailure('not_png', totalStopwatch.elapsed);
-        return null;
-      }
-
       NaiImageMetadata? metadata;
+      String? parseError;
 
-      // 使用统一解析器（带渐进式读取策略）
-      // 使用统一解析器（带渐进式读取策略）
+      // 容器格式由解析器根据文件签名判断，不能依赖拖拽来源是否提供扩展名。
       final parseStopwatch = Stopwatch()..start();
 
       try {
@@ -607,6 +599,8 @@ class ImageMetadataService {
 
         if (result.success && result.metadata != null) {
           metadata = result.metadata;
+        } else {
+          parseError = result.errorMessage;
         }
       } catch (e, _) {
         parseStopwatch.stop();
@@ -622,7 +616,10 @@ class ImageMetadataService {
         _statistics.recordSuccess(totalStopwatch.elapsed);
       } else {
         if (metadata == null) {
-          _statistics.recordFailure('no_metadata', totalStopwatch.elapsed);
+          _statistics.recordFailure(
+            parseError ?? 'no_metadata',
+            totalStopwatch.elapsed,
+          );
         } else {
           _statistics.recordFailure('empty_metadata', totalStopwatch.elapsed);
         }
@@ -659,7 +656,7 @@ class ImageMetadataService {
         return null;
       }
 
-      final result = UnifiedMetadataParser.parseFromPng(bytes);
+      final result = UnifiedMetadataParser.parseFromImage(bytes);
       final metadata = result.success ? result.metadata : null;
 
       if (metadata != null && metadata.hasData) {

--- a/lib/data/services/metadata/isolate_metadata_service.dart
+++ b/lib/data/services/metadata/isolate_metadata_service.dart
@@ -82,7 +82,7 @@ class IsolateParseResult {
 
 /// Isolate 元数据解析服务
 ///
-/// 在独立线程中执行 PNG 元数据解析，避免阻塞 UI。
+/// 在独立线程中执行图像元数据解析，避免阻塞 UI。
 /// 适用于详情页等需要实时响应的场景。
 ///
 /// 特性：
@@ -182,7 +182,7 @@ class IsolateMetadataService {
 
   /// 解析元数据（Isolate 中执行）
   ///
-  /// [filePath] PNG 文件路径
+  /// [filePath] 图像文件路径
   /// [config] 解析配置（超时、渐进式读取等）
   /// 返回解析结果，失败返回带错误信息的结果
   Future<IsolateParseResult> parseMetadata(
@@ -731,7 +731,7 @@ void _handleParseRequest(_ParseRequest request, SendPort sendPort) {
 
   try {
     // 在 Isolate 中执行解析
-    final result = UnifiedMetadataParser.parseFromPng(
+    final result = UnifiedMetadataParser.parseFromImage(
       request.bytes,
       filePathForLog: request.filePath,
     );

--- a/lib/data/services/metadata/unified_metadata_parser.dart
+++ b/lib/data/services/metadata/unified_metadata_parser.dart
@@ -6,6 +6,7 @@ import 'package:image/image.dart' as img;
 
 import '../../../core/utils/portable_logger.dart';
 import '../../models/gallery/nai_image_metadata.dart';
+import 'webp_exif_metadata_extractor.dart';
 
 /// 元数据解析结果
 class MetadataParseResult {
@@ -289,7 +290,43 @@ class UnifiedMetadataParser {
     }
   }
 
-  /// 从 PNG 字节中提取元数据
+  /// 根据文件签名从 PNG 或 WebP 字节中提取元数据。
+  ///
+  /// 格式判断只依据容器签名，因此剪贴板图像没有路径或文件扩展名时也能解析。
+  static MetadataParseResult parseFromImage(
+    Uint8List bytes, {
+    String? filePathForLog,
+    bool useCache = false,
+  }) {
+    if (isPngHeader(bytes)) {
+      return parseFromPng(
+        bytes,
+        filePathForLog: filePathForLog,
+        useCache: useCache,
+      );
+    }
+    if (WebpExifMetadataExtractor.hasWebpHeader(bytes)) {
+      return parseFromWebp(
+        bytes,
+        filePathForLog: filePathForLog,
+        useCache: useCache,
+      );
+    }
+
+    final stopwatch = Stopwatch()..start();
+    _statistics.totalAttempts++;
+    final fileInfo = filePathForLog != null ? 'file=$filePathForLog, ' : '';
+    final result = MetadataParseResult.failed(
+      const [],
+      'Unsupported image container, ${fileInfo}bytes length=${bytes.length}',
+      parseTime: stopwatch.elapsed,
+      bytesRead: bytes.length,
+    );
+    _updateStatistics(result, stopwatch.elapsed);
+    return result;
+  }
+
+  /// 从 PNG 字节中提取元数据。
   ///
   /// [bytes] PNG 字节数据
   /// [filePathForLog] 可选的文件路径，用于错误日志记录
@@ -412,7 +449,82 @@ class UnifiedMetadataParser {
     }
   }
 
-  /// 从 PNG textData Map 中解析元数据
+  /// 从 WebP EXIF `UserComment` 中提取元数据。
+  static MetadataParseResult parseFromWebp(
+    Uint8List bytes, {
+    String? filePathForLog,
+    bool useCache = false,
+  }) {
+    final stopwatch = Stopwatch()..start();
+    _statistics.totalAttempts++;
+
+    if (useCache) {
+      final cached = _resultCache[_generateBytesCacheKey(bytes)];
+      if (cached != null) return cached;
+    }
+
+    try {
+      final extraction = WebpExifMetadataExtractor.extract(bytes);
+      if (extraction.errorMessage != null) {
+        final result = MetadataParseResult.failed(
+          const ['WebP EXIF'],
+          extraction.errorMessage!,
+          parseTime: stopwatch.elapsed,
+          bytesRead: bytes.length,
+        );
+        _updateStatistics(result, stopwatch.elapsed);
+        return result;
+      }
+      if (!extraction.hasMetadata) {
+        final result = MetadataParseResult.failed(
+          const ['WebP EXIF'],
+          'No EXIF UserComment metadata found in WebP',
+          parseTime: stopwatch.elapsed,
+          bytesRead: bytes.length,
+        );
+        _updateStatistics(result, stopwatch.elapsed);
+        return result;
+      }
+
+      final parsed = parseFromTextData(extraction.textData);
+      final result = parsed.success && parsed.metadata != null
+          ? MetadataParseResult.success(
+              parsed.metadata!,
+              '${parsed.sourceFormat} WebP EXIF',
+              extraction.textData['Comment']!,
+              ['WebP EXIF', ...parsed.triedParsers],
+              parseTime: stopwatch.elapsed,
+              bytesRead: bytes.length,
+            )
+          : MetadataParseResult.failed(
+              ['WebP EXIF', ...parsed.triedParsers],
+              parsed.errorMessage ?? 'Invalid WebP EXIF metadata',
+              parseTime: stopwatch.elapsed,
+              bytesRead: bytes.length,
+            );
+
+      if (useCache && result.success) {
+        _resultCache[_generateBytesCacheKey(bytes)] = result;
+      }
+      _updateStatistics(result, stopwatch.elapsed);
+      return result;
+    } catch (e, stack) {
+      final fileInfo = filePathForLog != null ? 'file=$filePathForLog, ' : '';
+      final error =
+          'Error parsing metadata from WebP (${fileInfo}bytes=${bytes.length}): $e';
+      PortableLogger.e(error, e, stack, _tag);
+      final result = MetadataParseResult.failed(
+        const ['WebP EXIF'],
+        error,
+        parseTime: stopwatch.elapsed,
+        bytesRead: bytes.length,
+      );
+      _updateStatistics(result, stopwatch.elapsed);
+      return result;
+    }
+  }
+
+  /// 从容器文本字段 Map 中解析元数据
   ///
   /// 这是主要的解析入口，可以被 PngMetadataExtractor 和其他服务直接使用
   static MetadataParseResult parseFromTextData(Map<String, String> textData) {
@@ -631,6 +743,11 @@ class UnifiedMetadataParser {
         _statistics.gradualReadSuccesses++;
         return result;
       }
+      // A conclusive signature mismatch cannot change by reading more bytes.
+      if (result.errorMessage?.startsWith('Unsupported image container') ??
+          false) {
+        return result;
+      }
 
       // PortableLogger.d(
       //   '[UnifiedMetadataParser] No metadata in first ${threshold ~/ 1024}KB, will expand...',
@@ -655,7 +772,7 @@ class UnifiedMetadataParser {
       //   '[UnifiedMetadataParser] Full read: ${bytes.length} bytes',
       //   _tag,
       // );
-      return parseFromPng(bytes, filePathForLog: filePath);
+      return parseFromImage(bytes, filePathForLog: filePath);
     } catch (e) {
       final error = 'Error reading full file: $e';
       PortableLogger.e(error, e, null, _tag);
@@ -706,7 +823,7 @@ class UnifiedMetadataParser {
       //   _tag,
       // );
 
-      return parseFromPng(bytes, filePathForLog: filePath);
+      return parseFromImage(bytes, filePathForLog: filePath);
     } catch (e) {
       final error = 'Error with ${maxBytes ~/ 1024}KB read: $e';
       PortableLogger.d(error, _tag);

--- a/lib/data/services/metadata/webp_exif_metadata_extractor.dart
+++ b/lib/data/services/metadata/webp_exif_metadata_extractor.dart
@@ -1,0 +1,197 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+class WebpExifMetadataExtraction {
+  const WebpExifMetadataExtraction({
+    this.textData = const {},
+    this.errorMessage,
+  });
+
+  final Map<String, String> textData;
+  final String? errorMessage;
+
+  bool get hasMetadata => textData.containsKey('Comment');
+}
+
+/// Extracts NovelAI's file-level metadata from a WebP RIFF container.
+///
+/// NovelAI stores the generation JSON in EXIF `UserComment`, prefixed by the
+/// EXIF ASCII marker. Other EXIF fields are mapped to the names used by the PNG
+/// metadata path so the existing metadata parsers can consume both formats.
+class WebpExifMetadataExtractor {
+  WebpExifMetadataExtractor._();
+
+  static const List<int> _asciiUserCommentPrefix = [
+    0x41,
+    0x53,
+    0x43,
+    0x49,
+    0x49,
+    0x00,
+    0x00,
+    0x00,
+  ];
+
+  static bool hasWebpHeader(Uint8List bytes) {
+    return bytes.length >= 12 &&
+        _asciiAt(bytes, 0, 'RIFF') &&
+        _asciiAt(bytes, 8, 'WEBP');
+  }
+
+  static WebpExifMetadataExtraction extract(Uint8List bytes) {
+    if (!hasWebpHeader(bytes)) {
+      return const WebpExifMetadataExtraction(
+        errorMessage: 'Not a valid WebP RIFF header',
+      );
+    }
+
+    final byteData = ByteData.sublistView(bytes);
+    final declaredEnd = byteData.getUint32(4, Endian.little) + 8;
+    if (declaredEnd < 12) {
+      return const WebpExifMetadataExtraction(
+        errorMessage: 'Invalid WebP RIFF size',
+      );
+    }
+    if (declaredEnd > bytes.length) {
+      return WebpExifMetadataExtraction(
+        errorMessage:
+            'Truncated WebP RIFF container: declared $declaredEnd bytes, '
+            'received ${bytes.length}',
+      );
+    }
+
+    var offset = 12;
+    while (offset < declaredEnd) {
+      if (offset + 8 > declaredEnd) {
+        return const WebpExifMetadataExtraction(
+          errorMessage: 'Truncated WebP chunk header',
+        );
+      }
+
+      final chunkType = latin1.decode(bytes.sublist(offset, offset + 4));
+      final chunkSize = byteData.getUint32(offset + 4, Endian.little);
+      final dataStart = offset + 8;
+      final dataEnd = dataStart + chunkSize;
+      final paddedEnd = dataEnd + (chunkSize.isOdd ? 1 : 0);
+      if (dataEnd < dataStart || paddedEnd > declaredEnd) {
+        return WebpExifMetadataExtraction(
+          errorMessage: 'Truncated WebP $chunkType chunk',
+        );
+      }
+
+      if (chunkType == 'EXIF') {
+        return _extractExif(bytes.sublist(dataStart, dataEnd));
+      }
+
+      // Unknown RIFF chunks are valid and must be skipped using their padded
+      // size rather than interpreted as image or metadata data.
+      offset = paddedEnd;
+    }
+
+    return const WebpExifMetadataExtraction();
+  }
+
+  static WebpExifMetadataExtraction _extractExif(Uint8List exifBytes) {
+    try {
+      var tiffBytes = exifBytes;
+      if (exifBytes.length >= 6 &&
+          _asciiAt(exifBytes, 0, 'Exif') &&
+          exifBytes[4] == 0 &&
+          exifBytes[5] == 0) {
+        tiffBytes = Uint8List.sublistView(exifBytes, 6);
+      }
+      final isLittleEndian = _asciiAt(tiffBytes, 0, 'II');
+      final isBigEndian = _asciiAt(tiffBytes, 0, 'MM');
+      if (tiffBytes.length < 8 || (!isLittleEndian && !isBigEndian)) {
+        return const WebpExifMetadataExtraction(
+          errorMessage: 'Invalid WebP EXIF TIFF header',
+        );
+      }
+      final tiffData = ByteData.sublistView(tiffBytes);
+      final endian = isLittleEndian ? Endian.little : Endian.big;
+      final firstIfdOffset = tiffData.getUint32(4, endian);
+      if (tiffData.getUint16(2, endian) != 42 ||
+          firstIfdOffset < 8 ||
+          firstIfdOffset + 2 > tiffBytes.length) {
+        return const WebpExifMetadataExtraction(
+          errorMessage: 'Invalid WebP EXIF TIFF directory',
+        );
+      }
+
+      final exif = img.ExifData.fromInputBuffer(img.InputBuffer(tiffBytes));
+      final imageIfd = exif.imageIfd;
+      final exifIfd = imageIfd.sub.directories['exif'];
+      final userCommentValue = exifIfd?.data[0x9286] ?? imageIfd.data[0x9286];
+      if (userCommentValue == null) {
+        return const WebpExifMetadataExtraction();
+      }
+
+      final commentBytes = userCommentValue.toData();
+      if (commentBytes.length < _asciiUserCommentPrefix.length ||
+          !_startsWith(commentBytes, _asciiUserCommentPrefix)) {
+        return const WebpExifMetadataExtraction(
+          errorMessage:
+              'Unsupported WebP EXIF UserComment encoding; expected ASCII prefix',
+        );
+      }
+
+      var commentEnd = commentBytes.length;
+      while (commentEnd > _asciiUserCommentPrefix.length &&
+          commentBytes[commentEnd - 1] == 0) {
+        commentEnd--;
+      }
+      final comment = ascii.decode(
+        commentBytes.sublist(_asciiUserCommentPrefix.length, commentEnd),
+        allowInvalid: false,
+      );
+      if (comment.isEmpty) {
+        return const WebpExifMetadataExtraction(
+          errorMessage: 'WebP EXIF UserComment is empty',
+        );
+      }
+
+      final textData = <String, String>{'Comment': comment};
+      _copyAsciiTag(imageIfd, 0x010d, 'Title', textData);
+      _copyAsciiTag(imageIfd, 0x010e, 'Description', textData);
+      // NovelAI's WebP mapping stores the PNG `Source` value in EXIF Software.
+      _copyAsciiTag(imageIfd, 0x0131, 'Source', textData);
+      _copyAsciiTag(imageIfd, 0x013b, 'Artist', textData);
+      _copyAsciiTag(imageIfd, 0x8298, 'Copyright', textData);
+      return WebpExifMetadataExtraction(textData: textData);
+    } catch (error) {
+      return WebpExifMetadataExtraction(
+        errorMessage: 'Failed to parse WebP EXIF metadata: $error',
+      );
+    }
+  }
+
+  static void _copyAsciiTag(
+    img.IfdDirectory ifd,
+    int tag,
+    String targetKey,
+    Map<String, String> target,
+  ) {
+    final value = ifd.data[tag]?.toString().trim();
+    if (value != null && value.isNotEmpty) {
+      target[targetKey] = value;
+    }
+  }
+
+  static bool _asciiAt(Uint8List bytes, int offset, String value) {
+    if (offset < 0 || offset + value.length > bytes.length) return false;
+    for (var i = 0; i < value.length; i++) {
+      if (bytes[offset + i] != value.codeUnitAt(i)) return false;
+    }
+    return true;
+  }
+
+  static bool _startsWith(List<int> bytes, List<int> prefix) {
+    if (bytes.length < prefix.length) return false;
+    for (var i = 0; i < prefix.length; i++) {
+      if (bytes[i] != prefix[i]) return false;
+    }
+    return true;
+  }
+}

--- a/lib/presentation/widgets/drop/global_drop_handler.dart
+++ b/lib/presentation/widgets/drop/global_drop_handler.dart
@@ -58,8 +58,6 @@ Future<NaiImageMetadata?> detectImportableDroppedImageMetadata(
   String fileName,
   Uint8List bytes,
 ) async {
-  if (!fileName.toLowerCase().endsWith('.png')) return null;
-
   try {
     final metadata = await ImageMetadataService().getMetadataFromBytes(bytes);
     if (metadata != null && metadata.hasData) {

--- a/test/core/utils/dropped_file_reader_test.dart
+++ b/test/core/utils/dropped_file_reader_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/presentation/utils/dropped_file_reader.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 
+import '../../helpers/webp_metadata_fixture.dart';
+
 void main() {
   group('DroppedFileReader', () {
     test('skips remote URL lookup when remote images are disabled', () async {
@@ -16,6 +18,23 @@ void main() {
       );
 
       expect(result, isNull);
+    });
+
+    test('reads direct clipboard WebP bytes without a file URI', () async {
+      final bytes = buildNovelAiWebpFixture(
+        comment: const {'prompt': 'clipboard fixture'},
+      );
+      final reader = _WebpDataReader(bytes, fileName: 'clipboard.WEBP');
+
+      final result = await DroppedFileReader.read(
+        reader,
+        allowRemoteImages: false,
+      );
+
+      expect(result?.fileName, 'clipboard.WEBP');
+      expect(result?.bytes, bytes);
+      expect(result?.sourcePath, isNull);
+      expect(result?.sourceUri, isNull);
     });
   });
 }
@@ -79,6 +98,81 @@ class _PlainTextDataReader extends DataReader {
 
   @override
   List<PlatformFormat> get platformFormats => const [];
+}
+
+class _WebpDataReader extends DataReader {
+  _WebpDataReader(this.bytes, {required this.fileName});
+
+  final Uint8List bytes;
+  final String fileName;
+
+  @override
+  bool canProvide(DataFormat format) => identical(format, Formats.webp);
+
+  @override
+  List<DataFormat> getFormats(List<DataFormat> allFormats) => allFormats
+      .where((format) => identical(format, Formats.webp))
+      .toList(growable: false);
+
+  @override
+  ReadProgress? getFile(
+    FileFormat? format,
+    AsyncValueChanged<DataReaderFile> onFile, {
+    ValueChanged<Object>? onError,
+    bool allowVirtualFiles = true,
+    bool synthesizeFilesFromURIs = true,
+  }) {
+    if (!identical(format, Formats.webp)) return null;
+    Future<void>.microtask(
+      () async => onFile(_MemoryDataReaderFile(bytes, fileName: fileName)),
+    );
+    return _CompletedReadProgress();
+  }
+
+  @override
+  ReadProgress? getValue<T extends Object>(
+    ValueFormat<T> format,
+    AsyncValueChanged<T?> onValue, {
+    ValueChanged<Object>? onError,
+  }) => null;
+
+  @override
+  bool isSynthesized(DataFormat format) => false;
+
+  @override
+  bool isVirtual(DataFormat format) => false;
+
+  @override
+  Future<String?> getSuggestedName() async => fileName;
+
+  @override
+  Future<VirtualFileReceiver?> getVirtualFileReceiver({
+    FileFormat? format,
+  }) async => null;
+
+  @override
+  List<PlatformFormat> get platformFormats => const [];
+}
+
+class _MemoryDataReaderFile extends DataReaderFile {
+  _MemoryDataReaderFile(this.bytes, {required this.fileName});
+
+  final Uint8List bytes;
+
+  @override
+  final String fileName;
+
+  @override
+  int get fileSize => bytes.length;
+
+  @override
+  void close() {}
+
+  @override
+  Stream<Uint8List> getStream() => Stream.value(bytes);
+
+  @override
+  Future<Uint8List> readAll() async => bytes;
 }
 
 class _CompletedReadProgress extends ReadProgress {

--- a/test/data/services/metadata/unified_metadata_parser_webp_test.dart
+++ b/test/data/services/metadata/unified_metadata_parser_webp_test.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:nai_launcher/data/services/metadata/unified_metadata_parser.dart';
+
+import '../../../helpers/webp_metadata_fixture.dart';
+
+void main() {
+  const novelAiComment = <String, dynamic>{
+    'prompt': '1girl, webp metadata',
+    'uc': 'lowres',
+    'width': 832,
+    'height': 1216,
+    'seed': 123456789,
+    'steps': 28,
+    'scale': 5.0,
+    'sampler': 'k_euler',
+  };
+
+  test('format-dispatch entry preserves PNG metadata parsing', () {
+    final png = Uint8List.fromList(
+      img.encodePng(img.Image(width: 1, height: 1)),
+    );
+    final withMetadata = UnifiedMetadataParser.embedTextChunkOnly(
+      png,
+      'Comment',
+      jsonEncode(novelAiComment),
+    );
+
+    final result = UnifiedMetadataParser.parseFromImage(withMetadata);
+
+    expect(result.success, isTrue, reason: result.errorMessage);
+    expect(result.metadata?.prompt, '1girl, webp metadata');
+  });
+
+  group('UnifiedMetadataParser WebP', () {
+    test('extracts NovelAI JSON from EXIF UserComment in a real RIFF WebP', () {
+      final bytes = buildNovelAiWebpFixture(comment: novelAiComment);
+
+      // Guard the fixture itself: it includes a decodable lossless WebP image
+      // payload in addition to VP8X, unknown and EXIF chunks.
+      expect(img.decodeWebP(bytes), isNotNull);
+
+      final result = UnifiedMetadataParser.parseFromImage(bytes);
+
+      expect(result.success, isTrue, reason: result.errorMessage);
+      expect(result.sourceFormat, 'NovelAI WebP EXIF');
+      expect(result.metadata?.prompt, '1girl, webp metadata');
+      expect(result.metadata?.negativePrompt, 'lowres');
+      expect(result.metadata?.seed, 123456789);
+      expect(result.metadata?.width, 832);
+      expect(result.metadata?.height, 1216);
+      expect(result.metadata?.source, 'NovelAI Diffusion V4.5');
+      expect(result.triedParsers, contains('WebP EXIF'));
+    });
+
+    test('reports a valid WebP without EXIF metadata as unrecognized', () {
+      final bytes = buildNovelAiWebpFixture();
+
+      final result = UnifiedMetadataParser.parseFromImage(bytes);
+
+      expect(result.success, isFalse);
+      expect(result.metadata, isNull);
+      expect(result.errorMessage, contains('No EXIF UserComment'));
+    });
+
+    test('reports truncated WebP container without pretending success', () {
+      final complete = buildNovelAiWebpFixture(comment: novelAiComment);
+      final truncated = complete.sublist(0, complete.length - 5);
+
+      final result = UnifiedMetadataParser.parseFromImage(truncated);
+
+      expect(result.success, isFalse);
+      expect(result.metadata, isNull);
+      expect(result.errorMessage, contains('Truncated WebP RIFF container'));
+    });
+
+    test('rejects non-ASCII EXIF UserComment encoding with diagnostics', () {
+      final bytes = buildNovelAiWebpFixture(
+        comment: novelAiComment,
+        invalidUserCommentPrefix: true,
+      );
+
+      final result = UnifiedMetadataParser.parseFromImage(bytes);
+
+      expect(result.success, isFalse);
+      expect(result.metadata, isNull);
+      expect(result.errorMessage, contains('expected ASCII prefix'));
+    });
+
+    test('file parsing accepts an uppercase WebP extension', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'nai_webp_metadata_test_',
+      );
+      addTearDown(() => tempDir.delete(recursive: true));
+      final file = File('${tempDir.path}${Platform.pathSeparator}sample.WEBP');
+      await file.writeAsBytes(buildNovelAiWebpFixture(comment: novelAiComment));
+
+      final result = UnifiedMetadataParser.parseFromFile(
+        file.path,
+        useGradualRead: false,
+        useCache: false,
+      );
+
+      expect(result.success, isTrue, reason: result.errorMessage);
+      expect(result.metadata?.prompt, '1girl, webp metadata');
+    });
+  });
+}

--- a/test/helpers/webp_metadata_fixture.dart
+++ b/test/helpers/webp_metadata_fixture.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+/// Builds a 1×1 lossless WebP with NovelAI's EXIF UserComment layout.
+///
+/// The `ASCII\0\0\0 + JSON` mapping follows NovelAI's official
+/// `novelai-image-metadata` verifier. The pixel chunk comes from a
+/// Pillow-encoded transparent 1×1 WebP; EXIF and RIFF chunks are assembled here
+/// so fixtures stay small and auditable.
+Uint8List buildNovelAiWebpFixture({
+  Map<String, dynamic>? comment,
+  bool includeUnknownChunk = true,
+  bool invalidUserCommentPrefix = false,
+}) {
+  final chunks = <int>[
+    ..._riffChunk('VP8X', [
+      0x08, // EXIF metadata flag.
+      0,
+      0,
+      0,
+      0,
+      0,
+      0, // canvas width - 1 (24-bit little endian).
+      0,
+      0,
+      0, // canvas height - 1.
+    ]),
+    if (includeUnknownChunk) ..._riffChunk('JUNK', [1, 2, 3]),
+    if (comment != null)
+      ..._riffChunk(
+        'EXIF',
+        _buildExif(
+          jsonEncode(comment),
+          invalidUserCommentPrefix: invalidUserCommentPrefix,
+        ),
+      ),
+    // VP8L payload from a lossless transparent 1×1 WebP encoded by Pillow.
+    ..._riffChunk('VP8L', [
+      0x2f,
+      0x00,
+      0x00,
+      0x00,
+      0x10,
+      0x07,
+      0x10,
+      0x11,
+      0x11,
+      0x88,
+      0x88,
+      0xfe,
+      0x07,
+    ]),
+  ];
+
+  final output = BytesBuilder(copy: false)
+    ..add(ascii.encode('RIFF'))
+    ..add(_uint32LittleEndian(chunks.length + 4))
+    ..add(ascii.encode('WEBP'))
+    ..add(chunks);
+  return output.takeBytes();
+}
+
+List<int> _buildExif(String comment, {required bool invalidUserCommentPrefix}) {
+  final exif = img.ExifData();
+  exif.imageIfd['DocumentName'] = 'NovelAI image';
+  exif.imageIfd['ImageDescription'] = 'NovelAI generated image';
+  exif.imageIfd['Software'] = 'NovelAI Diffusion V4.5';
+  exif.exifIfd['UserComment'] = [
+    ...ascii.encode(
+      invalidUserCommentPrefix ? 'UNICODE\x00' : 'ASCII\x00\x00\x00',
+    ),
+    ...ascii.encode(comment),
+    0,
+  ];
+
+  final output = img.OutputBuffer();
+  exif.write(output);
+  return output.getBytes();
+}
+
+List<int> _riffChunk(String type, List<int> payload) => [
+  ...ascii.encode(type),
+  ..._uint32LittleEndian(payload.length),
+  ...payload,
+  if (payload.length.isOdd) 0,
+];
+
+Uint8List _uint32LittleEndian(int value) =>
+    (ByteData(4)..setUint32(0, value, Endian.little)).buffer.asUint8List();

--- a/test/presentation/widgets/drop/global_drop_handler_test.dart
+++ b/test/presentation/widgets/drop/global_drop_handler_test.dart
@@ -11,6 +11,8 @@ import 'package:nai_launcher/presentation/widgets/drop/global_drop_handler.dart'
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../helpers/webp_metadata_fixture.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -57,6 +59,45 @@ void main() {
       );
 
       expect(metadata, isNull);
+    });
+
+    test(
+      'clipboard WebP bytes without a file path use shared metadata parsing',
+      () async {
+        final metadata = await detectImportableDroppedImageMetadata(
+          'clipboard_image',
+          buildNovelAiWebpFixture(
+            comment: const {
+              'prompt': 'clipboard webp',
+              'uc': '',
+              'seed': 11,
+              'steps': 28,
+              'scale': 5.0,
+              'sampler': 'k_euler',
+            },
+          ),
+        );
+
+        expect(metadata?.prompt, 'clipboard webp');
+      },
+    );
+
+    test('dropped uppercase WebP uses shared metadata parsing', () async {
+      final metadata = await detectImportableDroppedImageMetadata(
+        'dropped_image.WEBP',
+        buildNovelAiWebpFixture(
+          comment: const {
+            'prompt': 'dropped webp',
+            'uc': '',
+            'seed': 12,
+            'steps': 28,
+            'scale': 5.0,
+            'sampler': 'k_euler',
+          },
+        ),
+      );
+
+      expect(metadata?.prompt, 'dropped webp');
     });
 
     test('only gallery internal drags bypass the global drop handler', () {


### PR DESCRIPTION
## 用户可见变化
- 支持从 NovelAI WebP 图片导入生成元数据
- 拖拽和无文件路径剪贴板导入统一支持 WebP
- 保持现有 PNG 元数据导入行为不变

## 实现
- 按 WebP RIFF `EXIF/UserComment` 容器格式校验并解析元数据
- 覆盖未知 chunk、无元数据、截断损坏及大写扩展名等边界

## 验证
- 55 项测试通过，1 项因缺少本地官方 PNG 样本跳过
- 相关 `flutter analyze` 通过
- `git diff --check origin/main...HEAD` 通过