### PR TITLE
feat(generation): 折叠并持久化角色二级菜单

### DIFF
--- a/lib/core/constants/storage_keys.dart
+++ b/lib/core/constants/storage_keys.dart
@@ -61,8 +61,12 @@ class StorageKeys {
   static const String fixedTagsSidebarViewMode = 'fixed_tags_sidebar_view_mode';
   static const String fixedTagsNegativeHeight = 'fixed_tags_negative_height';
 
-  // Panel Expansion State Keys (面板展开状态)
+  // Generation Workbench Panel Expansion State Keys (生图工作台面板展开状态)
   static const String advancedOptionsExpanded = 'advanced_options_expanded';
+  static const String generationParamsMenuExpanded =
+      'generation_params_menu_expanded';
+  static const String characterPanelExpanded = 'character_panel_expanded';
+  static const String reversePromptExpanded = 'reverse_prompt_expanded';
   static const String img2imgExpanded = 'img2img_expanded';
   static const String vibeTransferExpanded = 'vibe_transfer_expanded';
   static const String preciseRefExpanded = 'precise_ref_expanded';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1088,6 +1088,28 @@
       "index": {}
     }
   },
+  "character_summaryEmpty": "No characters added",
+  "character_summaryEnabled": "{count} enabled · {name}",
+  "@character_summaryEnabled": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "name": {"type": "String"}
+    }
+  },
+  "character_summaryMore": "{count} enabled · {name} +{additional}",
+  "@character_summaryMore": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "name": {"type": "String"},
+      "additional": {"type": "int"}
+    }
+  },
+  "character_summaryAllDisabled": "0 enabled · {count} disabled",
+  "@character_summaryAllDisabled": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "gallery_generationParams": "Generation Parameters",
   "gallery_metaModel": "Model",
   "gallery_metaResolution": "Resolution",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1077,6 +1077,28 @@
       "index": {}
     }
   },
+  "character_summaryEmpty": "キャラクター未追加",
+  "character_summaryEnabled": "{count}人有効 · {name}",
+  "@character_summaryEnabled": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "name": {"type": "String"}
+    }
+  },
+  "character_summaryMore": "{count}人有効 · {name} +{additional}",
+  "@character_summaryMore": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "name": {"type": "String"},
+      "additional": {"type": "int"}
+    }
+  },
+  "character_summaryAllDisabled": "0人有効 · {count}人無効",
+  "@character_summaryAllDisabled": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "gallery_generationParams": "生成パラメータ",
   "gallery_metaModel": "モデル",
   "gallery_metaResolution": "解像度",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4329,6 +4329,30 @@ abstract class AppLocalizations {
   /// **'Character {index}'**
   String character_number(Object index);
 
+  /// No description provided for @character_summaryEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No characters added'**
+  String get character_summaryEmpty;
+
+  /// No description provided for @character_summaryEnabled.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} enabled · {name}'**
+  String character_summaryEnabled(int count, String name);
+
+  /// No description provided for @character_summaryMore.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} enabled · {name} +{additional}'**
+  String character_summaryMore(int count, String name, int additional);
+
+  /// No description provided for @character_summaryAllDisabled.
+  ///
+  /// In en, this message translates to:
+  /// **'0 enabled · {count} disabled'**
+  String character_summaryAllDisabled(int count);
+
   /// No description provided for @gallery_generationParams.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2384,6 +2384,24 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get character_summaryEmpty => 'No characters added';
+
+  @override
+  String character_summaryEnabled(int count, String name) {
+    return '$count enabled · $name';
+  }
+
+  @override
+  String character_summaryMore(int count, String name, int additional) {
+    return '$count enabled · $name +$additional';
+  }
+
+  @override
+  String character_summaryAllDisabled(int count) {
+    return '0 enabled · $count disabled';
+  }
+
+  @override
   String get gallery_generationParams => 'Generation Parameters';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2334,6 +2334,24 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get character_summaryEmpty => 'キャラクター未追加';
+
+  @override
+  String character_summaryEnabled(int count, String name) {
+    return '$count人有効 · $name';
+  }
+
+  @override
+  String character_summaryMore(int count, String name, int additional) {
+    return '$count人有効 · $name +$additional';
+  }
+
+  @override
+  String character_summaryAllDisabled(int count) {
+    return '0人有効 · $count人無効';
+  }
+
+  @override
   String get gallery_generationParams => '生成パラメータ';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2300,6 +2300,24 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get character_summaryEmpty => '未添加角色';
+
+  @override
+  String character_summaryEnabled(int count, String name) {
+    return '已启用 $count 个 · $name';
+  }
+
+  @override
+  String character_summaryMore(int count, String name, int additional) {
+    return '已启用 $count 个 · $name +$additional';
+  }
+
+  @override
+  String character_summaryAllDisabled(int count) {
+    return '已启用 0 个 · 已停用 $count 个';
+  }
+
+  @override
   String get gallery_generationParams => '生成参数';
 
   @override
@@ -14377,6 +14395,24 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String character_number(Object index) {
     return '角色 $index';
+  }
+
+  @override
+  String get character_summaryEmpty => '未新增角色';
+
+  @override
+  String character_summaryEnabled(int count, String name) {
+    return '已啟用 $count 個 · $name';
+  }
+
+  @override
+  String character_summaryMore(int count, String name, int additional) {
+    return '已啟用 $count 個 · $name +$additional';
+  }
+
+  @override
+  String character_summaryAllDisabled(int count) {
+    return '已啟用 0 個 · 已停用 $count 個';
   }
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -995,6 +995,28 @@
   "character_addCharacter": "添加角色",
   "character_limitReached": "已达当前模型的角色上限（{limit} 个）",
   "character_number": "角色 {index}",
+  "character_summaryEmpty": "未添加角色",
+  "character_summaryEnabled": "已启用 {count} 个 · {name}",
+  "@character_summaryEnabled": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "name": {"type": "String"}
+    }
+  },
+  "character_summaryMore": "已启用 {count} 个 · {name} +{additional}",
+  "@character_summaryMore": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "name": {"type": "String"},
+      "additional": {"type": "int"}
+    }
+  },
+  "character_summaryAllDisabled": "已启用 0 个 · 已停用 {count} 个",
+  "@character_summaryAllDisabled": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "gallery_generationParams": "生成参数",
   "gallery_metaModel": "模型",
   "gallery_metaResolution": "分辨率",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1011,6 +1011,28 @@
   "character_addCharacter": "新增角色",
   "character_limitReached": "已達當前模型的角色上限（{limit} 個）",
   "character_number": "角色 {index}",
+  "character_summaryEmpty": "未新增角色",
+  "character_summaryEnabled": "已啟用 {count} 個 · {name}",
+  "@character_summaryEnabled": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "name": {"type": "String"}
+    }
+  },
+  "character_summaryMore": "已啟用 {count} 個 · {name} +{additional}",
+  "@character_summaryMore": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "name": {"type": "String"},
+      "additional": {"type": "int"}
+    }
+  },
+  "character_summaryAllDisabled": "已啟用 0 個 · 已停用 {count} 個",
+  "@character_summaryAllDisabled": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "gallery_generationParams": "生成引數",
   "gallery_metaModel": "模型",
   "gallery_metaResolution": "解析度",

