### PR TITLE
perf(gallery): 优化随机加载与任务取消

### DIFF
--- a/lib/data/datasources/remote/online_gallery/ai_tag_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/ai_tag_gallery_source_adapter.dart
@@ -593,65 +593,28 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     // Select random page
     final randomPage = randomGenerator.nextInt(totalInfo.totalPages) + 1;
 
-    try {
-      final searchRequest = GallerySearchRequest(
-        cursor: randomPage.toString(),
-        pageSize: request.pageSize,
-        query: request.query,
-        prompt: request.prompt,
-        timeRange: request.timeRange,
-        ratings: request.ratings,
-        blacklistTags: request.blacklistTags,
-      );
+    final searchRequest = GallerySearchRequest(
+      cursor: randomPage.toString(),
+      pageSize: request.pageSize,
+      query: request.query,
+      prompt: request.prompt,
+      timeRange: request.timeRange,
+      ratings: request.ratings,
+      blacklistTags: request.blacklistTags,
+    );
 
-      final pageResult = randomPage == 1 && totalInfo.probedPage != null
-          ? totalInfo.probedPage!
-          : await search(
-              searchRequest,
-              cancelToken: cancelToken,
-              noCache: true,
-            );
-      final shuffled = shuffleGalleryItems(pageResult.items, randomGenerator);
+    final pageResult = randomPage == 1 && totalInfo.probedPage != null
+        ? totalInfo.probedPage!
+        : await search(searchRequest, cancelToken: cancelToken, noCache: true);
+    final shuffled = shuffleGalleryItems(pageResult.items, randomGenerator);
 
-      return GalleryPage(
-        items: shuffled,
-        cursor: 'random',
-        nextCursor: null,
-        hasMore: false,
-        rawItemCount: pageResult.rawItemCount,
-      );
-    } catch (error) {
-      if (error is DioException && error.type == DioExceptionType.cancel) {
-        rethrow;
-      }
-      // Fallback to first page on error
-      final firstPageRequest = GallerySearchRequest(
-        cursor: '1',
-        pageSize: request.pageSize,
-        query: request.query,
-        prompt: request.prompt,
-        timeRange: request.timeRange,
-        ratings: request.ratings,
-        blacklistTags: request.blacklistTags,
-      );
-
-      final firstPage =
-          totalInfo.probedPage ??
-          await search(
-            firstPageRequest,
-            cancelToken: cancelToken,
-            noCache: true,
-          );
-      final shuffled = shuffleGalleryItems(firstPage.items, randomGenerator);
-
-      return GalleryPage(
-        items: shuffled,
-        cursor: 'random',
-        nextCursor: null,
-        hasMore: false,
-        rawItemCount: firstPage.rawItemCount,
-      );
-    }
+    return GalleryPage(
+      items: shuffled,
+      cursor: 'random',
+      nextCursor: null,
+      hasMore: false,
+      rawItemCount: pageResult.rawItemCount,
+    );
   }
 
   Future<GalleryPage> _randomRanking(
@@ -716,69 +679,34 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     // Select random page
     final randomPage = randomGenerator.nextInt(totalInfo.totalPages) + 1;
 
-    try {
-      final rankingRequest = GalleryRankingRequest(
-        cursor: randomPage.toString(),
-        pageSize: request.pageSize,
-        kind: request.kind,
-        date: request.date,
-        period: request.period,
-        query: request.query,
-        prompt: request.prompt,
-        ratings: request.ratings,
-        blacklistTags: request.blacklistTags,
-      );
+    final rankingRequest = GalleryRankingRequest(
+      cursor: randomPage.toString(),
+      pageSize: request.pageSize,
+      kind: request.kind,
+      date: request.date,
+      period: request.period,
+      query: request.query,
+      prompt: request.prompt,
+      ratings: request.ratings,
+      blacklistTags: request.blacklistTags,
+    );
 
-      final pageResult = randomPage == 1 && totalInfo.probedPage != null
-          ? totalInfo.probedPage!
-          : await ranking(
-              rankingRequest,
-              cancelToken: cancelToken,
-              noCache: true,
-            );
-      final shuffled = shuffleGalleryItems(pageResult.items, randomGenerator);
-
-      return GalleryPage(
-        items: shuffled,
-        cursor: 'random',
-        nextCursor: null,
-        hasMore: false,
-        rawItemCount: pageResult.rawItemCount,
-      );
-    } catch (error) {
-      if (error is DioException && error.type == DioExceptionType.cancel) {
-        rethrow;
-      }
-      // Fallback to first page on error
-      final firstPageRequest = GalleryRankingRequest(
-        cursor: '1',
-        pageSize: request.pageSize,
-        kind: request.kind,
-        date: request.date,
-        period: request.period,
-        query: request.query,
-        prompt: request.prompt,
-        ratings: request.ratings,
-        blacklistTags: request.blacklistTags,
-      );
-
-      final firstPage =
-          totalInfo.probedPage ??
-          await ranking(
-            firstPageRequest,
+    final pageResult = randomPage == 1 && totalInfo.probedPage != null
+        ? totalInfo.probedPage!
+        : await ranking(
+            rankingRequest,
             cancelToken: cancelToken,
             noCache: true,
           );
-      final shuffled = shuffleGalleryItems(firstPage.items, randomGenerator);
+    final shuffled = shuffleGalleryItems(pageResult.items, randomGenerator);
 
-      return GalleryPage(
-        items: shuffled,
-        cursor: 'random',
-        nextCursor: null,
-        hasMore: false,
-        rawItemCount: firstPage.rawItemCount,
-      );
-    }
+    return GalleryPage(
+      items: shuffled,
+      cursor: 'random',
+      nextCursor: null,
+      hasMore: false,
+      rawItemCount: pageResult.rawItemCount,
+    );
   }
 
   Future<AiTagTotalInfo> _probeTotalCount(
@@ -786,70 +714,56 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     AiTagSourceConfig config,
     CancelToken? cancelToken,
   ) async {
-    try {
-      final firstPageRequest = GallerySearchRequest(
-        cursor: '1',
-        pageSize: config.pageSize, // Use config page size for probe
-        query: request.query,
-        prompt: request.prompt,
-        timeRange: request.timeRange,
-        ratings: request.ratings,
-        blacklistTags: const {}, // Don't apply blacklist during probe
-      );
+    final firstPageRequest = GallerySearchRequest(
+      cursor: '1',
+      pageSize: config.pageSize,
+      query: request.query,
+      prompt: request.prompt,
+      timeRange: request.timeRange,
+      ratings: request.ratings,
+      blacklistTags: const {},
+    );
 
-      final firstPage = await search(
-        firstPageRequest,
-        cancelToken: cancelToken,
-        noCache: true,
-      );
+    final firstPage = await search(
+      firstPageRequest,
+      cancelToken: cancelToken,
+      noCache: true,
+    );
 
-      return AiTagTotalInfo(
-        totalCount: firstPage.total ?? firstPage.rawItemCount,
-        pageSize: config.pageSize,
-        probedPage: firstPage,
-      );
-    } on DioException catch (error) {
-      if (error.type == DioExceptionType.cancel) rethrow;
-      return const AiTagTotalInfo(totalCount: 0, pageSize: 0);
-    } catch (_) {
-      return const AiTagTotalInfo(totalCount: 0, pageSize: 0);
-    }
+    return AiTagTotalInfo(
+      totalCount: firstPage.total ?? firstPage.rawItemCount,
+      pageSize: config.pageSize,
+      probedPage: firstPage,
+    );
   }
 
   Future<AiTagTotalInfo> _probeRankingTotalCount(
     GalleryRandomRankingRequest request,
     CancelToken? cancelToken,
   ) async {
-    try {
-      final firstPageRequest = GalleryRankingRequest(
-        cursor: '1',
-        pageSize: 60, // Standard page size for probe
-        kind: request.kind,
-        date: request.date,
-        period: request.period,
-        query: request.query,
-        prompt: request.prompt,
-        ratings: request.ratings,
-        blacklistTags: const {}, // Don't apply blacklist during probe
-      );
+    final firstPageRequest = GalleryRankingRequest(
+      cursor: '1',
+      pageSize: 60,
+      kind: request.kind,
+      date: request.date,
+      period: request.period,
+      query: request.query,
+      prompt: request.prompt,
+      ratings: request.ratings,
+      blacklistTags: const {},
+    );
 
-      final firstPage = await ranking(
-        firstPageRequest,
-        cancelToken: cancelToken,
-        noCache: true,
-      );
+    final firstPage = await ranking(
+      firstPageRequest,
+      cancelToken: cancelToken,
+      noCache: true,
+    );
 
-      return AiTagTotalInfo(
-        totalCount: firstPage.total ?? firstPage.rawItemCount,
-        pageSize: 60,
-        probedPage: firstPage,
-      );
-    } on DioException catch (error) {
-      if (error.type == DioExceptionType.cancel) rethrow;
-      return const AiTagTotalInfo(totalCount: 0, pageSize: 0);
-    } catch (_) {
-      return const AiTagTotalInfo(totalCount: 0, pageSize: 0);
-    }
+    return AiTagTotalInfo(
+      totalCount: firstPage.total ?? firstPage.rawItemCount,
+      pageSize: 60,
+      probedPage: firstPage,
+    );
   }
 
   static List<String> _parseStringList(Object? value) {

--- a/lib/data/datasources/remote/online_gallery/donmai_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/donmai_gallery_source_adapter.dart
@@ -629,6 +629,15 @@ class DonmaiGallerySourceAdapter implements GallerySourceAdapter {
       if (boundary.isValid) _boundaryCache.put(cacheKey, boundary);
     }
     if (boundary?.isValid != true) {
+      if (boundary?.newestPageSize == 0) {
+        return const GalleryPage(
+          items: [],
+          cursor: 'random',
+          nextCursor: null,
+          hasMore: false,
+          rawItemCount: 0,
+        );
+      }
       return _fallbackToLatest(tags, request, cancelToken);
     }
 
@@ -660,63 +669,66 @@ class DonmaiGallerySourceAdapter implements GallerySourceAdapter {
       );
     }
 
-    for (var attempt = 0; attempt < 3; attempt++) {
-      final targetId =
-          randomGenerator.nextInt(
-            validBoundary.maxId - validBoundary.minId + 1,
-          ) +
-          validBoundary.minId;
-      final firstDirectionAfter = randomGenerator.nextBool();
-      for (final after in [firstDirectionAfter, !firstDirectionAfter]) {
-        final response = await _dio.get(
-          '$_baseUrl/posts.json',
-          queryParameters: {
-            'tags': tags,
-            'limit': request.pageSize,
-            'page': '${after ? 'a' : 'b'}$targetId',
+    final targetId =
+        randomGenerator.nextInt(validBoundary.maxId - validBoundary.minId + 1) +
+        validBoundary.minId;
+    final after = randomGenerator.nextBool();
+    Future<List<dynamic>> loadAroundTarget(bool useAfter) async {
+      final response = await _dio.get(
+        '$_baseUrl/posts.json',
+        queryParameters: {
+          'tags': tags,
+          'limit': request.pageSize,
+          'page': '${useAfter ? 'a' : 'b'}$targetId',
+        },
+        options: Options(
+          headers: {
+            ..._headers('$_baseUrl/posts.json'),
+            'Cache-Control': 'no-cache',
           },
-          options: Options(
-            headers: {
-              ..._headers('$_baseUrl/posts.json'),
-              'Cache-Control': 'no-cache',
-            },
-          ),
-          cancelToken: cancelToken,
-        );
-        final raw = response.data;
-        if (raw is! List) {
-          throw GallerySourceException(
-            GallerySourceErrorCode.malformedResponse,
-            source: sourceId,
-          );
-        }
-        if (raw.isEmpty) continue;
-        final parsed = raw
-            .whereType<Map>()
-            .map(
-              (value) => GalleryItem.fromDanbooruJson(
-                Map<String, dynamic>.from(value),
-                sourceId: sourceId,
-              ),
-            )
-            .where((item) => item.hasValidPreview)
-            .toList(growable: false);
-        final filtered = _filterLocally(
-          parsed,
-          request.ratings,
-          request.blacklistTags,
-        );
-        return GalleryPage(
-          items: shuffleGalleryItems(filtered, randomGenerator),
-          cursor: 'random',
-          nextCursor: null,
-          hasMore: false,
-          rawItemCount: raw.length,
+        ),
+        cancelToken: cancelToken,
+      );
+      final raw = response.data;
+      if (raw is! List) {
+        throw GallerySourceException(
+          GallerySourceErrorCode.malformedResponse,
+          source: sourceId,
         );
       }
+      return raw;
     }
 
-    return _fallbackToLatest(tags, request, cancelToken);
+    List<GalleryItem> usableItems(List<dynamic> raw) {
+      final parsed = raw
+          .whereType<Map>()
+          .map(
+            (value) => GalleryItem.fromDanbooruJson(
+              Map<String, dynamic>.from(value),
+              sourceId: sourceId,
+            ),
+          )
+          .where((item) => item.hasValidPreview)
+          .toList(growable: false);
+      return _filterLocally(parsed, request.ratings, request.blacklistTags);
+    }
+
+    var raw = await loadAroundTarget(after);
+    var filtered = usableItems(raw);
+    if (filtered.isEmpty) {
+      raw = await loadAroundTarget(!after);
+      filtered = usableItems(raw);
+    }
+    if (filtered.isEmpty) {
+      return _fallbackToLatest(tags, request, cancelToken);
+    }
+    return GalleryPage(
+      items: shuffleGalleryItems(filtered, randomGenerator),
+      cursor: 'random',
+      nextCursor: null,
+      hasMore: false,
+      rawItemCount: raw.length,
+    );
   }
 
   Future<DanbooruIdBoundary> _probeBoundary(
@@ -724,7 +736,6 @@ class DonmaiGallerySourceAdapter implements GallerySourceAdapter {
     GalleryRandomSearchRequest request,
     CancelToken? cancelToken,
   ) async {
-    // Probe newest 60 posts
     final newestResponse = await _dio.get(
       '$_baseUrl/posts.json',
       queryParameters: {'tags': tags, 'limit': 60},
@@ -736,7 +747,6 @@ class DonmaiGallerySourceAdapter implements GallerySourceAdapter {
       ),
       cancelToken: cancelToken,
     );
-
     final newestRaw = newestResponse.data as List;
     final newestItems = newestRaw
         .whereType<Map>()
@@ -753,7 +763,6 @@ class DonmaiGallerySourceAdapter implements GallerySourceAdapter {
       );
     }
 
-    // Probe oldest 60 posts
     final oldestResponse = await _dio.get(
       '$_baseUrl/posts.json',
       queryParameters: {'tags': tags, 'limit': 60, 'page': 'a0'},
@@ -765,20 +774,18 @@ class DonmaiGallerySourceAdapter implements GallerySourceAdapter {
       ),
       cancelToken: cancelToken,
     );
-
     final oldestRaw = oldestResponse.data as List;
     final oldestItems = oldestRaw
         .whereType<Map>()
         .map((value) => Map<String, dynamic>.from(value))
         .where((json) => json['id'] is int)
         .toList();
-
     if (oldestItems.isEmpty) {
-      return const DanbooruIdBoundary(
+      return DanbooruIdBoundary(
         minId: 0,
         maxId: 0,
         oldestPageSize: 0,
-        newestPageSize: 0,
+        newestPageSize: newestItems.length,
       );
     }
 

--- a/lib/data/datasources/remote/online_gallery/gallery_random_sampler.dart
+++ b/lib/data/datasources/remote/online_gallery/gallery_random_sampler.dart
@@ -43,6 +43,56 @@ class GalleryRandomSampler {
     }
     return result;
   }
+
+  /// Returns a deterministic slice of a keyed pseudo-random permutation.
+  ///
+  /// The Feistel permutation preserves full coverage without copying [values].
+  /// Cycle walking restricts its power-of-two domain to the exact list length,
+  /// so consecutive slices read only the requested entries and never repeat.
+  List<T> permutationSlice<T>(
+    List<T> values, {
+    required int seed,
+    required int offset,
+    required int count,
+  }) {
+    if (values.isEmpty || offset >= values.length || count <= 0) {
+      return const [];
+    }
+    final end = min(offset + count, values.length);
+    return [
+      for (var position = offset; position < end; position++)
+        values[_permutedIndex(position, values.length, seed)],
+    ];
+  }
+
+  int _permutedIndex(int position, int length, int seed) {
+    if (length == 1) return 0;
+    var halfBits = 1;
+    while ((1 << (halfBits * 2)) < length) {
+      halfBits++;
+    }
+    final halfMask = (1 << halfBits) - 1;
+    var value = position;
+    do {
+      var left = value >> halfBits;
+      var right = value & halfMask;
+      for (var round = 0; round < 6; round++) {
+        final nextLeft = right;
+        final nextRight = left ^ _roundFunction(right, seed, round, halfMask);
+        left = nextLeft;
+        right = nextRight;
+      }
+      value = (left << halfBits) | right;
+    } while (value >= length);
+    return value;
+  }
+
+  int _roundFunction(int value, int seed, int round, int mask) {
+    var mixed = (value ^ seed ^ (round * 0x9e3779b9)) & 0xffffffff;
+    mixed = ((mixed ^ (mixed >>> 16)) * 0x45d9f3b) & 0xffffffff;
+    mixed = ((mixed ^ (mixed >>> 16)) * 0x45d9f3b) & 0xffffffff;
+    return (mixed ^ (mixed >>> 16)) & mask;
+  }
 }
 
 /// LRU cache entry for gallery random sampling

--- a/lib/data/datasources/remote/online_gallery/quick_tag_cloud_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/quick_tag_cloud_gallery_source_adapter.dart
@@ -11,6 +11,7 @@ import '../../../services/online_gallery/quick_tag_cloud_access.dart';
 import '../../../services/online_gallery/quick_tag_cloud_media_resolver.dart';
 import '../../../services/online_gallery/quick_tag_cloud_remote_catalog_service.dart';
 import '../../../services/online_gallery/quick_tag_cloud_user_service.dart';
+import 'gallery_random_sampler.dart';
 import 'gallery_source_adapter.dart';
 
 enum QuickTagCloudBrowseScope { catalog, latest, recent }
@@ -313,17 +314,17 @@ class QuickTagCloudGallerySourceAdapter extends GallerySourceAdapter {
       searchText: searchText,
       selectedRatings: request.ratings,
       cancelToken: cancelToken,
+      sortByRelevance: false,
     );
-    final shuffled = List<_QuickTagCloudRecord>.of(records)
-      ..shuffle(Random(seed));
-    final pageRecords = offset >= shuffled.length
-        ? const <_QuickTagCloudRecord>[]
-        : shuffled.sublist(
-            offset,
-            min(offset + request.pageSize, shuffled.length),
-          );
+    _throwIfCancelled(cancelToken);
+    final pageRecords = GalleryRandomSampler().permutationSlice(
+      records,
+      seed: seed,
+      offset: offset,
+      count: request.pageSize,
+    );
     final nextOffset = offset + pageRecords.length;
-    final hasMore = nextOffset < shuffled.length;
+    final hasMore = nextOffset < records.length;
     for (final record in pageRecords) {
       _rememberRecord(record);
     }
@@ -468,35 +469,45 @@ class QuickTagCloudGallerySourceAdapter extends GallerySourceAdapter {
     required String searchText,
     required Set<String> selectedRatings,
     CancelToken? cancelToken,
+    bool sortByRelevance = true,
   }) async {
     _throwIfCancelled(cancelToken);
     await _userService.ensureInitialized();
+    _throwIfCancelled(cancelToken);
     final saved = query.favoritesOnly
         ? _userService.favorites
         : query.scope == QuickTagCloudBrowseScope.recent
         ? _userService.recent
         : null;
-    final records = saved != null
-        ? [
-            for (final item in saved)
-              _QuickTagCloudRecord(
-                item.meta,
-                item.codex,
-                item.entry,
-                item.media,
-              ),
-          ]
-        : await _loadCatalogRecords(query, cancelToken: cancelToken);
+    final List<_QuickTagCloudRecord> records;
+    if (saved == null) {
+      records = await _loadCatalogRecords(query, cancelToken: cancelToken);
+    } else {
+      records = <_QuickTagCloudRecord>[];
+      for (var index = 0; index < saved.length; index++) {
+        if (index > 0 && index % 256 == 0) {
+          await Future<void>.delayed(Duration.zero);
+          _throwIfCancelled(cancelToken);
+        }
+        final item = saved[index];
+        records.add(
+          _QuickTagCloudRecord(item.meta, item.codex, item.entry, item.media),
+        );
+      }
+    }
     final cacheRevision = _cacheRevision;
     final normalizedSearch = searchText.trim().toLowerCase();
     final ratingsKey = (selectedRatings.toList()..sort()).join();
     final matchingCacheKey = saved == null
-        ? '${_catalog?.release ?? ''}|${query.stableKey}|$ratingsKey|$normalizedSearch'
+        ? '${_catalog?.release ?? ''}|${query.stableKey}|$ratingsKey|$normalizedSearch|sort:$sortByRelevance'
         : null;
     final cachedMatches = matchingCacheKey == null
         ? null
         : _matchingRecordSets[matchingCacheKey];
-    if (cachedMatches != null) return cachedMatches;
+    if (cachedMatches != null) {
+      _throwIfCancelled(cancelToken);
+      return cachedMatches;
+    }
     final terms = normalizedSearch
         .split(RegExp(r'\s+'))
         .where((term) => term.isNotEmpty)
@@ -504,7 +515,11 @@ class QuickTagCloudGallerySourceAdapter extends GallerySourceAdapter {
     final filtered = <_QuickTagCloudRecord>[];
     final cacheSearchHaystacks = records.length <= 5000;
     for (var index = 0; index < records.length; index++) {
-      if (index % 256 == 0) _throwIfCancelled(cancelToken);
+      if (index % 256 == 0) {
+        _throwIfCancelled(cancelToken);
+        if (index > 0) await Future<void>.delayed(Duration.zero);
+        _throwIfCancelled(cancelToken);
+      }
       final record = records[index];
       if (!_isAccessible(record, query, selectedRatings)) continue;
       if (!_matchesCodex(record, query.codexId)) continue;
@@ -532,7 +547,7 @@ class QuickTagCloudGallerySourceAdapter extends GallerySourceAdapter {
       filtered.add(record);
     }
     _throwIfCancelled(cancelToken);
-    if (terms.isNotEmpty) {
+    if (sortByRelevance && terms.isNotEmpty) {
       filtered.sort((left, right) {
         final leftScore = _searchScore(left, normalizedSearch);
         final rightScore = _searchScore(right, normalizedSearch);

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -875,6 +875,10 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     ref.keepAlive();
     ref.onDispose(() {
       _blacklistRefreshDebounce?.cancel();
+      _requestGeneration++;
+      if (_cancelToken != null && !_cancelToken!.isCancelled) {
+        _cancelToken!.cancel('Online gallery notifier disposed');
+      }
       _detailCoordinator?.clear();
     });
     final storage = ref.read(localStorageServiceProvider);
@@ -1446,8 +1450,6 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     bool restart = false,
   }) async {
     if (!state.randomEnabled || !state.supportsRandom) return;
-    await _ensureQuickTagCloudFilterInitialized();
-    if (!state.randomEnabled || !state.supportsRandom) return;
     if (!replace &&
         (state.isLoading ||
             state.isLoadingMore ||
@@ -1455,7 +1457,16 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       return;
     }
 
+    // Establish latest-call-wins before any initialization await. Otherwise an
+    // earlier QuickTagCloud refresh can finish initialization later and cancel
+    // the request started by a newer click.
     final generation = _beginRequest();
+    await _ensureQuickTagCloudFilterInitialized();
+    if (generation != _requestGeneration ||
+        !state.randomEnabled ||
+        !state.supportsRandom) {
+      return;
+    }
     final cacheKey = state.currentCacheKey;
     state = state.copyWith(
       isLoading: replace,
@@ -1519,7 +1530,14 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       final seen = Set<String>.of(session.seenStableKeys);
       final seenCandidates = Set<String>.of(session.seenCandidateStableKeys);
       final candidates = <GalleryItem>[];
-      for (final item in page.items) {
+      for (var index = 0; index < page.items.length; index++) {
+        if (index > 0 && index % 256 == 0) {
+          await Future<void>.delayed(Duration.zero);
+          if (generation != _requestGeneration || !state.randomEnabled) {
+            return;
+          }
+        }
+        final item = page.items[index];
         final blocked = item.tags.any(
           (tag) => normalizedBlacklist.contains(
             tag.trim().toLowerCase().replaceAll(' ', '_'),
@@ -1629,6 +1647,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         clearError: true,
       );
     } catch (error) {
+      if (error is DioException && CancelToken.isCancel(error)) return;
       if (generation != _requestGeneration || !state.randomEnabled) return;
       final isArtistHuntDetailFailure = error is _ArtistHuntDetailException;
       state = state.copyWith(
@@ -1814,7 +1833,6 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       await _loadRandom(replace: refresh);
       return;
     }
-    await _ensureQuickTagCloudFilterInitialized();
     if (!refresh && (state.isLoading || state.isLoadingMore)) return;
     final restoredPage =
         !refresh && _pendingRestoredCacheKey == state.currentCacheKey
@@ -1875,6 +1893,10 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     required bool refresh,
     String? initialCursor,
   }) async {
+    final generation = _beginRequest();
+    await _ensureQuickTagCloudFilterInitialized();
+    if (generation != _requestGeneration || state.randomEnabled) return;
+
     final cache = state.currentCache;
     final cursor = initialCursor ?? (refresh ? '1' : cache.nextCursor);
     if (cursor == null) return;
@@ -1882,7 +1904,6 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         ? state.popularSourceId
         : state.sourceId;
     final adapter = _adapters[sourceId]!;
-    final generation = _beginRequest();
     final cacheKey = state.currentCacheKey;
     final isAppend = !refresh && cache.posts.isNotEmpty;
     state = state.copyWith(

--- a/lib/presentation/screens/online_gallery/online_gallery_screen.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen.dart
@@ -1207,14 +1207,12 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
       child: compact
           ? OutlinedButton(
               key: const ValueKey('online-gallery-random-toggle'),
-              onPressed: state.isLoading
-                  ? null
-                  : () {
-                      if (!state.randomEnabled) _saveScrollOffset();
-                      unawaited(
-                        _galleryNotifier.setRandomEnabled(!state.randomEnabled),
-                      );
-                    },
+              onPressed: () {
+                if (!state.randomEnabled) _saveScrollOffset();
+                unawaited(
+                  _galleryNotifier.setRandomEnabled(!state.randomEnabled),
+                );
+              },
               style: OutlinedButton.styleFrom(
                 backgroundColor: state.randomEnabled
                     ? theme.colorScheme.primaryContainer
@@ -1233,14 +1231,12 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
             )
           : OutlinedButton.icon(
               key: const ValueKey('online-gallery-random-toggle'),
-              onPressed: state.isLoading
-                  ? null
-                  : () {
-                      if (!state.randomEnabled) _saveScrollOffset();
-                      unawaited(
-                        _galleryNotifier.setRandomEnabled(!state.randomEnabled),
-                      );
-                    },
+              onPressed: () {
+                if (!state.randomEnabled) _saveScrollOffset();
+                unawaited(
+                  _galleryNotifier.setRandomEnabled(!state.randomEnabled),
+                );
+              },
               icon: const Icon(Icons.shuffle, size: 17),
               label: Text(context.l10n.onlineGallery_random),
               style: OutlinedButton.styleFrom(
@@ -1318,7 +1314,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         if (compact)
           FilledButton.tonal(
             key: const ValueKey('online-gallery-refresh'),
-            onPressed: state.isLoading ? null : refreshAction,
+            onPressed: refreshAction,
             style: FilledButton.styleFrom(
               minimumSize: const Size(0, 40),
               padding: const EdgeInsets.symmetric(horizontal: 8),
@@ -1338,7 +1334,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         else
           FilledButton.tonalIcon(
             key: const ValueKey('online-gallery-refresh'),
-            onPressed: state.isLoading ? null : refreshAction,
+            onPressed: refreshAction,
             icon: refreshIcon,
             label: Text(
               state.randomEnabled
@@ -1405,16 +1401,12 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         label: context.l10n.onlineGallery_artistHunt,
         child: OutlinedButton.icon(
           key: const ValueKey('online-gallery-artist-hunt-toggle'),
-          onPressed: state.isLoading
-              ? null
-              : () {
-                  _saveScrollOffset();
-                  unawaited(
-                    _galleryNotifier.setArtistHuntEnabled(
-                      !state.artistHuntEnabled,
-                    ),
-                  );
-                },
+          onPressed: () {
+            _saveScrollOffset();
+            unawaited(
+              _galleryNotifier.setArtistHuntEnabled(!state.artistHuntEnabled),
+            );
+          },
           icon: const Icon(Icons.brush_outlined, size: 17),
           label: Text(context.l10n.onlineGallery_artistHunt),
           style: OutlinedButton.styleFrom(

--- a/test/data/datasources/remote/online_gallery/gallery_random_sampler_test.dart
+++ b/test/data/datasources/remote/online_gallery/gallery_random_sampler_test.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:math';
 
 // ignore_for_file: prefer_const_constructors
@@ -327,5 +328,71 @@ void main() {
         expect(first.toSet(), {1, 2, 3, 4});
       },
     );
+
+    test('permutation slices cover the input exactly once across pages', () {
+      final sampler = GalleryRandomSampler(random: Random(1));
+      final values = List<int>.generate(101, (index) => index);
+      final sampled = <int>[];
+      for (var offset = 0; offset < values.length; offset += 13) {
+        sampled.addAll(
+          sampler.permutationSlice(values, seed: 77, offset: offset, count: 13),
+        );
+      }
+
+      expect(sampled, hasLength(values.length));
+      expect(sampled.toSet(), values.toSet());
+    });
+
+    test('permutation does not collapse into a fixed modular stride', () {
+      final values = List<int>.generate(257, (index) => index);
+      final sampled = GalleryRandomSampler().permutationSlice(
+        values,
+        seed: 77,
+        offset: 0,
+        count: values.length,
+      );
+      final strides = <int>{
+        for (var index = 1; index < sampled.length; index++)
+          (sampled[index] - sampled[index - 1]) % values.length,
+      };
+
+      expect(strides.length, greaterThan(32));
+    });
+
+    test('permutation slice work is bounded by the requested result count', () {
+      final values = _CountingList(1000000);
+      final sampled = GalleryRandomSampler().permutationSlice(
+        values,
+        seed: 123,
+        offset: 600,
+        count: 60,
+      );
+
+      expect(sampled, hasLength(60));
+      expect(values.readCount, 60);
+    });
   });
+}
+
+class _CountingList extends ListBase<int> {
+  _CountingList(this._length);
+
+  final int _length;
+  int readCount = 0;
+
+  @override
+  int get length => _length;
+
+  @override
+  int operator [](int index) {
+    readCount++;
+    return index;
+  }
+
+  @override
+  void operator []=(int index, int value) =>
+      throw UnsupportedError('read only');
+
+  @override
+  set length(int value) => throw UnsupportedError('fixed length');
 }

--- a/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
+++ b/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
@@ -224,6 +225,63 @@ void main() {
       expect(result.items.single.id, 500);
       expect(http.requests, hasLength(3));
     });
+
+    test(
+      'multi-tag random retries the opposite side of a sparse target',
+      () async {
+        var anchorRequests = 0;
+        final http = _RecordingHttpAdapter((request) {
+          final page = request.queryParameters['page'];
+          if (page == null) {
+            return [for (var id = 1000; id > 940; id--) _donmaiPost(id)];
+          }
+          if (page == 'a0') {
+            return [for (var id = 1; id <= 60; id++) _donmaiPost(id)];
+          }
+          anchorRequests++;
+          return anchorRequests == 1 ? <Object?>[] : [_donmaiPost(500)];
+        });
+        final adapter = DonmaiGallerySourceAdapter(
+          sourceId: GallerySourceId.danbooru,
+          dio: Dio()..httpClientAdapter = http,
+          random: Random(7),
+        );
+
+        final result = await adapter.random(
+          const GalleryRandomSearchRequest(
+            pageSize: 10,
+            query: '1girl sparse_unique',
+          ),
+        );
+
+        expect(result.items.single.id, 500);
+        expect(anchorRequests, 2);
+        expect(http.requests, hasLength(4));
+      },
+    );
+
+    test(
+      'empty multi-tag search stops after the newest boundary probe',
+      () async {
+        final http = _RecordingHttpAdapter((request) => <Object?>[]);
+        final adapter = DonmaiGallerySourceAdapter(
+          sourceId: GallerySourceId.danbooru,
+          dio: Dio()..httpClientAdapter = http,
+          random: Random(7),
+        );
+
+        final result = await adapter.random(
+          const GalleryRandomSearchRequest(
+            pageSize: 10,
+            query: '1girl no_results_unique',
+          ),
+        );
+
+        expect(result.items, isEmpty);
+        expect(http.requests, hasLength(1));
+        expect(http.requests.single.queryParameters['page'], isNull);
+      },
+    );
 
     test(
       'random ranking consumes every page in a four-page window once',
@@ -681,7 +739,7 @@ class _RecordedResponse {
 class _RecordingHttpAdapter implements HttpClientAdapter {
   _RecordingHttpAdapter(this.handler);
 
-  final Object? Function(RequestOptions request) handler;
+  final FutureOr<Object?> Function(RequestOptions request) handler;
   final List<RequestOptions> requests = [];
 
   @override
@@ -691,7 +749,7 @@ class _RecordingHttpAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     requests.add(options);
-    final value = handler(options);
+    final value = await handler(options);
     final response = value is _RecordedResponse
         ? value
         : _RecordedResponse(value, statusCode: 200);

--- a/test/presentation/providers/online_gallery_random_mode_test.dart
+++ b/test/presentation/providers/online_gallery_random_mode_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
@@ -397,25 +398,177 @@ void main() {
     expect(state.randomSession.seenStableKeys, {'danbooru:7'});
     expect(state.randomSession.exhausted, isFalse);
   });
+
+  test(
+    'source switch starts the new random request without awaiting the old one',
+    () async {
+      final oldRequest = Completer<GalleryPage>();
+      final danbooru = _ControlledRandomAdapter(
+        GallerySourceId.danbooru,
+        responses: [oldRequest.future],
+      );
+      final safebooru = _ControlledRandomAdapter(
+        GallerySourceId.safebooru,
+        responses: [
+          Future.value(_page([_sourceItem(2, GallerySourceId.safebooru)])),
+        ],
+      );
+      final container = _containerWithAdapters(danbooru, safebooru);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      final enabling = notifier.setRandomEnabled(true);
+      await Future<void>.delayed(Duration.zero);
+      await notifier.setSource(GallerySourceId.safebooru);
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(danbooru.cancelTokens.single.isCancelled, isTrue);
+      expect(safebooru.randomCalls, 1);
+      expect(state.sourceId, GallerySourceId.safebooru);
+      expect(state.posts.single.stableKey, 'safebooru:2');
+
+      oldRequest.complete(_page([_item(99)]));
+      await enabling;
+      expect(
+        container.read(onlineGalleryNotifierProvider).posts.single.stableKey,
+        'safebooru:2',
+      );
+    },
+  );
+
+  test('rapid source switches commit only the latest random query', () async {
+    final danbooruRequest = Completer<GalleryPage>();
+    final safebooruRequest = Completer<GalleryPage>();
+    final danbooru = _ControlledRandomAdapter(
+      GallerySourceId.danbooru,
+      responses: [danbooruRequest.future],
+    );
+    final safebooru = _ControlledRandomAdapter(
+      GallerySourceId.safebooru,
+      responses: [safebooruRequest.future],
+    );
+    final gelbooru = _ControlledRandomAdapter(
+      GallerySourceId.gelbooru,
+      responses: [
+        Future.value(_page([_sourceItem(3, GallerySourceId.gelbooru)])),
+      ],
+    );
+    final container = _containerWithAdapters(danbooru, safebooru, gelbooru);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    final first = notifier.setRandomEnabled(true);
+    await Future<void>.delayed(Duration.zero);
+    final second = notifier.setSource(GallerySourceId.safebooru);
+    await Future<void>.delayed(Duration.zero);
+    await notifier.setSource(GallerySourceId.gelbooru);
+
+    expect(danbooru.cancelTokens.single.isCancelled, isTrue);
+    expect(safebooru.cancelTokens.single.isCancelled, isTrue);
+    expect(
+      container.read(onlineGalleryNotifierProvider).posts.single.stableKey,
+      'gelbooru:3',
+    );
+
+    safebooruRequest.complete(
+      _page([_sourceItem(22, GallerySourceId.safebooru)]),
+    );
+    danbooruRequest.complete(_page([_item(11)]));
+    await Future.wait([first, second]);
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(state.sourceId, GallerySourceId.gelbooru);
+    expect(state.posts.single.stableKey, 'gelbooru:3');
+  });
+
+  test(
+    'refresh cancels the active random draw and starts a replacement',
+    () async {
+      final pending = Completer<GalleryPage>();
+      final adapter = _ControlledRandomAdapter(
+        GallerySourceId.danbooru,
+        responses: [
+          pending.future,
+          Future.value(_page([_item(8)])),
+        ],
+      );
+      final container = _containerWithAdapters(adapter);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      final first = notifier.setRandomEnabled(true);
+      await Future<void>.delayed(Duration.zero);
+      await notifier.refresh();
+
+      expect(adapter.randomCalls, 2);
+      expect(adapter.cancelTokens.first.isCancelled, isTrue);
+      expect(container.read(onlineGalleryNotifierProvider).posts.single.id, 8);
+
+      pending.complete(_page([_item(9)]));
+      await first;
+      expect(container.read(onlineGalleryNotifierProvider).posts.single.id, 8);
+    },
+  );
+
+  test(
+    'disabling random cancels an in-flight draw without reporting an error',
+    () async {
+      final pending = Completer<GalleryPage>();
+      final adapter = _ControlledRandomAdapter(
+        GallerySourceId.danbooru,
+        responses: [pending.future],
+      );
+      final container = _containerWithAdapters(adapter);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      final enabling = notifier.setRandomEnabled(true);
+      await Future<void>.delayed(Duration.zero);
+      await notifier.setRandomEnabled(false);
+
+      var state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.cancelTokens.single.isCancelled, isTrue);
+      expect(state.randomEnabled, isFalse);
+      expect(state.isLoading, isFalse);
+      expect(state.hasError, isFalse);
+
+      pending.complete(_page([_item(9)]));
+      await enabling;
+      state = container.read(onlineGalleryNotifierProvider);
+      expect(state.randomEnabled, isFalse);
+      expect(state.posts, isEmpty);
+    },
+  );
 }
 
-ProviderContainer _container(_RandomFakeAdapter danbooru) {
-  final adapters = <GallerySourceId, GallerySourceAdapter>{
+ProviderContainer _container(_RandomFakeAdapter danbooru) =>
+    _containerWithAdapters(danbooru);
+
+ProviderContainer _containerWithAdapters(
+  GallerySourceAdapter danbooru, [
+  GallerySourceAdapter? safebooru,
+  GallerySourceAdapter? gelbooru,
+]) {
+  final overrides = <GallerySourceId, GallerySourceAdapter>{
     GallerySourceId.danbooru: danbooru,
-    for (final source in GallerySourceId.values)
-      if (source != GallerySourceId.danbooru) source: _EmptyAdapter(source),
+    if (safebooru != null) GallerySourceId.safebooru: safebooru,
+    if (gelbooru != null) GallerySourceId.gelbooru: gelbooru,
   };
   return ProviderContainer(
     overrides: [
       localStorageServiceProvider.overrideWithValue(_MemoryStorage()),
-      onlineGallerySourceAdaptersProvider.overrideWithValue(adapters),
+      onlineGallerySourceAdaptersProvider.overrideWithValue({
+        for (final source in GallerySourceId.values)
+          source: overrides[source] ?? _EmptyAdapter(source),
+      }),
     ],
   );
 }
 
-GalleryItem _item(int id) => GalleryItem(
+GalleryItem _item(int id) => _sourceItem(id, GallerySourceId.danbooru);
+
+GalleryItem _sourceItem(int id, GallerySourceId sourceId) => GalleryItem(
   id: id,
-  sourceId: GallerySourceId.danbooru,
+  sourceId: sourceId,
   tags: const ['1girl'],
   cover: GalleryMedia(
     id: '$id',
@@ -461,6 +614,31 @@ class _MemoryStorage extends LocalStorageService {
   @override
   Future<void> deleteSetting(String key) async {
     _values.remove(key);
+  }
+}
+
+class _ControlledRandomAdapter extends GallerySourceAdapter {
+  _ControlledRandomAdapter(this.sourceId, {required this.responses});
+
+  @override
+  final GallerySourceId sourceId;
+  final List<Future<GalleryPage>> responses;
+  final List<CancelToken> cancelTokens = [];
+  int randomCalls = 0;
+
+  @override
+  Future<GalleryPage> search(
+    GallerySearchRequest request, {
+    CancelToken? cancelToken,
+  }) async => _page(const []);
+
+  @override
+  Future<GalleryPage> random(
+    GalleryRandomRequest request, {
+    CancelToken? cancelToken,
+  }) {
+    cancelTokens.add(cancelToken!);
+    return responses[randomCalls++];
   }
 }
 


### PR DESCRIPTION
## 用户可见变化
- 随机画廊不再为 QuickTagCloud 全量复制、排序和洗牌数据，按页生成无重复随机结果
- Danbooru、Safebooru 复杂随机查询和 AI TAG 随机探测使用有界请求，空结果及时停止
- 切换站点、刷新、关闭随机模式或销毁页面时立即取消旧任务
- 旧来源的结果、加载状态、错误和游标不会污染当前来源
- 加载过程中随机、刷新和画师狩猎按钮仍可操作

## 实现
- 新增确定性的有界随机采样器
- QuickTagCloud 随机分页由全量 `O(n)` 洗牌改为按页 `O(pageSize)` 置换
- 将取消信号贯穿来源适配器、Provider 初始化及过滤阶段
- 对稀疏结果和空页使用有限重试与明确终止条件

## 验证
- 受影响测试 224 项全部通过
- 限定 `flutter analyze`：No issues found
- 已变基到最新 `main`
- `git diff --check main...HEAD` 通过
- 工作区干净

## 实机验证
- 未发现可复用的 Flutter Debug 会话，因此未启动重复会话或触发热重载