### PR TITLE
feat(gallery): 统一本地与云端收藏视图

### DIFF
--- a/lib/data/models/online_gallery/chunked_gallery_items.dart
+++ b/lib/data/models/online_gallery/chunked_gallery_items.dart
@@ -36,6 +36,10 @@ class ChunkedGalleryItems extends ListBase<GalleryItem> {
       throw UnsupportedError('ChunkedGalleryItems is read-only');
 
   @override
+  Iterator<GalleryItem> get iterator =>
+      _chunks.expand((chunk) => chunk).iterator;
+
+  @override
   GalleryItem operator [](int index) {
     RangeError.checkValidIndex(index, this, 'index', length);
     var low = 0;
@@ -57,19 +61,101 @@ class ChunkedGalleryItems extends ListBase<GalleryItem> {
       throw UnsupportedError('ChunkedGalleryItems is read-only');
 
   ChunkedGalleryItems appendPage(Iterable<GalleryItem> page) {
-    final indices = Map<String, int>.of(_indicesByStableKey);
-    final unique = <GalleryItem>[];
-    for (final item in page) {
-      if (indices.containsKey(item.stableKey)) continue;
-      indices[item.stableKey] = length + unique.length;
-      unique.add(item);
-    }
-    if (unique.isEmpty) return this;
+    return mergePage(page);
+  }
 
-    final immutablePage = List<GalleryItem>.unmodifiable(unique);
+  /// Appends unseen rows and combines duplicate rows when requested.
+  ///
+  /// Existing chunks are shared unless they contain a replaced row, so a
+  /// local favorite snapshot can enrich a remote list row without rebuilding
+  /// the complete collection.
+  ChunkedGalleryItems mergePage(
+    Iterable<GalleryItem> page, {
+    GalleryItem Function(GalleryItem current, GalleryItem incoming)?
+    mergeDuplicate,
+  }) {
+    final indices = Map<String, int>.of(_indicesByStableKey);
+    final appended = <GalleryItem>[];
+    final replacements = <int, GalleryItem>{};
+    for (final item in page) {
+      final existingIndex = indices[item.stableKey];
+      if (existingIndex == null) {
+        indices[item.stableKey] = length + appended.length;
+        appended.add(item);
+        continue;
+      }
+      if (existingIndex >= length) {
+        final appendedIndex = existingIndex - length;
+        final current = appended[appendedIndex];
+        appended[appendedIndex] =
+            mergeDuplicate?.call(current, item) ?? current;
+        continue;
+      }
+      final current = replacements[existingIndex] ?? this[existingIndex];
+      final merged = mergeDuplicate?.call(current, item) ?? current;
+      if (!identical(merged, current)) replacements[existingIndex] = merged;
+    }
+    if (appended.isEmpty && replacements.isEmpty) return this;
+
+    final chunks = List<List<GalleryItem>>.of(_chunks);
+    if (replacements.isNotEmpty) {
+      var chunkStart = 0;
+      for (var chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+        final chunkEnd = _endOffsets[chunkIndex];
+        final affected = replacements.entries.where(
+          (entry) => entry.key >= chunkStart && entry.key < chunkEnd,
+        );
+        if (affected.isNotEmpty) {
+          final mutable = List<GalleryItem>.of(chunks[chunkIndex]);
+          for (final entry in affected) {
+            mutable[entry.key - chunkStart] = entry.value;
+          }
+          chunks[chunkIndex] = List<GalleryItem>.unmodifiable(mutable);
+        }
+        chunkStart = chunkEnd;
+      }
+    }
+    final endOffsets = List<int>.of(_endOffsets);
+    if (appended.isNotEmpty) {
+      final immutablePage = List<GalleryItem>.unmodifiable(appended);
+      chunks.add(immutablePage);
+      endOffsets.add(length + immutablePage.length);
+    }
     return ChunkedGalleryItems._(
-      chunks: <List<GalleryItem>>[..._chunks, immutablePage],
-      endOffsets: <int>[..._endOffsets, length + immutablePage.length],
+      chunks: chunks,
+      endOffsets: endOffsets,
+      indicesByStableKey: indices,
+    );
+  }
+
+  /// Removes rows without copying chunks that contain no matching keys.
+  ChunkedGalleryItems removeStableKeys(Set<String> stableKeys) {
+    if (stableKeys.isEmpty ||
+        !stableKeys.any(_indicesByStableKey.containsKey)) {
+      return this;
+    }
+
+    final chunks = <List<GalleryItem>>[];
+    final endOffsets = <int>[];
+    final indices = <String, int>{};
+    var length = 0;
+    for (final chunk in _chunks) {
+      final affected = chunk.any((item) => stableKeys.contains(item.stableKey));
+      final retained = affected
+          ? List<GalleryItem>.unmodifiable(
+              chunk.where((item) => !stableKeys.contains(item.stableKey)),
+            )
+          : chunk;
+      if (retained.isEmpty) continue;
+      for (final item in retained) {
+        indices[item.stableKey] = length++;
+      }
+      chunks.add(retained);
+      endOffsets.add(length);
+    }
+    return ChunkedGalleryItems._(
+      chunks: chunks,
+      endOffsets: endOffsets,
       indicesByStableKey: indices,
     );
   }

--- a/lib/data/repositories/online_gallery_local_favorites_repository.dart
+++ b/lib/data/repositories/online_gallery_local_favorites_repository.dart
@@ -156,52 +156,74 @@ class OnlineGalleryLocalFavoritesRepository {
     final candidateKeys = query.sourceId == null
         ? _sortedKeys
         : (_sortedKeysBySource[query.sourceId!] ?? const <String>[]);
-    final matches = candidateKeys
-        .map((key) => _records[key]!)
-        .where((record) {
-          if (query.sourceId != null && record.sourceId != query.sourceId) {
+    final restrictsRatings =
+        ratings.isNotEmpty && !ratings.containsAll(const {'g', 's', 'q', 'e'});
+    final hasFilters =
+        restrictsRatings ||
+        blacklist.isNotEmpty ||
+        terms.isNotEmpty ||
+        (query.codexId != null && query.codexId != 'all') ||
+        query.categoryPath.isNotEmpty ||
+        query.mediaFilter != 'all';
+    if (!hasFilters) {
+      final start = query.offset.clamp(0, candidateKeys.length);
+      final end = (start + query.limit).clamp(start, candidateKeys.length);
+      return OnlineGalleryFavoritePage(
+        records: List.unmodifiable(
+          candidateKeys.sublist(start, end).map((key) => _records[key]!),
+        ),
+        total: candidateKeys.length,
+        offset: query.offset,
+        limit: query.limit,
+      );
+    }
+    final matches = candidateKeys.map((key) => _records[key]!).where((record) {
+      if (query.sourceId != null && record.sourceId != query.sourceId) {
+        return false;
+      }
+      if (query.codexId != null &&
+          query.codexId != 'all' &&
+          record.detail.rawSourceMetadata['codexId'] != query.codexId) {
+        return false;
+      }
+      if (query.categoryPath.isNotEmpty) {
+        final recordPath = record.detail.categoryPath;
+        if (recordPath.length < query.categoryPath.length) return false;
+        for (var index = 0; index < query.categoryPath.length; index++) {
+          if (recordPath[index] != query.categoryPath[index]) {
             return false;
           }
-          if (query.codexId != null &&
-              query.codexId != 'all' &&
-              record.detail.rawSourceMetadata['codexId'] != query.codexId) {
-            return false;
-          }
-          if (query.categoryPath.isNotEmpty) {
-            final recordPath = record.detail.categoryPath;
-            if (recordPath.length < query.categoryPath.length) return false;
-            for (var index = 0; index < query.categoryPath.length; index++) {
-              if (recordPath[index] != query.categoryPath[index]) {
-                return false;
-              }
-            }
-          }
-          final hasMedia = record.detail.media.any(
-            (media) =>
-                media.previewUrl.isNotEmpty || media.displayUrl.isNotEmpty,
-          );
-          if (query.mediaFilter == 'withImages' && !hasMedia) return false;
-          if (query.mediaFilter == 'withoutImages' && hasMedia) {
-            return false;
-          }
-          final rating = record.item.rating?.toLowerCase() ?? '';
-          if (ratings.isNotEmpty && !ratings.contains(rating)) return false;
-          if (blacklist.isNotEmpty &&
-              _recordTags(record).any(blacklist.contains)) {
-            return false;
-          }
-          if (terms.isNotEmpty) {
-            final haystack = _searchHaystack(record);
-            if (!terms.every(haystack.contains)) return false;
-          }
-          return true;
-        })
-        .toList(growable: false);
-    final start = query.offset.clamp(0, matches.length);
-    final end = (start + query.limit).clamp(start, matches.length);
+        }
+      }
+      final hasMedia = record.detail.media.any(
+        (media) => media.previewUrl.isNotEmpty || media.displayUrl.isNotEmpty,
+      );
+      if (query.mediaFilter == 'withImages' && !hasMedia) return false;
+      if (query.mediaFilter == 'withoutImages' && hasMedia) {
+        return false;
+      }
+      final rating = record.item.rating?.toLowerCase() ?? '';
+      if (restrictsRatings && !ratings.contains(rating)) return false;
+      if (blacklist.isNotEmpty && _recordTags(record).any(blacklist.contains)) {
+        return false;
+      }
+      if (terms.isNotEmpty) {
+        final haystack = _searchHaystack(record);
+        if (!terms.every(haystack.contains)) return false;
+      }
+      return true;
+    });
+    var total = 0;
+    final pageRecords = <OnlineGalleryFavoriteRecord>[];
+    for (final record in matches) {
+      if (total >= query.offset && pageRecords.length < query.limit) {
+        pageRecords.add(record);
+      }
+      total++;
+    }
     return OnlineGalleryFavoritePage(
-      records: List.unmodifiable(matches.sublist(start, end)),
-      total: matches.length,
+      records: List.unmodifiable(pageRecords),
+      total: total,
       offset: query.offset,
       limit: query.limit,
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1130,12 +1130,12 @@
   "onlineGallery_sourceDoesNotSupportPopular": "The current source does not provide popular rankings",
   "onlineGallery_favorites": "Favorites",
   "onlineGallery_searchFavorites": "Search favorites by title, author, or tag…",
-  "onlineGallery_localFavorites": "Local favorites",
-  "onlineGallery_localFavoritesDescription": "Saved on this device and available for every source",
-  "onlineGallery_cloudFavorites": "Cloud favorites",
-  "onlineGallery_loginForCloudFavorites": "Sign in to view cloud favorites",
+  "onlineGallery_savedLocally": "Saved locally",
+  "onlineGallery_savedInCloud": "Saved in cloud",
   "onlineGallery_saveVisibleLocally": "Save page locally",
   "onlineGallery_visibleFavoritesAlreadySaved": "Everything on this page is already saved locally",
+  "onlineGallery_localFavoritesPartialFailure": "Local favorites failed to load; cloud results are still available",
+  "onlineGallery_cloudFavoritesPartialFailure": "Cloud favorites failed to load; local results are still available",
   "onlineGallery_visibleFavoritesSaved": "Saved {count} items to local favorites",
   "@onlineGallery_visibleFavoritesSaved": {
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1118,12 +1118,12 @@
   "onlineGallery_sourceDoesNotSupportPopular": "現在のサイトは人気ランキングに対応していません",
   "onlineGallery_favorites": "お気に入り",
   "onlineGallery_searchFavorites": "お気に入りのタイトル・作者・タグを検索…",
-  "onlineGallery_localFavorites": "ローカルお気に入り",
-  "onlineGallery_localFavoritesDescription": "このデバイスに保存され、すべてのサイトで利用できます",
-  "onlineGallery_cloudFavorites": "クラウドお気に入り",
-  "onlineGallery_loginForCloudFavorites": "ログインするとクラウドお気に入りを表示できます",
+  "onlineGallery_savedLocally": "ローカルに保存済み",
+  "onlineGallery_savedInCloud": "クラウドに保存済み",
   "onlineGallery_saveVisibleLocally": "このページをローカル保存",
   "onlineGallery_visibleFavoritesAlreadySaved": "このページはすべてローカル保存済みです",
+  "onlineGallery_localFavoritesPartialFailure": "ローカルお気に入りの読み込みに失敗しました。クラウドの結果は保持されています",
+  "onlineGallery_cloudFavoritesPartialFailure": "クラウドお気に入りの読み込みに失敗しました。ローカルの結果は保持されています",
   "onlineGallery_visibleFavoritesSaved": "{count} 件をローカルお気に入りに保存しました",
   "@onlineGallery_visibleFavoritesSaved": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4485,29 +4485,17 @@ abstract class AppLocalizations {
   /// **'Search favorites by title, author, or tag…'**
   String get onlineGallery_searchFavorites;
 
-  /// No description provided for @onlineGallery_localFavorites.
+  /// No description provided for @onlineGallery_savedLocally.
   ///
   /// In en, this message translates to:
-  /// **'Local favorites'**
-  String get onlineGallery_localFavorites;
+  /// **'Saved locally'**
+  String get onlineGallery_savedLocally;
 
-  /// No description provided for @onlineGallery_localFavoritesDescription.
+  /// No description provided for @onlineGallery_savedInCloud.
   ///
   /// In en, this message translates to:
-  /// **'Saved on this device and available for every source'**
-  String get onlineGallery_localFavoritesDescription;
-
-  /// No description provided for @onlineGallery_cloudFavorites.
-  ///
-  /// In en, this message translates to:
-  /// **'Cloud favorites'**
-  String get onlineGallery_cloudFavorites;
-
-  /// No description provided for @onlineGallery_loginForCloudFavorites.
-  ///
-  /// In en, this message translates to:
-  /// **'Sign in to view cloud favorites'**
-  String get onlineGallery_loginForCloudFavorites;
+  /// **'Saved in cloud'**
+  String get onlineGallery_savedInCloud;
 
   /// No description provided for @onlineGallery_saveVisibleLocally.
   ///
@@ -4520,6 +4508,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Everything on this page is already saved locally'**
   String get onlineGallery_visibleFavoritesAlreadySaved;
+
+  /// No description provided for @onlineGallery_localFavoritesPartialFailure.
+  ///
+  /// In en, this message translates to:
+  /// **'Local favorites failed to load; cloud results are still available'**
+  String get onlineGallery_localFavoritesPartialFailure;
+
+  /// No description provided for @onlineGallery_cloudFavoritesPartialFailure.
+  ///
+  /// In en, this message translates to:
+  /// **'Cloud favorites failed to load; local results are still available'**
+  String get onlineGallery_cloudFavoritesPartialFailure;
 
   /// No description provided for @onlineGallery_visibleFavoritesSaved.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2472,18 +2472,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Search favorites by title, author, or tag…';
 
   @override
-  String get onlineGallery_localFavorites => 'Local favorites';
+  String get onlineGallery_savedLocally => 'Saved locally';
 
   @override
-  String get onlineGallery_localFavoritesDescription =>
-      'Saved on this device and available for every source';
-
-  @override
-  String get onlineGallery_cloudFavorites => 'Cloud favorites';
-
-  @override
-  String get onlineGallery_loginForCloudFavorites =>
-      'Sign in to view cloud favorites';
+  String get onlineGallery_savedInCloud => 'Saved in cloud';
 
   @override
   String get onlineGallery_saveVisibleLocally => 'Save page locally';
@@ -2491,6 +2483,14 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get onlineGallery_visibleFavoritesAlreadySaved =>
       'Everything on this page is already saved locally';
+
+  @override
+  String get onlineGallery_localFavoritesPartialFailure =>
+      'Local favorites failed to load; cloud results are still available';
+
+  @override
+  String get onlineGallery_cloudFavoritesPartialFailure =>
+      'Cloud favorites failed to load; local results are still available';
 
   @override
   String onlineGallery_visibleFavoritesSaved(int count) {

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2419,17 +2419,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get onlineGallery_searchFavorites => 'お気に入りのタイトル・作者・タグを検索…';
 
   @override
-  String get onlineGallery_localFavorites => 'ローカルお気に入り';
+  String get onlineGallery_savedLocally => 'ローカルに保存済み';
 
   @override
-  String get onlineGallery_localFavoritesDescription =>
-      'このデバイスに保存され、すべてのサイトで利用できます';
-
-  @override
-  String get onlineGallery_cloudFavorites => 'クラウドお気に入り';
-
-  @override
-  String get onlineGallery_loginForCloudFavorites => 'ログインするとクラウドお気に入りを表示できます';
+  String get onlineGallery_savedInCloud => 'クラウドに保存済み';
 
   @override
   String get onlineGallery_saveVisibleLocally => 'このページをローカル保存';
@@ -2437,6 +2430,14 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get onlineGallery_visibleFavoritesAlreadySaved =>
       'このページはすべてローカル保存済みです';
+
+  @override
+  String get onlineGallery_localFavoritesPartialFailure =>
+      'ローカルお気に入りの読み込みに失敗しました。クラウドの結果は保持されています';
+
+  @override
+  String get onlineGallery_cloudFavoritesPartialFailure =>
+      'クラウドお気に入りの読み込みに失敗しました。ローカルの結果は保持されています';
 
   @override
   String onlineGallery_visibleFavoritesSaved(int count) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2384,22 +2384,22 @@ class AppLocalizationsZh extends AppLocalizations {
   String get onlineGallery_searchFavorites => '搜索收藏的标题、作者或标签…';
 
   @override
-  String get onlineGallery_localFavorites => '本地收藏';
+  String get onlineGallery_savedLocally => '已保存在本地';
 
   @override
-  String get onlineGallery_localFavoritesDescription => '保存在此设备，所有站点均可使用';
-
-  @override
-  String get onlineGallery_cloudFavorites => '云端收藏';
-
-  @override
-  String get onlineGallery_loginForCloudFavorites => '登录后可查看云端收藏';
+  String get onlineGallery_savedInCloud => '已保存在云端';
 
   @override
   String get onlineGallery_saveVisibleLocally => '保存本页到本地';
 
   @override
   String get onlineGallery_visibleFavoritesAlreadySaved => '本页内容已全部保存到本地收藏';
+
+  @override
+  String get onlineGallery_localFavoritesPartialFailure => '本地收藏加载失败，已保留云端结果';
+
+  @override
+  String get onlineGallery_cloudFavoritesPartialFailure => '云端收藏加载失败，已保留本地结果';
 
   @override
   String onlineGallery_visibleFavoritesSaved(int count) {
@@ -14464,22 +14464,22 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get onlineGallery_searchFavorites => '搜尋收藏的標題、作者或標籤…';
 
   @override
-  String get onlineGallery_localFavorites => '本機收藏';
+  String get onlineGallery_savedLocally => '已儲存在本機';
 
   @override
-  String get onlineGallery_localFavoritesDescription => '儲存在此裝置，所有來源均可使用';
-
-  @override
-  String get onlineGallery_cloudFavorites => '雲端收藏';
-
-  @override
-  String get onlineGallery_loginForCloudFavorites => '登入後可檢視雲端收藏';
+  String get onlineGallery_savedInCloud => '已儲存在雲端';
 
   @override
   String get onlineGallery_saveVisibleLocally => '將本頁儲存至本機';
 
   @override
   String get onlineGallery_visibleFavoritesAlreadySaved => '本頁內容已全部儲存至本機收藏';
+
+  @override
+  String get onlineGallery_localFavoritesPartialFailure => '本機收藏載入失敗，已保留雲端結果';
+
+  @override
+  String get onlineGallery_cloudFavoritesPartialFailure => '雲端收藏載入失敗，已保留本機結果';
 
   @override
   String onlineGallery_visibleFavoritesSaved(int count) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1037,12 +1037,12 @@
   "onlineGallery_sourceDoesNotSupportPopular": "当前站点不支持热门榜单",
   "onlineGallery_favorites": "收藏",
   "onlineGallery_searchFavorites": "搜索收藏的标题、作者或标签…",
-  "onlineGallery_localFavorites": "本地收藏",
-  "onlineGallery_localFavoritesDescription": "保存在此设备，所有站点均可使用",
-  "onlineGallery_cloudFavorites": "云端收藏",
-  "onlineGallery_loginForCloudFavorites": "登录后可查看云端收藏",
+  "onlineGallery_savedLocally": "已保存在本地",
+  "onlineGallery_savedInCloud": "已保存在云端",
   "onlineGallery_saveVisibleLocally": "保存本页到本地",
   "onlineGallery_visibleFavoritesAlreadySaved": "本页内容已全部保存到本地收藏",
+  "onlineGallery_localFavoritesPartialFailure": "本地收藏加载失败，已保留云端结果",
+  "onlineGallery_cloudFavoritesPartialFailure": "云端收藏加载失败，已保留本地结果",
   "onlineGallery_visibleFavoritesSaved": "已保存 {count} 项到本地收藏",
   "@onlineGallery_visibleFavoritesSaved": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1052,12 +1052,12 @@
   "onlineGallery_sourceDoesNotSupportPopular": "目前站點不支援熱門榜單",
   "onlineGallery_favorites": "收藏",
   "onlineGallery_searchFavorites": "搜尋收藏的標題、作者或標籤…",
-  "onlineGallery_localFavorites": "本機收藏",
-  "onlineGallery_localFavoritesDescription": "儲存在此裝置，所有來源均可使用",
-  "onlineGallery_cloudFavorites": "雲端收藏",
-  "onlineGallery_loginForCloudFavorites": "登入後可檢視雲端收藏",
+  "onlineGallery_savedLocally": "已儲存在本機",
+  "onlineGallery_savedInCloud": "已儲存在雲端",
   "onlineGallery_saveVisibleLocally": "將本頁儲存至本機",
   "onlineGallery_visibleFavoritesAlreadySaved": "本頁內容已全部儲存至本機收藏",
+  "onlineGallery_localFavoritesPartialFailure": "本機收藏載入失敗，已保留雲端結果",
+  "onlineGallery_cloudFavoritesPartialFailure": "雲端收藏載入失敗，已保留本機結果",
   "onlineGallery_visibleFavoritesSaved": "已將 {count} 個項目儲存至本機收藏",
   "@onlineGallery_visibleFavoritesSaved": {
     "placeholders": {

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -87,8 +87,6 @@ List<GalleryItem> parsePostsInIsolate(Map<String, dynamic> data) {
 
 enum GalleryViewMode { search, popular, favorites }
 
-enum GalleryFavoritesScope { local, remote }
-
 enum OnlineGalleryErrorCode {
   credentialsRequired,
   credentialsInvalid,
@@ -243,6 +241,14 @@ class ModeCache {
     this.anchorStableKey,
     this.anchorLocalOffset = 0,
     this.appendErrorCode,
+    this.localFavoritesOffset = 0,
+    this.remoteFavoritesPage = 1,
+    this.localFavoritesHasMore = true,
+    this.remoteFavoritesHasMore = true,
+    this.localFavoritesErrorCode,
+    this.remoteFavoritesErrorCode,
+    this.localFavoriteItemKeys = const {},
+    this.remoteFavoriteItemKeys = const {},
     this.endedByDuplicatePage = false,
     this.artistHuntCandidateCount = 0,
     this.artistHuntResolvedCount = 0,
@@ -258,7 +264,18 @@ class ModeCache {
   final String? anchorStableKey;
   final double anchorLocalOffset;
   final OnlineGalleryErrorCode? appendErrorCode;
+  final int localFavoritesOffset;
+  final int remoteFavoritesPage;
+  final bool localFavoritesHasMore;
+  final bool remoteFavoritesHasMore;
+  final OnlineGalleryErrorCode? localFavoritesErrorCode;
+  final OnlineGalleryErrorCode? remoteFavoritesErrorCode;
+  final Set<String> localFavoriteItemKeys;
+  final Set<String> remoteFavoriteItemKeys;
   final bool endedByDuplicatePage;
+
+  bool get hasFavoritesPartialFailure =>
+      localFavoritesErrorCode != null || remoteFavoritesErrorCode != null;
   final int artistHuntCandidateCount;
   final int artistHuntResolvedCount;
   final int artistHuntFailureCount;
@@ -274,6 +291,16 @@ class ModeCache {
     double? anchorLocalOffset,
     OnlineGalleryErrorCode? appendErrorCode,
     bool clearAppendError = false,
+    int? localFavoritesOffset,
+    int? remoteFavoritesPage,
+    bool? localFavoritesHasMore,
+    bool? remoteFavoritesHasMore,
+    OnlineGalleryErrorCode? localFavoritesErrorCode,
+    OnlineGalleryErrorCode? remoteFavoritesErrorCode,
+    bool clearLocalFavoritesError = false,
+    bool clearRemoteFavoritesError = false,
+    Set<String>? localFavoriteItemKeys,
+    Set<String>? remoteFavoriteItemKeys,
     bool? endedByDuplicatePage,
     int? artistHuntCandidateCount,
     int? artistHuntResolvedCount,
@@ -291,6 +318,24 @@ class ModeCache {
       appendErrorCode: clearAppendError
           ? null
           : (appendErrorCode ?? this.appendErrorCode),
+      localFavoritesOffset: localFavoritesOffset ?? this.localFavoritesOffset,
+      remoteFavoritesPage: remoteFavoritesPage ?? this.remoteFavoritesPage,
+      localFavoritesHasMore:
+          localFavoritesHasMore ?? this.localFavoritesHasMore,
+      remoteFavoritesHasMore:
+          remoteFavoritesHasMore ?? this.remoteFavoritesHasMore,
+      localFavoritesErrorCode: clearLocalFavoritesError
+          ? null
+          : (localFavoritesErrorCode ?? this.localFavoritesErrorCode),
+      remoteFavoritesErrorCode: clearRemoteFavoritesError
+          ? null
+          : (remoteFavoritesErrorCode ?? this.remoteFavoritesErrorCode),
+      localFavoriteItemKeys: Set.unmodifiable(
+        localFavoriteItemKeys ?? this.localFavoriteItemKeys,
+      ),
+      remoteFavoriteItemKeys: Set.unmodifiable(
+        remoteFavoriteItemKeys ?? this.remoteFavoriteItemKeys,
+      ),
       endedByDuplicatePage: endedByDuplicatePage ?? this.endedByDuplicatePage,
       artistHuntCandidateCount:
           artistHuntCandidateCount ?? this.artistHuntCandidateCount,
@@ -349,14 +394,11 @@ class OnlineGalleryState {
     this.sourceId = GallerySourceId.danbooru,
     this.popularSourceId = GallerySourceId.danbooru,
     this.favoritesSourceId = GallerySourceId.danbooru,
-    this.favoritesScope = GalleryFavoritesScope.remote,
     this.favoriteSearchQuery = '',
     this.selectedRatings = kAllRatings,
     this.viewMode = GalleryViewMode.search,
     this.searchCache = const ModeCache(),
     this.popularCache = const ModeCache(),
-    this.danbooruFavoritesCache = const ModeCache(),
-    this.gelbooruFavoritesCache = const ModeCache(),
     this.caches = const {},
     this.popularScale = PopularScale.day,
     this.popularDate,
@@ -365,6 +407,8 @@ class OnlineGalleryState {
     this.quickTagCloudFilterKey = QuickTagCloudGalleryQuery.defaultStableKey,
     this.aiTagConfig,
     this.favoritedPostKeys = const {},
+    this.localFavoritedPostKeys = const {},
+    this.remoteFavoritedPostKeys = const {},
     this.favoriteLoadingPostKeys = const {},
     this.dateRangeStart,
     this.dateRangeEnd,
@@ -387,14 +431,11 @@ class OnlineGalleryState {
   final GallerySourceId sourceId;
   final GallerySourceId popularSourceId;
   final GallerySourceId favoritesSourceId;
-  final GalleryFavoritesScope favoritesScope;
   final String favoriteSearchQuery;
   final Set<String> selectedRatings;
   final GalleryViewMode viewMode;
   final ModeCache searchCache;
   final ModeCache popularCache;
-  final ModeCache danbooruFavoritesCache;
-  final ModeCache gelbooruFavoritesCache;
   final Map<String, ModeCache> caches;
   final PopularScale popularScale;
   final DateTime? popularDate;
@@ -403,6 +444,8 @@ class OnlineGalleryState {
   final String quickTagCloudFilterKey;
   final AiTagSourceConfig? aiTagConfig;
   final Set<String> favoritedPostKeys;
+  final Set<String> localFavoritedPostKeys;
+  final Set<String> remoteFavoritedPostKeys;
   final Set<String> favoriteLoadingPostKeys;
   final DateTime? dateRangeStart;
   final DateTime? dateRangeEnd;
@@ -441,7 +484,7 @@ class OnlineGalleryState {
       case GalleryViewMode.popular:
         return 'popular:${popularSourceId.key}:${popularScale.name}|${popularDate?.toIso8601String() ?? ''}|$aiTagPopularPeriod|${popularQuery.trim()}|${popularPromptQuery.trim()}|${_ratingsKey(selectedRatings)}|artistHunt:${popularSourceId == GallerySourceId.aiTag && artistHuntEnabled}|blacklist:$blacklistRevision';
       case GalleryViewMode.favorites:
-        return 'favorites:${favoritesSourceId.key}:${favoritesScope.name}|${favoriteSearchQuery.trim()}|${_ratingsKey(selectedRatings)}|codex:${favoritesSourceId == GallerySourceId.quickTagCloud ? quickTagCloudFilterKey : ''}|blacklist:$blacklistRevision';
+        return 'favorites:${favoritesSourceId.key}|${favoriteSearchQuery.trim()}|${_ratingsKey(selectedRatings)}|codex:${favoritesSourceId == GallerySourceId.quickTagCloud ? quickTagCloudFilterKey : ''}|blacklist:$blacklistRevision';
     }
   }
 
@@ -466,11 +509,8 @@ class OnlineGalleryState {
 
   ModeCache favoritesCacheFor(GallerySourceId sourceId) {
     final key =
-        'favorites:${sourceId.key}:${favoritesScope.name}|${favoriteSearchQuery.trim()}|${_ratingsKey(selectedRatings)}|codex:${sourceId == GallerySourceId.quickTagCloud ? quickTagCloudFilterKey : ''}|blacklist:$blacklistRevision';
-    return caches[key] ??
-        (sourceId == GallerySourceId.gelbooru
-            ? gelbooruFavoritesCache
-            : danbooruFavoritesCache);
+        'favorites:${sourceId.key}|${favoriteSearchQuery.trim()}|${_ratingsKey(selectedRatings)}|codex:${sourceId == GallerySourceId.quickTagCloud ? quickTagCloudFilterKey : ''}|blacklist:$blacklistRevision';
+    return caches[key] ?? const ModeCache();
   }
 
   bool get hasError => error != null || errorCode != null;
@@ -497,14 +537,11 @@ class OnlineGalleryState {
     GallerySourceId? sourceId,
     GallerySourceId? popularSourceId,
     GallerySourceId? favoritesSourceId,
-    GalleryFavoritesScope? favoritesScope,
     String? favoriteSearchQuery,
     Set<String>? selectedRatings,
     GalleryViewMode? viewMode,
     ModeCache? searchCache,
     ModeCache? popularCache,
-    ModeCache? danbooruFavoritesCache,
-    ModeCache? gelbooruFavoritesCache,
     Map<String, ModeCache>? caches,
     PopularScale? popularScale,
     DateTime? popularDate,
@@ -513,6 +550,8 @@ class OnlineGalleryState {
     String? quickTagCloudFilterKey,
     AiTagSourceConfig? aiTagConfig,
     Set<String>? favoritedPostKeys,
+    Set<String>? localFavoritedPostKeys,
+    Set<String>? remoteFavoritedPostKeys,
     Set<String>? favoriteLoadingPostKeys,
     DateTime? dateRangeStart,
     DateTime? dateRangeEnd,
@@ -539,7 +578,6 @@ class OnlineGalleryState {
       sourceId: sourceId ?? this.sourceId,
       popularSourceId: popularSourceId ?? this.popularSourceId,
       favoritesSourceId: favoritesSourceId ?? this.favoritesSourceId,
-      favoritesScope: favoritesScope ?? this.favoritesScope,
       favoriteSearchQuery: favoriteSearchQuery ?? this.favoriteSearchQuery,
       selectedRatings: Set.unmodifiable(
         selectedRatings ?? this.selectedRatings,
@@ -547,10 +585,6 @@ class OnlineGalleryState {
       viewMode: viewMode ?? this.viewMode,
       searchCache: searchCache ?? this.searchCache,
       popularCache: popularCache ?? this.popularCache,
-      danbooruFavoritesCache:
-          danbooruFavoritesCache ?? this.danbooruFavoritesCache,
-      gelbooruFavoritesCache:
-          gelbooruFavoritesCache ?? this.gelbooruFavoritesCache,
       caches: Map.unmodifiable(caches ?? this.caches),
       popularScale: popularScale ?? this.popularScale,
       popularDate: clearPopularDate ? null : (popularDate ?? this.popularDate),
@@ -561,6 +595,12 @@ class OnlineGalleryState {
       aiTagConfig: aiTagConfig ?? this.aiTagConfig,
       favoritedPostKeys: Set.unmodifiable(
         favoritedPostKeys ?? this.favoritedPostKeys,
+      ),
+      localFavoritedPostKeys: Set.unmodifiable(
+        localFavoritedPostKeys ?? this.localFavoritedPostKeys,
+      ),
+      remoteFavoritedPostKeys: Set.unmodifiable(
+        remoteFavoritedPostKeys ?? this.remoteFavoritedPostKeys,
       ),
       favoriteLoadingPostKeys: Set.unmodifiable(
         favoriteLoadingPostKeys ?? this.favoriteLoadingPostKeys,
@@ -587,9 +627,7 @@ class OnlineGalleryState {
       case GalleryViewMode.popular:
         return copyWith(caches: updated, popularCache: cache);
       case GalleryViewMode.favorites:
-        return favoritesSourceId == GallerySourceId.gelbooru
-            ? copyWith(caches: updated, gelbooruFavoritesCache: cache)
-            : copyWith(caches: updated, danbooruFavoritesCache: cache);
+        return copyWith(caches: updated);
     }
   }
 
@@ -598,14 +636,12 @@ class OnlineGalleryState {
     ModeCache cache,
   ) {
     final key =
-        'favorites:${sourceId.key}:${favoritesScope.name}|${favoriteSearchQuery.trim()}|${_ratingsKey(selectedRatings)}|codex:${sourceId == GallerySourceId.quickTagCloud ? quickTagCloudFilterKey : ''}|blacklist:$blacklistRevision';
+        'favorites:${sourceId.key}|${favoriteSearchQuery.trim()}|${_ratingsKey(selectedRatings)}|codex:${sourceId == GallerySourceId.quickTagCloud ? quickTagCloudFilterKey : ''}|blacklist:$blacklistRevision';
     final updated = LinkedHashMap<String, ModeCache>.of(caches)
       ..remove(key)
       ..[key] = cache;
     _trimCaches(updated, currentCacheKey);
-    return sourceId == GallerySourceId.gelbooru
-        ? copyWith(caches: updated, gelbooruFavoritesCache: cache)
-        : copyWith(caches: updated, danbooruFavoritesCache: cache);
+    return copyWith(caches: updated);
   }
 
   static void _trimCaches(
@@ -644,12 +680,11 @@ String encodeOnlineGalleryBrowsingSession(OnlineGalleryState state) {
   }
 
   return jsonEncode({
-    'version': 1,
+    'version': 2,
     'viewMode': state.viewMode.name,
     'sourceId': state.sourceId.key,
     'popularSourceId': state.popularSourceId.key,
     'favoritesSourceId': state.favoritesSourceId.key,
-    'favoritesScope': state.favoritesScope.name,
     'favoriteSearchQuery': state.favoriteSearchQuery,
     'searchQuery': state.searchQuery,
     'promptQuery': state.promptQuery,
@@ -677,7 +712,8 @@ OnlineGalleryState decodeOnlineGalleryBrowsingSession(String? encoded) {
   }
   try {
     final decoded = jsonDecode(encoded);
-    if (decoded is! Map || decoded['version'] != 1) {
+    if (decoded is! Map ||
+        (decoded['version'] != 1 && decoded['version'] != 2)) {
       return const OnlineGalleryState();
     }
     final json = Map<String, dynamic>.from(decoded);
@@ -688,21 +724,7 @@ OnlineGalleryState decodeOnlineGalleryBrowsingSession(String? encoded) {
     final popularSourceId = popularSourceCandidate.capabilities.supportsRanking
         ? popularSourceCandidate
         : GallerySourceId.danbooru;
-    final favoritesSourceCandidate = _decodeGallerySource(
-      json['favoritesSourceId'],
-    );
-    final favoritesSourceId = favoritesSourceCandidate;
-    final requestedFavoritesScope = _decodeEnumByName(
-      GalleryFavoritesScope.values,
-      json['favoritesScope'],
-      GalleryFavoritesScope.remote,
-    );
-    final favoritesScope =
-        requestedFavoritesScope == GalleryFavoritesScope.remote &&
-            favoritesSourceId.capabilities.remoteFavorites !=
-                GalleryRemoteFavoritesCapability.none
-        ? GalleryFavoritesScope.remote
-        : GalleryFavoritesScope.local;
+    final favoritesSourceId = _decodeGallerySource(json['favoritesSourceId']);
     final viewMode = _decodeEnumByName(
       GalleryViewMode.values,
       json['viewMode'],
@@ -723,7 +745,6 @@ OnlineGalleryState decodeOnlineGalleryBrowsingSession(String? encoded) {
       sourceId: sourceId,
       popularSourceId: popularSourceId,
       favoritesSourceId: favoritesSourceId,
-      favoritesScope: favoritesScope,
       favoriteSearchQuery: _decodeBoundedString(
         json['favoriteSearchQuery'],
         maxLength: 500,
@@ -755,13 +776,28 @@ OnlineGalleryState decodeOnlineGalleryBrowsingSession(String? encoded) {
     );
 
     final caches = <String, ModeCache>{};
+    final cachePriorities = <String, int>{};
+    final legacyFavoritesScope = json['favoritesScope'];
     final rawPositions = json['positions'];
     if (rawPositions is Map) {
       for (final entry in rawPositions.entries.take(12)) {
-        final key = entry.key;
-        if (key is! String || key.isEmpty || key.length > 4096) continue;
+        final rawKey = entry.key;
+        if (rawKey is! String || rawKey.isEmpty || rawKey.length > 4096) {
+          continue;
+        }
+        final key = _migrateFavoritesCacheKey(rawKey);
         final position = _decodeGalleryPosition(entry.value);
-        if (position != null) caches[key] = position;
+        if (position == null) continue;
+        final legacyMatch = _legacyFavoritesCacheKeyPattern.firstMatch(rawKey);
+        final priority = legacyMatch == null
+            ? 3
+            : legacyMatch.group(2) == legacyFavoritesScope
+            ? 2
+            : 1;
+        if (priority > (cachePriorities[key] ?? 0)) {
+          caches[key] = position;
+          cachePriorities[key] = priority;
+        }
       }
     }
     var restored = base.copyWith(caches: caches);
@@ -794,7 +830,7 @@ Map<String, dynamic> _encodeGalleryPosition(ModeCache cache) => {
 ModeCache? _decodeGalleryPosition(Object? raw) {
   if (raw is! Map) return null;
   final pageValue = raw['page'];
-  final offsetValue = raw['scrollOffset'];
+  final offsetValue = raw['scrollOffset'] ?? raw['offset'];
   final localOffsetValue = raw['anchorLocalOffset'];
   final page = pageValue is num
       ? pageValue.toInt().clamp(1, 1000000).toInt()
@@ -813,6 +849,16 @@ ModeCache? _decodeGalleryPosition(Object? raw) {
     anchorStableKey: anchor is String && anchor.length <= 256 ? anchor : null,
     anchorLocalOffset: localOffset,
   );
+}
+
+final _legacyFavoritesCacheKeyPattern = RegExp(
+  r'^favorites:(danbooru|safebooru|gelbooru|ai_tag|quick_tag_cloud):(local|remote)\|',
+);
+
+String _migrateFavoritesCacheKey(String key) {
+  final match = _legacyFavoritesCacheKeyPattern.firstMatch(key);
+  if (match == null) return key;
+  return 'favorites:${match.group(1)}|${key.substring(match.end)}';
 }
 
 GallerySourceId _decodeGallerySource(Object? value) {
@@ -904,24 +950,26 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         await ref
             .read(onlineGalleryLocalFavoritesProvider.notifier)
             .initialize();
-        _handleLocalFavoritesChanged();
+        _handleLocalFavoritesChanged(reloadFavorites: false);
       });
       ref.listen<(bool, int)>(
         onlineGalleryLocalFavoritesProvider.select(
           (value) => (value.isInitialized, value.revision),
         ),
-        (_, _) => _handleLocalFavoritesChanged(),
+        (previous, next) => _handleLocalFavoritesChanged(
+          reloadFavorites: previous?.$2 != next.$2,
+        ),
       );
     }
     ref.listen<String?>(
       danbooruAuthProvider.select((value) => value.user?.name),
-      (_, _) => _handleRandomAccountIdentityChanged(GallerySourceId.danbooru),
+      (_, _) => _handleAccountIdentityChanged(GallerySourceId.danbooru),
     );
     ref.listen<String?>(
       gelbooruAuthProvider.select(
         (value) => value.credentials?.userId.toString(),
       ),
-      (_, _) => _handleRandomAccountIdentityChanged(GallerySourceId.gelbooru),
+      (_, _) => _handleAccountIdentityChanged(GallerySourceId.gelbooru),
     );
     ref.listen<String>(
       onlineGalleryBlacklistNotifierProvider.select((value) {
@@ -957,7 +1005,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     });
   }
 
-  void _handleLocalFavoritesChanged() {
+  void _handleLocalFavoritesChanged({bool reloadFavorites = true}) {
     final localState = ref.read(onlineGalleryLocalFavoritesProvider);
     if (!localState.isInitialized) return;
     final nextLocalKeys = ref
@@ -965,17 +1013,16 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         .stableKeys;
     final retainedCaches = <String, ModeCache>{
       for (final entry in state.caches.entries)
-        if (!(entry.key.startsWith('favorites:') &&
-            entry.key.contains(':local|')))
-          entry.key: entry.value,
+        if (!entry.key.startsWith('favorites:')) entry.key: entry.value,
     };
     _localFavoriteKeys = nextLocalKeys;
     state = state.copyWith(
       caches: retainedCaches,
       favoritedPostKeys: {..._localFavoriteKeys, ..._remoteFavoriteKeys},
+      localFavoritedPostKeys: _localFavoriteKeys,
+      remoteFavoritedPostKeys: _remoteFavoriteKeys,
     );
-    if (state.viewMode == GalleryViewMode.favorites &&
-        state.favoritesScope == GalleryFavoritesScope.local) {
+    if (reloadFavorites && state.viewMode == GalleryViewMode.favorites) {
       _cancelCurrentRequest();
       if (state.randomEnabled) {
         state = state.copyWith(randomSession: const RandomGallerySession());
@@ -1005,14 +1052,34 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     });
   }
 
-  void _handleRandomAccountIdentityChanged(GallerySourceId sourceId) {
-    if (!state.randomEnabled || state.activeSourceId != sourceId) return;
-    _cancelCurrentRequest();
-    state = state.copyWith(
-      randomSession: const RandomGallerySession(),
-      clearError: true,
+  void _handleAccountIdentityChanged(GallerySourceId sourceId) {
+    final retainedCaches = <String, ModeCache>{
+      for (final entry in state.caches.entries)
+        if (!entry.key.startsWith('favorites:${sourceId.key}'))
+          entry.key: entry.value,
+    };
+    _remoteFavoriteKeys.removeWhere(
+      (key) => key.startsWith('${sourceId.key}:'),
     );
-    unawaited(_loadRandom(replace: true, restart: true));
+    state = state.copyWith(
+      caches: retainedCaches,
+      favoritedPostKeys: {..._localFavoriteKeys, ..._remoteFavoriteKeys},
+      remoteFavoritedPostKeys: _remoteFavoriteKeys,
+    );
+    if (state.activeSourceId != sourceId ||
+        (!state.randomEnabled && state.viewMode != GalleryViewMode.favorites)) {
+      return;
+    }
+    _cancelCurrentRequest();
+    if (state.randomEnabled) {
+      state = state.copyWith(
+        randomSession: const RandomGallerySession(),
+        clearError: true,
+      );
+      unawaited(_loadRandom(replace: true, restart: true));
+    } else if (state.viewMode == GalleryViewMode.favorites) {
+      unawaited(loadPosts(refresh: true));
+    }
   }
 
   Map<GallerySourceId, GallerySourceAdapter> get _adapters =>
@@ -1105,25 +1172,9 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       await ref.read(gelbooruAuthProvider.notifier).ensureInitialized();
     }
     _cancelCurrentRequest();
-    final capabilities = sourceId.capabilities;
-    final remoteAvailable =
-        capabilities.remoteFavorites != GalleryRemoteFavoritesCapability.none;
-    final remoteAuthenticated = switch (sourceId) {
-      GallerySourceId.danbooru => _danbooruAuth.isLoggedIn,
-      GallerySourceId.gelbooru => _gelbooruAuth.isAuthenticated,
-      _ => false,
-    };
-    final localStoreReady = Hive.isBoxOpen(StorageKeys.localFavoritesBox);
-    final scope =
-        state.favoritesScope == GalleryFavoritesScope.remote &&
-            (!remoteAvailable || !remoteAuthenticated) &&
-            localStoreReady
-        ? GalleryFavoritesScope.local
-        : state.favoritesScope;
     state = state.copyWith(
       viewMode: GalleryViewMode.favorites,
       favoritesSourceId: sourceId,
-      favoritesScope: scope,
       clearError: true,
     );
     if (state.randomEnabled || state.currentCache.posts.isEmpty) {
@@ -1178,25 +1229,9 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     if (sourceId == null || !sourceId.capabilities.supportsLocalFavorites) {
       return;
     }
+    if (state.favoritesSourceId == sourceId) return;
     if (sourceId == GallerySourceId.gelbooru) {
       await ref.read(gelbooruAuthProvider.notifier).ensureInitialized();
-    }
-    final remoteAuthenticated = switch (sourceId) {
-      GallerySourceId.danbooru => _danbooruAuth.isLoggedIn,
-      GallerySourceId.gelbooru => _gelbooruAuth.isAuthenticated,
-      _ => false,
-    };
-    final useRemote =
-        (sourceId.capabilities.remoteFavorites !=
-                GalleryRemoteFavoritesCapability.none &&
-            remoteAuthenticated) ||
-        !Hive.isBoxOpen(StorageKeys.localFavoritesBox);
-    final defaultScope = useRemote
-        ? GalleryFavoritesScope.remote
-        : GalleryFavoritesScope.local;
-    if (state.favoritesSourceId == sourceId &&
-        state.favoritesScope == defaultScope) {
-      return;
     }
     _cancelCurrentRequest();
     state = state.copyWith(
@@ -1205,28 +1240,9 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
           ? sourceId
           : state.popularSourceId,
       favoritesSourceId: sourceId,
-      favoritesScope: defaultScope,
       quickTagCloudFilterKey: sourceId == GallerySourceId.quickTagCloud
           ? ref.read(quickTagCloudFilterProvider).stableKey
           : state.quickTagCloudFilterKey,
-      clearError: true,
-      clearNotice: true,
-    );
-    if (state.viewMode == GalleryViewMode.favorites) {
-      await loadPosts(refresh: true);
-    }
-  }
-
-  Future<void> setFavoritesScope(GalleryFavoritesScope scope) async {
-    if (state.favoritesScope == scope) return;
-    final capabilities = state.favoritesSourceId.capabilities;
-    if (scope == GalleryFavoritesScope.remote &&
-        capabilities.remoteFavorites == GalleryRemoteFavoritesCapability.none) {
-      return;
-    }
-    _cancelCurrentRequest();
-    state = state.copyWith(
-      favoritesScope: scope,
       clearError: true,
       clearNotice: true,
     );
@@ -1420,6 +1436,8 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         randomEnabled: false,
         randomSession: state.randomSession,
         favoritedPostKeys: state.favoritedPostKeys,
+        localFavoritedPostKeys: state.localFavoritedPostKeys,
+        remoteFavoritedPostKeys: state.remoteFavoritedPostKeys,
         favoriteLoadingPostKeys: state.favoriteLoadingPostKeys,
         aiTagConfig: state.aiTagConfig,
         artistHuntEnabled: state.artistHuntEnabled,
@@ -1483,7 +1501,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
           .read(onlineGalleryBlacklistNotifierProvider)
           .effectiveTags;
       if (state.viewMode == GalleryViewMode.favorites &&
-          state.favoritesScope == GalleryFavoritesScope.local) {
+          !_canLoadRemoteFavorites(state.favoritesSourceId)) {
         await _loadRandomLocalFavorites(
           generation: generation,
           cacheKey: cacheKey,
@@ -2126,197 +2144,479 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
 
   Future<void> _loadFavorites({required bool refresh, int? targetPage}) async {
     final sourceId = state.favoritesSourceId;
-    if (state.favoritesScope == GalleryFavoritesScope.local) {
-      await _loadLocalFavorites(refresh: refresh, targetPage: targetPage);
-      return;
-    }
-    final authMissing = sourceId == GallerySourceId.danbooru
-        ? !_danbooruAuth.isLoggedIn || _danbooruAuth.user == null
-        : false;
-    if (authMissing) {
-      state = state.copyWith(
-        isLoading: false,
-        errorCode: OnlineGalleryErrorCode.credentialsRequired,
-      );
-      return;
-    }
-    if (sourceId == GallerySourceId.gelbooru) {
+    if (sourceId == GallerySourceId.danbooru) {
+      await ref.read(danbooruAuthProvider.notifier).ensureInitialized();
+    } else if (sourceId == GallerySourceId.gelbooru) {
       await ref.read(gelbooruAuthProvider.notifier).ensureInitialized();
-      if (!_gelbooruAuth.isAuthenticated || _gelbooruAuth.credentials == null) {
-        state = state.copyWith(
-          isLoading: false,
-          errorCode: _gelbooruAuth.status == GelbooruAuthStatus.invalid
-              ? OnlineGalleryErrorCode.gelbooruCredentialsInvalid
-              : OnlineGalleryErrorCode.gelbooruCredentialsRequired,
-        );
-        return;
-      }
     }
-    final cache = state.currentCache;
-    final pageNumber = targetPage ?? (refresh ? 1 : cache.page + 1);
+    if (state.viewMode != GalleryViewMode.favorites ||
+        state.favoritesSourceId != sourceId) {
+      return;
+    }
+    final previousCache = state.currentCache;
+    final pageNumber = targetPage ?? (refresh ? 1 : previousCache.page + 1);
     final generation = _beginRequest();
     final cacheKey = state.currentCacheKey;
-    final isAppend = !refresh && cache.posts.isNotEmpty;
+    final resetBranches = refresh || targetPage != null;
+    final isAppend = !resetBranches && previousCache.posts.isNotEmpty;
+    var cache = resetBranches
+        ? ModeCache(
+            posts: previousCache.posts,
+            page: pageNumber,
+            localFavoritesOffset: (pageNumber - 1) * _pageSize,
+            remoteFavoritesPage: pageNumber,
+            localFavoriteItemKeys: previousCache.localFavoriteItemKeys,
+            remoteFavoriteItemKeys: previousCache.remoteFavoriteItemKeys,
+            scrollOffset: refresh ? 0 : previousCache.scrollOffset,
+          )
+        : previousCache;
+    var posts = cache.posts is ChunkedGalleryItems
+        ? cache.posts as ChunkedGalleryItems
+        : ChunkedGalleryItems.from(cache.posts);
     state = state.copyWith(
       isLoading: !isAppend,
       isLoadingMore: isAppend,
       clearError: true,
     );
+
+    Object? localError;
+    Object? remoteError;
     try {
       await ref
           .read(onlineGalleryBlacklistNotifierProvider.notifier)
           .ensureInitialized();
+      if (!_isCurrentRequest(generation, cacheKey)) return;
       final blacklist = ref
           .read(onlineGalleryBlacklistNotifierProvider)
           .effectiveTags;
-      final filtered = <GalleryItem>[];
-      var requestPage = pageNumber;
-      var lastFetchedPage = pageNumber;
-      var upstreamEnded = false;
-      var fetchedAnyRaw = false;
-      while (filtered.length < _pageSize && !upstreamEnded) {
-        final List<GalleryItem> raw;
-        final int rawCount;
-        lastFetchedPage = requestPage;
-        if (sourceId == GallerySourceId.danbooru) {
-          raw = await _danbooruApi.getFavorites(
-            username: _danbooruAuth.user!.name,
-            page: requestPage,
-            limit: _pageSize,
+      final quickTagFilter = sourceId == GallerySourceId.quickTagCloud
+          ? ref.read(quickTagCloudFilterProvider)
+          : null;
+
+      if (cache.localFavoritesHasMore) {
+        try {
+          final localFavorites = ref.read(
+            onlineGalleryLocalFavoritesProvider.notifier,
           );
-          rawCount = raw.length;
-        } else {
-          final result = await _gelbooruApi.getFavorites(
-            credentials: _gelbooruAuth.credentials!,
-            pid: requestPage - 1,
-            limit: _pageSize,
-            cancelToken: _cancelToken,
+          await localFavorites.initialize();
+          if (!_isCurrentRequest(generation, cacheKey)) return;
+          final localPage = localFavorites.query(
+            OnlineGalleryFavoriteQuery(
+              sourceId: sourceId,
+              searchText: state.favoriteSearchQuery,
+              ratings: sourceId.capabilities.supportsRatings
+                  ? state.selectedRatings
+                  : const {},
+              blacklistTags: blacklist,
+              codexId: quickTagFilter?.codexId,
+              categoryPath: quickTagFilter?.categoryPath ?? const [],
+              mediaFilter: quickTagFilter?.mediaFilter.name ?? 'all',
+              offset: cache.localFavoritesOffset,
+              limit: _pageSize,
+            ),
           );
-          raw = result.posts;
-          rawCount = result.rawCount;
+          final loadedLocalItemKeys = localPage.items
+              .map(onlineGalleryPostKey)
+              .toSet();
+          if (resetBranches) {
+            posts = _removeFavoriteBranch(
+              posts,
+              branchKeys: cache.localFavoriteItemKeys.difference(
+                loadedLocalItemKeys,
+              ),
+              retainedByOtherBranch: cache.remoteFavoriteItemKeys,
+            );
+          }
+          posts = posts.mergePage(
+            localPage.items,
+            mergeDuplicate: _mergeFavoriteItem,
+          );
+          final localItemKeys = resetBranches
+              ? loadedLocalItemKeys
+              : {
+                  ...cache.localFavoriteItemKeys,
+                  ...localPage.items.map(onlineGalleryPostKey),
+                };
+          cache = cache.copyWith(
+            posts: posts,
+            localFavoritesOffset:
+                cache.localFavoritesOffset + localPage.records.length,
+            localFavoritesHasMore: localPage.hasMore,
+            localFavoriteItemKeys: localItemKeys,
+            clearLocalFavoritesError: true,
+          );
+          state = state.updateCurrentCache(cache);
+        } catch (error, stack) {
+          localError = error;
+          AppLogger.e(
+            'Failed to load local favorites',
+            error,
+            stack,
+            'OnlineGallery',
+          );
+          cache = cache.copyWith(
+            localFavoritesHasMore: false,
+            localFavoritesErrorCode: _errorCode(error),
+          );
         }
-        if (!_isCurrentRequest(generation, cacheKey)) return;
-        fetchedAnyRaw = fetchedAnyRaw || rawCount > 0;
-        final ratingFiltered = _filterLocal(raw, const {});
-        filtered.addAll(
-          await _filterByBlacklistCompletingDetails(ratingFiltered, blacklist),
-        );
-        if (!_isCurrentRequest(generation, cacheKey)) return;
-        upstreamEnded = rawCount < _pageSize;
-        if (!upstreamEnded) requestPage++;
       }
-      final base = refresh
-          ? ChunkedGalleryItems()
-          : cache.posts is ChunkedGalleryItems
-          ? cache.posts as ChunkedGalleryItems
-          : ChunkedGalleryItems.from(cache.posts);
-      final merged = base.appendPage(filtered);
+
+      if (_canLoadRemoteFavorites(sourceId) && cache.remoteFavoritesHasMore) {
+        try {
+          final requestPage = cache.remoteFavoritesPage;
+          final List<GalleryItem> raw;
+          final int rawCount;
+          if (sourceId == GallerySourceId.danbooru) {
+            raw = await _danbooruApi.getFavorites(
+              username: _danbooruAuth.user!.name,
+              page: requestPage,
+              limit: _pageSize,
+            );
+            rawCount = raw.length;
+          } else {
+            final result = await _gelbooruApi.getFavorites(
+              credentials: _gelbooruAuth.credentials!,
+              pid: requestPage - 1,
+              limit: _pageSize,
+              cancelToken: _cancelToken,
+            );
+            raw = result.posts;
+            rawCount = result.rawCount;
+          }
+          if (!_isCurrentRequest(generation, cacheKey)) return;
+          final matching = _filterLocal(
+            raw,
+            const {},
+          ).where(_matchesFavoriteSearch).toList(growable: false);
+          final remoteItems = await _filterByBlacklistCompletingDetails(
+            matching,
+            blacklist,
+          );
+          if (!_isCurrentRequest(generation, cacheKey)) return;
+          final upstreamEnded = rawCount < _pageSize;
+          final nextRequestPage = requestPage + 1;
+          final loadedRemoteItemKeys = remoteItems
+              .map(onlineGalleryPostKey)
+              .toSet();
+          if (resetBranches) {
+            posts = _removeFavoriteBranch(
+              posts,
+              branchKeys: cache.remoteFavoriteItemKeys.difference(
+                loadedRemoteItemKeys,
+              ),
+              retainedByOtherBranch: cache.localFavoriteItemKeys,
+            );
+            _remoteFavoriteKeys.removeAll(cache.remoteFavoriteItemKeys);
+          }
+          posts = posts.mergePage(
+            remoteItems,
+            mergeDuplicate: _mergeFavoriteItem,
+          );
+          final remoteItemKeys = resetBranches
+              ? loadedRemoteItemKeys
+              : {
+                  ...cache.remoteFavoriteItemKeys,
+                  ...remoteItems.map(onlineGalleryPostKey),
+                };
+          _remoteFavoriteKeys.addAll(remoteItemKeys);
+          cache = cache.copyWith(
+            posts: posts,
+            remoteFavoritesPage: nextRequestPage,
+            remoteFavoritesHasMore: !upstreamEnded,
+            remoteFavoriteItemKeys: remoteItemKeys,
+            clearRemoteFavoritesError: true,
+          );
+        } on GelbooruApiException catch (error, stack) {
+          if (error.type == GelbooruApiErrorType.cancelled) return;
+          remoteError = error;
+          if (error.type == GelbooruApiErrorType.invalidCredentials) {
+            ref.read(gelbooruAuthProvider.notifier).markInvalid();
+          }
+          AppLogger.e(
+            'Failed to load remote favorites',
+            error,
+            stack,
+            'OnlineGallery',
+          );
+          cache = cache.copyWith(
+            remoteFavoritesHasMore: false,
+            remoteFavoritesErrorCode: _errorCode(error),
+          );
+        } catch (error, stack) {
+          remoteError = error;
+          AppLogger.e(
+            'Failed to load remote favorites',
+            error,
+            stack,
+            'OnlineGallery',
+          );
+          cache = cache.copyWith(
+            remoteFavoritesHasMore: false,
+            remoteFavoritesErrorCode: _errorCode(error),
+          );
+        }
+      } else if (!_canLoadRemoteFavorites(sourceId)) {
+        if (resetBranches) {
+          posts = _removeFavoriteBranch(
+            posts,
+            branchKeys: cache.remoteFavoriteItemKeys,
+            retainedByOtherBranch: cache.localFavoriteItemKeys,
+          );
+          _remoteFavoriteKeys.removeAll(cache.remoteFavoriteItemKeys);
+        }
+        cache = cache.copyWith(
+          posts: posts,
+          remoteFavoritesHasMore: false,
+          remoteFavoriteItemKeys: const {},
+          clearRemoteFavoritesError: true,
+        );
+      }
+
+      if (!_isCurrentRequest(generation, cacheKey)) return;
+      final remoteAvailable = _canLoadRemoteFavorites(sourceId);
+      final allAvailableBranchesFailed =
+          localError != null && (!remoteAvailable || remoteError != null);
+      if (allAvailableBranchesFailed) {
+        cache = cache.copyWith(
+          clearLocalFavoritesError: true,
+          clearRemoteFavoritesError: true,
+        );
+      }
+      if (isAppend &&
+          cache.localFavoritesHasMore &&
+          cache.localFavoriteItemKeys.length ==
+              previousCache.localFavoriteItemKeys.length) {
+        cache = cache.copyWith(localFavoritesHasMore: false);
+      }
+      if (isAppend &&
+          cache.remoteFavoritesHasMore &&
+          cache.remoteFavoriteItemKeys.length ==
+              previousCache.remoteFavoriteItemKeys.length) {
+        cache = cache.copyWith(remoteFavoritesHasMore: false);
+      }
       final duplicatePage =
-          !refresh && fetchedAnyRaw && merged.length == base.length;
-      _remoteFavoriteKeys.addAll(filtered.map(onlineGalleryPostKey));
-      final nextCache = ModeCache(
-        posts: merged,
-        page: lastFetchedPage,
-        nextCursor: duplicatePage || upstreamEnded
-            ? null
-            : '${lastFetchedPage + 1}',
-        hasMore: !duplicatePage && !upstreamEnded,
-        scrollOffset: refresh ? 0 : cache.scrollOffset,
+          isAppend &&
+          posts.length == previousCache.posts.length &&
+          !cache.localFavoritesHasMore &&
+          !cache.remoteFavoritesHasMore;
+      final hasMore =
+          cache.localFavoritesHasMore || cache.remoteFavoritesHasMore;
+      cache = cache.copyWith(
+        posts: posts,
+        page: pageNumber,
+        nextCursor: hasMore ? '${pageNumber + 1}' : null,
+        hasMore: hasMore,
         endedByDuplicatePage: duplicatePage,
+        appendErrorCode: allAvailableBranchesFailed && isAppend
+            ? _errorCode(remoteError ?? localError)
+            : null,
+        clearAppendError: !allAvailableBranchesFailed || !isAppend,
       );
       state = state
           .copyWith(
             isLoading: false,
             isLoadingMore: false,
+            errorCode: allAvailableBranchesFailed && !isAppend
+                ? _errorCode(remoteError ?? localError)
+                : null,
             favoritedPostKeys: {..._localFavoriteKeys, ..._remoteFavoriteKeys},
-            clearError: true,
+            localFavoritedPostKeys: _localFavoriteKeys,
+            remoteFavoritedPostKeys: _remoteFavoriteKeys,
+            clearError: !allAvailableBranchesFailed || isAppend,
           )
-          .updateCurrentCache(nextCache);
-    } on GelbooruApiException catch (error, stack) {
-      if (error.type == GelbooruApiErrorType.cancelled) return;
-      if (error.type == GelbooruApiErrorType.invalidCredentials) {
-        ref.read(gelbooruAuthProvider.notifier).markInvalid();
-        invalidateGelbooruFavorites();
-      }
-      AppLogger.e('Failed to load favorites', error, stack, 'OnlineGallery');
-      _finishRequestError(error, generation, cacheKey, isAppend, cache);
+          .updateCurrentCache(cache);
     } catch (error, stack) {
       AppLogger.e('Failed to load favorites', error, stack, 'OnlineGallery');
-      _finishRequestError(error, generation, cacheKey, isAppend, cache);
+      _finishRequestError(error, generation, cacheKey, isAppend, previousCache);
     }
   }
 
-  Future<void> _loadLocalFavorites({
-    required bool refresh,
-    int? targetPage,
-  }) async {
-    final cache = state.currentCache;
-    final pageNumber = targetPage ?? (refresh ? 1 : cache.page + 1);
-    final generation = _beginRequest();
-    final cacheKey = state.currentCacheKey;
-    final isAppend = !refresh && cache.posts.isNotEmpty;
-    state = state.copyWith(
-      isLoading: !isAppend,
-      isLoadingMore: isAppend,
-      clearError: true,
-    );
-    try {
-      await ref.read(onlineGalleryLocalFavoritesProvider.notifier).initialize();
-      await ref
-          .read(onlineGalleryBlacklistNotifierProvider.notifier)
-          .ensureInitialized();
-      if (!_isCurrentRequest(generation, cacheKey)) return;
-      final capabilities = state.favoritesSourceId.capabilities;
-      final quickTagFilter =
-          state.favoritesSourceId == GallerySourceId.quickTagCloud
-          ? ref.read(quickTagCloudFilterProvider)
-          : null;
-      final page = ref
-          .read(onlineGalleryLocalFavoritesProvider.notifier)
-          .query(
-            OnlineGalleryFavoriteQuery(
-              sourceId: state.favoritesSourceId,
-              searchText: state.favoriteSearchQuery,
-              ratings: capabilities.supportsRatings
-                  ? state.selectedRatings
-                  : const {},
-              blacklistTags: ref
-                  .read(onlineGalleryBlacklistNotifierProvider)
-                  .effectiveTags,
-              codexId: quickTagFilter?.codexId,
-              categoryPath: quickTagFilter?.categoryPath ?? const [],
-              mediaFilter: quickTagFilter?.mediaFilter.name ?? 'all',
-              offset: (pageNumber - 1) * _pageSize,
-              limit: _pageSize,
-            ),
-          );
-      if (!_isCurrentRequest(generation, cacheKey)) return;
-      final base = refresh
-          ? ChunkedGalleryItems()
-          : cache.posts is ChunkedGalleryItems
-          ? cache.posts as ChunkedGalleryItems
-          : ChunkedGalleryItems.from(cache.posts);
-      final merged = base.appendPage(page.items);
-      final nextCache = ModeCache(
-        posts: merged,
-        page: pageNumber,
-        nextCursor: page.hasMore ? '${pageNumber + 1}' : null,
-        hasMore: page.hasMore,
-        total: page.total,
-        scrollOffset: refresh ? 0 : cache.scrollOffset,
-      );
-      state = state
-          .copyWith(isLoading: false, isLoadingMore: false, clearError: true)
-          .updateCurrentCache(nextCache);
-    } catch (error, stack) {
-      AppLogger.e(
-        'Failed to load local favorites',
-        error,
-        stack,
-        'OnlineGallery',
-      );
-      _finishRequestError(error, generation, cacheKey, isAppend, cache);
+  bool _canLoadRemoteFavorites(GallerySourceId sourceId) {
+    if (sourceId.capabilities.remoteFavorites ==
+        GalleryRemoteFavoritesCapability.none) {
+      return false;
     }
+    return switch (sourceId) {
+      GallerySourceId.danbooru =>
+        _danbooruAuth.isLoggedIn && _danbooruAuth.user != null,
+      GallerySourceId.gelbooru =>
+        _gelbooruAuth.isAuthenticated && _gelbooruAuth.credentials != null,
+      _ => false,
+    };
+  }
+
+  bool _matchesFavoriteSearch(GalleryItem item) {
+    final terms = state.favoriteSearchQuery
+        .trim()
+        .toLowerCase()
+        .replaceAll('_', ' ')
+        .split(RegExp(r'\s+'))
+        .where((term) => term.isNotEmpty);
+    if (terms.isEmpty) return true;
+    final haystack = [
+      item.title,
+      item.author,
+      item.description,
+      item.tagString,
+      item.tagStringGeneral,
+      item.tagStringCharacter,
+      item.tagStringCopyright,
+      item.tagStringArtist,
+      item.tagStringMeta,
+    ].whereType<String>().join(' ').toLowerCase().replaceAll('_', ' ');
+    return terms.every(haystack.contains);
+  }
+
+  ChunkedGalleryItems _removeFavoriteBranch(
+    ChunkedGalleryItems posts, {
+    required Set<String> branchKeys,
+    required Set<String> retainedByOtherBranch,
+  }) {
+    if (branchKeys.isEmpty) return posts;
+    final keysToRemove = branchKeys.difference(retainedByOtherBranch);
+    if (keysToRemove.isEmpty) return posts;
+    return posts.removeStableKeys(keysToRemove);
+  }
+
+  GalleryItem _mergeFavoriteItem(GalleryItem current, GalleryItem incoming) {
+    final incomingIsRicher =
+        _favoriteItemCompleteness(incoming) >=
+        _favoriteItemCompleteness(current);
+    final primary = incomingIsRicher ? incoming : current;
+    final secondary = incomingIsRicher ? current : incoming;
+    String fill(String value, String fallback) =>
+        value.isNotEmpty ? value : fallback;
+    String? fillNullable(String? value, String? fallback) =>
+        value?.isNotEmpty == true ? value : fallback;
+    final primaryCover = primary.cover;
+    final secondaryCover = secondary.cover;
+    return primary.copyWith(
+      title: fillNullable(primary.title, secondary.title),
+      author: fillNullable(primary.author, secondary.author),
+      description: fillNullable(primary.description, secondary.description),
+      aiType: fillNullable(primary.aiType, secondary.aiType),
+      createdAt: fill(primary.createdAt, secondary.createdAt),
+      uploaderId: primary.uploaderId != 0
+          ? primary.uploaderId
+          : secondary.uploaderId,
+      score: primary.score ?? secondary.score,
+      source: fill(primary.source, secondary.source),
+      md5: fill(primary.md5, secondary.md5),
+      rating: fillNullable(primary.rating, secondary.rating),
+      imageWidth: primary.imageWidth > 0
+          ? primary.imageWidth
+          : secondary.imageWidth,
+      imageHeight: primary.imageHeight > 0
+          ? primary.imageHeight
+          : secondary.imageHeight,
+      tagString: fill(primary.tagString, secondary.tagString),
+      tags: {...primary.tags, ...secondary.tags}.toList(growable: false),
+      tagStringGeneral: fill(
+        primary.tagStringGeneral,
+        secondary.tagStringGeneral,
+      ),
+      tagStringCharacter: fill(
+        primary.tagStringCharacter,
+        secondary.tagStringCharacter,
+      ),
+      tagStringCopyright: fill(
+        primary.tagStringCopyright,
+        secondary.tagStringCopyright,
+      ),
+      tagStringArtist: fill(primary.tagStringArtist, secondary.tagStringArtist),
+      tagStringMeta: fill(primary.tagStringMeta, secondary.tagStringMeta),
+      fileExt: fillNullable(primary.fileExt, secondary.fileExt),
+      fileSize: primary.fileSize ?? secondary.fileSize,
+      fileUrl: fillNullable(primary.fileUrl, secondary.fileUrl),
+      largeFileUrl: fillNullable(primary.largeFileUrl, secondary.largeFileUrl),
+      previewFileUrl: fillNullable(
+        primary.previewFileUrl,
+        secondary.previewFileUrl,
+      ),
+      sampleUrl: fillNullable(primary.sampleUrl, secondary.sampleUrl),
+      sampleWidth: primary.sampleWidth ?? secondary.sampleWidth,
+      sampleHeight: primary.sampleHeight ?? secondary.sampleHeight,
+      cover: GalleryMedia(
+        id: fill(primaryCover.id, secondaryCover.id),
+        previewUrl: fill(primaryCover.previewUrl, secondaryCover.previewUrl),
+        displayUrl: fill(primaryCover.displayUrl, secondaryCover.displayUrl),
+        downloadUrl: fill(primaryCover.downloadUrl, secondaryCover.downloadUrl),
+        width: primaryCover.width > 0
+            ? primaryCover.width
+            : secondaryCover.width,
+        height: primaryCover.height > 0
+            ? primaryCover.height
+            : secondaryCover.height,
+        extension: fillNullable(
+          primaryCover.extension,
+          secondaryCover.extension,
+        ),
+        mimeType: fillNullable(primaryCover.mimeType, secondaryCover.mimeType),
+        rawMetadata: fillNullable(
+          primaryCover.rawMetadata,
+          secondaryCover.rawMetadata,
+        ),
+        mediaType: fill(primaryCover.mediaType, secondaryCover.mediaType),
+        prompt: fillNullable(primaryCover.prompt, secondaryCover.prompt),
+        negativePrompt: fillNullable(
+          primaryCover.negativePrompt,
+          secondaryCover.negativePrompt,
+        ),
+        metadataFormat: fillNullable(
+          primaryCover.metadataFormat,
+          secondaryCover.metadataFormat,
+        ),
+        metadataError: fillNullable(
+          primaryCover.metadataError,
+          secondaryCover.metadataError,
+        ),
+        metadata: {...secondaryCover.metadata, ...primaryCover.metadata},
+      ),
+      mediaCount: max(primary.mediaCount, secondary.mediaCount),
+      viewCount: primary.viewCount ?? secondary.viewCount,
+      favoriteCount: primary.favoriteCount ?? secondary.favoriteCount,
+      rank: primary.rank ?? secondary.rank,
+      rankingName: fillNullable(primary.rankingName, secondary.rankingName),
+      focusedMediaId: fillNullable(
+        primary.focusedMediaId,
+        secondary.focusedMediaId,
+      ),
+      focusedMediaIndex:
+          primary.focusedMediaIndex ?? secondary.focusedMediaIndex,
+      artistChain: primary.artistChain ?? secondary.artistChain,
+      rawSourceMetadata: {
+        ...secondary.rawSourceMetadata,
+        ...primary.rawSourceMetadata,
+      },
+    );
+  }
+
+  int _favoriteItemCompleteness(GalleryItem item) {
+    int textScore(String? value) {
+      final length = value?.trim().length ?? 0;
+      return length == 0 ? 0 : 1 + min(4, length ~/ 40);
+    }
+
+    final cover = item.cover;
+    return (textScore(item.title) +
+            textScore(item.author) +
+            textScore(item.description) +
+            textScore(item.tagString) +
+            textScore(item.tagStringGeneral) +
+            textScore(item.tagStringCharacter) +
+            textScore(item.tagStringCopyright) +
+            textScore(item.tagStringArtist) +
+            textScore(item.tagStringMeta) +
+            min(20, item.tags.length) +
+            (item.imageWidth > 0 && item.imageHeight > 0 ? 3 : 0) +
+            (item.fileUrl?.isNotEmpty == true ? 3 : 0) +
+            (item.largeFileUrl?.isNotEmpty == true ? 2 : 0) +
+            (item.previewFileUrl?.isNotEmpty == true ? 2 : 0) +
+            (cover.displayUrl.isNotEmpty ? 2 : 0) +
+            (cover.downloadUrl.isNotEmpty ? 2 : 0) +
+            min(10, item.rawSourceMetadata.length) +
+            min(10, cover.metadata.length))
+        .toInt();
   }
 
   Future<List<GalleryItem>> _filterByBlacklistCompletingDetails(
@@ -2518,9 +2818,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     bool forceRefresh = false,
     GalleryDetailPriority priority = GalleryDetailPriority.interactive,
   }) {
-    if (!forceRefresh &&
-        state.viewMode == GalleryViewMode.favorites &&
-        state.favoritesScope == GalleryFavoritesScope.local) {
+    if (!forceRefresh && state.viewMode == GalleryViewMode.favorites) {
       final record = ref
           .read(onlineGalleryLocalFavoritesProvider.notifier)
           .getByStableKey(item.stableKey);
@@ -2542,16 +2840,34 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     state = state.copyWith(
       favoriteLoadingPostKeys: {...state.favoriteLoadingPostKeys, key},
     );
-    final success = await _danbooruApi.addFavorite(postId);
-    final loading = {...state.favoriteLoadingPostKeys}..remove(key);
-    if (success) _remoteFavoriteKeys.add(key);
-    state = success
-        ? state.copyWith(
-            favoritedPostKeys: {..._localFavoriteKeys, ..._remoteFavoriteKeys},
-            favoriteLoadingPostKeys: loading,
-          )
-        : state.copyWith(favoriteLoadingPostKeys: loading);
-    return success;
+    try {
+      final success = await _danbooruApi.addFavorite(postId);
+      if (success) _remoteFavoriteKeys.add(key);
+      state = success
+          ? state.copyWith(
+              favoritedPostKeys: {
+                ..._localFavoriteKeys,
+                ..._remoteFavoriteKeys,
+              },
+              localFavoritedPostKeys: _localFavoriteKeys,
+              remoteFavoritedPostKeys: _remoteFavoriteKeys,
+            )
+          : state;
+      return success;
+    } catch (error, stack) {
+      AppLogger.e(
+        'Failed to add remote favorite',
+        error,
+        stack,
+        'OnlineGallery',
+      );
+      return false;
+    } finally {
+      state = state.copyWith(
+        favoriteLoadingPostKeys: {...state.favoriteLoadingPostKeys}
+          ..remove(key),
+      );
+    }
   }
 
   Future<bool> removeFavorite(Object postOrId) async {
@@ -2561,28 +2877,42 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     state = state.copyWith(
       favoriteLoadingPostKeys: {...state.favoriteLoadingPostKeys, key},
     );
-    final success = await _danbooruApi.removeFavorite(postId);
-    final loading = {...state.favoriteLoadingPostKeys}..remove(key);
-    if (success) {
+    try {
+      final success = await _danbooruApi.removeFavorite(postId);
+      if (!success) return false;
       _remoteFavoriteKeys.remove(key);
       state = state.copyWith(
         favoritedPostKeys: {..._localFavoriteKeys, ..._remoteFavoriteKeys},
-        favoriteLoadingPostKeys: loading,
+        localFavoritedPostKeys: _localFavoriteKeys,
+        remoteFavoritedPostKeys: _remoteFavoriteKeys,
       );
       if (state.viewMode == GalleryViewMode.favorites &&
-          state.favoritesSourceId == GallerySourceId.danbooru) {
+          state.favoritesSourceId == GallerySourceId.danbooru &&
+          !_localFavoriteKeys.contains(key)) {
+        final posts = state.currentCache.posts is ChunkedGalleryItems
+            ? state.currentCache.posts as ChunkedGalleryItems
+            : ChunkedGalleryItems.from(state.currentCache.posts);
         state = state.updateCurrentCache(
           state.currentCache.copyWith(
-            posts: ChunkedGalleryItems.from(
-              state.currentCache.posts.where((item) => item.id != postId),
-            ),
+            posts: posts.removeStableKeys({'danbooru:$postId'}),
           ),
         );
       }
-    } else {
-      state = state.copyWith(favoriteLoadingPostKeys: loading);
+      return true;
+    } catch (error, stack) {
+      AppLogger.e(
+        'Failed to remove remote favorite',
+        error,
+        stack,
+        'OnlineGallery',
+      );
+      return false;
+    } finally {
+      state = state.copyWith(
+        favoriteLoadingPostKeys: {...state.favoriteLoadingPostKeys}
+          ..remove(key),
+      );
     }
-    return success;
   }
 
   Future<void> recordQuickTagCloudViewed(GalleryItem item) async {
@@ -2644,15 +2974,8 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
           : addFavorite(postOrId);
     }
 
-    if (postOrId.sourceId == GallerySourceId.gelbooru &&
-        state.viewMode == GalleryViewMode.favorites &&
-        state.favoritesScope == GalleryFavoritesScope.remote) {
-      return false;
-    }
-
     if (postOrId.sourceId == GallerySourceId.danbooru &&
-        _danbooruAuth.isLoggedIn &&
-        state.favoritesScope == GalleryFavoritesScope.remote) {
+        _danbooruAuth.isLoggedIn) {
       return _remoteFavoriteKeys.contains(postOrId.stableKey)
           ? removeFavorite(postOrId)
           : addFavorite(postOrId);
@@ -2694,25 +3017,23 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
 
   bool isFavorited(Object postOrId) {
     if (postOrId is GalleryItem) {
-      final key = postOrId.stableKey;
-      final usesRemoteState =
-          (postOrId.sourceId == GallerySourceId.danbooru &&
-              _danbooruAuth.isLoggedIn &&
-              state.favoritesScope == GalleryFavoritesScope.remote) ||
-          (postOrId.sourceId == GallerySourceId.gelbooru &&
-              state.viewMode == GalleryViewMode.favorites &&
-              state.favoritesScope == GalleryFavoritesScope.remote);
-      return usesRemoteState
-          ? _remoteFavoriteKeys.contains(key)
-          : _localFavoriteKeys.contains(key);
+      return postOrId.sourceId == GallerySourceId.danbooru &&
+              _danbooruAuth.isLoggedIn
+          ? _remoteFavoriteKeys.contains(postOrId.stableKey)
+          : _localFavoriteKeys.contains(postOrId.stableKey);
     }
     if (postOrId is! int) return false;
     final key = 'danbooru:$postOrId';
-    return _danbooruAuth.isLoggedIn &&
-            state.favoritesScope == GalleryFavoritesScope.remote
+    return _danbooruAuth.isLoggedIn
         ? _remoteFavoriteKeys.contains(key)
         : _localFavoriteKeys.contains(key);
   }
+
+  bool isLocallyFavorited(GalleryItem item) =>
+      _localFavoriteKeys.contains(item.stableKey);
+
+  bool isRemotelyFavorited(GalleryItem item) =>
+      _remoteFavoriteKeys.contains(item.stableKey);
 
   int? _danbooruFavoritePostId(Object postOrId) {
     if (postOrId is GalleryItem) {
@@ -2731,8 +3052,9 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     _remoteFavoriteKeys.removeWhere((key) => key.startsWith('gelbooru:'));
     state = state.copyWith(
       caches: filteredCaches,
-      gelbooruFavoritesCache: const ModeCache(),
       favoritedPostKeys: {..._localFavoriteKeys, ..._remoteFavoriteKeys},
+      localFavoritedPostKeys: _localFavoriteKeys,
+      remoteFavoritedPostKeys: _remoteFavoriteKeys,
       favoriteLoadingPostKeys: state.favoriteLoadingPostKeys
           .where((key) => !key.startsWith('gelbooru:'))
           .toSet(),

--- a/lib/presentation/screens/online_gallery/online_gallery_screen.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen.dart
@@ -745,13 +745,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
             children: [
               _buildSourceSelector(state),
               const SizedBox(width: 8),
-              _buildModeSelector(
-                theme,
-                state,
-                authState,
-                gelbooruAuthState,
-                compact: compactModes,
-              ),
+              _buildModeSelector(theme, state, compact: compactModes),
               const SizedBox(width: 8),
               _buildRatingControl(theme, state, compact: compactRating),
             ],
@@ -859,9 +853,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
 
   Widget _buildModeSelector(
     ThemeData theme,
-    OnlineGalleryState state,
-    DanbooruAuthState authState,
-    GelbooruAuthState gelbooruAuthState, {
+    OnlineGalleryState state, {
     required bool compact,
   }) {
     final activeSourceId = state.activeSourceId;
@@ -917,15 +909,6 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
               _galleryNotifier.switchToFavorites();
             },
             isLast: true,
-            showBadge:
-                state.favoritesScope == GalleryFavoritesScope.remote &&
-                switch (state.favoritesSourceId) {
-                  GallerySourceId.gelbooru =>
-                    !gelbooruAuthState.isAuthenticated,
-                  GallerySourceId.danbooru => !authState.isLoggedIn,
-                  _ => false,
-                },
-            badgeHint: context.l10n.onlineGallery_loginForCloudFavorites,
             selectedBackgroundColor: const Color(0xFFBE185D),
             selectedForegroundColor: Colors.white,
           ),
@@ -1704,8 +1687,9 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
     final capabilities = gallerySourceCapabilities[activeSourceId]!;
     final controls = <Widget>[];
 
-    if (state.viewMode == GalleryViewMode.favorites) {
-      controls.add(_buildFavoritesScopeControl(theme, state));
+    if (state.viewMode == GalleryViewMode.favorites &&
+        state.currentCache.hasFavoritesPartialFailure) {
+      controls.add(_buildFavoritesPartialFailureNotice(theme, state));
     }
     if (activeSourceId == GallerySourceId.quickTagCloud) {
       controls.add(
@@ -1749,7 +1733,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
       }
       if (state.viewMode == GalleryViewMode.favorites &&
           state.favoritesSourceId == GallerySourceId.gelbooru &&
-          state.favoritesScope == GalleryFavoritesScope.remote) {
+          ref.watch(gelbooruAuthProvider).isAuthenticated) {
         controls
           ..add(_buildGelbooruFavoritesNotice(theme))
           ..add(
@@ -1786,60 +1770,37 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
     );
   }
 
-  Widget _buildFavoritesScopeControl(
+  Widget _buildFavoritesPartialFailureNotice(
     ThemeData theme,
     OnlineGalleryState state,
   ) {
-    final capabilities = state.favoritesSourceId.capabilities;
-    if (capabilities.remoteFavorites == GalleryRemoteFavoritesCapability.none) {
-      return Tooltip(
-        message: context.l10n.onlineGallery_localFavoritesDescription,
-        child: Chip(
-          avatar: const Icon(Icons.devices_rounded, size: 16),
-          label: Text(context.l10n.onlineGallery_localFavorites),
-          visualDensity: VisualDensity.compact,
-        ),
-      );
-    }
-    final remoteAuthenticated = switch (state.favoritesSourceId) {
-      GallerySourceId.danbooru => ref.watch(danbooruAuthProvider).isLoggedIn,
-      GallerySourceId.gelbooru =>
-        ref.watch(gelbooruAuthProvider).isAuthenticated,
-      _ => false,
-    };
-    return SegmentedButton<GalleryFavoritesScope>(
-      showSelectedIcon: false,
-      segments: [
-        ButtonSegment(
-          value: GalleryFavoritesScope.local,
-          icon: const Icon(Icons.devices_rounded, size: 16),
-          label: Text(context.l10n.onlineGallery_localFavorites),
-        ),
-        ButtonSegment(
-          value: GalleryFavoritesScope.remote,
-          enabled: remoteAuthenticated,
-          icon: Icon(
-            capabilities.remoteFavorites ==
-                    GalleryRemoteFavoritesCapability.readOnly
-                ? Icons.cloud_download_outlined
-                : Icons.cloud_outlined,
+    final localFailed = state.currentCache.localFavoritesErrorCode != null;
+    final message = localFailed
+        ? context.l10n.onlineGallery_localFavoritesPartialFailure
+        : context.l10n.onlineGallery_cloudFavoritesPartialFailure;
+    return Container(
+      padding: const EdgeInsetsDirectional.only(start: 10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer.withValues(alpha: 0.55),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.warning_amber_rounded,
             size: 16,
+            color: theme.colorScheme.onErrorContainer,
           ),
-          label: Text(context.l10n.onlineGallery_cloudFavorites),
-          tooltip: remoteAuthenticated
-              ? null
-              : context.l10n.onlineGallery_loginForCloudFavorites,
-        ),
-      ],
-      selected: {state.favoritesScope},
-      onSelectionChanged: (selection) {
-        if (selection.isNotEmpty) {
-          _galleryNotifier.setFavoritesScope(selection.first);
-        }
-      },
-      style: const ButtonStyle(
-        visualDensity: VisualDensity.compact,
-        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          const SizedBox(width: 6),
+          Text(message),
+          IconButton(
+            tooltip: context.l10n.common_retry,
+            onPressed: state.isLoading ? null : _galleryNotifier.refresh,
+            icon: const Icon(Icons.refresh_rounded, size: 17),
+            visualDensity: VisualDensity.compact,
+          ),
+        ],
       ),
     );
   }
@@ -2449,11 +2410,6 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
 
   bool _canWriteFavorites(OnlineGalleryState state) {
     final sourceId = _activeSource(state);
-    if (sourceId == GallerySourceId.gelbooru &&
-        state.viewMode == GalleryViewMode.favorites &&
-        state.favoritesScope == GalleryFavoritesScope.remote) {
-      return false;
-    }
     final capabilities = gallerySourceCapabilities[sourceId]!;
     return capabilities.supportsWritableFavorites ||
         capabilities.supportsLocalFavorites;
@@ -2787,15 +2743,10 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
     required double layoutAspectRatio,
     GalleryDetail? detail,
   }) {
-    final favoriteReadOnly =
-        post.sourceId == GallerySourceId.gelbooru &&
-        state.viewMode == GalleryViewMode.favorites &&
-        state.favoritesScope == GalleryFavoritesScope.remote;
     final capabilities = gallerySourceCapabilities[post.sourceId]!;
     final canWriteFavorite =
-        !favoriteReadOnly &&
-        (capabilities.supportsWritableFavorites ||
-            capabilities.supportsLocalFavorites);
+        capabilities.supportsWritableFavorites ||
+        capabilities.supportsLocalFavorites;
     final targetMedia = post.focusedMediaId != null
         ? post.cover
         : detail != null && detail.media.isNotEmpty
@@ -2808,16 +2759,23 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         final favoriteState = cardRef.watch(
           onlineGalleryNotifierProvider.select(
             (value) => (
-              value.favoritedPostKeys,
+              value.localFavoritedPostKeys,
+              value.remoteFavoritedPostKeys,
               value.favoriteLoadingPostKeys.contains(postKey),
-              value.favoritesScope,
-              value.viewMode,
             ),
           ),
         );
-        final isFavorited = cardRef
-            .read(onlineGalleryNotifierProvider.notifier)
-            .isFavorited(post);
+        final localFavorited = favoriteState.$1.contains(postKey);
+        final remoteFavorited = favoriteState.$2.contains(postKey);
+        final writesRemotely =
+            post.sourceId == GallerySourceId.danbooru &&
+            cardRef.watch(
+              danbooruAuthProvider.select((value) => value.isLoggedIn),
+            );
+        final isFavorited = writesRemotely ? remoteFavorited : localFavorited;
+        final hasSecondaryFavorite = writesRemotely
+            ? localFavorited
+            : remoteFavorited;
         final selectionState = cardRef.watch(
           onlineGallerySelectionNotifierProvider.select(
             (value) =>
@@ -2860,9 +2818,19 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
           itemWidth: itemWidth,
           layoutAspectRatio: layoutAspectRatio,
           isFavorited: isFavorited,
-          isFavoriteLoading: favoriteState.$2,
-          showFavoriteAction: canWriteFavorite || favoriteReadOnly,
-          favoriteReadOnly: favoriteReadOnly,
+          isFavoriteLoading: favoriteState.$3,
+          showFavoriteAction: canWriteFavorite,
+          favoriteReadOnly: false,
+          secondaryFavoriteIcon: hasSecondaryFavorite
+              ? writesRemotely
+                    ? Icons.download_done
+                    : Icons.cloud_done
+              : null,
+          secondaryFavoriteTooltip: hasSecondaryFavorite
+              ? writesRemotely
+                    ? context.l10n.onlineGallery_savedLocally
+                    : context.l10n.onlineGallery_savedInCloud
+              : null,
           selectionMode: selectionState.$1,
           isSelected: selectionState.$2,
           canSelect:
@@ -3220,10 +3188,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
           favoriteLoading: galleryState.favoriteLoadingPostKeys.contains(
             stableKey,
           ),
-          canToggleFavorite:
-              !(item.sourceId == GallerySourceId.gelbooru &&
-                  galleryState.viewMode == GalleryViewMode.favorites &&
-                  galleryState.favoritesScope == GalleryFavoritesScope.remote),
+          canToggleFavorite: true,
           labels: GalleryDetailDialogLabels(
             sourceName: item.sourceId == GallerySourceId.quickTagCloud
                 ? l10n.onlineGallery_sourceQuickTagCloud
@@ -4273,9 +4238,7 @@ class _ModeButton extends StatelessWidget {
   final VoidCallback? onTap;
   final bool isFirst;
   final bool isLast;
-  final bool showBadge;
   final bool compact;
-  final String? badgeHint;
   final String? disabledHint;
   final Color selectedBackgroundColor;
   final Color selectedForegroundColor;
@@ -4288,9 +4251,7 @@ class _ModeButton extends StatelessWidget {
     required this.onTap,
     this.isFirst = false,
     this.isLast = false,
-    this.showBadge = false,
     this.compact = false,
-    this.badgeHint,
     this.disabledHint,
     required this.selectedBackgroundColor,
     required this.selectedForegroundColor,
@@ -4310,16 +4271,13 @@ class _ModeButton extends StatelessWidget {
         ? selectedForegroundColor
         : theme.colorScheme.onSurfaceVariant;
 
-    final tooltip =
-        disabledHint ??
-        (showBadge && badgeHint != null ? '$label · $badgeHint' : label);
+    final tooltip = disabledHint ?? label;
     return Tooltip(
       message: tooltip,
       child: Semantics(
         button: true,
         enabled: enabled,
         selected: isSelected,
-        hint: showBadge ? badgeHint : null,
         child: Material(
           color: isSelected ? selectedBackgroundColor : Colors.transparent,
           borderRadius: borderRadius,
@@ -4352,16 +4310,6 @@ class _ModeButton extends StatelessWidget {
                         color: foregroundColor,
                       ),
                     ),
-                    if (showBadge)
-                      Container(
-                        margin: const EdgeInsets.only(left: 4),
-                        width: 6,
-                        height: 6,
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.error,
-                          shape: BoxShape.circle,
-                        ),
-                      ),
                   ],
                 ),
               ),

--- a/lib/presentation/widgets/danbooru_post_card.dart
+++ b/lib/presentation/widgets/danbooru_post_card.dart
@@ -46,6 +46,8 @@ class DanbooruPostCard extends StatefulWidget {
   final bool isFavoriteLoading;
   final bool showFavoriteAction;
   final bool favoriteReadOnly;
+  final IconData? secondaryFavoriteIcon;
+  final String? secondaryFavoriteTooltip;
   final bool selectionMode;
   final bool isSelected;
   final bool canSelect;
@@ -75,6 +77,8 @@ class DanbooruPostCard extends StatefulWidget {
     this.isFavoriteLoading = false,
     this.showFavoriteAction = true,
     this.favoriteReadOnly = false,
+    this.secondaryFavoriteIcon,
+    this.secondaryFavoriteTooltip,
     this.selectionMode = false,
     this.isSelected = false,
     this.canSelect = true,
@@ -572,6 +576,28 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
                                 ),
                               ),
                             ),
+                          if (widget.secondaryFavoriteIcon != null &&
+                              widget.secondaryFavoriteTooltip != null &&
+                              !_isHovering)
+                            Positioned(
+                              top: 4,
+                              right: widget.favoriteReadOnly ? 38 : 4,
+                              child: Tooltip(
+                                message: widget.secondaryFavoriteTooltip!,
+                                child: Container(
+                                  padding: const EdgeInsets.all(5),
+                                  decoration: BoxDecoration(
+                                    color: Colors.black.withValues(alpha: 0.6),
+                                    shape: BoxShape.circle,
+                                  ),
+                                  child: Icon(
+                                    widget.secondaryFavoriteIcon,
+                                    size: 14,
+                                    color: Colors.redAccent,
+                                  ),
+                                ),
+                              ),
+                            ),
                           if (widget.post.rank != null)
                             Positioned(
                               top: 4,
@@ -815,9 +841,13 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
                                 icon: widget.isFavorited
                                     ? Icons.favorite
                                     : Icons.favorite_border,
-                                tooltip: widget.isFavorited
-                                    ? context.l10n.common_unfavorite
-                                    : context.l10n.common_favorite,
+                                tooltip: [
+                                  widget.isFavorited
+                                      ? context.l10n.common_unfavorite
+                                      : context.l10n.common_favorite,
+                                  if (widget.secondaryFavoriteTooltip != null)
+                                    widget.secondaryFavoriteTooltip!,
+                                ].join(' · '),
                                 iconColor: widget.isFavorited
                                     ? Colors.red
                                     : Colors.white,

--- a/test/data/models/online_gallery/chunked_gallery_items_test.dart
+++ b/test/data/models/online_gallery/chunked_gallery_items_test.dart
@@ -141,6 +141,69 @@ void main() {
       expect(identical(result, chunked), true);
     });
 
+    test('mergePage deduplicates and enriches its first incoming page', () {
+      final brief = item1.copyWith(title: 'brief');
+      final complete = item1.copyWith(title: 'complete');
+
+      final result = ChunkedGalleryItems().mergePage([
+        brief,
+        complete,
+        item2,
+      ], mergeDuplicate: (_, incoming) => incoming);
+
+      expect(result.map((item) => item.id), [1, 2]);
+      expect(result.first.title, 'complete');
+      expect(result.indexOfStableKey(item2.stableKey), 1);
+    });
+
+    test('mergePage replaces a duplicate in place and appends new items', () {
+      final original = item1.copyWith(title: 'brief');
+      final richer = item1.copyWith(title: 'complete');
+      final chunked = ChunkedGalleryItems.from([original, item2]);
+
+      final result = chunked.mergePage(
+        [richer, item3],
+        mergeDuplicate: (current, incoming) =>
+            (incoming.title?.length ?? 0) > (current.title?.length ?? 0)
+            ? incoming
+            : current,
+      );
+
+      expect(result.map((item) => item.id), [1, 2, 3]);
+      expect(result.first.title, 'complete');
+      expect(result.chunkCount, 2);
+      expect(chunked.first.title, 'brief');
+    });
+
+    test('removeStableKeys preserves order, chunks, and indices', () {
+      final chunked = ChunkedGalleryItems.from([
+        item1,
+        item2,
+      ]).appendPage([item3, item4]);
+
+      final result = chunked.removeStableKeys({
+        item2.stableKey,
+        item3.stableKey,
+      });
+
+      expect(result.map((item) => item.id), [1, 4]);
+      expect(result.chunkSizes, [1, 1]);
+      expect(result.indexOfStableKey(item1.stableKey), 0);
+      expect(result.indexOfStableKey(item4.stableKey), 1);
+      expect(result.containsStableKey(item2.stableKey), isFalse);
+      expect(chunked.map((item) => item.id), [1, 2, 3, 4]);
+    });
+
+    test('removeStableKeys returns the same instance without matches', () {
+      final chunked = ChunkedGalleryItems.from([item1, item2]);
+
+      expect(identical(chunked.removeStableKeys(const {}), chunked), isTrue);
+      expect(
+        identical(chunked.removeStableKeys({item3.stableKey}), chunked),
+        isTrue,
+      );
+    });
+
     test('containsStableKey works correctly', () {
       final chunked = ChunkedGalleryItems.from([item1, item2]);
       expect(chunked.containsStableKey(item1.stableKey), true);

--- a/test/presentation/providers/online_gallery_browsing_session_test.dart
+++ b/test/presentation/providers/online_gallery_browsing_session_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -76,6 +78,55 @@ void main() {
     expect(restored.currentCache.scrollOffset, 2048);
     expect(restored.currentCache.anchorStableKey, 'ai_tag:42');
     expect(restored.randomSession.cache.scrollOffset, 512);
+  });
+
+  test('legacy favorite scope is removed and its position is migrated', () {
+    final restored = decodeOnlineGalleryBrowsingSession(
+      jsonEncode({
+        'version': 1,
+        'viewMode': 'favorites',
+        'favoritesSourceId': 'gelbooru',
+        'favoritesScope': 'remote',
+        'positions': {
+          'favorites:gelbooru:remote||egqs|codex:|blacklist:0': {
+            'page': 4,
+            'offset': 96,
+          },
+        },
+      }),
+    );
+
+    expect(restored.viewMode, GalleryViewMode.favorites);
+    expect(restored.currentCache.page, 4);
+    expect(restored.currentCache.scrollOffset, 96);
+    expect(
+      encodeOnlineGalleryBrowsingSession(restored),
+      isNot(contains('favoritesScope')),
+    );
+  });
+
+  test('legacy favorite migration prefers the selected scope position', () {
+    final restored = decodeOnlineGalleryBrowsingSession(
+      jsonEncode({
+        'version': 1,
+        'viewMode': 'favorites',
+        'favoritesSourceId': 'danbooru',
+        'favoritesScope': 'remote',
+        'positions': {
+          'favorites:danbooru:local||egqs|codex:|blacklist:0': {
+            'page': 2,
+            'offset': 20,
+          },
+          'favorites:danbooru:remote||egqs|codex:|blacklist:0': {
+            'page': 8,
+            'offset': 80,
+          },
+        },
+      }),
+    );
+
+    expect(restored.currentCache.page, 8);
+    expect(restored.currentCache.scrollOffset, 80);
   });
 
   test('invalid or obsolete session safely falls back to defaults', () {
@@ -167,6 +218,29 @@ void main() {
       expect(restored.mediaFilter, QuickTagCloudMediaFilter.withoutImages);
     },
   );
+
+  test('favorite caches never leak across sources or queries', () {
+    const aiItem = GalleryItem(
+      id: 1,
+      sourceId: GallerySourceId.aiTag,
+      workId: 'ai-1',
+    );
+    var state = const OnlineGalleryState(
+      viewMode: GalleryViewMode.favorites,
+      favoritesSourceId: GallerySourceId.aiTag,
+    );
+    state = state.updateFavoritesCache(
+      GallerySourceId.aiTag,
+      const ModeCache(posts: [aiItem], hasMore: false),
+    );
+
+    expect(state.favoritesCacheFor(GallerySourceId.aiTag).posts, [aiItem]);
+    expect(state.favoritesCacheFor(GallerySourceId.danbooru).posts, isEmpty);
+    expect(state.favoritesCacheFor(GallerySourceId.gelbooru).posts, isEmpty);
+
+    state = state.copyWith(favoriteSearchQuery: 'different query');
+    expect(state.favoritesCacheFor(GallerySourceId.aiTag).posts, isEmpty);
+  });
 
   test('mode changes keep the currently selected source', () async {
     final storage = _MemoryStorage();

--- a/test/presentation/providers/online_gallery_gelbooru_auth_test.dart
+++ b/test/presentation/providers/online_gallery_gelbooru_auth_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -10,8 +11,11 @@ import 'package:nai_launcher/core/constants/storage_keys.dart';
 import 'package:nai_launcher/core/storage/secure_storage_service.dart';
 import 'package:nai_launcher/data/datasources/remote/danbooru_api_service.dart';
 import 'package:nai_launcher/data/datasources/remote/gelbooru_api_service.dart';
+import 'package:nai_launcher/data/datasources/remote/online_gallery/gallery_source_adapter.dart';
+import 'package:nai_launcher/data/models/danbooru/danbooru_user.dart';
 import 'package:nai_launcher/data/models/online_gallery/danbooru_post.dart';
 import 'package:nai_launcher/data/models/online_gallery/gelbooru_credentials.dart';
+import 'package:nai_launcher/data/services/danbooru_auth_service.dart';
 import 'package:nai_launcher/data/services/gelbooru_auth_service.dart';
 import 'package:nai_launcher/presentation/providers/online_gallery_local_favorites_provider.dart';
 import 'package:nai_launcher/presentation/providers/online_gallery_provider.dart';
@@ -29,13 +33,29 @@ void main() {
     _FakeGelbooruApiService? gelbooruApi,
     _GalleryHttpAdapter? httpAdapter,
     _FakeDanbooruApiService? danbooruApi,
+    bool danbooruLoggedIn = false,
+    _MutableDanbooruAuth? danbooruAuth,
+    Map<GallerySourceId, GallerySourceAdapter>? galleryAdapters,
   }) {
     final adapter = httpAdapter ?? _GalleryHttpAdapter();
     final dio = Dio()..httpClientAdapter = adapter;
     return ProviderContainer(
       overrides: [
         secureStorageServiceProvider.overrideWithValue(
-          _FakeSecureStorage(gelbooru: storedCredentials),
+          _FakeSecureStorage(
+            gelbooru: storedCredentials,
+            danbooru: danbooruLoggedIn
+                ? jsonEncode(
+                    const DanbooruCredentials(
+                      username: 'tester',
+                      apiKey: 'dan-key',
+                    ).toJson(),
+                  )
+                : null,
+          ),
+        ),
+        danbooruCredentialVerifierProvider.overrideWithValue(
+          _FakeDanbooruCredentialVerifier(),
         ),
         gelbooruApiServiceProvider.overrideWithValue(
           gelbooruApi ?? _FakeGelbooruApiService(),
@@ -44,6 +64,12 @@ void main() {
         danbooruApiServiceProvider.overrideWithValue(
           danbooruApi ?? _FakeDanbooruApiService(),
         ),
+        if (danbooruAuth != null)
+          danbooruAuthProvider.overrideWith(() => danbooruAuth),
+        if (galleryAdapters != null)
+          onlineGallerySourceAdaptersProvider.overrideWithValue(
+            galleryAdapters,
+          ),
       ],
     );
   }
@@ -183,39 +209,164 @@ void main() {
     );
   });
 
-  test(
-    'Gelbooru favorites are source-scoped and never call Danbooru writes',
-    () async {
-      final gelbooruApi = _FakeGelbooruApiService(
-        favoritesResult: GelbooruPostPage(
-          posts: [_gelbooruPost(123)],
-          rawCount: 1,
-        ),
-      );
-      final danbooruApi = _FakeDanbooruApiService();
-      final container = createContainer(
-        storedCredentials: stored(credentials),
-        gelbooruApi: gelbooruApi,
-        danbooruApi: danbooruApi,
-      );
-      addTearDown(container.dispose);
-      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+  test('favorites without credentials use local data only', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-local-favorites-fallback-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
 
-      await notifier.setFavoritesSource('gelbooru');
-      await notifier.switchToFavorites();
+    final item = _gelbooruPost(77);
+    final gelbooruApi = _FakeGelbooruApiService();
+    final container = createContainer(gelbooruApi: gelbooruApi);
+    addTearDown(container.dispose);
+    await container
+        .read(onlineGalleryLocalFavoritesProvider.notifier)
+        .upsert(GalleryDetail(item: item, media: [item.cover]));
 
-      final state = container.read(onlineGalleryNotifierProvider);
-      expect(gelbooruApi.favoritesCalls, 1);
-      expect(state.gelbooruFavoritesCache.posts, hasLength(1));
-      expect(state.danbooruFavoritesCache.posts, isEmpty);
-      expect(state.favoritedPostKeys, contains('gelbooru:123'));
-      expect(state.favoritedPostKeys, isNot(contains('danbooru:123')));
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    await notifier.setFavoritesSource(GallerySourceId.gelbooru);
+    await notifier.switchToFavorites();
 
-      expect(await notifier.toggleFavorite(state.posts.single), isFalse);
-      expect(danbooruApi.addFavoriteCalls, 0);
-      expect(danbooruApi.removeFavoriteCalls, 0);
-    },
-  );
+    expect(gelbooruApi.favoritesCalls, 0);
+    expect(
+      container
+          .read(onlineGalleryNotifierProvider)
+          .posts
+          .map((post) => post.id),
+      [77],
+    );
+  });
+
+  test('authenticated Danbooru favorite writes use the cloud', () async {
+    final danbooruApi = _FakeDanbooruApiService();
+    final container = createContainer(
+      danbooruApi: danbooruApi,
+      danbooruLoggedIn: true,
+    );
+    addTearDown(container.dispose);
+    await container.read(danbooruAuthProvider.notifier).ensureInitialized();
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    final item = _danbooruPost(88);
+
+    expect(await notifier.toggleFavorite(item), isTrue);
+    expect(danbooruApi.addFavoriteCalls, 1);
+    expect(notifier.isRemotelyFavorited(item), isTrue);
+    expect(notifier.isLocallyFavorited(item), isFalse);
+
+    expect(await notifier.toggleFavorite(item), isTrue);
+    expect(danbooruApi.removeFavoriteCalls, 1);
+    expect(notifier.isRemotelyFavorited(item), isFalse);
+  });
+
+  test('unauthenticated Danbooru favorite writes fall back locally', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-danbooru-local-favorite-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
+
+    final danbooruApi = _FakeDanbooruApiService();
+    final container = createContainer(danbooruApi: danbooruApi);
+    addTearDown(container.dispose);
+    await container.read(danbooruAuthProvider.notifier).ensureInitialized();
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    final item = _danbooruPost(89);
+
+    expect(await notifier.toggleFavorite(item), isTrue);
+    expect(danbooruApi.addFavoriteCalls, 0);
+    expect(notifier.isLocallyFavorited(item), isTrue);
+
+    expect(await notifier.toggleFavorite(item), isTrue);
+    expect(danbooruApi.removeFavoriteCalls, 0);
+    expect(notifier.isLocallyFavorited(item), isFalse);
+  });
+
+  for (final sourceId in [
+    GallerySourceId.aiTag,
+    GallerySourceId.quickTagCloud,
+  ]) {
+    test(
+      '${sourceId.key} favorites use the generic local write path',
+      () async {
+        final hiveDirectory = await Directory.systemTemp.createTemp(
+          'online-gallery-${sourceId.key}-local-favorite-',
+        );
+        Hive.init(hiveDirectory.path);
+        await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+        await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+        addTearDown(() async {
+          await Hive.close();
+          await hiveDirectory.delete(recursive: true);
+        });
+
+        final adapter = _StaticDetailGalleryAdapter(sourceId);
+        final container = createContainer(galleryAdapters: {sourceId: adapter});
+        addTearDown(container.dispose);
+        final item = GalleryItem(
+          id: sourceId.index + 1,
+          workId: 'work-${sourceId.key}',
+          sourceId: sourceId,
+          title: '${sourceId.label} work',
+          cover: GalleryMedia(
+            id: 'media-${sourceId.key}',
+            displayUrl: 'https://example.test/${sourceId.key}.webp',
+          ),
+        );
+        final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+        expect(await notifier.toggleFavorite(item), isTrue);
+        expect(adapter.detailCalls, 1);
+        expect(notifier.isLocallyFavorited(item), isTrue);
+        expect(await notifier.toggleFavorite(item), isTrue);
+        expect(notifier.isLocallyFavorited(item), isFalse);
+      },
+    );
+  }
+
+  test('Gelbooru remote favorites never call Danbooru writes', () async {
+    final gelbooruApi = _FakeGelbooruApiService(
+      favoritesResult: GelbooruPostPage(
+        posts: [_gelbooruPost(123)],
+        rawCount: 1,
+      ),
+    );
+    final danbooruApi = _FakeDanbooruApiService();
+    final container = createContainer(
+      storedCredentials: stored(credentials),
+      gelbooruApi: gelbooruApi,
+      danbooruApi: danbooruApi,
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.setFavoritesSource('gelbooru');
+    await notifier.switchToFavorites();
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(gelbooruApi.favoritesCalls, 1);
+    expect(
+      state.favoritesCacheFor(GallerySourceId.gelbooru).posts,
+      hasLength(1),
+    );
+    expect(state.favoritesCacheFor(GallerySourceId.danbooru).posts, isEmpty);
+    expect(state.favoritedPostKeys, contains('gelbooru:123'));
+    expect(state.favoritedPostKeys, isNot(contains('danbooru:123')));
+
+    expect(await notifier.toggleFavorite(state.posts.single), isFalse);
+    expect(danbooruApi.addFavoriteCalls, 0);
+    expect(danbooruApi.removeFavoriteCalls, 0);
+  });
 
   test(
     'Gelbooru local and remote favorite membership remain independent',
@@ -232,6 +383,10 @@ void main() {
       });
 
       final item = _gelbooruPost(321);
+      final localItem = item.copyWith(
+        title: 'Saved title',
+        description: 'Complete local description',
+      );
       final gelbooruApi = _FakeGelbooruApiService(
         favoritesResult: GelbooruPostPage(posts: [item], rawCount: 1),
       );
@@ -244,7 +399,7 @@ void main() {
         onlineGalleryLocalFavoritesProvider.notifier,
       );
       await localFavorites.upsert(
-        GalleryDetail(item: item, media: [item.cover]),
+        GalleryDetail(item: localItem, media: [localItem.cover]),
       );
       final notifier = container.read(onlineGalleryNotifierProvider.notifier);
 
@@ -252,20 +407,382 @@ void main() {
       await notifier.switchToFavorites();
       expect(notifier.isFavorited(item), isTrue);
 
+      final mergedPosts = container.read(onlineGalleryNotifierProvider).posts;
+      expect(mergedPosts, hasLength(1));
+      expect(mergedPosts.single.title, 'Saved title');
+      expect(mergedPosts.single.previewUrl, item.previewUrl);
+      expect(notifier.isRemotelyFavorited(item), isTrue);
+      expect(notifier.isLocallyFavorited(item), isTrue);
+
+      expect(await notifier.toggleFavorite(item), isTrue);
+      expect(notifier.isFavorited(item), isFalse);
+      expect(notifier.isRemotelyFavorited(item), isTrue);
+      expect(notifier.isLocallyFavorited(item), isFalse);
+
       notifier.invalidateGelbooruFavorites();
       expect(notifier.isFavorited(item), isFalse);
-      expect(
-        container
-            .read(onlineGalleryNotifierProvider)
-            .favoritedPostKeys
-            .contains(item.stableKey),
-        isTrue,
-      );
-
-      await notifier.setFavoritesScope(GalleryFavoritesScope.local);
-      expect(notifier.isFavorited(item), isTrue);
+      expect(notifier.isRemotelyFavorited(item), isFalse);
     },
   );
+
+  test('favorite search filters both local and remote results', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-favorites-search-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
+
+    final localMatch = _gelbooruPost(701, tagString: 'blue dog');
+    final remoteMatch = _gelbooruPost(702, tagString: 'red dog');
+    final remoteMiss = _gelbooruPost(703, tagString: 'green cat');
+    final gelbooruApi = _FakeGelbooruApiService(
+      favoritesResult: GelbooruPostPage(
+        posts: [remoteMatch, remoteMiss],
+        rawCount: 2,
+      ),
+    );
+    final container = createContainer(
+      storedCredentials: stored(credentials),
+      gelbooruApi: gelbooruApi,
+    );
+    addTearDown(container.dispose);
+    await container
+        .read(onlineGalleryLocalFavoritesProvider.notifier)
+        .upsert(GalleryDetail(item: localMatch, media: [localMatch.cover]));
+
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    await notifier.setFavoritesSource(GallerySourceId.gelbooru);
+    await notifier.searchFavorites('dog');
+
+    expect(
+      container
+          .read(onlineGalleryNotifierProvider)
+          .posts
+          .map((item) => item.stableKey),
+      [localMatch.stableKey, remoteMatch.stableKey],
+    );
+  });
+
+  test('complete favorite failure does not expose a partial failure', () async {
+    final container = createContainer(
+      storedCredentials: stored(credentials),
+      gelbooruApi: _FakeGelbooruApiService(
+        searchError: const GelbooruApiException(
+          GelbooruApiErrorType.rateLimited,
+          statusCode: 429,
+        ),
+      ),
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.setFavoritesSource(GallerySourceId.gelbooru);
+    await notifier.switchToFavorites();
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(state.errorCode, isNotNull);
+    expect(state.currentCache.hasFavoritesPartialFailure, isFalse);
+    expect(state.currentCache.localFavoritesErrorCode, isNull);
+    expect(state.currentCache.remoteFavoritesErrorCode, isNull);
+  });
+
+  test('remote favorites failure preserves local favorites', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-partial-favorites-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
+
+    final item = _gelbooruPost(888);
+    final remoteItem = _gelbooruPost(889);
+    final gelbooruApi = _FakeGelbooruApiService(
+      favoritesResult: GelbooruPostPage(posts: [remoteItem], rawCount: 1),
+    );
+    final container = createContainer(
+      storedCredentials: stored(credentials),
+      gelbooruApi: gelbooruApi,
+    );
+    addTearDown(container.dispose);
+    await container
+        .read(onlineGalleryLocalFavoritesProvider.notifier)
+        .upsert(GalleryDetail(item: item, media: [item.cover]));
+
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    await notifier.setFavoritesSource(GallerySourceId.gelbooru);
+    await notifier.switchToFavorites();
+    gelbooruApi.searchError = const GelbooruApiException(
+      GelbooruApiErrorType.rateLimited,
+      statusCode: 429,
+    );
+    await notifier.refresh();
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(state.posts.map((post) => post.stableKey), [
+      item.stableKey,
+      remoteItem.stableKey,
+    ]);
+    expect(state.errorCode, isNull);
+    expect(
+      state.currentCache.remoteFavoritesErrorCode,
+      OnlineGalleryErrorCode.gelbooruRateLimited,
+    );
+    expect(state.currentCache.localFavoritesErrorCode, isNull);
+  });
+
+  test('cancelled remote favorites cannot overwrite a newer mode', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-favorites-cancellation-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
+
+    final remoteResult = Completer<GelbooruPostPage>();
+    final remoteStarted = Completer<void>();
+    final gelbooruApi = _FakeGelbooruApiService(
+      favoritesLoader: (pid) {
+        if (!remoteStarted.isCompleted) remoteStarted.complete();
+        return remoteResult.future;
+      },
+    );
+    final container = createContainer(
+      storedCredentials: stored(credentials),
+      gelbooruApi: gelbooruApi,
+    );
+    addTearDown(container.dispose);
+    final localItem = _gelbooruPost(888);
+    await container
+        .read(onlineGalleryLocalFavoritesProvider.notifier)
+        .upsert(GalleryDetail(item: localItem, media: [localItem.cover]));
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    await notifier.setFavoritesSource(GallerySourceId.gelbooru);
+
+    final pendingFavorites = notifier.switchToFavorites();
+    await remoteStarted.future;
+    await notifier.switchToSearch();
+    remoteResult.complete(
+      GelbooruPostPage(posts: [_gelbooruPost(999)], rawCount: 1),
+    );
+    await pendingFavorites;
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(state.viewMode, GalleryViewMode.search);
+    expect(
+      state
+          .favoritesCacheFor(GallerySourceId.gelbooru)
+          .posts
+          .map((item) => item.id),
+      [888],
+    );
+  });
+
+  test('account login reloads the active unified favorites view', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-favorites-auth-reload-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
+
+    final auth = _MutableDanbooruAuth();
+    final remoteItem = _danbooruPost(902);
+    final api = _FakeDanbooruApiService(favoritesResult: [remoteItem]);
+    final container = createContainer(danbooruApi: api, danbooruAuth: auth);
+    addTearDown(container.dispose);
+    final localItem = _danbooruPost(901);
+    await container
+        .read(onlineGalleryLocalFavoritesProvider.notifier)
+        .upsert(GalleryDetail(item: localItem, media: [localItem.cover]));
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.switchToFavorites();
+    expect(
+      container.read(onlineGalleryNotifierProvider).posts.single.stableKey,
+      localItem.stableKey,
+    );
+
+    auth.logIn();
+    for (var attempt = 0; attempt < 20; attempt++) {
+      await Future<void>.delayed(Duration.zero);
+      final state = container.read(onlineGalleryNotifierProvider);
+      if (!state.isLoading && state.posts.length == 2) break;
+    }
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(state.posts.map((item) => item.stableKey), {
+      localItem.stableKey,
+      remoteItem.stableKey,
+    });
+    expect(api.favoritesCalls, 1);
+  });
+
+  test('cross-branch duplicate pages do not truncate later results', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-favorites-cross-branch-duplicates-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
+
+    final gelbooruApi = _FakeGelbooruApiService(
+      favoritesByPid: {
+        0: GelbooruPostPage(
+          posts: [for (var id = 61; id <= 120; id++) _gelbooruPost(id)],
+          rawCount: 60,
+        ),
+        1: GelbooruPostPage(
+          posts: [for (var id = 1; id <= 60; id++) _gelbooruPost(id)],
+          rawCount: 60,
+        ),
+        2: GelbooruPostPage(posts: [_gelbooruPost(121)], rawCount: 1),
+      },
+    );
+    final container = createContainer(
+      storedCredentials: stored(credentials),
+      gelbooruApi: gelbooruApi,
+    );
+    addTearDown(container.dispose);
+    await container
+        .read(onlineGalleryLocalFavoritesProvider.notifier)
+        .upsertAll([
+          for (var id = 1; id <= 60; id++)
+            GalleryDetail(
+              item: _gelbooruPost(id),
+              media: [_gelbooruPost(id).cover],
+            ),
+        ]);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    await notifier.setFavoritesSource(GallerySourceId.gelbooru);
+    await notifier.switchToFavorites();
+
+    await notifier.loadMore();
+    var state = container.read(onlineGalleryNotifierProvider);
+    expect(state.posts, hasLength(120));
+    expect(state.hasMore, isTrue);
+
+    await notifier.loadMore();
+    state = container.read(onlineGalleryNotifierProvider);
+    expect(state.posts.map((item) => item.id), contains(121));
+    expect(gelbooruApi.favoritePids, [0, 1, 2]);
+  });
+
+  test('deduplication keeps the more complete favorite row', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-favorites-richer-row-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
+
+    final localItem = _gelbooruPost(777).copyWith(
+      title: 'Complete local title',
+      description: 'A complete local description with useful details',
+      tags: const ['one', 'two', 'three'],
+    );
+    final remoteItem = _gelbooruPost(
+      777,
+    ).copyWith(title: 'x', description: 'y');
+    final container = createContainer(
+      storedCredentials: stored(credentials),
+      gelbooruApi: _FakeGelbooruApiService(
+        favoritesResult: GelbooruPostPage(posts: [remoteItem], rawCount: 1),
+      ),
+    );
+    addTearDown(container.dispose);
+    await container
+        .read(onlineGalleryLocalFavoritesProvider.notifier)
+        .upsert(GalleryDetail(item: localItem, media: [localItem.cover]));
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    await notifier.setFavoritesSource(GallerySourceId.gelbooru);
+    await notifier.switchToFavorites();
+
+    final merged = container.read(onlineGalleryNotifierProvider).posts.single;
+    expect(merged.title, 'Complete local title');
+    expect(merged.description, contains('useful details'));
+    expect(merged.tags, containsAll(['one', 'two', 'three']));
+  });
+
+  test('local and remote favorites advance independent cursors', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-favorites-pagination-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
+
+    final gelbooruApi = _FakeGelbooruApiService(
+      favoritesByPid: {
+        0: GelbooruPostPage(
+          posts: [for (var id = 1; id <= 60; id++) _gelbooruPost(id)],
+          rawCount: 60,
+        ),
+        1: GelbooruPostPage(posts: [_gelbooruPost(62)], rawCount: 1),
+      },
+    );
+    final container = createContainer(
+      storedCredentials: stored(credentials),
+      gelbooruApi: gelbooruApi,
+    );
+    addTearDown(container.dispose);
+    await container
+        .read(onlineGalleryLocalFavoritesProvider.notifier)
+        .upsertAll([
+          for (var id = 61; id >= 1; id--)
+            GalleryDetail(
+              item: _gelbooruPost(id),
+              media: [_gelbooruPost(id).cover],
+            ),
+        ]);
+
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    await notifier.setFavoritesSource(GallerySourceId.gelbooru);
+    await notifier.switchToFavorites();
+    var state = container.read(onlineGalleryNotifierProvider);
+    expect(state.posts, hasLength(60));
+    expect(state.currentCache.localFavoritesOffset, 60);
+    expect(state.currentCache.remoteFavoritesPage, 2);
+    expect(state.currentCache.localFavoritesHasMore, isTrue);
+    expect(state.currentCache.remoteFavoritesHasMore, isTrue);
+
+    await notifier.loadMore();
+    state = container.read(onlineGalleryNotifierProvider);
+    expect(state.posts, hasLength(62));
+    expect(state.posts.map((item) => item.id), containsAll([61, 62]));
+    expect(state.currentCache.localFavoritesOffset, 61);
+    expect(state.currentCache.remoteFavoritesPage, 3);
+    expect(state.currentCache.hasMore, isFalse);
+    expect(gelbooruApi.favoritePids, [0, 1]);
+  });
 
   test('favorite caches retain independent scroll and pagination state', () {
     final danbooruCache = ModeCache(
@@ -291,7 +808,7 @@ void main() {
 
     expect(state.currentCache.page, 5);
     expect(state.currentCache.scrollOffset, 340);
-    expect(state.danbooruFavoritesCache.scrollOffset, 120);
+    expect(state.favoritesCacheFor(GallerySourceId.danbooru).scrollOffset, 120);
     expect(state.favoritedPostKeys, hasLength(2));
   });
 
@@ -349,14 +866,14 @@ void main() {
   });
 }
 
-DanbooruPost _gelbooruPost(int id) {
+DanbooruPost _gelbooruPost(int id, {String tagString = 'solo'}) {
   return DanbooruPost(
     id: id,
     site: 'gelbooru',
     rating: 'g',
     width: 1200,
     height: 800,
-    tagString: 'solo',
+    tagString: tagString,
     fileExt: 'jpg',
     previewFileUrl: 'https://img3.gelbooru.com/thumb/$id.jpg',
   );
@@ -376,9 +893,10 @@ DanbooruPost _danbooruPost(int id) {
 }
 
 class _FakeSecureStorage extends SecureStorageService {
-  _FakeSecureStorage({this.gelbooru});
+  _FakeSecureStorage({this.gelbooru, this.danbooru});
 
   String? gelbooru;
+  String? danbooru;
 
   @override
   Future<String?> getGelbooruCredentials() async => gelbooru;
@@ -389,19 +907,32 @@ class _FakeSecureStorage extends SecureStorageService {
   }
 
   @override
-  Future<String?> getDanbooruCredentials() async => null;
+  Future<String?> getDanbooruCredentials() async => danbooru;
+}
+
+class _FakeDanbooruCredentialVerifier extends DanbooruCredentialVerifier {
+  @override
+  Future<(DanbooruUser?, bool isNetworkError)> verify(
+    DanbooruCredentials credentials,
+  ) async {
+    return (DanbooruUser(id: 1, name: credentials.username), false);
+  }
 }
 
 class _FakeGelbooruApiService extends GelbooruApiService {
   _FakeGelbooruApiService({
     this.searchResult = const GelbooruPostPage(posts: [], rawCount: 0),
     this.favoritesResult = const GelbooruPostPage(posts: [], rawCount: 0),
+    this.favoritesByPid,
+    this.favoritesLoader,
     this.searchError,
   }) : super(Dio());
 
   final GelbooruPostPage searchResult;
   final GelbooruPostPage favoritesResult;
-  final GelbooruApiException? searchError;
+  final Map<int, GelbooruPostPage>? favoritesByPid;
+  final Future<GelbooruPostPage> Function(int pid)? favoritesLoader;
+  GelbooruApiException? searchError;
   int searchCalls = 0;
   int favoritesCalls = 0;
   final List<int> searchPids = [];
@@ -432,15 +963,30 @@ class _FakeGelbooruApiService extends GelbooruApiService {
     favoritesCalls++;
     favoritePids.add(pid);
     if (searchError != null) throw searchError!;
-    return favoritesResult;
+    final loader = favoritesLoader;
+    if (loader != null) return loader(pid);
+    return favoritesByPid?[pid] ?? favoritesResult;
   }
 }
 
 class _FakeDanbooruApiService extends DanbooruApiService {
-  _FakeDanbooruApiService() : super(Dio());
+  _FakeDanbooruApiService({this.favoritesResult = const []}) : super(Dio());
 
+  final List<DanbooruPost> favoritesResult;
+  int favoritesCalls = 0;
   int addFavoriteCalls = 0;
   int removeFavoriteCalls = 0;
+
+  @override
+  Future<List<DanbooruPost>> getFavorites({
+    String? username,
+    int? userId,
+    dynamic page = 1,
+    int limit = 40,
+  }) async {
+    favoritesCalls++;
+    return favoritesResult;
+  }
 
   @override
   Future<bool> addFavorite(int postId) async {
@@ -452,6 +998,53 @@ class _FakeDanbooruApiService extends DanbooruApiService {
   Future<bool> removeFavorite(int postId) async {
     removeFavoriteCalls++;
     return true;
+  }
+}
+
+class _StaticDetailGalleryAdapter extends GallerySourceAdapter {
+  _StaticDetailGalleryAdapter(this.sourceId);
+
+  @override
+  final GallerySourceId sourceId;
+  int detailCalls = 0;
+
+  @override
+  Future<GalleryPage> search(
+    GallerySearchRequest request, {
+    CancelToken? cancelToken,
+  }) async => const GalleryPage(
+    items: [],
+    cursor: '1',
+    nextCursor: null,
+    hasMore: false,
+  );
+
+  @override
+  Future<GalleryDetail> detail(
+    GalleryItem item, {
+    CancelToken? cancelToken,
+  }) async {
+    detailCalls++;
+    return GalleryDetail(item: item, media: [item.cover]);
+  }
+}
+
+class _MutableDanbooruAuth extends DanbooruAuth {
+  @override
+  DanbooruAuthState build() => const DanbooruAuthState();
+
+  @override
+  Future<void> ensureInitialized() async {}
+
+  void logIn() {
+    state = DanbooruAuthState(
+      credentials: const DanbooruCredentials(
+        username: 'tester',
+        apiKey: 'dan-key',
+      ),
+      user: const DanbooruUser(id: 1, name: 'tester'),
+      lastVerifiedAt: DateTime.now(),
+    );
   }
 }
 
@@ -474,19 +1067,33 @@ class _GalleryHttpAdapter implements HttpClientAdapter {
         },
       );
     }
+    const danbooruPost = {
+      'id': 10,
+      'rating': 'g',
+      'image_width': 640,
+      'image_height': 480,
+      'tag_string_general': 'solo',
+      'file_ext': 'jpg',
+      'preview_file_url': 'https://cdn.donmai.us/preview/10.jpg',
+    };
     if (options.uri.path == '/posts.json') {
       return ResponseBody.fromString(
-        jsonEncode([
-          {
-            'id': 10,
-            'rating': 'g',
-            'image_width': 640,
-            'image_height': 480,
-            'tag_string_general': 'solo',
-            'file_ext': 'jpg',
-            'preview_file_url': 'https://cdn.donmai.us/preview/10.jpg',
-          },
-        ]),
+        jsonEncode([danbooruPost]),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+    }
+    if (options.uri.path.startsWith('/posts/') &&
+        options.uri.path.endsWith('.json')) {
+      final id = int.parse(options.uri.path.split('/').last.split('.').first);
+      return ResponseBody.fromString(
+        jsonEncode({
+          ...danbooruPost,
+          'id': id,
+          'preview_file_url': 'https://cdn.donmai.us/preview/$id.jpg',
+        }),
         200,
         headers: {
           Headers.contentTypeHeader: [Headers.jsonContentType],

--- a/test/presentation/providers/online_gallery_random_mode_test.dart
+++ b/test/presentation/providers/online_gallery_random_mode_test.dart
@@ -186,7 +186,6 @@ void main() {
     const initialState = OnlineGalleryState(
       viewMode: GalleryViewMode.favorites,
       favoritesSourceId: GallerySourceId.quickTagCloud,
-      favoritesScope: GalleryFavoritesScope.local,
     );
     final favoriteCacheKey = initialState.currentCacheKey;
     await storage.setSetting(
@@ -257,8 +256,8 @@ void main() {
       GalleryViewMode.favorites,
     );
     expect(
-      container.read(onlineGalleryNotifierProvider).favoritesScope,
-      GalleryFavoritesScope.local,
+      container.read(onlineGalleryNotifierProvider).favoritesSourceId,
+      GallerySourceId.quickTagCloud,
     );
 
     await notifier.setRandomEnabled(true);

--- a/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
@@ -349,6 +349,7 @@ void main() {
         _selectedModeColor(tester, 'online-gallery-mode-favorites'),
         const Color(0xFFBE185D),
       );
+      expect(find.byIcon(Icons.cloud_done), findsOneWidget);
       await tester.tap(
         find.byKey(const ValueKey('online-gallery-source-filters')),
       );
@@ -357,6 +358,8 @@ void main() {
 
       expect(find.text('Read-only favorites'), findsWidgets);
       expect(find.textContaining('Sorted by post ID'), findsOneWidget);
+      expect(find.text('Local favorites'), findsNothing);
+      expect(find.text('Cloud favorites'), findsNothing);
       final avatar = find.byKey(
         const ValueKey('online-gallery-account-avatar'),
       );
@@ -367,6 +370,56 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  for (final width in [700.0, 840.0, 1180.0, 1600.0]) {
+    testWidgets('unified favorites stay aligned at width $width', (
+      tester,
+    ) async {
+      await _setViewSize(tester, width);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            onlineGalleryNotifierProvider.overrideWith(
+              _GelbooruFavoritesGalleryNotifier.new,
+            ),
+            danbooruAuthProvider.overrideWith(_LoggedOutDanbooruAuth.new),
+            gelbooruAuthProvider.overrideWith(_AuthenticatedGelbooruAuth.new),
+            danbooruSuggestionNotifierProvider.overrideWith(
+              _EmptyDanbooruSuggestionNotifier.new,
+            ),
+          ],
+          child: const _TestApp(),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Local favorites'), findsNothing);
+      expect(find.text('Cloud favorites'), findsNothing);
+      final primaryRow = tester.getRect(
+        find.byKey(const ValueKey('online-gallery-toolbar-primary-row')),
+      );
+      for (final key in [
+        'online-gallery-source-selector',
+        'online-gallery-mode-favorites',
+        'online-gallery-rating-filter',
+        'online-gallery-primary-search',
+        'online-gallery-blacklist',
+        'online-gallery-output-filter',
+        'online-gallery-random-toggle',
+        'online-gallery-refresh',
+        'online-gallery-multi-select',
+        'online-gallery-account-avatar',
+      ]) {
+        final rect = tester.getRect(find.byKey(ValueKey(key)));
+        expect(
+          (rect.center.dy - primaryRow.center.dy).abs(),
+          lessThan(1),
+          reason: '$key must stay in the primary row at width $width',
+        );
+      }
+      expect(tester.takeException(), isNull);
+    });
+  }
 
   for (final width in [700.0, 840.0, 1180.0, 1600.0]) {
     testWidgets('AI TAG controls adapt without overflow at width $width', (
@@ -1549,8 +1602,11 @@ class _GelbooruFavoritesGalleryNotifier extends OnlineGalleryNotifier {
     return const OnlineGalleryState(
       viewMode: GalleryViewMode.favorites,
       favoritesSourceId: GallerySourceId.gelbooru,
-      gelbooruFavoritesCache: ModeCache(posts: [_gelbooruPost], hasMore: false),
       favoritedPostKeys: {'gelbooru:301'},
+      remoteFavoritedPostKeys: {'gelbooru:301'},
+    ).updateFavoritesCache(
+      GallerySourceId.gelbooru,
+      const ModeCache(posts: [_gelbooruPost], hasMore: false),
     );
   }
 }
@@ -1558,6 +1614,9 @@ class _GelbooruFavoritesGalleryNotifier extends OnlineGalleryNotifier {
 class _LoggedOutDanbooruAuth extends DanbooruAuth {
   @override
   DanbooruAuthState build() => const DanbooruAuthState();
+
+  @override
+  Future<void> ensureInitialized() async {}
 }
 
 class _UnconfiguredGelbooruAuth extends GelbooruAuth {


### PR DESCRIPTION
## 变更
- 合并在线画廊本地与云端收藏视图，按来源稳定键去重
- 同一作品保留更完整数据，并分别维护本地与远端收藏状态
- 修复账号登录、退出和切换后的自动重载
- 修复跨本地/云端重复页导致分页提前结束
- 完善旧收藏 scope 迁移、完整失败提示及 AI TAG / QuickTagCloud 本地收藏写入

## 验证
- scripts/test_affected.ps1：201 项通过
- 相关 Provider 测试：23 项通过
- scoped flutter analyze：通过
- 700 / 840 / 1180 / 1600 收藏布局回归通过