### PR TITLE
fix(fixed-tags): 修复悬浮预览越出窗口

### DIFF
--- a/lib/presentation/widgets/common/gallery_hover_controller.dart
+++ b/lib/presentation/widgets/common/gallery_hover_controller.dart
@@ -8,11 +8,13 @@ import 'package:flutter/material.dart';
 /// The follower stays attached to its card while its layout delegate keeps the
 /// preview inside the visible window, including when neither side has enough
 /// room for the preferred size.
-class GalleryHoverController {
+class GalleryHoverController with WidgetsBindingObserver {
   OverlayEntry? _entry;
   Timer? _showTimer;
   int _revision = 0;
   String? _stableKey;
+  bool _observingMetrics = false;
+  bool _metricsRebuildScheduled = false;
 
   String? get activeStableKey => _stableKey;
   bool get isShowing => _entry != null;
@@ -31,8 +33,13 @@ class GalleryHoverController {
     dismiss();
     final revision = ++_revision;
     _stableKey = stableKey;
+    _startObservingMetrics();
     _showTimer = Timer(delay, () {
-      if (_revision != revision || _stableKey != stableKey) return;
+      if (_revision != revision ||
+          _stableKey != stableKey ||
+          !context.mounted) {
+        return;
+      }
       final overlay = Overlay.of(context, rootOverlay: true);
       _entry = OverlayEntry(
         builder: (overlayContext) {
@@ -48,6 +55,9 @@ class GalleryHoverController {
               renderObject is RenderBox && renderObject.attached
               ? renderObject.localToGlobal(Offset.zero) & renderObject.size
               : targetRect;
+          if (!liveTargetRect.overlaps(Offset.zero & mediaSize)) {
+            return const SizedBox.shrink();
+          }
           return Positioned.fill(
             child: IgnorePointer(
               child: CompositedTransformFollower(
@@ -76,6 +86,31 @@ class GalleryHoverController {
     if (_stableKey == stableKey) dismiss();
   }
 
+  void markNeedsBuild() => _entry?.markNeedsBuild();
+
+  void _startObservingMetrics() {
+    if (_observingMetrics) return;
+    WidgetsBinding.instance.addObserver(this);
+    _observingMetrics = true;
+  }
+
+  void _stopObservingMetrics() {
+    if (!_observingMetrics) return;
+    WidgetsBinding.instance.removeObserver(this);
+    _observingMetrics = false;
+    _metricsRebuildScheduled = false;
+  }
+
+  @override
+  void didChangeMetrics() {
+    if (_metricsRebuildScheduled) return;
+    _metricsRebuildScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _metricsRebuildScheduled = false;
+      _entry?.markNeedsBuild();
+    });
+  }
+
   void dismiss() {
     _revision++;
     _showTimer?.cancel();
@@ -83,6 +118,7 @@ class GalleryHoverController {
     _entry?.remove();
     _entry = null;
     _stableKey = null;
+    _stopObservingMetrics();
   }
 
   void dispose() => dismiss();

--- a/lib/presentation/widgets/tag_library/tag_library_entry_hover_preview.dart
+++ b/lib/presentation/widgets/tag_library/tag_library_entry_hover_preview.dart
@@ -1,10 +1,9 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../../../core/utils/localization_extension.dart';
 import '../../../data/models/tag_library/tag_library_entry.dart';
+import '../common/gallery_hover_controller.dart';
 import '../common/themed_divider.dart';
 import '../common/thumbnail_display.dart';
 
@@ -28,59 +27,64 @@ class TagLibraryEntryHoverPreview extends StatefulWidget {
 
 class _TagLibraryEntryHoverPreviewState
     extends State<TagLibraryEntryHoverPreview> {
+  static const _previewSize = Size(320, 400);
+
   final _layerLink = LayerLink();
-  OverlayEntry? _overlayEntry;
-  Timer? _hoverTimer;
+  late final GalleryHoverController _hoverController;
+  ScrollPosition? _scrollPosition;
   bool _isHovering = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _hoverController = GalleryHoverController();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final nextScrollPosition = Scrollable.maybeOf(context)?.position;
+    if (nextScrollPosition == _scrollPosition) return;
+    _scrollPosition?.removeListener(_dismissForScroll);
+    _scrollPosition = nextScrollPosition;
+    _scrollPosition?.addListener(_dismissForScroll);
+  }
 
   @override
   void didUpdateWidget(TagLibraryEntryHoverPreview oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.entry != widget.entry) {
-      _overlayEntry?.markNeedsBuild();
+    if (oldWidget.entry.id != widget.entry.id) {
+      _hoverController.dismissFor(oldWidget.entry.id);
+      if (_isHovering) _schedulePreviewOverlay();
+    } else if (oldWidget.entry != widget.entry) {
+      _hoverController.markNeedsBuild();
     }
   }
 
   @override
   void dispose() {
-    _hidePreviewOverlay();
+    _scrollPosition?.removeListener(_dismissForScroll);
+    _hoverController.dispose();
     super.dispose();
   }
 
-  void _schedulePreviewOverlay() {
-    _hoverTimer?.cancel();
-    _hoverTimer = Timer(widget.hoverDelay, () {
-      if (mounted && _isHovering) {
-        _showPreviewOverlay();
-      }
-    });
+  void _dismissForScroll() {
+    _hoverController.dismissFor(widget.entry.id);
   }
 
-  void _showPreviewOverlay() {
-    if (_overlayEntry != null) return;
-
+  void _schedulePreviewOverlay() {
     final renderObject = context.findRenderObject();
     if (renderObject is! RenderBox || !renderObject.hasSize) return;
-    final cardSize = renderObject.size;
-    final cardPosition = renderObject.localToGlobal(Offset.zero);
 
-    _overlayEntry = OverlayEntry(
-      builder: (context) => TagLibraryEntryPreviewOverlay(
-        entry: widget.entry,
-        layerLink: _layerLink,
-        cardSize: cardSize,
-        cardPosition: cardPosition,
-        onDismiss: _hidePreviewOverlay,
-      ),
+    _hoverController.schedule(
+      context: context,
+      stableKey: widget.entry.id,
+      layerLink: _layerLink,
+      targetRect: renderObject.localToGlobal(Offset.zero) & renderObject.size,
+      previewSize: _previewSize,
+      delay: widget.hoverDelay,
+      builder: (_) => TagLibraryEntryPreviewOverlay(entry: widget.entry),
     );
-    Overlay.of(context).insert(_overlayEntry!);
-  }
-
-  void _hidePreviewOverlay() {
-    _hoverTimer?.cancel();
-    _hoverTimer = null;
-    _overlayEntry?.remove();
-    _overlayEntry = null;
   }
 
   @override
@@ -94,7 +98,7 @@ class _TagLibraryEntryHoverPreviewState
         },
         onExit: (_) {
           _isHovering = false;
-          _hidePreviewOverlay();
+          _hoverController.dismissFor(widget.entry.id);
         },
         child: widget.child,
       ),
@@ -104,155 +108,126 @@ class _TagLibraryEntryHoverPreviewState
 
 /// 词库卡片和其他词库来源条目共享的完整预览面板。
 class TagLibraryEntryPreviewOverlay extends StatelessWidget {
-  const TagLibraryEntryPreviewOverlay({
-    super.key,
-    required this.entry,
-    required this.layerLink,
-    required this.cardSize,
-    required this.cardPosition,
-    required this.onDismiss,
-  });
+  const TagLibraryEntryPreviewOverlay({super.key, required this.entry});
 
   final TagLibraryEntry entry;
-  final LayerLink layerLink;
-  final Size cardSize;
-  final Offset cardPosition;
-  final VoidCallback onDismiss;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final screenSize = MediaQuery.sizeOf(context);
 
     const previewWidth = 320.0;
     const previewMaxHeight = 400.0;
 
-    final rightSpace = screenSize.width - (cardPosition.dx + cardSize.width);
-    final showOnRight = rightSpace >= previewWidth + 16;
-
-    return Positioned(
-      left: 0,
-      top: 0,
-      child: CompositedTransformFollower(
-        link: layerLink,
-        showWhenUnlinked: false,
-        offset: Offset(showOnRight ? cardSize.width + 8 : -previewWidth - 8, 0),
-        child: MouseRegion(
-          onExit: (_) => onDismiss(),
-          child: Material(
-            key: const ValueKey('tag-library-entry-preview-overlay'),
-            elevation: 16,
-            borderRadius: BorderRadius.circular(16),
-            color: theme.colorScheme.surfaceContainerHigh,
-            child: Container(
-              width: previewWidth,
-              constraints: const BoxConstraints(maxHeight: previewMaxHeight),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.1),
-                  width: 1,
-                ),
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(16),
-                child: SingleChildScrollView(
+    return Material(
+      key: const ValueKey('tag-library-entry-preview-overlay'),
+      elevation: 16,
+      borderRadius: BorderRadius.circular(16),
+      color: theme.colorScheme.surfaceContainerHigh,
+      child: Container(
+        width: previewWidth,
+        constraints: const BoxConstraints(maxHeight: previewMaxHeight),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: Colors.white.withValues(alpha: 0.1),
+            width: 1,
+          ),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(16),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (entry.hasThumbnail && entry.thumbnail != null)
+                  ThumbnailDisplay(
+                    imagePath: entry.thumbnail!,
+                    offsetX: entry.thumbnailOffsetX,
+                    offsetY: entry.thumbnailOffsetY,
+                    scale: entry.thumbnailScale,
+                    width: previewWidth,
+                    height: 180,
+                    borderRadius: const BorderRadius.vertical(
+                      top: Radius.circular(16),
+                    ),
+                  ),
+                Padding(
+                  padding: const EdgeInsets.all(16),
                   child: Column(
-                    mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      if (entry.hasThumbnail && entry.thumbnail != null)
-                        ThumbnailDisplay(
-                          imagePath: entry.thumbnail!,
-                          offsetX: entry.thumbnailOffsetX,
-                          offsetY: entry.thumbnailOffsetY,
-                          scale: entry.thumbnailScale,
-                          width: previewWidth,
-                          height: 180,
-                          borderRadius: const BorderRadius.vertical(
-                            top: Radius.circular(16),
-                          ),
-                        ),
-                      Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              entry.displayName,
-                              style: theme.textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            const SizedBox(height: 8),
-                            const ThemedDivider(height: 1),
-                            const SizedBox(height: 8),
-                            Text(
-                              entry.content,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                fontFamily: 'monospace',
-                                color: theme.colorScheme.onSurfaceVariant,
-                                height: 1.4,
-                              ),
-                              maxLines: 8,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            if (entry.tags.isNotEmpty) ...[
-                              const SizedBox(height: 12),
-                              Wrap(
-                                spacing: 4,
-                                runSpacing: 4,
-                                children: entry.tags.map((tag) {
-                                  return Container(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 8,
-                                      vertical: 2,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      color: theme.colorScheme.primaryContainer
-                                          .withValues(alpha: 0.5),
-                                      borderRadius: BorderRadius.circular(10),
-                                    ),
-                                    child: Text(
-                                      tag,
-                                      style: TextStyle(
-                                        fontSize: 11,
-                                        color: theme
-                                            .colorScheme
-                                            .onPrimaryContainer,
-                                      ),
-                                    ),
-                                  );
-                                }).toList(),
-                              ),
-                            ],
-                            if (entry.lastUsedAt != null) ...[
-                              const SizedBox(height: 12),
-                              Row(
-                                children: [
-                                  Icon(
-                                    Icons.access_time,
-                                    size: 14,
-                                    color: theme.colorScheme.outline,
-                                  ),
-                                  const SizedBox(width: 4),
-                                  Text(
-                                    _formatLastUsed(context, entry.lastUsedAt!),
-                                    style: TextStyle(
-                                      fontSize: 12,
-                                      color: theme.colorScheme.outline,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ],
-                          ],
+                      Text(
+                        entry.displayName,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
+                      const SizedBox(height: 8),
+                      const ThemedDivider(height: 1),
+                      const SizedBox(height: 8),
+                      Text(
+                        entry.content,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          fontFamily: 'monospace',
+                          color: theme.colorScheme.onSurfaceVariant,
+                          height: 1.4,
+                        ),
+                        maxLines: 8,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      if (entry.tags.isNotEmpty) ...[
+                        const SizedBox(height: 12),
+                        Wrap(
+                          spacing: 4,
+                          runSpacing: 4,
+                          children: entry.tags.map((tag) {
+                            return Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 2,
+                              ),
+                              decoration: BoxDecoration(
+                                color: theme.colorScheme.primaryContainer
+                                    .withValues(alpha: 0.5),
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              child: Text(
+                                tag,
+                                style: TextStyle(
+                                  fontSize: 11,
+                                  color: theme.colorScheme.onPrimaryContainer,
+                                ),
+                              ),
+                            );
+                          }).toList(),
+                        ),
+                      ],
+                      if (entry.lastUsedAt != null) ...[
+                        const SizedBox(height: 12),
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.access_time,
+                              size: 14,
+                              color: theme.colorScheme.outline,
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              _formatLastUsed(context, entry.lastUsedAt!),
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: theme.colorScheme.outline,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
                     ],
                   ),
                 ),
-              ),
+              ],
             ),
           ),
         ),

--- a/test/presentation/widgets/tag_library/tag_library_entry_hover_preview_test.dart
+++ b/test/presentation/widgets/tag_library/tag_library_entry_hover_preview_test.dart
@@ -7,17 +7,27 @@ import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/widgets/tag_library/tag_library_entry_hover_preview.dart';
 
 void main() {
-  testWidgets('词库来源条目悬浮后显示完整词库同款预览', (tester) async {
-    tester.view.physicalSize = const Size(1000, 700);
-    tester.view.devicePixelRatio = 1;
+  const previewKey = ValueKey('tag-library-entry-preview-overlay');
+
+  final entry = TagLibraryEntry.create(
+    name: '角色预设',
+    content: '1girl, blue eyes',
+    tags: const ['角色', '蓝色'],
+  ).copyWith(useCount: 7, lastUsedAt: DateTime.now());
+
+  Future<TestGesture> showPreview(
+    WidgetTester tester, {
+    required Size viewport,
+    required Alignment alignment,
+    double devicePixelRatio = 1,
+  }) async {
+    tester.view.physicalSize = Size(
+      viewport.width * devicePixelRatio,
+      viewport.height * devicePixelRatio,
+    );
+    tester.view.devicePixelRatio = devicePixelRatio;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
-
-    final entry = TagLibraryEntry.create(
-      name: '角色预设',
-      content: '1girl, blue eyes',
-      tags: const ['角色', '蓝色'],
-    ).copyWith(useCount: 7, lastUsedAt: DateTime.now());
 
     await tester.pumpWidget(
       MaterialApp(
@@ -25,12 +35,14 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
-          body: Center(
+          body: Align(
+            alignment: alignment,
             child: SizedBox(
-              width: 260,
+              width: 80,
               height: 64,
               child: TagLibraryEntryHoverPreview(
                 entry: entry,
+                hoverDelay: Duration.zero,
                 child: const ColoredBox(color: Colors.black),
               ),
             ),
@@ -40,19 +52,33 @@ void main() {
     );
 
     final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await mouse.addPointer();
-    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
     await mouse.moveTo(
       tester.getCenter(find.byType(TagLibraryEntryHoverPreview)),
     );
-    await tester.pump(const Duration(milliseconds: 499));
-
-    const previewKey = ValueKey('tag-library-entry-preview-overlay');
-    expect(find.byKey(previewKey), findsNothing);
-
+    await tester.pump();
     await tester.pump(const Duration(milliseconds: 1));
-
     expect(find.byKey(previewKey), findsOneWidget);
+    return mouse;
+  }
+
+  void expectInsideViewport(WidgetTester tester, Size viewport) {
+    final rect = tester.getRect(find.byKey(previewKey));
+    expect(rect.left, greaterThanOrEqualTo(10));
+    expect(rect.top, greaterThanOrEqualTo(10));
+    expect(rect.right, lessThanOrEqualTo(viewport.width - 10));
+    expect(rect.bottom, lessThanOrEqualTo(viewport.height - 10));
+    expect(tester.takeException(), isNull);
+  }
+
+  testWidgets('词库来源条目悬浮后显示完整词库同款预览', (tester) async {
+    final mouse = await showPreview(
+      tester,
+      viewport: const Size(1000, 700),
+      alignment: Alignment.center,
+    );
+    addTearDown(mouse.removePointer);
+
     expect(find.text('角色预设'), findsOneWidget);
     expect(find.text('1girl, blue eyes'), findsOneWidget);
     expect(find.text('角色'), findsOneWidget);
@@ -62,6 +88,121 @@ void main() {
     expect(find.byIcon(Icons.access_time), findsOneWidget);
 
     await mouse.moveTo(const Offset(10, 10));
+    await tester.pump();
+    expect(find.byKey(previewKey), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  for (final testCase in <({String name, Alignment alignment})>[
+    (name: '靠左锚点向右展开', alignment: Alignment.centerLeft),
+    (name: '靠右锚点向左展开', alignment: Alignment.centerRight),
+    (name: '靠上锚点向下夹紧', alignment: Alignment.topCenter),
+    (name: '靠下锚点向上夹紧', alignment: Alignment.bottomCenter),
+  ]) {
+    testWidgets('${testCase.name}且预览完整位于窗口内', (tester) async {
+      const viewport = Size(1000, 700);
+      final mouse = await showPreview(
+        tester,
+        viewport: viewport,
+        alignment: testCase.alignment,
+      );
+      addTearDown(mouse.removePointer);
+
+      expectInsideViewport(tester, viewport);
+      final anchor = tester.getRect(find.byType(TagLibraryEntryHoverPreview));
+      final preview = tester.getRect(find.byKey(previewKey));
+      if (testCase.alignment == Alignment.centerLeft) {
+        expect(preview.left, greaterThan(anchor.right));
+      } else if (testCase.alignment == Alignment.centerRight) {
+        expect(preview.right, lessThan(anchor.left));
+      } else if (testCase.alignment == Alignment.topCenter) {
+        expect(preview.top, 10);
+      } else {
+        expect(preview.bottom, viewport.height - 10);
+      }
+    });
+  }
+
+  testWidgets('高 DPI 窄窗口约束预览尺寸且保持完整可见', (tester) async {
+    const viewport = Size(260, 220);
+    final mouse = await showPreview(
+      tester,
+      viewport: viewport,
+      alignment: Alignment.center,
+      devicePixelRatio: 2,
+    );
+    addTearDown(mouse.removePointer);
+
+    expectInsideViewport(tester, viewport);
+    final rect = tester.getRect(find.byKey(previewKey));
+    expect(rect.width, lessThan(320));
+    expect(rect.height, lessThanOrEqualTo(200));
+  });
+
+  testWidgets('窗口缩放使锚点离开鼠标时及时关闭预览', (tester) async {
+    final mouse = await showPreview(
+      tester,
+      viewport: const Size(1000, 700),
+      alignment: Alignment.centerRight,
+    );
+    addTearDown(mouse.removePointer);
+
+    tester.view.physicalSize = const Size(260, 220);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(previewKey), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('滚动列表时及时关闭悬浮预览且不残留 OverlayEntry', (tester) async {
+    tester.view.physicalSize = const Size(600, 400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ListView(
+            controller: scrollController,
+            children: [
+              const SizedBox(height: 100),
+              SizedBox(
+                height: 64,
+                child: TagLibraryEntryHoverPreview(
+                  entry: entry,
+                  hoverDelay: Duration.zero,
+                  child: const ColoredBox(color: Colors.black),
+                ),
+              ),
+              const SizedBox(height: 600),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(
+      tester.getCenter(find.byType(TagLibraryEntryHoverPreview)),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(find.byKey(previewKey), findsOneWidget);
+
+    scrollController.jumpTo(20);
+    await tester.pump();
+    expect(find.byKey(previewKey), findsNothing);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
     await tester.pump();
     expect(find.byKey(previewKey), findsNothing);
     expect(tester.takeException(), isNull);


### PR DESCRIPTION
## 用户可见变化
- 固定词悬浮预览会根据窗口边界自动左右翻转并进行四边夹紧
- 窄窗口、高 DPI、滚动和窗口缩放时不再越出可视区域
- 离开、滚动或页面销毁后会及时清理预览

## 验证
- 受影响测试 16 项通过
- 限定 `flutter analyze` 通过
- `git diff --check origin/main...HEAD` 通过

## 说明
- 当前没有可复用的 Windows Debug 会话，未进行实机截图验证