--- a/lib/presentation/providers/generation/generation_panel_expansion_provider.dart
+++ b/lib/presentation/providers/generation/generation_panel_expansion_provider.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/constants/storage_keys.dart';
+import '../../../core/storage/local_storage_service.dart';
+import '../../../core/utils/app_logger.dart';
+
+/// 生图工作台顶层二级菜单。
+///
+/// 每个菜单使用独立存储键，新增菜单或旧配置损坏时不会影响其他菜单。
+enum GenerationWorkbenchPanel {
+  generationParameters,
+  characters,
+  reversePrompt,
+  img2img,
+  vibeTransfer,
+  preciseReference,
+}
+
+extension GenerationWorkbenchPanelStorage on GenerationWorkbenchPanel {
+  String get storageKey => switch (this) {
+    GenerationWorkbenchPanel.generationParameters =>
+      StorageKeys.generationParamsMenuExpanded,
+    GenerationWorkbenchPanel.characters => StorageKeys.characterPanelExpanded,
+    GenerationWorkbenchPanel.reversePrompt => StorageKeys.reversePromptExpanded,
+    GenerationWorkbenchPanel.img2img => StorageKeys.img2imgExpanded,
+    GenerationWorkbenchPanel.vibeTransfer => StorageKeys.vibeTransferExpanded,
+    GenerationWorkbenchPanel.preciseReference => StorageKeys.preciseRefExpanded,
+  };
+
+  /// 旧版本没有可靠的顶层面板持久状态，统一从紧凑的收起状态开始。
+  bool get defaultExpanded => false;
+}
+
+class GenerationPanelExpansionState {
+  const GenerationPanelExpansionState(this._values);
+
+  final Map<GenerationWorkbenchPanel, bool> _values;
+
+  bool isExpanded(GenerationWorkbenchPanel panel) =>
+      _values[panel] ?? panel.defaultExpanded;
+
+  GenerationPanelExpansionState copyWith(
+    GenerationWorkbenchPanel panel,
+    bool expanded,
+  ) {
+    return GenerationPanelExpansionState(
+      Map.unmodifiable({..._values, panel: expanded}),
+    );
+  }
+}
+
+final generationPanelExpansionProvider =
+    NotifierProvider<
+      GenerationPanelExpansionNotifier,
+      GenerationPanelExpansionState
+    >(GenerationPanelExpansionNotifier.new);
+
+class GenerationPanelExpansionNotifier
+    extends Notifier<GenerationPanelExpansionState> {
+  LocalStorageService get _storage => ref.read(localStorageServiceProvider);
+
+  @override
+  GenerationPanelExpansionState build() {
+    return GenerationPanelExpansionState(
+      Map.unmodifiable({
+        for (final panel in GenerationWorkbenchPanel.values)
+          panel: _readExpanded(panel),
+      }),
+    );
+  }
+
+  bool _readExpanded(GenerationWorkbenchPanel panel) {
+    final value = _storage.getSetting<dynamic>(panel.storageKey);
+    return value is bool ? value : panel.defaultExpanded;
+  }
+
+  Future<void> setExpanded(
+    GenerationWorkbenchPanel panel,
+    bool expanded,
+  ) async {
+    if (state.isExpanded(panel) == expanded) return;
+    state = state.copyWith(panel, expanded);
+    try {
+      await _storage.setSetting(panel.storageKey, expanded);
+    } catch (error, stackTrace) {
+      AppLogger.e(
+        'Failed to persist ${panel.name} panel expansion state',
+        error,
+        stackTrace,
+        'GenerationPanelExpansion',
+      );
+    }
+  }
+
+  Future<void> toggle(GenerationWorkbenchPanel panel) {
+    return setExpanded(panel, !state.isExpanded(panel));
+  }
+}

--- a/lib/presentation/providers/generation/image_workflow_controller.dart
+++ b/lib/presentation/providers/generation/image_workflow_controller.dart
@@ -12,6 +12,7 @@ import '../../../core/utils/app_logger.dart';
 import '../../../core/utils/focused_inpaint_utils.dart';
 import '../../../core/utils/nai_resolution_adapter.dart';
 import '../../../data/models/image/image_params.dart';
+import 'generation_panel_expansion_provider.dart';
 import 'generation_params_notifier.dart';
 
 enum ImageWorkflowMode { base, inpaint, enhance, upscale }
@@ -488,10 +489,12 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
   ImageWorkflowState _buildDefaultState({
     EnhanceWorkflowSettings? enhance,
     UpscaleWorkflowSettings? upscale,
+    bool? isPanelExpanded,
   }) {
     return ImageWorkflowState(
       enhance: enhance ?? const EnhanceWorkflowSettings(),
       upscale: upscale ?? const UpscaleWorkflowSettings(),
+      isPanelExpanded: isPanelExpanded ?? false,
     );
   }
 
@@ -510,7 +513,20 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
         }
       },
     );
+    ref.listen<bool>(
+      generationPanelExpansionProvider.select(
+        (value) => value.isExpanded(GenerationWorkbenchPanel.img2img),
+      ),
+      (previous, next) {
+        if (state.isPanelExpanded != next) {
+          state = state.copyWith(isPanelExpanded: next);
+        }
+      },
+    );
 
+    final persistedPanelExpanded = ref
+        .read(generationPanelExpansionProvider)
+        .isExpanded(GenerationWorkbenchPanel.img2img);
     final persistedScale = _readPersistedUpscaleScale();
     final legacyPersistedModel = _readPersistedStringSetting(
       StorageKeys.comfyuiUpscaleModel,
@@ -592,6 +608,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
 
     return _buildDefaultState(
       enhance: persistedEnhance,
+      isPanelExpanded: persistedPanelExpanded,
       upscale: UpscaleWorkflowSettings(
         backend: persistedBackend,
         comfyModule: persistedComfyModule,
@@ -1078,11 +1095,22 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
 
     _paramsNotifier.clearImg2Img();
     _paramsNotifier.setMaskImage(null);
-    state = _buildDefaultState(enhance: state.enhance, upscale: state.upscale);
+    state = _buildDefaultState(
+      enhance: state.enhance,
+      upscale: state.upscale,
+      isPanelExpanded: state.isPanelExpanded,
+    );
   }
 
   void setPanelExpanded(bool value) {
-    state = state.copyWith(isPanelExpanded: value);
+    if (state.isPanelExpanded != value) {
+      state = state.copyWith(isPanelExpanded: value);
+    }
+    unawaited(
+      ref
+          .read(generationPanelExpansionProvider.notifier)
+          .setExpanded(GenerationWorkbenchPanel.img2img, value),
+    );
   }
 
   void setSourceImageDimensions(int? width, int? height) {
@@ -1110,6 +1138,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       isPanelExpanded: true,
       isOutpaint: false,
     );
+    setPanelExpanded(true);
     _applySourceSizeToParams();
     _paramsNotifier.updateIsOutpaint(false);
     _paramsNotifier.updateAction(ImageGenerationAction.img2img);
@@ -1382,6 +1411,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       focusedSelectionRect: constrainedSelection,
       clearFocusedSelectionRect: !effectiveFocusedInpaintEnabled,
     );
+    setPanelExpanded(true);
 
     _applySourceSizeToParams();
     _paramsNotifier.setMaskImage(maskImage);
@@ -1403,6 +1433,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       isPanelExpanded: true,
       isOutpaint: false,
     );
+    setPanelExpanded(true);
     _paramsNotifier.updateIsOutpaint(false);
     _applyEnhanceToParams();
   }
@@ -1444,6 +1475,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       isPanelExpanded: true,
       isOutpaint: false,
     );
+    setPanelExpanded(true);
 
     _applySourceSizeToParams();
     _syncInpaintRequestState();

