### PR TITLE
fix(generation): 修复透明生成结果残留旧图

### DIFF
--- a/lib/presentation/screens/generation/widgets/history_panel.dart
+++ b/lib/presentation/screens/generation/widgets/history_panel.dart
@@ -88,8 +88,9 @@ class _HistoryPanelState extends ConsumerState<HistoryPanel> {
   Timer? _historyPreheatTimer;
   Timer? _hoverPreheatTimer;
   bool _isHistoryScrolling = false;
+  bool _isTrackingGenerationPreviews = false;
   String? _lastSharePreparationMaintenanceKey;
-  Uint8List? _lastStreamPreviewBytes;
+  final Map<int, Uint8List> _streamPreviewBytesByImageNumber = {};
   final Map<String, Uint8List> _completionPreviewPlaceholders = {};
   final Map<String, bool> _favoriteStates = {};
   final Map<String, String?> _favoriteStatePaths = {};
@@ -455,19 +456,35 @@ class _HistoryPanelState extends ConsumerState<HistoryPanel> {
   }
 
   void _syncCompletionPreviewPlaceholder(ImageGenerationState state) {
-    if (state.hasStreamPreview) {
-      _lastStreamPreviewBytes = state.streamPreview;
-      return;
+    if (state.isGenerating && !_isTrackingGenerationPreviews) {
+      _streamPreviewBytesByImageNumber.clear();
+      _isTrackingGenerationPreviews = true;
+    } else if (!state.isGenerating) {
+      _isTrackingGenerationPreviews = false;
     }
 
-    if (_lastStreamPreviewBytes != null && state.currentImages.isNotEmpty) {
-      final newestImage = state.currentImages.first;
-      _completionPreviewPlaceholders.putIfAbsent(
-        newestImage.id,
-        () => _lastStreamPreviewBytes!,
-      );
-      _lastStreamPreviewBytes = null;
+    for (final slot in state.streamPreviewSlots) {
+      final previewBytes = slot.previewBytes;
+      if (previewBytes != null && previewBytes.isNotEmpty) {
+        _streamPreviewBytesByImageNumber[slot.imageNumber] = previewBytes;
+      }
     }
+    final streamPreview = state.streamPreview;
+    if (streamPreview != null &&
+        streamPreview.isNotEmpty &&
+        state.currentImage > 0) {
+      _streamPreviewBytesByImageNumber[state.currentImage] = streamPreview;
+    }
+
+    _streamPreviewBytesByImageNumber.removeWhere((imageNumber, previewBytes) {
+      final imageIndex = imageNumber - 1;
+      if (imageIndex < 0 || imageIndex >= state.currentImages.length) {
+        return false;
+      }
+      final image = state.currentImages[imageIndex];
+      _completionPreviewPlaceholders.putIfAbsent(image.id, () => previewBytes);
+      return true;
+    });
 
     final retainedIds = <String>{
       for (final image in state.currentImages) image.id,

--- a/lib/presentation/screens/generation/widgets/image_preview.dart
+++ b/lib/presentation/screens/generation/widgets/image_preview.dart
@@ -621,6 +621,7 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
     final card = SelectableImageCard(
       imageBytes: imageBytes,
       sourceFilePath: image.filePath,
+      imageIdentity: image.id,
       index: index,
       showIndex: showIndex,
       // 透明像素透出所选底色（棋盘格/纯色），与官网结果区一致

--- a/lib/presentation/widgets/common/image_detail/components/detail_thumbnail_bar.dart
+++ b/lib/presentation/widgets/common/image_detail/components/detail_thumbnail_bar.dart
@@ -56,6 +56,7 @@ class DetailThumbnailBar extends StatelessWidget {
           itemCount: images.length,
           itemBuilder: (context, index) {
             return _ThumbnailItem(
+              key: ValueKey(images[index].identifier),
               image: images[index],
               index: index,
               isSelected: index == currentIndex,
@@ -76,6 +77,7 @@ class _ThumbnailItem extends StatefulWidget {
   final VoidCallback onTap;
 
   const _ThumbnailItem({
+    super.key,
     required this.image,
     required this.index,
     required this.isSelected,

--- a/lib/presentation/widgets/common/selectable_image_card.dart
+++ b/lib/presentation/widgets/common/selectable_image_card.dart
@@ -255,6 +255,7 @@ class _SelectableImageCardState extends ConsumerState<SelectableImageCard>
   late bool _showPreparedIndexBadge;
   late bool _completedImageHasFrame;
   bool _completionPlaceholderSettledNotified = false;
+  int _completionImageEpoch = 0;
   Uint8List? _precachingCompletedImageBytes;
   Uint8List? _lastStreamPreviewBytes;
   Timer? _completionPlaceholderFallbackTimer;
@@ -328,8 +329,14 @@ class _SelectableImageCardState extends ConsumerState<SelectableImageCard>
       _glowAnimation = null;
     }
 
+    // Preserve the stream only for generating -> completed; a reused completed
+    // card must not use another result's frame as its placeholder.
     if (widget.streamPreview?.isNotEmpty == true) {
       _lastStreamPreviewBytes = widget.streamPreview;
+    } else if (oldWidget.imageBytes != null &&
+        (oldWidget.imageIdentity != widget.imageIdentity ||
+            oldWidget.imageBytes != widget.imageBytes)) {
+      _lastStreamPreviewBytes = null;
     }
 
     if (oldWidget.imageBytes != widget.imageBytes ||
@@ -342,9 +349,11 @@ class _SelectableImageCardState extends ConsumerState<SelectableImageCard>
     }
 
     if (oldWidget.imageBytes != widget.imageBytes ||
+        oldWidget.imageIdentity != widget.imageIdentity ||
         oldWidget.completionPlaceholderBytes !=
             widget.completionPlaceholderBytes ||
         (oldWidget.isGenerating && !widget.isGenerating)) {
+      _completionImageEpoch++;
       _completedImageHasFrame = _effectiveCompletionPlaceholderBytes == null;
       _completionPlaceholderSettledNotified = false;
       _precachingCompletedImageBytes = null;
@@ -418,14 +427,16 @@ class _SelectableImageCardState extends ConsumerState<SelectableImageCard>
       return;
     }
 
+    final completionImageEpoch = _completionImageEpoch;
     _precachingCompletedImageBytes = imageBytes;
     unawaited(
       precacheImage(MemoryImage(imageBytes), context).then((_) {
         if (!mounted ||
+            completionImageEpoch != _completionImageEpoch ||
             !identical(_precachingCompletedImageBytes, imageBytes)) {
           return;
         }
-        _markCompletedImageReady();
+        _markCompletedImageReady(completionImageEpoch);
       }),
     );
   }
@@ -437,19 +448,21 @@ class _SelectableImageCardState extends ConsumerState<SelectableImageCard>
       return;
     }
 
+    final completionImageEpoch = _completionImageEpoch;
     _completionPlaceholderFallbackTimer = Timer(
       _completionPlaceholderFallbackDuration,
       () {
-        if (!mounted) {
+        if (!mounted || completionImageEpoch != _completionImageEpoch) {
           return;
         }
-        _markCompletedImageReady();
+        _markCompletedImageReady(completionImageEpoch);
       },
     );
   }
 
-  void _markCompletedImageReady() {
-    if (_completedImageHasFrame) {
+  void _markCompletedImageReady([int? expectedEpoch]) {
+    if ((expectedEpoch != null && expectedEpoch != _completionImageEpoch) ||
+        _completedImageHasFrame) {
       return;
     }
     _completionPlaceholderFallbackTimer?.cancel();
@@ -471,11 +484,14 @@ class _SelectableImageCardState extends ConsumerState<SelectableImageCard>
     bool wasSynchronouslyLoaded,
   ) {
     if ((frame != null || wasSynchronouslyLoaded) && !_completedImageHasFrame) {
+      final completionImageEpoch = _completionImageEpoch;
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted || _completedImageHasFrame) {
+        if (!mounted ||
+            completionImageEpoch != _completionImageEpoch ||
+            _completedImageHasFrame) {
           return;
         }
-        _markCompletedImageReady();
+        _markCompletedImageReady(completionImageEpoch);
       });
     }
     return child;
@@ -830,6 +846,9 @@ class _SelectableImageCardState extends ConsumerState<SelectableImageCard>
     final completionPlaceholderBytes = _effectiveCompletionPlaceholderBytes;
     final showCompletionPlaceholder =
         completionPlaceholderBytes != null && !_completedImageHasFrame;
+    final displayedImageBytes = showCompletionPlaceholder
+        ? completionPlaceholderBytes
+        : widget.imageBytes!;
 
     return MouseRegion(
       onEnter: (_) => _onHoverEnter(),
@@ -902,23 +921,16 @@ class _SelectableImageCardState extends ConsumerState<SelectableImageCard>
                 // 0. 垫层：图片透明像素处透出的底色
                 if (widget.underlay != null) widget.underlay!,
 
-                // 1. 图片层
-                if (showCompletionPlaceholder)
-                  RepaintBoundary(
-                    child: DecodedMemoryImage(
-                      key: const ValueKey(
-                        'completed-image-preview-placeholder',
-                      ),
-                      bytes: completionPlaceholderBytes,
-                      fit: BoxFit.cover,
-                    ),
-                  ),
+                // 1. 图片层。预览与结果共用同一个 Image/RenderImage，
+                // 避免透明结果首帧与旧预览同时合成。
                 RepaintBoundary(
                   child: DecodedMemoryImage(
-                    key: const ValueKey('selectable-image-completed-image'),
-                    bytes: widget.imageBytes!,
+                    key: const ValueKey('selectable-image-content'),
+                    bytes: displayedImageBytes,
                     fit: BoxFit.cover,
-                    frameBuilder: _buildCompletedImageFrame,
+                    frameBuilder: showCompletionPlaceholder
+                        ? null
+                        : _buildCompletedImageFrame,
                   ),
                 ),
 

--- a/test/presentation/screens/generation/widgets/history_panel_interaction_test.dart
+++ b/test/presentation/screens/generation/widgets/history_panel_interaction_test.dart
@@ -355,6 +355,132 @@ void main() {
     final scrollable = tester.state<ScrollableState>(find.byType(Scrollable));
     expect(scrollable.position.pixels, greaterThan(0));
   });
+
+  testWidgets('maps each batch stream preview to its completed image', (
+    tester,
+  ) async {
+    final firstPreview = _solidPng(255, 0, 0);
+    final secondPreview = _solidPng(0, 0, 255);
+    final container = _createContainer([]);
+    addTearDown(container.dispose);
+    final notifier = container.read(imageGenerationNotifierProvider.notifier);
+    notifier.state = notifier.state.copyWith(
+      status: GenerationStatus.generating,
+      currentImage: 2,
+      totalImages: 2,
+      streamPreview: secondPreview,
+      streamPreviewSlots: [
+        StreamPreviewSlot(
+          imageNumber: 1,
+          totalImages: 2,
+          progress: 0.9,
+          previewBytes: firstPreview,
+        ),
+        StreamPreviewSlot(
+          imageNumber: 2,
+          totalImages: 2,
+          progress: 0.8,
+          previewBytes: secondPreview,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(_historyApp(container));
+    await tester.pump();
+
+    notifier.state = notifier.state.copyWith(
+      status: GenerationStatus.completed,
+      currentImages: [_image('batch-first'), _image('batch-second')],
+      clearStreamPreview: true,
+    );
+    await tester.pump();
+
+    final firstCard = tester.widget<SelectableImageCard>(
+      find.byKey(const ValueKey('batch-first')),
+    );
+    final secondCard = tester.widget<SelectableImageCard>(
+      find.byKey(const ValueKey('batch-second')),
+    );
+    expect(
+      listEquals(firstCard.completionPlaceholderBytes, firstPreview),
+      isTrue,
+    );
+    expect(
+      listEquals(secondCard.completionPlaceholderBytes, secondPreview),
+      isTrue,
+    );
+  });
+
+  testWidgets(
+    'does not reuse a cancelled run preview for the next generation',
+    (tester) async {
+      final cancelledPreview = _solidPng(255, 0, 0);
+      final nextPreview = _solidPng(0, 255, 0);
+      final container = _createContainer([]);
+      addTearDown(container.dispose);
+      final notifier = container.read(imageGenerationNotifierProvider.notifier);
+      notifier.state = notifier.state.copyWith(
+        status: GenerationStatus.generating,
+        currentImage: 1,
+        totalImages: 1,
+        streamPreview: cancelledPreview,
+        streamPreviewSlots: [
+          StreamPreviewSlot(
+            imageNumber: 1,
+            totalImages: 1,
+            progress: 0.8,
+            previewBytes: cancelledPreview,
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(_historyApp(container));
+      await tester.pump();
+
+      notifier.state = notifier.state.copyWith(
+        status: GenerationStatus.cancelled,
+        currentImages: const [],
+        clearStreamPreview: true,
+      );
+      await tester.pump();
+      notifier.state = notifier.state.copyWith(
+        status: GenerationStatus.generating,
+        currentImage: 1,
+        totalImages: 1,
+        streamPreview: nextPreview,
+        streamPreviewSlots: [
+          StreamPreviewSlot(
+            imageNumber: 1,
+            totalImages: 1,
+            progress: 0.8,
+            previewBytes: nextPreview,
+          ),
+        ],
+      );
+      await tester.pump();
+      notifier.state = notifier.state.copyWith(
+        status: GenerationStatus.completed,
+        currentImages: [_image('after-cancel')],
+        clearStreamPreview: true,
+      );
+      await tester.pump();
+
+      final card = tester.widget<SelectableImageCard>(
+        find.byKey(const ValueKey('after-cancel')),
+      );
+      expect(listEquals(card.completionPlaceholderBytes, nextPreview), isTrue);
+      expect(
+        listEquals(card.completionPlaceholderBytes, cancelledPreview),
+        isFalse,
+      );
+    },
+  );
+}
+
+Uint8List _solidPng(int red, int green, int blue) {
+  final image = img.Image(width: 4, height: 4, numChannels: 4);
+  img.fill(image, color: img.ColorRgba8(red, green, blue, 255));
+  return Uint8List.fromList(img.encodePng(image));
 }
 
 ProviderContainer _createContainer(

--- a/test/presentation/widgets/common/decoded_memory_image_test.dart
+++ b/test/presentation/widgets/common/decoded_memory_image_test.dart
@@ -56,6 +56,7 @@ void main() {
 
     final image = tester.widget<Image>(find.byType(Image));
     expect(image.image, isA<ResizeImage>());
+    expect(image.gaplessPlayback, isTrue);
 
     final provider = image.image as ResizeImage;
     expect(provider.width, 100);

--- a/test/presentation/widgets/common/detail_thumbnail_bar_test.dart
+++ b/test/presentation/widgets/common/detail_thumbnail_bar_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
@@ -33,12 +34,57 @@ void main() {
     expect(thumbnailProvider.imageProvider, same(sourceProvider));
     expect(thumbnailProvider.imageProvider, isNot(isA<ResizeImage>()));
   });
+
+  testWidgets('replacing an identifier resets thumbnail interaction state', (
+    tester,
+  ) async {
+    final firstProvider = MemoryImage(Uint8List.fromList(const [1]));
+    final secondProvider = MemoryImage(Uint8List.fromList(const [2]));
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    Widget buildThumbnail(_TestImageDetailData data) {
+      return MaterialApp(
+        home: DetailThumbnailBar(
+          images: [data],
+          currentIndex: -1,
+          scrollController: scrollController,
+          onTap: (_) {},
+        ),
+      );
+    }
+
+    await tester.pumpWidget(
+      buildThumbnail(_TestImageDetailData(firstProvider, identifier: 'first')),
+    );
+    final thumbnail = find.byType(AnimatedContainer);
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(thumbnail));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(thumbnail).width, 86);
+
+    await tester.pumpWidget(
+      buildThumbnail(
+        _TestImageDetailData(secondProvider, identifier: 'second'),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.getSize(thumbnail).width, 80);
+    final image = tester.widget<Image>(find.byType(Image));
+    expect((image.image as ResizeImage).imageProvider, same(secondProvider));
+  });
 }
 
 class _TestImageDetailData implements ImageDetailData {
-  _TestImageDetailData(this.provider);
+  _TestImageDetailData(this.provider, {this.identifier = 'test'});
 
   final ImageProvider<Object> provider;
+
+  @override
+  final String identifier;
 
   @override
   ImageProvider<Object> getImageProvider() => provider;
@@ -51,9 +97,6 @@ class _TestImageDetailData implements ImageDetailData {
 
   @override
   bool get isFavorite => false;
-
-  @override
-  String get identifier => 'test';
 
   @override
   FileInfo? get fileInfo => null;

--- a/test/presentation/widgets/common/draggable_memory_image_test.dart
+++ b/test/presentation/widgets/common/draggable_memory_image_test.dart
@@ -273,7 +273,7 @@ void main() {
 
   group('SelectableImageCard hover gating', () {
     testWidgets(
-        'keeps the last stream preview behind completed image until first frame',
+        'keeps the last stream preview as the only image until completion is ready',
         (tester) async {
       var placeholderSettled = false;
 
@@ -298,25 +298,24 @@ void main() {
         ),
       );
 
-      final placeholderFinder = find.byKey(
-        const ValueKey('completed-image-preview-placeholder'),
+      final contentFinder = find.byKey(
+        const ValueKey('selectable-image-content'),
       );
-      expect(placeholderFinder, findsOneWidget);
-      expect(
-        find.byKey(const ValueKey('selectable-image-completed-image')),
-        findsOneWidget,
-      );
+      expect(contentFinder, findsOneWidget);
+      expect(find.byType(DecodedMemoryImage), findsOneWidget);
 
       await tester.pump(const Duration(milliseconds: 899));
 
       expect(placeholderSettled, isFalse);
-      expect(placeholderFinder, findsOneWidget);
+      expect(contentFinder, findsOneWidget);
+      expect(find.byType(DecodedMemoryImage), findsOneWidget);
 
       await tester.pump(const Duration(milliseconds: 1));
       await tester.pump();
 
       expect(placeholderSettled, isTrue);
-      expect(placeholderFinder, findsNothing);
+      expect(contentFinder, findsOneWidget);
+      expect(find.byType(DecodedMemoryImage), findsOneWidget);
     });
 
     testWidgets('reuses stream preview when the same card becomes completed',
@@ -361,9 +360,10 @@ void main() {
       );
 
       expect(
-        find.byKey(const ValueKey('completed-image-preview-placeholder')),
+        find.byKey(const ValueKey('selectable-image-content')),
         findsOneWidget,
       );
+      expect(find.byType(DecodedMemoryImage), findsOneWidget);
     });
 
     testWidgets(

--- a/test/presentation/widgets/common/selectable_image_card_transparency_test.dart
+++ b/test/presentation/widgets/common/selectable_image_card_transparency_test.dart
@@ -1,0 +1,193 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:nai_launcher/presentation/widgets/common/decoded_memory_image.dart';
+import 'package:nai_launcher/presentation/widgets/common/selectable_image_card.dart';
+
+void main() {
+  final transparentResults = <String, Uint8List>{
+    'PNG': _halfTransparentPng(const Color(0xff0000ff)),
+    'WebP': base64Decode(
+      'UklGRiQAAABXRUJQVlA4TBcAAAAvD8ADEA8QMf/zHwyxYDJ/6e4MIvofuQA=',
+    ),
+  };
+
+  for (final entry in transparentResults.entries) {
+    testWidgets(
+      '${entry.key} transparent completion atomically replaces the opaque preview',
+      (tester) => _verifyAtomicReplacement(tester, entry.value),
+    );
+  }
+}
+
+Future<void> _verifyAtomicReplacement(
+  WidgetTester tester,
+  Uint8List transparentResult,
+) async {
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final boundaryKey = GlobalKey();
+  final opaquePreview = _opaquePng(const Color(0xffff0000));
+
+  await tester.pumpWidget(
+    _buildCard(
+      boundaryKey: boundaryKey,
+      imageBytes: opaquePreview,
+      imageIdentity: 'previous-result',
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  await tester.pumpWidget(
+    _buildCard(
+      boundaryKey: boundaryKey,
+      imageBytes: transparentResult,
+      imageIdentity: 'new-transparent-result',
+      completionPlaceholderBytes: opaquePreview,
+    ),
+  );
+
+  expect(
+    find.byType(DecodedMemoryImage),
+    findsOneWidget,
+    reason: 'The previous preview and completed image must never be layered',
+  );
+
+  var sawCompletedFrame = false;
+  for (var frame = 0; frame < 100; frame++) {
+    await tester.pump(const Duration(milliseconds: 10));
+    final pixels = (await tester.runAsync(() => _captureCard(boundaryKey)))!;
+    final opaqueHalf = pixels.pixelAt(16, 32);
+    final transparentHalf = pixels.pixelAt(48, 32);
+
+    if (_isCloseTo(opaqueHalf, const Color(0xff0000ff))) {
+      sawCompletedFrame = true;
+      expect(
+        _isCloseTo(transparentHalf, const Color(0xff00ff00)),
+        isTrue,
+        reason:
+            'The completed frame was visible while its transparent half '
+            'still exposed the previous opaque preview: $transparentHalf',
+      );
+      break;
+    }
+  }
+
+  expect(sawCompletedFrame, isTrue);
+  await tester.pumpAndSettle();
+
+  final finalPixels = (await tester.runAsync(() => _captureCard(boundaryKey)))!;
+  expect(
+    _isCloseTo(finalPixels.pixelAt(16, 32), const Color(0xff0000ff)),
+    isTrue,
+  );
+  expect(
+    _isCloseTo(finalPixels.pixelAt(48, 32), const Color(0xff00ff00)),
+    isTrue,
+  );
+}
+
+Widget _buildCard({
+  required GlobalKey boundaryKey,
+  required Uint8List imageBytes,
+  required Object imageIdentity,
+  Uint8List? completionPlaceholderBytes,
+}) {
+  return ProviderScope(
+    child: MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: RepaintBoundary(
+            key: boundaryKey,
+            child: SizedBox(
+              width: 64,
+              height: 64,
+              child: SelectableImageCard(
+                imageBytes: imageBytes,
+                imageIdentity: imageIdentity,
+                completionPlaceholderBytes: completionPlaceholderBytes,
+                underlay: const ColoredBox(color: Color(0xff00ff00)),
+                enableSelection: false,
+                enableContextMenu: false,
+                enableHoverScale: false,
+                enableGlossEffect: false,
+                hoverEffectsEnabled: false,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Uint8List _opaquePng(Color color) {
+  final image = img.Image(width: 16, height: 16, numChannels: 4);
+  img.fill(image, color: _imageColor(color));
+  return Uint8List.fromList(img.encodePng(image));
+}
+
+Uint8List _halfTransparentPng(Color color) {
+  final image = img.Image(width: 16, height: 16, numChannels: 4);
+  img.fill(image, color: img.ColorRgba8(0, 0, 0, 0));
+  img.fillRect(image, x1: 0, y1: 0, x2: 7, y2: 15, color: _imageColor(color));
+  return Uint8List.fromList(img.encodePng(image));
+}
+
+img.ColorRgba8 _imageColor(Color color) {
+  return img.ColorRgba8(
+    (color.r * 255).round(),
+    (color.g * 255).round(),
+    (color.b * 255).round(),
+    (color.a * 255).round(),
+  );
+}
+
+Future<_CapturedPixels> _captureCard(GlobalKey boundaryKey) async {
+  final boundary =
+      boundaryKey.currentContext!.findRenderObject()! as RenderRepaintBoundary;
+  final image = await boundary.toImage(pixelRatio: 1);
+  try {
+    final byteData = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+    return _CapturedPixels(
+      byteData!.buffer.asUint8List(),
+      image.width,
+      image.height,
+    );
+  } finally {
+    image.dispose();
+  }
+}
+
+bool _isCloseTo(Color actual, Color expected) {
+  return (actual.r - expected.r).abs() <= 0.04 &&
+      (actual.g - expected.g).abs() <= 0.04 &&
+      (actual.b - expected.b).abs() <= 0.04 &&
+      (actual.a - expected.a).abs() <= 0.04;
+}
+
+class _CapturedPixels {
+  const _CapturedPixels(this.bytes, this.width, this.height);
+
+  final Uint8List bytes;
+  final int width;
+  final int height;
+
+  Color pixelAt(int x, int y) {
+    assert(x >= 0 && x < width && y >= 0 && y < height);
+    final offset = (y * width + x) * 4;
+    return Color.fromARGB(
+      bytes[offset + 3],
+      bytes[offset],
+      bytes[offset + 1],
+      bytes[offset + 2],
+    );
+  }
+}


### PR DESCRIPTION
## 变更
- 将完成图与流式预览从双层叠加改为单渲染层原子切换
- 修复透明像素透出上一张生成结果的问题
- 补齐批量槽位映射、取消隔离、异步 epoch 防护与结果身份校验

## 验证
- affected tests：68 项通过
- scoped flutter analyze：通过
- PNG / WebP 像素级透明回归通过
- 批量生成、取消重生成、历史与缩略图回归通过