### PR TITLE
feat(fixed-tags): 添加词库条目悬浮预览

### DIFF
--- a/lib/presentation/screens/tag_library_page/widgets/entry_card.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_card.dart
@@ -58,55 +58,15 @@ class EntryCard extends StatefulWidget {
 class _EntryCardState extends State<EntryCard> {
   bool _isHovering = false;
   bool _isDragging = false;
-  OverlayEntry? _overlayEntry;
-  final _layerLink = LayerLink();
-
-  @override
-  void dispose() {
-    _hidePreviewOverlay();
-    super.dispose();
-  }
-
-  void _showPreviewOverlay() {
-    if (_overlayEntry != null) return;
-
-    final overlay = Overlay.of(context);
-    final renderBox = context.findRenderObject() as RenderBox;
-    final cardSize = renderBox.size;
-    final cardPosition = renderBox.localToGlobal(Offset.zero);
-
-    _overlayEntry = OverlayEntry(
-      builder: (context) => TagLibraryEntryPreviewOverlay(
-        entry: widget.entry,
-        layerLink: _layerLink,
-        cardSize: cardSize,
-        cardPosition: cardPosition,
-        onDismiss: _hidePreviewOverlay,
-      ),
-    );
-
-    overlay.insert(_overlayEntry!);
-  }
-
-  void _hidePreviewOverlay() {
-    _overlayEntry?.remove();
-    _overlayEntry = null;
-  }
 
   void _onEnter() {
     if (!_isDragging && !widget.isSelectionMode) {
       setState(() => _isHovering = true);
-      Future.delayed(const Duration(milliseconds: 500), () {
-        if (_isHovering && mounted && !_isDragging) {
-          _showPreviewOverlay();
-        }
-      });
     }
   }
 
   void _onExit() {
     setState(() => _isHovering = false);
-    _hidePreviewOverlay();
   }
 
   @override
@@ -187,78 +147,80 @@ class _EntryCardState extends State<EntryCard> {
     );
 
     // 外层包装：MouseRegion + 悬浮按钮层
-    final cardContent = CompositedTransformTarget(
-      link: _layerLink,
-      child: MouseRegion(
-        onEnter: (_) => _onEnter(),
-        onExit: (_) => _onExit(),
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 150),
-          curve: Curves.easeOut,
-          height: 80,
-          transform: Matrix4.identity()
-            ..translateByDouble(0, _isHovering ? -4 : 0, 0, 1)
-            ..scaleByDouble(
-              _isHovering ? 1.02 : 1,
-              _isHovering ? 1.02 : 1,
-              _isHovering ? 1.02 : 1,
-              1,
-            ),
-          transformAlignment: Alignment.center,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(16),
-            boxShadow: _isHovering
-                ? [
-                    BoxShadow(
-                      color: theme.colorScheme.primary.withValues(alpha: 0.3),
-                      blurRadius: 16,
-                      offset: const Offset(0, 8),
-                      spreadRadius: 2,
-                    ),
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.15),
-                      blurRadius: 24,
-                      offset: const Offset(0, 12),
-                    ),
-                  ]
-                : [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.2),
-                      blurRadius: 4,
-                    ),
-                  ],
+    final cardVisual = MouseRegion(
+      onEnter: (_) => _onEnter(),
+      onExit: (_) => _onExit(),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeOut,
+        height: 80,
+        transform: Matrix4.identity()
+          ..translateByDouble(0, _isHovering ? -4 : 0, 0, 1)
+          ..scaleByDouble(
+            _isHovering ? 1.02 : 1,
+            _isHovering ? 1.02 : 1,
+            _isHovering ? 1.02 : 1,
+            1,
           ),
-          foregroundDecoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: borderColor,
-              width: widget.isSelected ? 3 : (_isHovering ? 1.5 : 0),
-            ),
+        transformAlignment: Alignment.center,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: _isHovering
+              ? [
+                  BoxShadow(
+                    color: theme.colorScheme.primary.withValues(alpha: 0.3),
+                    blurRadius: 16,
+                    offset: const Offset(0, 8),
+                    spreadRadius: 2,
+                  ),
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.15),
+                    blurRadius: 24,
+                    offset: const Offset(0, 12),
+                  ),
+                ]
+              : [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.2),
+                    blurRadius: 4,
+                  ),
+                ],
+        ),
+        foregroundDecoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: borderColor,
+            width: widget.isSelected ? 3 : (_isHovering ? 1.5 : 0),
           ),
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              cardBody,
-              if (!widget.isSelectionMode)
-                Positioned.fill(
-                  child: IgnorePointer(
-                    ignoring: !_isHovering,
-                    child: Opacity(
-                      opacity: _isHovering ? 1 : 0,
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(16),
-                        child: Container(
-                          color: Colors.black.withValues(alpha: 0.5),
-                          child: _buildFloatingButtons(theme, entry),
-                        ),
+        ),
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            cardBody,
+            if (!widget.isSelectionMode)
+              Positioned.fill(
+                child: IgnorePointer(
+                  ignoring: !_isHovering,
+                  child: Opacity(
+                    opacity: _isHovering ? 1 : 0,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(16),
+                      child: Container(
+                        color: Colors.black.withValues(alpha: 0.5),
+                        child: _buildFloatingButtons(theme, entry),
                       ),
                     ),
                   ),
                 ),
-            ],
-          ),
+              ),
+          ],
         ),
       ),