--- a/lib/presentation/screens/generation/widgets/img2img_panel.dart
+++ b/lib/presentation/screens/generation/widgets/img2img_panel.dart
@@ -20,6 +20,7 @@ import '../../../../data/models/image/image_params.dart';
 import '../../../../data/services/precise_ref_library_storage_service.dart';
 import '../../../providers/comfyui/comfyui_provider.dart';
 import '../../../providers/cost_estimate_provider.dart';
+import '../../../providers/generation/generation_panel_expansion_provider.dart';
 import '../../../providers/generation/generation_params_selectors.dart';
 import '../../../providers/image_generation_provider.dart';
 import '../../../providers/image_save_settings_provider.dart';
@@ -108,16 +109,21 @@ class _Img2ImgPanelState extends ConsumerState<Img2ImgPanel> {
       generationParamsNotifierProvider.select(selectImg2ImgPanelViewData),
     );
     final workflow = ref.watch(imageWorkflowControllerProvider);
+    final isExpanded = ref.watch(
+      generationPanelExpansionProvider.select(
+        (value) => value.isExpanded(GenerationWorkbenchPanel.img2img),
+      ),
+    );
     final hasSourceImage = params.sourceImage != null;
-    final showBackground = hasSourceImage && !workflow.isPanelExpanded;
+    final showBackground = hasSourceImage && !isExpanded;
 
     return CollapsibleImagePanel(
       title: context.l10n.img2img_title,
       icon: Icons.image,
-      isExpanded: workflow.isPanelExpanded,
+      isExpanded: isExpanded,
       onToggle: () => ref
           .read(imageWorkflowControllerProvider.notifier)
-          .setPanelExpanded(!workflow.isPanelExpanded),
+          .setPanelExpanded(!isExpanded),
       hasData: hasSourceImage,
       backgroundImage: hasSourceImage
           ? DecodedMemoryImage(
@@ -143,7 +149,7 @@ class _Img2ImgPanelState extends ConsumerState<Img2ImgPanel> {
           ),
         ),
       ),
-      child: Padding(
+      childBuilder: (context) => Padding(
         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/presentation/screens/generation/widgets/precise_reference_panel.dart
+++ b/lib/presentation/screens/generation/widgets/precise_reference_panel.dart
@@ -12,6 +12,7 @@ import '../../../../../core/extensions/precise_ref_type_extensions.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../data/models/image/image_params.dart';
 import '../../../../data/services/precise_ref_library_storage_service.dart';
+import '../../../providers/generation/generation_panel_expansion_provider.dart';
 import '../../../providers/image_generation_provider.dart';
 import '../../../providers/precise_ref_library_provider.dart';
 import '../../../utils/dropped_file_reader.dart';
@@ -44,7 +45,8 @@ class PreciseReferencePanel extends ConsumerStatefulWidget {
 }
 
 class _PreciseReferencePanelState extends ConsumerState<PreciseReferencePanel> {
-  bool _isExpanded = false;
+  static const _panel = GenerationWorkbenchPanel.preciseReference;
+
   bool _isFileDraggingOver = false;
   bool _isProcessingDroppedFiles = false;
 
@@ -54,6 +56,11 @@ class _PreciseReferencePanelState extends ConsumerState<PreciseReferencePanel> {
     final references = ref.watch(
       generationParamsNotifierProvider.select(
         (params) => params.preciseReferences,
+      ),
+    );
+    final isExpanded = ref.watch(
+      generationPanelExpansionProvider.select(
+        (value) => value.isExpanded(_panel),
       ),
     );
     final hasReferences = references.isNotEmpty;
@@ -68,13 +75,15 @@ class _PreciseReferencePanelState extends ConsumerState<PreciseReferencePanel> {
     );
 
     // 判断是否显示背景（折叠且有数据时显示）
-    final showBackground = hasReferences && !_isExpanded;
+    final showBackground = hasReferences && !isExpanded;
 
     return CollapsibleImagePanel(
       title: context.l10n.preciseRef_title,
       icon: Icons.person_pin,
-      isExpanded: _isExpanded,
-      onToggle: () => setState(() => _isExpanded = !_isExpanded),
+      isExpanded: isExpanded,
+      onToggle: () => unawaited(
+        ref.read(generationPanelExpansionProvider.notifier).toggle(_panel),
+      ),
       hasData: hasReferences,
       backgroundImage: showBackground
           ? (references.length == 1
@@ -157,7 +166,7 @@ class _PreciseReferencePanelState extends ConsumerState<PreciseReferencePanel> {
               ),
             )
           : null,
-      child: Padding(
+      childBuilder: (context) => Padding(
         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -250,7 +259,9 @@ class _PreciseReferencePanelState extends ConsumerState<PreciseReferencePanel> {
                 Expanded(
                   child: OutlinedButton.icon(
                     key: const Key('precise-ref-panel-from-library'),
-                    onPressed: supportsPreciseReference ? _importFromLibrary : null,
+                    onPressed: supportsPreciseReference
+                        ? _importFromLibrary
+                        : null,
                     icon: const Icon(Icons.photo_library_outlined, size: 16),
                     label: Text(
                       context.l10n.preciseRefLib_fromLibrary,

--- a/lib/presentation/screens/generation/widgets/reverse_prompt_panel.dart
+++ b/lib/presentation/screens/generation/widgets/reverse_prompt_panel.dart
@@ -9,6 +9,7 @@ import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 import '../../../../data/models/character/character_prompt.dart';
 import '../../../../data/models/tag_library/tag_library_entry.dart';
 import '../../../../data/services/local_onnx_model_service.dart';
+import '../../../providers/generation/generation_panel_expansion_provider.dart';
 import '../../../providers/generation/generation_params_notifier.dart';
 import '../../../providers/reverse_prompt_provider.dart';
 import '../../../providers/tag_library_page_provider.dart';
@@ -30,21 +31,29 @@ class ReversePromptPanel extends ConsumerStatefulWidget {
 }
 
 class _ReversePromptPanelState extends ConsumerState<ReversePromptPanel> {
-  bool _isExpanded = false;
+  static const _panel = GenerationWorkbenchPanel.reversePrompt;
+
   bool _isDragging = false;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final state = ref.watch(reversePromptProvider);
+    final isExpanded = ref.watch(
+      generationPanelExpansionProvider.select(
+        (value) => value.isExpanded(_panel),
+      ),
+    );
     final hasImages = state.images.isNotEmpty;
-    final showBackground = hasImages && !_isExpanded;
+    final showBackground = hasImages && !isExpanded;
 
     return CollapsibleImagePanel(
       title: context.l10n.reversePrompt_title,
       icon: Icons.manage_search_rounded,
-      isExpanded: _isExpanded,
-      onToggle: () => setState(() => _isExpanded = !_isExpanded),
+      isExpanded: isExpanded,
+      onToggle: () => unawaited(
+        ref.read(generationPanelExpansionProvider.notifier).toggle(_panel),
+      ),
       hasData: hasImages || state.finalPrompt.isNotEmpty,
       backgroundImage: showBackground
           ? DecodedMemoryImage(
@@ -54,7 +63,7 @@ class _ReversePromptPanelState extends ConsumerState<ReversePromptPanel> {
             )
           : null,
       badge: _buildBadge(context, state, showBackground),
-      child: Padding(
+      childBuilder: (context) => Padding(
         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/presentation/screens/generation/widgets/unified_reference_panel.dart
+++ b/lib/presentation/screens/generation/widgets/unified_reference_panel.dart
@@ -16,6 +16,7 @@ import '../../../widgets/common/themed_divider.dart';
 import '../../../../data/models/vibe/vibe_library_entry.dart';
 import '../../../../data/models/vibe/vibe_reference.dart';
 import '../../../../data/services/vibe_library_storage_service.dart';
+import '../../../providers/generation/generation_panel_expansion_provider.dart';
 import '../../../providers/generation/generation_params_selectors.dart';
 import '../../../providers/image_generation_provider.dart';
 import '../../../providers/vibe_library_provider.dart';
@@ -50,7 +51,8 @@ class UnifiedReferencePanel extends ConsumerStatefulWidget {
 }
 
 class _UnifiedReferencePanelState extends ConsumerState<UnifiedReferencePanel> {
-  bool _isExpanded = false;
+  static const _panel = GenerationWorkbenchPanel.vibeTransfer;
+
   bool _isRecentCollapsed = true;
   List<VibeLibraryEntry> _recentEntries = [];
 
@@ -332,14 +334,21 @@ class _UnifiedReferencePanelState extends ConsumerState<UnifiedReferencePanel> {
       generationParamsNotifierProvider.select(selectVibePanelViewData),
     );
     final vibes = panelData.vibes;
+    final isExpanded = ref.watch(
+      generationPanelExpansionProvider.select(
+        (value) => value.isExpanded(_panel),
+      ),
+    );
     final hasVibes = vibes.isNotEmpty;
-    final showBackground = hasVibes && !_isExpanded;
+    final showBackground = hasVibes && !isExpanded;
 
     return CollapsibleImagePanel(
       title: context.l10n.vibe_title,
       icon: Icons.auto_fix_high,
-      isExpanded: _isExpanded,
-      onToggle: () => setState(() => _isExpanded = !_isExpanded),
+      isExpanded: isExpanded,
+      onToggle: () => unawaited(
+        ref.read(generationPanelExpansionProvider.notifier).toggle(_panel),
+      ),
       hasData: hasVibes,
       backgroundImage: _buildBackgroundImage(vibes),
       headerActions: hasVibes
@@ -367,7 +376,7 @@ class _UnifiedReferencePanelState extends ConsumerState<UnifiedReferencePanel> {
           ),
         ),
       ),
-      child: Padding(
+      childBuilder: (context) => Padding(
         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/presentation/screens/generation/widgets/web_left_panel.dart
+++ b/lib/presentation/screens/generation/widgets/web_left_panel.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:nai_launcher/core/utils/localization_extension.dart';
 import '../../../../core/constants/api_constants.dart';
+import '../../../providers/generation/generation_panel_expansion_provider.dart';
 import '../../../providers/image_generation_provider.dart';
 import '../../../providers/layout_state_provider.dart';
 import '../../../widgets/character/inline_character_section.dart';
@@ -38,7 +41,7 @@ class WebLeftPanel extends ConsumerStatefulWidget {
 
 class _WebLeftPanelState extends ConsumerState<WebLeftPanel>
     with SingleTickerProviderStateMixin {
-  /// 参数二级菜单是否挂载（动画收起完毕后卸载，瞬态不持久化）
+  /// 参数二级菜单是否挂载（动画收起完毕后卸载）。
   bool _paramsMenuMounted = false;
 
   late final AnimationController _menuController = AnimationController(
@@ -58,12 +61,27 @@ class _WebLeftPanelState extends ConsumerState<WebLeftPanel>
   @override
   void initState() {
     super.initState();
+    final restored = ref
+        .read(generationPanelExpansionProvider)
+        .isExpanded(GenerationWorkbenchPanel.generationParameters);
+    _paramsMenuMounted = restored;
+    _menuController.value = restored ? 1 : 0;
     // 收起动画播完再卸载浮层
     _menuController.addStatusListener((status) {
       if (status == AnimationStatus.dismissed && mounted) {
         setState(() => _paramsMenuMounted = false);
       }
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final duration = MediaQuery.disableAnimationsOf(context)
+        ? Duration.zero
+        : const Duration(milliseconds: 220);
+    _menuController.duration = duration;
+    _menuController.reverseDuration = duration;
   }
 
   @override
@@ -74,18 +92,28 @@ class _WebLeftPanelState extends ConsumerState<WebLeftPanel>
   }
 
   void _toggleParamsMenu() {
-    final opening = _menuController.status == AnimationStatus.dismissed ||
+    final opening =
+        _menuController.status == AnimationStatus.dismissed ||
         _menuController.status == AnimationStatus.reverse;
-    if (opening) {
+    _setParamsMenuExpanded(opening);
+  }
+
+  void _closeParamsMenu() => _setParamsMenuExpanded(false);
+
+  void _setParamsMenuExpanded(bool expanded) {
+    if (expanded && !_paramsMenuMounted) {
       setState(() => _paramsMenuMounted = true);
+    }
+    if (expanded) {
       _menuController.forward();
     } else {
       _menuController.reverse();
     }
-  }
-
-  void _closeParamsMenu() {
-    _menuController.reverse();
+    unawaited(
+      ref
+          .read(generationPanelExpansionProvider.notifier)
+          .setExpanded(GenerationWorkbenchPanel.generationParameters, expanded),
+    );
   }
 
   @override
@@ -98,9 +126,7 @@ class _WebLeftPanelState extends ConsumerState<WebLeftPanel>
         : 40.0;
     final decoration = BoxDecoration(
       color: theme.colorScheme.surface,
-      border: Border(
-        right: BorderSide(color: theme.dividerColor, width: 1),
-      ),
+      border: Border(right: BorderSide(color: theme.dividerColor, width: 1)),
     );
 
     final child = layoutState.webLeftPanelExpanded
@@ -248,8 +274,9 @@ class _WebLeftPanelState extends ConsumerState<WebLeftPanel>
                                   border: Border(
                                     top: BorderSide(color: theme.dividerColor),
                                     left: BorderSide(color: theme.dividerColor),
-                                    right:
-                                        BorderSide(color: theme.dividerColor),
+                                    right: BorderSide(
+                                      color: theme.dividerColor,
+                                    ),
                                   ),
                                 ),
                                 child: const SingleChildScrollView(
@@ -315,8 +342,10 @@ class _WebLeftPanelState extends ConsumerState<WebLeftPanel>
                   const SizedBox(width: 4),
                   // 箭头随抽屉开合旋转（收起朝上提示拉出方向）
                   RotationTransition(
-                    turns: Tween<double>(begin: 0, end: 0.5)
-                        .animate(_menuAnimation),
+                    turns: Tween<double>(
+                      begin: 0,
+                      end: 0.5,
+                    ).animate(_menuAnimation),
                     child: const Icon(Icons.keyboard_arrow_up, size: 20),
                   ),
                 ],

--- a/lib/presentation/widgets/character/inline_character_section.dart
+++ b/lib/presentation/widgets/character/inline_character_section.dart
@@ -1,124 +1,146 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
 
 import '../../../core/constants/api_constants.dart';
+import '../../../data/models/character/character_prompt.dart';
 import '../../providers/character_prompt_provider.dart';
+import '../../providers/generation/generation_panel_expansion_provider.dart';
 import '../../providers/image_generation_provider.dart';
+import '../common/collapsible_image_panel.dart';
+import '../common/themed_divider.dart';
 import 'add_character_buttons.dart';
 import 'character_position_canvas.dart';
 import 'inline_character_card.dart';
 import 'inline_character_editor.dart';
 
-/// 内联角色区块（官网布局左栏用，竖排）
+/// 构建角色二级菜单的单行摘要。
 ///
-/// 位于主提示词正下方，与主提示词同屏对照编辑：
-/// - 标题行：图标 + 数量徽章 + 清空菜单
-/// - 角色卡竖排（内容常显，点击即编辑）
-/// - 底部添加按钮行（女/男/其他/词库）
+/// 摘要只统计启用角色；没有可用名称时使用本地化序号，保证窄栏中仍可识别。
+String buildCharacterPanelSummary(
+  AppLocalizations l10n,
+  List<CharacterPrompt> characters,
+) {
+  if (characters.isEmpty) return l10n.character_summaryEmpty;
+
+  final enabled = characters.where((character) => character.enabled).toList();
+  if (enabled.isEmpty) {
+    return l10n.character_summaryAllDisabled(characters.length);
+  }
+
+  final first = enabled.first;
+  final firstIndex = characters.indexWhere((item) => item.id == first.id);
+  final name = first.name.trim().isEmpty
+      ? l10n.character_number(firstIndex + 1)
+      : first.name.trim();
+  if (enabled.length == 1) {
+    return l10n.character_summaryEnabled(1, name);
+  }
+  return l10n.character_summaryMore(enabled.length, name, enabled.length - 1);
+}
+
+/// 官网布局左栏的角色二级菜单。
 ///
-/// 仅 V4+ 模型显示（多角色为 V4 专属能力）。
+/// 标题与反推等工作台面板复用同一壳层；角色业务状态始终由 Provider 持有，
+/// 折叠只影响展示，不改变生成参数。
 class InlineCharacterSection extends ConsumerWidget {
   const InlineCharacterSection({super.key});
 
+  static const panel = GenerationWorkbenchPanel.characters;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
     final isV4Model = ref.watch(
       generationParamsNotifierProvider.select(
         (params) => ImageModels.isV4Model(params.model),
       ),
     );
-    if (!isV4Model) {
-      return const SizedBox.shrink();
-    }
+    if (!isV4Model) return const SizedBox.shrink();
 
     final config = ref.watch(characterPromptNotifierProvider);
     final characters = config.characters;
+    final isExpanded = ref.watch(
+      generationPanelExpansionProvider.select(
+        (state) => state.isExpanded(panel),
+      ),
+    );
+
+    return CollapsibleImagePanel(
+      key: const Key('character-secondary-menu'),
+      title: l10n.character_buttonLabel,
+      icon: Icons.people,
+      isExpanded: isExpanded,
+      onToggle: () => unawaited(
+        ref.read(generationPanelExpansionProvider.notifier).toggle(panel),
+      ),
+      hasData: characters.isNotEmpty,
+      summary: Text(
+        buildCharacterPanelSummary(l10n, characters),
+        key: const Key('character-panel-summary'),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        textAlign: TextAlign.end,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+      childBuilder: (context) => _CharacterPanelContent(characters: characters),
+    );
+  }
+}
+
+class _CharacterPanelContent extends ConsumerWidget {
+  const _CharacterPanelContent({required this.characters});
+
+  final List<CharacterPrompt> characters;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context)!;
     final hasCharacters = characters.isNotEmpty;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Padding(
-          padding: const EdgeInsets.only(bottom: 6),
-          child: Row(
-            children: [
-              Icon(
-                Icons.people,
-                size: 16,
-                color: hasCharacters
-                    ? theme.colorScheme.primary
-                    : theme.colorScheme.onSurfaceVariant,
-              ),
-              const SizedBox(width: 6),
-              Text(
-                l10n.character_buttonLabel,
-                style: theme.textTheme.labelMedium?.copyWith(
-                  color: hasCharacters
-                      ? theme.colorScheme.primary
-                      : theme.colorScheme.onSurfaceVariant,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              if (hasCharacters) ...[
-                const SizedBox(width: 6),
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 6,
-                    vertical: 1,
-                  ),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Text(
-                    '${characters.length}',
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: theme.colorScheme.onPrimaryContainer,
-                    ),
-                  ),
-                ),
-              ],
-              const Spacer(),
-              // 位置模式常驻在角色模块头部（有角色时显示）
-              if (hasCharacters) ...[
-                const CharacterPositionModeSegments(),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const ThemedDivider(),
+          if (hasCharacters) ...[
+            Row(
+              children: [
+                const Expanded(child: CharacterPositionModeSegments()),
                 const SizedBox(width: 8),
-              ],
-              if (hasCharacters)
-                Tooltip(
-                  message: l10n.characterEditor_clearAll,
-                  waitDuration: const Duration(milliseconds: 500),
-                  child: InkWell(
-                    onTap: () => confirmClearAllCharacters(context, ref),
-                    borderRadius: BorderRadius.circular(4),
-                    child: Padding(
-                      padding: const EdgeInsets.all(2),
-                      child: Icon(
-                        Icons.delete_sweep,
-                        size: 16,
-                        color: theme.colorScheme.error,
-                      ),
-                    ),
+                IconButton(
+                  key: const Key('character-clear-all'),
+                  onPressed: () => confirmClearAllCharacters(context, ref),
+                  tooltip: l10n.characterEditor_clearAll,
+                  icon: Icon(
+                    Icons.delete_sweep_outlined,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.error,
                   ),
+                  visualDensity: VisualDensity.compact,
                 ),
-            ],
-          ),
-        ),
-        for (var i = 0; i < characters.length; i++)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 6),
-            child: InlineCharacterCard(
-              key: ValueKey(characters[i].id),
-              character: characters[i],
-              index: i,
-              total: characters.length,
+              ],
             ),
-          ),
-        const AddCharacterButtons(),
-      ],
+            const SizedBox(height: 6),
+          ],
+          for (var i = 0; i < characters.length; i++)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: InlineCharacterCard(
+                key: ValueKey(characters[i].id),
+                character: characters[i],
+                index: i,
+                total: characters.length,
+              ),
+            ),
+          const AddCharacterButtons(),
+        ],
+      ),
     );
   }
 }

--- a/lib/presentation/widgets/common/collapsible_image_panel.dart
+++ b/lib/presentation/widgets/common/collapsible_image_panel.dart
@@ -1,20 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
-/// A common collapsible panel with optional background image support.
+/// 生图工作台二级菜单的统一壳层。
 ///
-/// Used for Precise Reference, Vibe Transfer, and Img2Img panels.
-class CollapsibleImagePanel extends StatelessWidget {
-  final String title;
-  final IconData icon;
-  final bool isExpanded;
-  final VoidCallback onToggle;
-  final Widget? backgroundImage;
-  final bool hasData;
-  final Widget? badge;
-  final Widget? trailing;
-  final List<Widget>? headerActions;
-  final Widget child;
-
+/// 角色、反推、图生图、风格迁移和精准参考共用同一套标题行、交互与动画。
+/// 内容首次展开前不会构建；展开过后收起只停止布局与动画，保留输入、焦点和滚动状态。
+class CollapsibleImagePanel extends StatefulWidget {
   const CollapsibleImagePanel({
     super.key,
     required this.title,
@@ -24,29 +15,113 @@ class CollapsibleImagePanel extends StatelessWidget {
     this.backgroundImage,
     this.hasData = false,
     this.badge,
+    this.summary,
     this.trailing,
     this.headerActions,
-    required this.child,
-  });
+    this.child,
+    this.childBuilder,
+  }) : assert(child != null || childBuilder != null);
+
+  final String title;
+  final IconData icon;
+  final bool isExpanded;
+  final VoidCallback onToggle;
+  final Widget? backgroundImage;
+  final bool hasData;
+  final Widget? badge;
+  final Widget? summary;
+  final Widget? trailing;
+  final List<Widget>? headerActions;
+  final Widget? child;
+  final WidgetBuilder? childBuilder;
+
+  @override
+  State<CollapsibleImagePanel> createState() => _CollapsibleImagePanelState();
+}
+
+class _CollapsibleImagePanelState extends State<CollapsibleImagePanel>
+    with SingleTickerProviderStateMixin {
+  static const _duration = Duration(milliseconds: 180);
+
+  final FocusNode _headerFocusNode = FocusNode();
+
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: _duration,
+    value: widget.isExpanded ? 1 : 0,
+  )..addStatusListener(_handleAnimationStatus);
+  late final CurvedAnimation _curve = CurvedAnimation(
+    parent: _controller,
+    curve: Curves.easeOutCubic,
+    reverseCurve: Curves.easeInCubic,
+  );
+
+  late bool _hasBuiltContent = widget.isExpanded;
+  bool _isAnimating = false;
+  bool _disableAnimations = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final disableAnimations = MediaQuery.disableAnimationsOf(context);
+    if (_disableAnimations == disableAnimations) return;
+    _disableAnimations = disableAnimations;
+    _controller.duration = disableAnimations ? Duration.zero : _duration;
+    _controller.reverseDuration = disableAnimations ? Duration.zero : _duration;
+  }
+
+  @override
+  void didUpdateWidget(CollapsibleImagePanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.isExpanded == widget.isExpanded) return;
+
+    if (widget.isExpanded) {
+      _hasBuiltContent = true;
+      _controller.forward();
+    } else {
+      _controller.reverse();
+    }
+  }
+
+  void _handleAnimationStatus(AnimationStatus status) {
+    final isAnimating =
+        status == AnimationStatus.forward || status == AnimationStatus.reverse;
+    if (_isAnimating != isAnimating && mounted) {
+      setState(() => _isAnimating = isAnimating);
+    }
+  }
+
+  @override
+  void dispose() {
+    _headerFocusNode.dispose();
+    _curve.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final showBackground = hasData && !isExpanded;
+    final showBackground = widget.hasData && !widget.isExpanded;
+    final highContrast = MediaQuery.highContrastOf(context);
 
     return Card(
       clipBehavior: Clip.antiAlias,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: highContrast
+            ? BorderSide(color: theme.colorScheme.outline, width: 1.5)
+            : BorderSide.none,
+      ),
       child: Stack(
         children: [
-          // Background Image Layer
-          if (showBackground && backgroundImage != null)
+          if (showBackground && widget.backgroundImage != null)
             Positioned.fill(
               child: Stack(
                 fit: StackFit.expand,
                 children: [
-                  _CollapsedBackgroundImage(child: backgroundImage!),
-                  // Dark Overlay
-                  Container(
+                  _CollapsedBackgroundImage(child: widget.backgroundImage!),
+                  DecoratedBox(
                     decoration: BoxDecoration(
                       gradient: LinearGradient(
                         begin: Alignment.topCenter,
@@ -61,84 +136,148 @@ class CollapsibleImagePanel extends StatelessWidget {
                 ],
               ),
             ),
-
-          // Content Layer
           Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // Header
-              InkWell(
-                onTap: onToggle,
-                borderRadius:
-                    const BorderRadius.vertical(top: Radius.circular(12)),
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Row(
-                    children: [
-                      Icon(
-                        icon,
-                        size: 20,
-                        color: showBackground
-                            ? Colors.white
-                            : hasData
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurface
-                                    .withValues(alpha: 0.6),
+              Semantics(
+                button: true,
+                expanded: widget.isExpanded,
+                label: widget.title,
+                child: Focus(
+                  focusNode: _headerFocusNode,
+                  onKeyEvent: (node, event) {
+                    if (event is KeyDownEvent &&
+                        (event.logicalKey == LogicalKeyboardKey.enter ||
+                            event.logicalKey == LogicalKeyboardKey.space)) {
+                      widget.onToggle();
+                      return KeyEventResult.handled;
+                    }
+                    return KeyEventResult.ignored;
+                  },
+                  child: Material(
+                    type: MaterialType.transparency,
+                    child: InkWell(
+                      key: ValueKey('collapsible-header-${widget.title}'),
+                      canRequestFocus: false,
+                      onTap: () {
+                        _headerFocusNode.requestFocus();
+                        widget.onToggle();
+                      },
+                      borderRadius: const BorderRadius.vertical(
+                        top: Radius.circular(12),
                       ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          title,
-                          style: theme.textTheme.titleSmall?.copyWith(
-                            color: showBackground
-                                ? Colors.white
-                                : hasData
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(minHeight: 44),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 10,
+                          ),
+                          child: Row(
+                            children: [
+                              Icon(
+                                widget.icon,
+                                size: 20,
+                                color: showBackground
+                                    ? Colors.white
+                                    : widget.hasData
                                     ? theme.colorScheme.primary
-                                    : null,
+                                    : theme.colorScheme.onSurfaceVariant,
+                              ),
+                              const SizedBox(width: 8),
+                              Flexible(
+                                child: Text(
+                                  widget.title,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: theme.textTheme.titleSmall?.copyWith(
+                                    color: showBackground
+                                        ? Colors.white
+                                        : widget.hasData
+                                        ? theme.colorScheme.primary
+                                        : null,
+                                  ),
+                                ),
+                              ),
+                              if (widget.summary != null) ...[
+                                const SizedBox(width: 8),
+                                Expanded(child: widget.summary!),
+                              ] else
+                                const Spacer(),
+                              if (widget.headerActions case final actions?
+                                  when actions.isNotEmpty) ...[
+                                Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: actions,
+                                ),
+                                const SizedBox(width: 6),
+                              ],
+                              if (widget.trailing != null) ...[
+                                widget.trailing!,
+                                const SizedBox(width: 4),
+                              ],
+                              if (widget.hasData && widget.badge != null) ...[
+                                widget.badge!,
+                                const SizedBox(width: 6),
+                              ],
+                              ExcludeSemantics(
+                                child: RotationTransition(
+                                  turns: Tween<double>(
+                                    begin: 0,
+                                    end: 0.5,
+                                  ).animate(_curve),
+                                  child: Icon(
+                                    Icons.keyboard_arrow_down,
+                                    size: 20,
+                                    color: showBackground ? Colors.white : null,
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ),
-                      // Header actions (e.g. export button)
-                      if (headerActions != null &&
-                          headerActions!.isNotEmpty) ...[
-                        Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: headerActions!,
-                        ),
-                        const SizedBox(width: 8),
-                      ],
-                      if (trailing != null) ...[
-                        trailing!,
-                        const SizedBox(width: 4),
-                      ],
-                      if (hasData && badge != null) ...[
-                        badge!,
-                        const SizedBox(width: 8),
-                      ],
-                      Icon(
-                        isExpanded
-                            ? Icons.keyboard_arrow_up
-                            : Icons.keyboard_arrow_down,
-                        size: 20,
-                        color: showBackground ? Colors.white : null,
-                      ),
-                    ],
+                    ),
                   ),
                 ),
               ),
-
-              // Expandable Content
-              AnimatedCrossFade(
-                duration: const Duration(milliseconds: 200),
-                crossFadeState: isExpanded
-                    ? CrossFadeState.showSecond
-                    : CrossFadeState.showFirst,
-                firstChild: const SizedBox.shrink(),
-                secondChild: child,
-              ),
+              _buildContent(),
             ],
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    if (!_hasBuiltContent) return const SizedBox.shrink();
+
+    final child = widget.childBuilder?.call(context) ?? widget.child!;
+    if (!widget.isExpanded && !_isAnimating) {
+      return Offstage(
+        offstage: true,
+        child: TickerMode(enabled: false, child: child),
+      );
+    }
+
+    return ClipRect(
+      child: AnimatedBuilder(
+        key: ValueKey('collapsible-content-${widget.title}'),
+        animation: _curve,
+        child: RepaintBoundary(child: child),
+        builder: (context, child) {
+          return Align(
+            alignment: Alignment.topCenter,
+            heightFactor: _curve.value,
+            child: Opacity(
+              opacity: _curve.value,
+              child: IgnorePointer(
+                ignoring: !widget.isExpanded,
+                child: TickerMode(enabled: widget.isExpanded, child: child!),
+              ),
+            ),
+          );
+        },
       ),
     );
   }
@@ -156,9 +295,7 @@ class _CollapsedBackgroundImage extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final width = constraints.maxWidth;
-        if (!width.isFinite || width <= 0) {
-          return child;
-        }
+        if (!width.isFinite || width <= 0) return child;
         return ClipRect(
           child: OverflowBox(
             alignment: Alignment.center,
@@ -166,11 +303,7 @@ class _CollapsedBackgroundImage extends StatelessWidget {
             maxWidth: width,
             minHeight: _previewHeight,
             maxHeight: _previewHeight,
-            child: SizedBox(
-              width: width,
-              height: _previewHeight,
-              child: child,
-            ),
+            child: SizedBox(width: width, height: _previewHeight, child: child),
           ),
         );
       },

--- a/test/presentation/providers/generation/generation_panel_expansion_provider_test.dart
+++ b/test/presentation/providers/generation/generation_panel_expansion_provider_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/presentation/providers/generation/generation_panel_expansion_provider.dart';
+
+class _MemoryStorage extends LocalStorageService {
+  _MemoryStorage([Map<String, Object?>? initial])
+    : values = Map<String, Object?>.from(initial ?? const {});
+
+  final Map<String, Object?> values;
+
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) {
+    final value = values[key];
+    return value is T ? value : defaultValue;
+  }
+
+  @override
+  Future<void> setSetting<T>(String key, T value) async {
+    values[key] = value;
+  }
+}
+
+void main() {
+  ProviderContainer buildContainer(_MemoryStorage storage) {
+    final container = ProviderContainer(
+      overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('旧用户缺失配置时所有工作台二级菜单默认收起', () {
+    final container = buildContainer(_MemoryStorage());
+    final state = container.read(generationPanelExpansionProvider);
+
+    for (final panel in GenerationWorkbenchPanel.values) {
+      expect(state.isExpanded(panel), isFalse, reason: panel.name);
+    }
+  });
+
+  test('分别恢复每个菜单状态并忽略异常旧值', () {
+    final storage = _MemoryStorage({
+      StorageKeys.generationParamsMenuExpanded: true,
+      StorageKeys.characterPanelExpanded: true,
+      StorageKeys.reversePromptExpanded: false,
+      StorageKeys.img2imgExpanded: 'broken',
+      StorageKeys.vibeTransferExpanded: true,
+      StorageKeys.preciseRefExpanded: true,
+    });
+    final state = buildContainer(
+      storage,
+    ).read(generationPanelExpansionProvider);
+
+    expect(
+      state.isExpanded(GenerationWorkbenchPanel.generationParameters),
+      isTrue,
+    );
+    expect(state.isExpanded(GenerationWorkbenchPanel.characters), isTrue);
+    expect(state.isExpanded(GenerationWorkbenchPanel.reversePrompt), isFalse);
+    expect(state.isExpanded(GenerationWorkbenchPanel.img2img), isFalse);
+    expect(state.isExpanded(GenerationWorkbenchPanel.vibeTransfer), isTrue);
+    expect(state.isExpanded(GenerationWorkbenchPanel.preciseReference), isTrue);
+  });
+
+  test('切换只更新目标菜单并写入对应 key', () async {
+    final storage = _MemoryStorage({StorageKeys.reversePromptExpanded: true});
+    final container = buildContainer(storage);
+    final notifier = container.read(generationPanelExpansionProvider.notifier);
+
+    await notifier.toggle(GenerationWorkbenchPanel.characters);
+
+    final state = container.read(generationPanelExpansionProvider);
+    expect(state.isExpanded(GenerationWorkbenchPanel.characters), isTrue);
+    expect(state.isExpanded(GenerationWorkbenchPanel.reversePrompt), isTrue);
+    expect(storage.values[StorageKeys.characterPanelExpanded], isTrue);
+    expect(storage.values[StorageKeys.reversePromptExpanded], isTrue);
+  });
+
+  test('Provider 重建后从持久化状态恢复', () async {
+    final storage = _MemoryStorage();
+    final first = ProviderContainer(
+      overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+    );
+    await first
+        .read(generationPanelExpansionProvider.notifier)
+        .setExpanded(GenerationWorkbenchPanel.preciseReference, true);
+    first.dispose();
+
+    final second = buildContainer(storage);
+    expect(
+      second
+          .read(generationPanelExpansionProvider)
+          .isExpanded(GenerationWorkbenchPanel.preciseReference),
+      isTrue,
+    );
+  });
+}

--- a/test/presentation/screens/generation/widgets/parameter_panel_test.dart
+++ b/test/presentation/screens/generation/widgets/parameter_panel_test.dart
@@ -377,6 +377,19 @@ class _FakeFilePicker extends FilePicker {
 }
 
 class _TestLocalStorageService extends LocalStorageService {
+  final Map<String, Object?> _settings = {};
+
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) {
+    final value = _settings[key];
+    return value is T ? value : defaultValue;
+  }
+
+  @override
+  Future<void> setSetting<T>(String key, T value) async {
+    _settings[key] = value;
+  }
+
   @override
   String getLastPrompt() => '';
 

--- a/test/presentation/widgets/character/character_panel_summary_test.dart
+++ b/test/presentation/widgets/character/character_panel_summary_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/character/character_prompt.dart';
+import 'package:nai_launcher/l10n/app_localizations_en.dart';
+import 'package:nai_launcher/l10n/app_localizations_ja.dart';
+import 'package:nai_launcher/l10n/app_localizations_zh.dart';
+import 'package:nai_launcher/presentation/widgets/character/inline_character_section.dart';
+
+CharacterPrompt character(String id, String name, {bool enabled = true}) {
+  return CharacterPrompt(id: id, name: name, enabled: enabled);
+}
+
+void main() {
+  test('空角色与全部停用状态有明确摘要', () {
+    final l10n = AppLocalizationsZh();
+
+    expect(buildCharacterPanelSummary(l10n, const []), '未添加角色');
+    expect(
+      buildCharacterPanelSummary(l10n, [
+        character('1', 'Alice', enabled: false),
+        character('2', 'Bob', enabled: false),
+      ]),
+      '已启用 0 个 · 已停用 2 个',
+    );
+  });
+
+  test('摘要优先使用第一个启用角色并实时反映启用数量', () {
+    final l10n = AppLocalizationsEn();
+    final characters = [
+      character('1', 'Disabled', enabled: false),
+      character('2', 'Alice'),
+      character('3', 'Bob'),
+    ];
+
+    expect(
+      buildCharacterPanelSummary(l10n, characters),
+      '2 enabled · Alice +1',
+    );
+    expect(
+      buildCharacterPanelSummary(
+        l10n,
+        characters.map((item) => item.copyWith(enabled: true)).toList(),
+      ),
+      '3 enabled · Disabled +2',
+    );
+  });
+
+  test('空白名称回退到本地化角色编号', () {
+    expect(
+      buildCharacterPanelSummary(AppLocalizationsJa(), [character('1', '   ')]),
+      '1人有効 · キャラクター 1',
+    );
+  });
+}

--- a/test/presentation/widgets/character/inline_character_section_test.dart
+++ b/test/presentation/widgets/character/inline_character_section_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/data/models/character/character_prompt.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/providers/character_prompt_provider.dart';
+import 'package:nai_launcher/presentation/widgets/character/inline_character_card.dart';
+import 'package:nai_launcher/presentation/widgets/character/inline_character_section.dart';
+
+class _TestCharacterPromptNotifier extends CharacterPromptNotifier {
+  @override
+  CharacterPromptConfig build() {
+    return const CharacterPromptConfig(
+      characters: [
+        CharacterPrompt(id: 'alice', name: 'Alice', prompt: 'red hair'),
+        CharacterPrompt(id: 'bob', name: 'Bob', prompt: 'blue hair'),
+      ],
+    );
+  }
+}
+
+class _MemoryStorage extends LocalStorageService {
+  final Map<String, Object?> values = {};
+
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) {
+    final value = values[key];
+    return value is T ? value : defaultValue;
+  }
+
+  @override
+  Future<void> setSetting<T>(String key, T value) async {
+    values[key] = value;
+  }
+}
+
+void main() {
+  ProviderContainer createContainer() {
+    final storage = _MemoryStorage();
+    final container = ProviderContainer(
+      overrides: [
+        localStorageServiceProvider.overrideWith((ref) => storage),
+        characterPromptNotifierProvider.overrideWith(
+          _TestCharacterPromptNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Widget subject(ProviderContainer container, double width) {
+    return UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        locale: const Locale('zh'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        home: Scaffold(
+          body: SizedBox(width: width, child: const InlineCharacterSection()),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('默认折叠显示实时摘要，展开内容与生成角色状态不变', (tester) async {
+    final container = createContainer();
+    final before = container.read(characterPromptNotifierProvider);
+
+    await tester.pumpWidget(subject(container, 700));
+    await tester.pumpAndSettle();
+
+    expect(find.text('已启用 2 个 · Alice +1'), findsOneWidget);
+    expect(find.byType(InlineCharacterCard), findsNothing);
+
+    await tester.tap(find.byKey(const Key('collapsible-header-角色')).first);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(InlineCharacterCard), findsNWidgets(2));
+    expect(container.read(characterPromptNotifierProvider), before);
+
+    await tester.tap(find.byKey(const Key('collapsible-header-角色')).first);
+    await tester.pumpAndSettle();
+    expect(find.text('已启用 2 个 · Alice +1'), findsOneWidget);
+  });
+
+  for (final width in [700.0, 840.0, 1180.0, 1600.0]) {
+    testWidgets('角色菜单在 $width 宽度无 RenderFlex overflow', (tester) async {
+      final container = createContainer();
+      await tester.binding.setSurfaceSize(Size(width, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(subject(container, width));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('collapsible-header-角色')).first);
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(InlineCharacterCard), findsNWidgets(2));
+    });
+  }
+}

--- a/test/presentation/widgets/common/collapsible_image_panel_test.dart
+++ b/test/presentation/widgets/common/collapsible_image_panel_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/presentation/widgets/common/collapsible_image_panel.dart';
+
+void main() {
+  Widget buildSubject({
+    required double width,
+    required bool expanded,
+    required VoidCallback onToggle,
+    bool disableAnimations = false,
+    WidgetBuilder? childBuilder,
+  }) {
+    return MaterialApp(
+      home: MediaQuery(
+        data: MediaQueryData(
+          size: Size(width, 900),
+          disableAnimations: disableAnimations,
+        ),
+        child: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: width,
+              child: CollapsibleImagePanel(
+                title: '角色',
+                icon: Icons.people_outline,
+                isExpanded: expanded,
+                onToggle: onToggle,
+                summary: const Text('3 个启用 · Alice +2'),
+                childBuilder:
+                    childBuilder ??
+                    (context) =>
+                        const SizedBox(key: Key('panel-body'), height: 120),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('折叠时不构建内容，展开后收起保留子树', (tester) async {
+    var expanded = false;
+    var buildCount = 0;
+    late StateSetter setHostState;
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          setHostState = setState;
+          return buildSubject(
+            width: 320,
+            expanded: expanded,
+            onToggle: () => setState(() => expanded = !expanded),
+            childBuilder: (context) {
+              buildCount++;
+              return const Text('延迟内容', key: Key('lazy-body'));
+            },
+          );
+        },
+      ),
+    );
+
+    expect(buildCount, 0);
+    expect(find.byKey(const Key('lazy-body')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('collapsible-header-角色')));
+    await tester.pumpAndSettle();
+    expect(expanded, isTrue);
+    expect(buildCount, greaterThan(0));
+    expect(find.byKey(const Key('lazy-body')), findsOneWidget);
+
+    setHostState(() => expanded = false);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('lazy-body'), skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('lazy-body')), findsNothing);
+  });
+
+  testWidgets('标题行支持键盘切换并暴露可点击语义', (tester) async {
+    var expanded = false;
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) => buildSubject(
+          width: 320,
+          expanded: expanded,
+          onToggle: () => setState(() => expanded = !expanded),
+        ),
+      ),
+    );
+
+    final header = find.byKey(const Key('collapsible-header-角色'));
+    final semantics = tester.getSemantics(header).getSemanticsData();
+    expect(semantics.label, contains('角色'));
+    expect(semantics.hasAction(SemanticsAction.tap), isTrue);
+
+    await tester.tap(header);
+    await tester.pumpAndSettle();
+    expect(expanded, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(expanded, isFalse);
+  });
+
+  testWidgets('reduced motion 立即完成展开动画', (tester) async {
+    var expanded = false;
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) => buildSubject(
+          width: 320,
+          expanded: expanded,
+          disableAnimations: true,
+          onToggle: () => setState(() => expanded = !expanded),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('collapsible-header-角色')));
+    await tester.pump();
+
+    expect(expanded, isTrue);
+    expect(find.byKey(const Key('panel-body')), findsOneWidget);
+    final opacity = tester.widget<Opacity>(
+      find.descendant(
+        of: find.byKey(const Key('collapsible-content-角色')),
+        matching: find.byType(Opacity),
+      ),
+    );
+    expect(opacity.opacity, 1);
+  });
+
+  for (final width in [700.0, 840.0, 1180.0, 1600.0]) {
+    testWidgets('$width 宽度下标题摘要无溢出', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(width: width, expanded: false, onToggle: () {}),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('3 个启用 · Alice +2'), findsOneWidget);
+    });
+  }
+}


### PR DESCRIPTION
## 变更
- 将角色、反推、图生图、风格迁移、精准参考和参数区域统一为可折叠二级菜单
- 分别持久化各面板展开状态，角色折叠时显示实时简短摘要
- 完善键盘、无障碍、reduced motion、懒挂载及中英日繁中本地化

## 验证
- affected tests：204 项通过
- scoped flutter analyze：通过
- 700 / 840 / 1180 / 1600 宽度回归通过
- Windows Debug 实际界面截图核对通过，临时截图已清理

## 备注
- 仓库基线已有 12 个未引用 onlineGallery ARB key 导致完整 i18n_regression_test 失败，本分支未新增该问题。