+    );
+    final cardContent = TagLibraryEntryHoverPreview(
+      entry: entry,
+      enabled: !widget.isSelectionMode && !_isDragging,
+      child: cardVisual,
     );
 
     // 保持根节点稳定，避免切换多选模式时重建缩略图子树。
@@ -271,7 +233,6 @@ class _EntryCardState extends State<EntryCard> {
       childWhenDragging: Opacity(opacity: 0.4, child: cardContent),
       onDragStarted: () {
         HapticFeedback.mediumImpact();
-        _hidePreviewOverlay();
         setState(() {
           _isDragging = true;
           _isHovering = false;

--- a/lib/presentation/widgets/prompt/fixed_tags_dialog.dart
+++ b/lib/presentation/widgets/prompt/fixed_tags_dialog.dart
@@ -1048,7 +1048,7 @@ class _FixedTagsDialogState extends ConsumerState<FixedTagsDialog> {
 
     showDialog(
       context: context,
-      builder: (ctx) => _LibraryPickerDialog(
+      builder: (ctx) => FixedTagLibraryPickerDialog(
         entries: entries,
         onSelect: (entry) => _addFromLibrary(entry, promptType),
       ),
@@ -1144,17 +1144,23 @@ class _FixedTagsDialogState extends ConsumerState<FixedTagsDialog> {
 }
 
 /// 词库选择对话框
-class _LibraryPickerDialog extends StatefulWidget {
+class FixedTagLibraryPickerDialog extends StatefulWidget {
+  const FixedTagLibraryPickerDialog({
+    super.key,
+    required this.entries,
+    required this.onSelect,
+  });
+
   final List<TagLibraryEntry> entries;
   final ValueChanged<TagLibraryEntry> onSelect;
 
-  const _LibraryPickerDialog({required this.entries, required this.onSelect});
-
   @override
-  State<_LibraryPickerDialog> createState() => _LibraryPickerDialogState();
+  State<FixedTagLibraryPickerDialog> createState() =>
+      _FixedTagLibraryPickerDialogState();
 }
 
-class _LibraryPickerDialogState extends State<_LibraryPickerDialog> {
+class _FixedTagLibraryPickerDialogState
+    extends State<FixedTagLibraryPickerDialog> {
   String _searchQuery = '';
   final _searchController = TextEditingController();
 
@@ -1251,12 +1257,18 @@ class _LibraryPickerDialogState extends State<_LibraryPickerDialog> {
                       itemCount: filtered.length,
                       itemBuilder: (context, index) {
                         final entry = filtered[index];
-                        return _LibraryEntryTile(
+                        final tile = _LibraryEntryTile(
+                          key: ValueKey('fixed-tag-library-entry-${entry.id}'),
                           entry: entry,
                           onTap: () {
                             widget.onSelect(entry);
                             Navigator.of(context).pop();
                           },
+                        );
+                        if (!entry.hasThumbnail) return tile;
+                        return TagLibraryEntryHoverPreview(
+                          entry: entry,
+                          child: tile,
                         );
                       },
                     ),
@@ -1271,10 +1283,14 @@ class _LibraryPickerDialogState extends State<_LibraryPickerDialog> {
 
 /// 词库条目选项
 class _LibraryEntryTile extends StatelessWidget {
+  const _LibraryEntryTile({
+    super.key,
+    required this.entry,
+    required this.onTap,
+  });
+
   final TagLibraryEntry entry;
   final VoidCallback onTap;
-
-  const _LibraryEntryTile({required this.entry, required this.onTap});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/widgets/tag_library/tag_library_entry_hover_preview.dart
+++ b/lib/presentation/widgets/tag_library/tag_library_entry_hover_preview.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
@@ -13,11 +15,13 @@ class TagLibraryEntryHoverPreview extends StatefulWidget {
     super.key,
     required this.entry,
     required this.child,
+    this.enabled = true,
     this.hoverDelay = const Duration(milliseconds: 500),
   });
 
   final TagLibraryEntry entry;
   final Widget child;
+  final bool enabled;
   final Duration hoverDelay;
 
   @override
@@ -55,7 +59,11 @@ class _TagLibraryEntryHoverPreviewState
     super.didUpdateWidget(oldWidget);
     if (oldWidget.entry.id != widget.entry.id) {
       _hoverController.dismissFor(oldWidget.entry.id);
-      if (_isHovering) _schedulePreviewOverlay();
+      if (_isHovering && widget.enabled) _schedulePreviewOverlay();
+    } else if (oldWidget.enabled != widget.enabled ||
+        oldWidget.hoverDelay != widget.hoverDelay) {
+      _hoverController.dismissFor(widget.entry.id);
+      if (_isHovering && widget.enabled) _schedulePreviewOverlay();
     } else if (oldWidget.entry != widget.entry) {
       _hoverController.markNeedsBuild();
     }
@@ -73,6 +81,7 @@ class _TagLibraryEntryHoverPreviewState
   }
 
   void _schedulePreviewOverlay() {
+    if (!widget.enabled) return;
     final renderObject = context.findRenderObject();
     if (renderObject is! RenderBox || !renderObject.hasSize) return;
 
@@ -116,122 +125,132 @@ class TagLibraryEntryPreviewOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    const previewWidth = 320.0;
-    const previewMaxHeight = 400.0;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const preferredWidth = 320.0;
+        const preferredMaxHeight = 400.0;
+        final previewWidth = math.min(preferredWidth, constraints.maxWidth);
+        final previewMaxHeight = math.min(
+          preferredMaxHeight,
+          constraints.maxHeight,
+        );
 
-    return Material(
-      key: const ValueKey('tag-library-entry-preview-overlay'),
-      elevation: 16,
-      borderRadius: BorderRadius.circular(16),
-      color: theme.colorScheme.surfaceContainerHigh,
-      child: Container(
-        width: previewWidth,
-        constraints: const BoxConstraints(maxHeight: previewMaxHeight),
-        decoration: BoxDecoration(
+        return Material(
+          key: const ValueKey('tag-library-entry-preview-overlay'),
+          elevation: 16,
           borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: Colors.white.withValues(alpha: 0.1),
-            width: 1,
-          ),
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(16),
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (entry.hasThumbnail && entry.thumbnail != null)
-                  ThumbnailDisplay(
-                    imagePath: entry.thumbnail!,
-                    offsetX: entry.thumbnailOffsetX,
-                    offsetY: entry.thumbnailOffsetY,
-                    scale: entry.thumbnailScale,
-                    width: previewWidth,
-                    height: 180,
-                    borderRadius: const BorderRadius.vertical(
-                      top: Radius.circular(16),
-                    ),
-                  ),
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        entry.displayName,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
+          color: theme.colorScheme.surfaceContainerHigh,
+          child: Container(
+            width: previewWidth,
+            constraints: BoxConstraints(maxHeight: previewMaxHeight),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.1),
+                width: 1,
+              ),
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (entry.hasThumbnail && entry.thumbnail != null)
+                      ThumbnailDisplay(
+                        imagePath: entry.thumbnail!,
+                        offsetX: entry.thumbnailOffsetX,
+                        offsetY: entry.thumbnailOffsetY,
+                        scale: entry.thumbnailScale,
+                        width: previewWidth,
+                        height: math.min(180, previewMaxHeight),
+                        borderRadius: const BorderRadius.vertical(
+                          top: Radius.circular(16),
                         ),
                       ),
-                      const SizedBox(height: 8),
-                      const ThemedDivider(height: 1),
-                      const SizedBox(height: 8),
-                      Text(
-                        entry.content,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          fontFamily: 'monospace',
-                          color: theme.colorScheme.onSurfaceVariant,
-                          height: 1.4,
-                        ),
-                        maxLines: 8,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      if (entry.tags.isNotEmpty) ...[
-                        const SizedBox(height: 12),
-                        Wrap(
-                          spacing: 4,
-                          runSpacing: 4,
-                          children: entry.tags.map((tag) {
-                            return Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 8,
-                                vertical: 2,
-                              ),
-                              decoration: BoxDecoration(
-                                color: theme.colorScheme.primaryContainer
-                                    .withValues(alpha: 0.5),
-                                borderRadius: BorderRadius.circular(10),
-                              ),
-                              child: Text(
-                                tag,
-                                style: TextStyle(
-                                  fontSize: 11,
-                                  color: theme.colorScheme.onPrimaryContainer,
-                                ),
-                              ),
-                            );
-                          }).toList(),
-                        ),
-                      ],
-                      if (entry.lastUsedAt != null) ...[
-                        const SizedBox(height: 12),
-                        Row(
-                          children: [
-                            Icon(
-                              Icons.access_time,
-                              size: 14,
-                              color: theme.colorScheme.outline,
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            entry.displayName,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
                             ),
-                            const SizedBox(width: 4),
-                            Text(
-                              _formatLastUsed(context, entry.lastUsedAt!),
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: theme.colorScheme.outline,
-                              ),
+                          ),
+                          const SizedBox(height: 8),
+                          const ThemedDivider(height: 1),
+                          const SizedBox(height: 8),
+                          Text(
+                            entry.content,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              fontFamily: 'monospace',
+                              color: theme.colorScheme.onSurfaceVariant,
+                              height: 1.4,
+                            ),
+                            maxLines: 8,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          if (entry.tags.isNotEmpty) ...[
+                            const SizedBox(height: 12),
+                            Wrap(
+                              spacing: 4,
+                              runSpacing: 4,
+                              children: entry.tags.map((tag) {
+                                return Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 8,
+                                    vertical: 2,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: theme.colorScheme.primaryContainer
+                                        .withValues(alpha: 0.5),
+                                    borderRadius: BorderRadius.circular(10),
+                                  ),
+                                  child: Text(
+                                    tag,
+                                    style: TextStyle(
+                                      fontSize: 11,
+                                      color:
+                                          theme.colorScheme.onPrimaryContainer,
+                                    ),
+                                  ),
+                                );
+                              }).toList(),
                             ),
                           ],
-                        ),
-                      ],
-                    ],
-                  ),
+                          if (entry.lastUsedAt != null) ...[
+                            const SizedBox(height: 12),
+                            Row(
+                              children: [
+                                Icon(
+                                  Icons.access_time,
+                                  size: 14,
+                                  color: theme.colorScheme.outline,
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  _formatLastUsed(context, entry.lastUsedAt!),
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color: theme.colorScheme.outline,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 

--- a/test/presentation/screens/tag_library_page/widgets/entry_card_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/entry_card_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show PointerDeviceKind;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
@@ -97,5 +99,56 @@ void main() {
       find.byType(Draggable<TagLibraryEntry>),
     );
     expect(draggable.maxSimultaneousDrags, 0);
+  });
+
+  testWidgets('词库卡片复用共享预览并在进入多选模式时清理', (tester) async {
+    final entry = TagLibraryEntry(
+      id: 'hover-entry',
+      name: '悬浮词条',
+      content: '1girl, solo',
+      thumbnail: 'missing-thumbnail.png',
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+    );
+
+    Future<void> pumpCard({required bool isSelectionMode}) {
+      return tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 240,
+                height: 80,
+                child: EntryCard(
+                  entry: entry,
+                  isSelectionMode: isSelectionMode,
+                  onToggleSelection: () {},
+                  onTap: () {},
+                  onDelete: () {},
+                  onToggleFavorite: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await pumpCard(isSelectionMode: false);
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer();
+    await mouse.moveTo(tester.getCenter(find.byType(EntryCard)));
+    await tester.pump(const Duration(milliseconds: 500));
+
+    const previewKey = ValueKey('tag-library-entry-preview-overlay');
+    expect(find.byKey(previewKey), findsOneWidget);
+
+    await pumpCard(isSelectionMode: true);
+    await tester.pump();
+    expect(find.byKey(previewKey), findsNothing);
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/presentation/widgets/prompt/fixed_tags_library_picker_test.dart
+++ b/test/presentation/widgets/prompt/fixed_tags_library_picker_test.dart
@@ -1,0 +1,266 @@
+import 'dart:io';
+import 'dart:ui' show PointerDeviceKind;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/widgets/common/thumbnail_display.dart';
+import 'package:nai_launcher/presentation/widgets/prompt/fixed_tags_dialog.dart';
+
+void main() {
+  late Directory temporaryDirectory;
+  late String thumbnailPath;
+
+  setUp(() {
+    temporaryDirectory = Directory.systemTemp.createTempSync(
+      'fixed_tag_library_picker_test_',
+    );
+    final thumbnail = File('${temporaryDirectory.path}/preview.png');
+    thumbnail.writeAsBytesSync(
+      img.encodePng(img.Image(width: 160, height: 90)),
+    );
+    thumbnailPath = thumbnail.path;
+  });
+
+  tearDown(() {
+    if (temporaryDirectory.existsSync()) {
+      temporaryDirectory.deleteSync(recursive: true);
+    }
+  });
+
+  testWidgets('有图条目悬浮显示共享预览且窄窗口内不越界', (tester) async {
+    _setViewport(tester, const Size(500, 360));
+    final entry = _entry(
+      id: 'with-image',
+      name: '角色预设',
+      thumbnail: thumbnailPath,
+    );
+
+    await _openPicker(tester, entries: [entry]);
+    final mouse = await _hoverEntry(tester, entry.id);
+    addTearDown(mouse.removePointer);
+    await tester.pump(const Duration(milliseconds: 500));
+
+    const previewKey = ValueKey('tag-library-entry-preview-overlay');
+    expect(find.byKey(previewKey), findsOneWidget);
+    expect(find.text('角色预设'), findsNWidgets(2));
+    final thumbnail = tester.widget<ThumbnailDisplay>(
+      find.descendant(
+        of: find.byKey(previewKey),
+        matching: find.byType(ThumbnailDisplay),
+      ),
+    );
+    expect(thumbnail.imagePath, thumbnailPath);
+
+    final previewRect = tester.getRect(find.byKey(previewKey));
+    expect(previewRect.left, greaterThanOrEqualTo(10));
+    expect(previewRect.top, greaterThanOrEqualTo(10));
+    expect(previewRect.right, lessThanOrEqualTo(490));
+    expect(previewRect.bottom, lessThanOrEqualTo(350));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('无图条目悬浮不创建预览浮层', (tester) async {
+    _setViewport(tester, const Size(800, 600));
+    final entry = _entry(id: 'without-image', name: '纯文本预设');
+
+    await _openPicker(tester, entries: [entry]);
+    final mouse = await _hoverEntry(tester, entry.id);
+    addTearDown(mouse.removePointer);
+    await tester.pump(const Duration(milliseconds: 600));
+
+    expect(
+      find.byKey(const ValueKey('tag-library-entry-preview-overlay')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('离开、滚动和关闭选择器都会清理预览', (tester) async {
+    _setViewport(tester, const Size(900, 640));
+    final entries = [
+      for (var index = 0; index < 30; index++)
+        _entry(id: 'entry-$index', name: '预设 $index', thumbnail: thumbnailPath),
+    ];
+
+    await _openPicker(tester, entries: entries);
+    final mouse = await _hoverEntry(tester, entries.first.id);
+    addTearDown(mouse.removePointer);
+    await tester.pump(const Duration(milliseconds: 500));
+
+    const previewKey = ValueKey('tag-library-entry-preview-overlay');
+    expect(find.byKey(previewKey), findsOneWidget);
+
+    await mouse.moveTo(const Offset(5, 5));
+    await tester.pump();
+    expect(find.byKey(previewKey), findsNothing);
+
+    await mouse.moveTo(
+      tester.getCenter(
+        find.byKey(ValueKey('fixed-tag-library-entry-${entries.first.id}')),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.byKey(previewKey), findsOneWidget);
+
+    final scrollable = tester.state<ScrollableState>(
+      find
+          .descendant(
+            of: find.byType(ListView),
+            matching: find.byType(Scrollable),
+          )
+          .first,
+    );
+    scrollable.position.jumpTo(100);
+    await tester.pump();
+    expect(find.byKey(previewKey), findsNothing);
+
+    final visibleEntry = entries[3];
+    await mouse.moveTo(
+      tester.getCenter(
+        find.byKey(ValueKey('fixed-tag-library-entry-${visibleEntry.id}')),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.byKey(previewKey), findsOneWidget);
+
+    Navigator.of(
+      tester.element(find.byType(FixedTagLibraryPickerDialog)),
+    ).pop();
+    await tester.pumpAndSettle();
+    expect(find.byType(FixedTagLibraryPickerDialog), findsNothing);
+    expect(find.byKey(previewKey), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('点击有图条目仍执行添加并关闭选择器', (tester) async {
+    _setViewport(tester, const Size(800, 600));
+    final entry = _entry(
+      id: 'clickable',
+      name: '可添加预设',
+      thumbnail: thumbnailPath,
+    );
+    TagLibraryEntry? selected;
+
+    await _openPicker(
+      tester,
+      entries: [entry],
+      onSelect: (value) => selected = value,
+    );
+    final mouse = await _hoverEntry(tester, entry.id);
+    addTearDown(mouse.removePointer);
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(
+      find.byKey(const ValueKey('tag-library-entry-preview-overlay')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(ValueKey('fixed-tag-library-entry-${entry.id}')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(selected, entry);
+    expect(find.byType(FixedTagLibraryPickerDialog), findsNothing);
+    expect(
+      find.byKey(const ValueKey('tag-library-entry-preview-overlay')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('搜索后无图条目仍可正常添加', (tester) async {
+    _setViewport(tester, const Size(800, 600));
+    final hiddenEntry = _entry(id: 'hidden', name: '其他预设');
+    final targetEntry = _entry(id: 'target', name: '目标预设');
+    TagLibraryEntry? selected;
+
+    await _openPicker(
+      tester,
+      entries: [hiddenEntry, targetEntry],
+      onSelect: (value) => selected = value,
+    );
+    await tester.enterText(find.byType(TextField), '目标');
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('fixed-tag-library-entry-hidden')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('fixed-tag-library-entry-target')),
+      findsOneWidget,
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('fixed-tag-library-entry-target')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(selected, targetEntry);
+    expect(find.byType(FixedTagLibraryPickerDialog), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+TagLibraryEntry _entry({
+  required String id,
+  required String name,
+  String? thumbnail,
+}) {
+  return TagLibraryEntry.create(
+    name: name,
+    content: '1girl, blue eyes',
+    thumbnail: thumbnail,
+    tags: const ['角色'],
+  ).copyWith(id: id);
+}
+
+void _setViewport(WidgetTester tester, Size size) {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+Future<void> _openPicker(
+  WidgetTester tester, {
+  required List<TagLibraryEntry> entries,
+  ValueChanged<TagLibraryEntry>? onSelect,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: const Locale('zh'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => FilledButton(
+            onPressed: () {
+              showDialog<void>(
+                context: context,
+                builder: (_) => FixedTagLibraryPickerDialog(
+                  entries: entries,
+                  onSelect: onSelect ?? (_) {},
+                ),
+              );
+            },
+            child: const Text('打开'),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('打开'));
+  await tester.pumpAndSettle();
+}
+
+Future<TestGesture> _hoverEntry(WidgetTester tester, String entryId) async {
+  final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+  await mouse.addPointer();
+  await mouse.moveTo(
+    tester.getCenter(find.byKey(ValueKey('fixed-tag-library-entry-$entryId'))),
+  );
+  return mouse;
+}


### PR DESCRIPTION
## 用户可见变化
- 在词库页面条目和“从词库添加固定词”选择列表中提供图片悬浮预览
- 复用词库条目的缩略图与裁剪参数，不新增图片来源或猜测路径
- 无图片条目不创建预览，仍可正常搜索和添加
- 预览在窄窗口中自动约束尺寸，并在滚动、离开、条目更新、拖拽及页面销毁时清理

## 兼容与合并
- 已变基到最新 `main`
- 已整合 PR #104 的根 Overlay 边界定位实现
- 原有搜索、添加、多选和拖拽行为保持不变

## 验证
- 受影响测试 4 个文件，共 36 项通过
- 限定 `flutter analyze` 无问题
- `dart format` 与 `git diff --check main...HEAD` 通过
- 工作区干净

## 实机验证
- 未发现可复用的 Flutter Debug 会话，因此未启动重复会话、未进行实际窗口截图