### PR TITLE
feat(gallery): 支持全来源六 Tag 组合搜索

### DIFF
--- a/lib/core/autocomplete/tag_catalog_repository.dart
+++ b/lib/core/autocomplete/tag_catalog_repository.dart
@@ -124,6 +124,52 @@ class TagCatalogRepository implements CompletionSource {
     return records[canonicalTag.trim().toLowerCase()]?.postCount;
   }
 
+  Future<Map<String, TagCatalogRecord>> resolveExactTags(
+    Iterable<String> terms,
+  ) async {
+    final normalized = terms
+        .map(
+          (term) => term.trim().toLowerCase().replaceAll(RegExp(r'\s+'), '_'),
+        )
+        .where((term) => term.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (normalized.isEmpty) return const {};
+    await initialize();
+
+    final result = <String, TagCatalogRecord>{};
+    for (var offset = 0; offset < normalized.length; offset += 400) {
+      final chunk = normalized.skip(offset).take(400).toList(growable: false);
+      final placeholders = List.filled(chunk.length, '?').join(',');
+      final rows = await _database!.rawQuery(
+        '''
+        SELECT t.name AS term, t.name, t.category, t.post_count, 0 AS kind
+        FROM tags t
+        WHERE t.name IN ($placeholders)
+        UNION ALL
+        SELECT a.alias AS term, t.name, t.category, t.post_count, 1 AS kind
+        FROM aliases a
+        JOIN tags t ON t.id = a.tag_id
+        WHERE a.alias IN ($placeholders)
+        ORDER BY kind ASC, post_count DESC
+        ''',
+        [...chunk, ...chunk],
+      );
+      for (final row in rows) {
+        final term = row['term'] as String;
+        if (result.containsKey(term)) continue;
+        final category = TagCategory.fromCatalog(row['category'] as int);
+        if (category == null) continue;
+        result[term] = TagCatalogRecord(
+          canonicalTag: row['name'] as String,
+          category: category,
+          postCount: row['post_count'] as int,
+        );
+      }
+    }
+    return result;
+  }
+
   Future<Map<String, TagCatalogRecord>> recordsByCanonicalTag(
     Iterable<String> canonicalTags,
   ) async {

--- a/lib/core/online_gallery/gallery_tag_query.dart
+++ b/lib/core/online_gallery/gallery_tag_query.dart
@@ -1,0 +1,284 @@
+import 'dart:math' as math;
+
+const int maxGallerySearchTags = 6;
+
+class GalleryTagQueryLimitException implements Exception {
+  const GalleryTagQueryLimitException(this.actual);
+
+  final int actual;
+}
+
+class GalleryTagMetatagUnsupportedException implements Exception {
+  const GalleryTagMetatagUnsupportedException({
+    required this.sourceKey,
+    required this.feedKey,
+  });
+
+  final String sourceKey;
+  final String feedKey;
+}
+
+enum GalleryTagClauseKind { positive, negative, metatag }
+
+class GalleryTagClause {
+  const GalleryTagClause({
+    required this.raw,
+    required this.value,
+    required this.kind,
+  });
+
+  final String raw;
+  final String value;
+  final GalleryTagClauseKind kind;
+
+  bool get isOrdinary => kind != GalleryTagClauseKind.metatag;
+  bool get isNegative => kind == GalleryTagClauseKind.negative;
+
+  GalleryTagClause canonicalized(String canonical) =>
+      GalleryTagClause(raw: raw, value: canonical, kind: kind);
+
+  String get searchToken => isNegative ? '-$value' : value;
+
+  String? get metatagPrefix {
+    if (kind != GalleryTagClauseKind.metatag) return null;
+    final token = value.startsWith('-') ? value.substring(1) : value;
+    final colon = token.indexOf(':');
+    return colon > 0 ? token.substring(0, colon) : null;
+  }
+}
+
+class GalleryTagQuery {
+  const GalleryTagQuery({required this.raw, required this.clauses});
+
+  final String raw;
+  final List<GalleryTagClause> clauses;
+
+  List<GalleryTagClause> get ordinaryClauses =>
+      clauses.where((clause) => clause.isOrdinary).toList(growable: false);
+  List<GalleryTagClause> get positiveClauses => clauses
+      .where((clause) => clause.kind == GalleryTagClauseKind.positive)
+      .toList(growable: false);
+  List<GalleryTagClause> get negativeClauses => clauses
+      .where((clause) => clause.kind == GalleryTagClauseKind.negative)
+      .toList(growable: false);
+  List<GalleryTagClause> get metatags => clauses
+      .where((clause) => clause.kind == GalleryTagClauseKind.metatag)
+      .toList(growable: false);
+  int get ordinaryTagCount => ordinaryClauses.length;
+  bool get isValid => ordinaryTagCount <= maxGallerySearchTags;
+  bool get isEmpty => clauses.isEmpty;
+
+  GalleryTagQuery canonicalized(Map<String, String> canonicalByInput) {
+    final canonicalClauses = <GalleryTagClause>[];
+    final seen = <String>{};
+    for (final clause in clauses) {
+      final canonical = clause.isOrdinary
+          ? clause.canonicalized(canonicalByInput[clause.value] ?? clause.value)
+          : clause;
+      if (seen.add('${canonical.kind.name}:${canonical.value}')) {
+        canonicalClauses.add(canonical);
+      }
+    }
+    return GalleryTagQuery(
+      raw: raw,
+      clauses: List.unmodifiable(canonicalClauses),
+    );
+  }
+}
+
+const Set<String> danbooruGalleryMetatagPrefixes = {
+  'age',
+  'approver',
+  'arttags',
+  'chartags',
+  'child',
+  'commenter',
+  'commentary',
+  'copytags',
+  'date',
+  'downvote',
+  'duration',
+  'embedded',
+  'fav',
+  'favcount',
+  'filesize',
+  'filetype',
+  'gentags',
+  'has',
+  'height',
+  'id',
+  'is',
+  'limit',
+  'md5',
+  'metatags',
+  'mpixels',
+  'noter',
+  'noteupdater',
+  'order',
+  'parent',
+  'pixiv',
+  'pool',
+  'random',
+  'rating',
+  'ratio',
+  'score',
+  'search',
+  'source',
+  'status',
+  'tagcount',
+  'uploader',
+  'upvote',
+  'user',
+  'width',
+};
+
+const Set<String> gelbooruGalleryMetatagPrefixes = {
+  'id',
+  'md5',
+  'parent',
+  'rating',
+  'score',
+  'sort',
+  'source',
+  'user',
+  'width',
+  'height',
+};
+
+abstract final class GalleryTagQueryParser {
+  // A colon by itself remains legal in ordinary tags (for example,
+  // artist:name). Known source syntaxes are classified before the selected
+  // source validates its exact supported subset.
+  static const Set<String> _metatagPrefixes = {
+    ...danbooruGalleryMetatagPrefixes,
+    'sort',
+  };
+
+  static GalleryTagQuery parse(String input) {
+    final clauses = <GalleryTagClause>[];
+    final seen = <String>{};
+    for (final rawToken in input.trim().split(RegExp(r'[,，\s]+'))) {
+      final token = rawToken.trim();
+      if (token.isEmpty) continue;
+      final negative = token.startsWith('-') && token.length > 1;
+      final body = negative ? token.substring(1) : token;
+      final normalized = normalizeGalleryTag(body);
+      if (normalized.isEmpty) continue;
+      final colon = normalized.indexOf(':');
+      final isMetatag =
+          colon > 0 &&
+          _metatagPrefixes.contains(normalized.substring(0, colon));
+      final kind = isMetatag
+          ? GalleryTagClauseKind.metatag
+          : negative
+          ? GalleryTagClauseKind.negative
+          : GalleryTagClauseKind.positive;
+      final value = isMetatag && negative ? '-$normalized' : normalized;
+      final identity = '${kind.name}:$value';
+      if (!seen.add(identity)) continue;
+      clauses.add(GalleryTagClause(raw: token, value: value, kind: kind));
+    }
+    return GalleryTagQuery(raw: input, clauses: List.unmodifiable(clauses));
+  }
+}
+
+String normalizeGalleryTag(String value) =>
+    value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), '_');
+
+Set<String> normalizeGalleryTagSet(Iterable<String> tags) {
+  final normalized = <String>{};
+  for (final tag in tags) {
+    final value = normalizeGalleryTag(tag);
+    if (value.isNotEmpty) normalized.add(value);
+  }
+  return normalized;
+}
+
+class GalleryTagQueryPlan {
+  GalleryTagQueryPlan({
+    required this.query,
+    required this.serverTagLimit,
+    required List<GalleryTagClause> pushdown,
+  }) : pushdown = List.unmodifiable(pushdown),
+       residual = List.unmodifiable(
+         query.ordinaryClauses.where((clause) => !pushdown.contains(clause)),
+       ),
+       _wildcardPatterns = Map.unmodifiable({
+         for (final clause in query.ordinaryClauses)
+           if (clause.value.contains('*'))
+             clause.value: RegExp(
+               '^${RegExp.escape(clause.value).replaceAll(r'\*', '.*')}\$',
+               caseSensitive: false,
+             ),
+       });
+
+  final GalleryTagQuery query;
+  final int serverTagLimit;
+  final List<GalleryTagClause> pushdown;
+  final List<GalleryTagClause> residual;
+  final Map<String, RegExp> _wildcardPatterns;
+
+  List<GalleryTagClause> get seedClauses => pushdown;
+  List<GalleryTagClause> get residualClauses => residual;
+
+  bool get requiresLocalFiltering => residual.isNotEmpty;
+  String get serverQuery => [
+    ...pushdown.map((clause) => clause.searchToken),
+    ...query.metatags.map((clause) => clause.searchToken),
+  ].join(' ');
+
+  bool matchesTags(Iterable<String> candidateTags) =>
+      matchesNormalizedTags(normalizeGalleryTagSet(candidateTags));
+
+  bool matchesNormalizedTags(Set<String> tags) {
+    if (!matchesPositiveClauses(tags)) return false;
+    return !matchesAnyNegativeClause(tags);
+  }
+
+  bool matchesPositiveClauses(Set<String> tags) => query.ordinaryClauses
+      .where((clause) => !clause.isNegative)
+      .every((clause) => _matchesClause(tags, clause.value));
+
+  bool matchesAnyNegativeClause(Set<String> tags) => query.ordinaryClauses
+      .where((clause) => clause.isNegative)
+      .any((clause) => _matchesClause(tags, clause.value));
+
+  bool get hasNegativeClauses =>
+      query.ordinaryClauses.any((clause) => clause.isNegative);
+
+  bool _matchesClause(Set<String> tags, String query) {
+    final pattern = _wildcardPatterns[query];
+    if (pattern == null) return tags.contains(query);
+    return tags.any(pattern.hasMatch);
+  }
+}
+
+abstract final class GalleryTagQueryPlanner {
+  static GalleryTagQueryPlan plan(
+    GalleryTagQuery query, {
+    required int serverTagLimit,
+    Map<String, int> postCounts = const {},
+    bool allowNegativePushdown = true,
+  }) {
+    final ordinary = [
+      for (final clause in query.ordinaryClauses)
+        if (allowNegativePushdown || !clause.isNegative) clause,
+    ];
+    ordinary.sort((left, right) {
+      if (left.isNegative != right.isNegative) {
+        return left.isNegative ? 1 : -1;
+      }
+      final leftCount = postCounts[left.value] ?? 1 << 62;
+      final rightCount = postCounts[right.value] ?? 1 << 62;
+      final countOrder = leftCount.compareTo(rightCount);
+      if (countOrder != 0) return countOrder;
+      return left.value.compareTo(right.value);
+    });
+    final limit = math.max(0, math.min(serverTagLimit, ordinary.length));
+    return GalleryTagQueryPlan(
+      query: query,
+      serverTagLimit: serverTagLimit,
+      pushdown: ordinary.take(limit).toList(growable: false),
+    );
+  }
+}

--- a/lib/data/datasources/remote/online_gallery/ai_tag_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/ai_tag_gallery_source_adapter.dart
@@ -121,7 +121,7 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
       queryParameters: {
         'page': page,
         'page_size': config.pageSize,
-        'q': request.query,
+        'q': _toAiTagWeightedQuery(request.query),
         'prompt': request.prompt,
         'sort': 'new',
         'time_range': request.timeRange,
@@ -145,7 +145,7 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     final queryParameters = <String, dynamic>{
       'page': page,
       'page_size': config.pageSize,
-      'q': request.query,
+      'q': _toAiTagWeightedQuery(request.query),
       'prompt': request.prompt,
     };
     if (period == 'current') {
@@ -241,6 +241,9 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
         total: total,
         hasMore: hasMore,
         rawItemCount: rawItems.length,
+        rawPageIdentity: rawItems
+            .map((value) => value is Map ? value['id'] : null)
+            .join(','),
       );
     } on GallerySourceException {
       rethrow;
@@ -297,8 +300,9 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
         );
       }
       final work = Map<String, dynamic>.from(payload['work'] as Map);
+      final imageRows = payload['images'] as List;
       final media = <GalleryMedia>[];
-      for (final raw in payload['images'] as List) {
+      for (final raw in imageRows) {
         if (raw is! Map) continue;
         try {
           media.add(
@@ -322,9 +326,37 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
           source: GallerySourceId.aiTag,
         );
       }
-      final detailedItem = _parseListItem(
-        work,
-      ).copyWith(cover: media.first, mediaCount: media.length, rank: item.rank);
+      final listItem = _parseListItem(work);
+      final searchableTags = <String>{
+        ...listItem.tags,
+        for (final image in media)
+          if (image.prompt != null) ..._parsePromptTags(image.prompt!),
+      };
+      final searchTerms = <String>{
+        ...listItem.searchTerms,
+        ...searchableTags,
+        for (final tag in searchableTags) ..._searchTextTerms(tag),
+        for (final image in media) ...[
+          ..._searchTextTerms(image.metadata['model']?.toString()),
+          ..._searchTextTerms(image.metadata['source_model']?.toString()),
+        ],
+      };
+      final promptMetadataComplete =
+          media.length == imageRows.length &&
+          media.every(
+            (image) =>
+                image.metadataError == null &&
+                image.prompt != null &&
+                image.prompt!.trim().isNotEmpty,
+          );
+      final detailedItem = listItem.copyWith(
+        cover: media.first,
+        mediaCount: media.length,
+        rank: item.rank,
+        tags: List.unmodifiable(searchableTags),
+        searchTerms: List.unmodifiable(searchTerms),
+        tagsComplete: promptMetadataComplete,
+      );
       return GalleryDetail(
         item: detailedItem,
         media: List.unmodifiable(media),
@@ -354,6 +386,23 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     if (id == null || id <= 0) {
       throw const FormatException('AI TAG work id is invalid');
     }
+    final caption = json['caption']?.toString() ?? '';
+    final description = _plainText(caption);
+    final title = json['title']?.toString().trim();
+    final author = json['userName']?.toString().trim();
+    final aiType = (json['AI_type'] ?? json['ai_type'])?.toString();
+    final searchableTags = <String>{..._parseStringList(json['tags'])};
+    final searchTerms = <String>{
+      ...searchableTags,
+      for (final tag in searchableTags) ..._searchTextTerms(tag),
+      ..._searchTextTerms(title),
+      ..._searchTextTerms(author),
+      ..._searchTextTerms(description),
+      ..._searchTextTerms(aiType),
+      ..._searchTextTerms(
+        (json['model'] ?? json['model_name'] ?? json['modelName'])?.toString(),
+      ),
+    };
     return GalleryItem(
       id: id,
       sourceId: GallerySourceId.aiTag,
@@ -361,15 +410,19 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
       uploaderId: _asInt(json['userId'] ?? json['userid']) ?? 0,
       score: _asNum(json['score'])?.round(),
       rating: null,
-      title: json['title']?.toString().trim(),
-      author: json['userName']?.toString().trim(),
-      description: _plainText(json['caption']?.toString() ?? ''),
+      title: title,
+      author: author,
+      description: description,
       viewCount: _asInt(json['total_view']),
       favCount: _asInt(json['total_bookmarks']),
-      aiType: (json['AI_type'] ?? json['ai_type'])?.toString(),
+      aiType: aiType,
       mediaCount: (_asInt(json['image_count']) ?? 1).clamp(1, 10000),
       rank: rank,
-      tags: _parseStringList(json['tags']),
+      tags: List<String>.unmodifiable(searchableTags),
+      searchTerms: List<String>.unmodifiable(searchTerms),
+      // The list payload omits per-media prompts searched by the upstream q
+      // endpoint. Detail loading must aggregate every media prompt first.
+      tagsComplete: false,
       cover: GalleryMedia(
         id: '${id}_pending',
         previewUrl: '',
@@ -498,6 +551,15 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
   int _mediaPageIndex(String value) {
     final match = RegExp(r'_p(\d+)(?:\D|$)').firstMatch(value);
     return int.tryParse(match?.group(1) ?? '') ?? 0;
+  }
+
+  String _toAiTagWeightedQuery(String query) {
+    return query
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((term) => term.isNotEmpty)
+        .map((term) => '$term::1')
+        .join(' ');
   }
 
   static int? _asInt(Object? value) {
@@ -766,12 +828,44 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     );
   }
 
+  List<String> _parsePromptTags(String raw) {
+    if (raw.trim().isEmpty) return const [];
+    return _plainText(raw)
+        .split(RegExp(r'[,\n]+'))
+        .map(_cleanPromptTag)
+        .where((tag) => tag.isNotEmpty && tag.length <= 200)
+        .toList(growable: false);
+  }
+
+  static List<String> _searchTextTerms(String? raw) {
+    final value = raw?.trim() ?? '';
+    if (value.isEmpty) return const [];
+    return <String>{
+      value,
+      ...value
+          .split(RegExp(r'[\s,，;；/|:：\-—]+'))
+          .map((term) => term.trim())
+          .where((term) => term.isNotEmpty),
+    }.toList(growable: false);
+  }
+
   static List<String> _parseStringList(Object? value) {
     final decoded = _decodeList(value);
     return decoded
-        .map((item) => item?.toString().trim() ?? '')
+        .map((item) => _cleanPromptTag(item?.toString() ?? ''))
         .where((item) => item.isNotEmpty)
         .toList(growable: false);
+  }
+
+  static String _cleanPromptTag(String raw) {
+    var value = raw.trim();
+    value = value.replaceAll(RegExp(r'^[{}\[\]()\s]+|[{}\[\]()\s]+$'), '');
+    value = value.replaceFirst(RegExp(r'^-?\d+(?:\.\d+)?::'), '');
+    value = value.replaceFirst(RegExp(r'::$'), '');
+    value = value.replaceFirst(RegExp(r'::-?\d+(?:\.\d+)?$'), '');
+    value = value.replaceFirst(RegExp(r':-?\d+(?:\.\d+)?$'), '');
+    value = value.replaceAll(RegExp(r'^[{}\[\]()\s]+|[{}\[\]()\s,，;；]+$'), '');
+    return value.trim();
   }
 
   static List<dynamic> _decodeList(Object? value) {

--- a/lib/data/datasources/remote/online_gallery/donmai_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/donmai_gallery_source_adapter.dart
@@ -112,6 +112,9 @@ class DonmaiGallerySourceAdapter implements GallerySourceAdapter {
         nextCursor: nextCursor,
         hasMore: raw.length >= request.pageSize && nextCursor != null,
         rawItemCount: raw.length,
+        rawPageIdentity: raw
+            .map((value) => value is Map ? value['id'] : null)
+            .join(','),
       );
     } on GallerySourceException {
       rethrow;
@@ -190,6 +193,9 @@ class DonmaiGallerySourceAdapter implements GallerySourceAdapter {
         // conclusively means the end. Repeated pages are stopped by the provider.
         hasMore: raw.isNotEmpty,
         rawItemCount: raw.length,
+        rawPageIdentity: raw
+            .map((value) => value is Map ? value['id'] : null)
+            .join(','),
       );
     } on GallerySourceException {
       rethrow;

--- a/lib/data/datasources/remote/online_gallery/gelbooru_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/gelbooru_gallery_source_adapter.dart
@@ -178,6 +178,7 @@ class GelbooruGallerySourceAdapter implements GallerySourceAdapter {
       nextCursor: hasMore ? '${page + 1}' : null,
       hasMore: hasMore,
       rawItemCount: rawCount,
+      rawPageIdentity: items.map((item) => item.stableKey).join(','),
     );
   }
 

--- a/lib/data/datasources/remote/online_gallery/quick_tag_cloud_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/quick_tag_cloud_gallery_source_adapter.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:dio/dio.dart';
 import 'package:path/path.dart' as p;
 
+import '../../../../core/online_gallery/gallery_tag_query.dart';
 import '../../../../core/utils/prompt_tag_utils.dart';
 import '../../../models/online_gallery/gallery_item.dart';
 import '../../../models/online_gallery/gallery_source.dart';
@@ -508,9 +509,12 @@ class QuickTagCloudGallerySourceAdapter extends GallerySourceAdapter {
       _throwIfCancelled(cancelToken);
       return cachedMatches;
     }
-    final terms = normalizedSearch
-        .split(RegExp(r'\s+'))
-        .where((term) => term.isNotEmpty)
+    final localTagPlan = GalleryTagQueryPlanner.plan(
+      GalleryTagQueryParser.parse(normalizedSearch),
+      serverTagLimit: maxGallerySearchTags,
+    );
+    final terms = localTagPlan.query.ordinaryClauses
+        .map((clause) => clause.value)
         .toList(growable: false);
     final filtered = <_QuickTagCloudRecord>[];
     final cacheSearchHaystacks = records.length <= 5000;
@@ -540,9 +544,12 @@ class QuickTagCloudGallerySourceAdapter extends GallerySourceAdapter {
           record.entry.hasImage) {
         continue;
       }
-      if (terms.isNotEmpty) {
+      if (terms.length == 1) {
         final haystack = _searchHaystack(record, cache: cacheSearchHaystacks);
-        if (!terms.every(haystack.contains)) continue;
+        if (!haystack.contains(terms.single)) continue;
+      } else if (terms.length > 1 &&
+          !localTagPlan.matchesNormalizedTags(record.normalizedTags)) {
+        continue;
       }
       filtered.add(record);
     }
@@ -796,7 +803,8 @@ class QuickTagCloudGallerySourceAdapter extends GallerySourceAdapter {
       imageWidth: cover.width,
       imageHeight: cover.height,
       tagString: entry.tags,
-      tags: _promptTags(entry.tags),
+      tags: record.promptTags,
+      tagsComplete: true,
       fileExt: cover.extension,
       fileUrl: cover.downloadUrl.isEmpty ? null : cover.downloadUrl,
       largeFileUrl: cover.displayUrl.isEmpty ? null : cover.displayUrl,
@@ -977,9 +985,6 @@ class QuickTagCloudGallerySourceAdapter extends GallerySourceAdapter {
     }
   }
 
-  List<String> _promptTags(String prompt) =>
-      PromptTagUtils.parseForDisplay(prompt);
-
   int _stableNumericId(String value) {
     var hash = 0x811c9dc5;
     for (final unit in value.codeUnits) {
@@ -991,12 +996,19 @@ class QuickTagCloudGallerySourceAdapter extends GallerySourceAdapter {
 }
 
 class _QuickTagCloudRecord {
-  const _QuickTagCloudRecord(this.meta, this.codex, this.entry, this.media);
+  _QuickTagCloudRecord(this.meta, this.codex, this.entry, this.media);
 
   final QuickTagCloudCodexMeta meta;
   final QuickTagCloudCodex codex;
   final QuickTagCloudEntry entry;
   final QuickTagCloudMediaConfig media;
+
+  late final List<String> promptTags = List.unmodifiable(
+    PromptTagUtils.parseForDisplay(entry.tags),
+  );
+  late final Set<String> normalizedTags = Set.unmodifiable(
+    normalizeGalleryTagSet(promptTags),
+  );
 
   String get workId => quickTagCloudEntryWorkId(codex.id, entry.id);
 

--- a/lib/data/models/online_gallery/gallery_item.dart
+++ b/lib/data/models/online_gallery/gallery_item.dart
@@ -96,6 +96,8 @@ class GalleryItem {
     int? height,
     this.tagString = '',
     List<String>? tags,
+    this.searchTerms = const [],
+    this.tagsComplete = true,
     this.tagStringGeneral = '',
     this.tagStringCharacter = '',
     this.tagStringCopyright = '',
@@ -148,6 +150,10 @@ class GalleryItem {
   final int imageHeight;
   final String tagString;
   final List<String>? _tags;
+
+  /// Source-defined searchable text that is not necessarily a display tag.
+  final List<String> searchTerms;
+  final bool tagsComplete;
   final String tagStringGeneral;
   final String tagStringCharacter;
   final String tagStringCopyright;
@@ -332,6 +338,8 @@ class GalleryItem {
     int? imageHeight,
     String? tagString,
     List<String>? tags,
+    List<String>? searchTerms,
+    bool? tagsComplete,
     String? tagStringGeneral,
     String? tagStringCharacter,
     String? tagStringCopyright,
@@ -376,6 +384,8 @@ class GalleryItem {
       imageHeight: imageHeight ?? this.imageHeight,
       tagString: tagString ?? this.tagString,
       tags: tags ?? _tags,
+      searchTerms: searchTerms ?? this.searchTerms,
+      tagsComplete: tagsComplete ?? this.tagsComplete,
       tagStringGeneral: tagStringGeneral ?? this.tagStringGeneral,
       tagStringCharacter: tagStringCharacter ?? this.tagStringCharacter,
       tagStringCopyright: tagStringCopyright ?? this.tagStringCopyright,
@@ -473,6 +483,7 @@ class GalleryPage {
     required this.hasMore,
     this.total,
     this.rawItemCount = 0,
+    this.rawPageIdentity,
   });
 
   final List<GalleryItem> items;
@@ -481,4 +492,7 @@ class GalleryPage {
   final bool hasMore;
   final int? total;
   final int rawItemCount;
+
+  /// Stable identity of the upstream page before adapter-side filtering.
+  final String? rawPageIdentity;
 }

--- a/lib/data/models/online_gallery/gallery_source.dart
+++ b/lib/data/models/online_gallery/gallery_source.dart
@@ -1,3 +1,5 @@
+import 'package:nai_launcher/core/online_gallery/gallery_tag_query.dart';
+
 enum GallerySourceId {
   danbooru('danbooru', 'Danbooru'),
   safebooru('safebooru', 'Safebooru'),
@@ -26,6 +28,69 @@ enum GalleryRemoteFavoritesCapability { none, readOnly, readWrite }
 
 enum GalleryRemoteBlacklistCapability { none, readWrite }
 
+enum GalleryTagSearchStrategy {
+  accountTierSeedResidual,
+  fixedSeedResidual,
+  native,
+  localPredicate,
+}
+
+class GalleryTagSearchCapabilities {
+  const GalleryTagSearchCapabilities({
+    required this.strategy,
+    required this.anonymousLimit,
+    this.authenticatedLimit,
+    this.goldLimit,
+    this.unlimitedFromLevel,
+    this.listTagsComplete = true,
+    this.supportsNegativePushdown = true,
+    this.searchMetatagPrefixes = const {},
+    this.rankingMetatagPrefixes = const {},
+    this.rankingAppliesOrdinaryQuery = false,
+    this.validatesPushdownLocally = false,
+  });
+
+  final GalleryTagSearchStrategy strategy;
+  final int anonymousLimit;
+  final int? authenticatedLimit;
+  final int? goldLimit;
+  final int? unlimitedFromLevel;
+  final bool listTagsComplete;
+  final bool supportsNegativePushdown;
+  final Set<String> searchMetatagPrefixes;
+  final Set<String> rankingMetatagPrefixes;
+  final bool rankingAppliesOrdinaryQuery;
+  final bool validatesPushdownLocally;
+
+  Set<String> metatagPrefixes(GalleryFeedKind feed) => switch (feed) {
+    GalleryFeedKind.search => searchMetatagPrefixes,
+    GalleryFeedKind.ranking => rankingMetatagPrefixes,
+    GalleryFeedKind.favorites => const {},
+  };
+
+  bool appliesOrdinaryQuery(GalleryFeedKind feed) => switch (feed) {
+    GalleryFeedKind.search => true,
+    GalleryFeedKind.ranking => rankingAppliesOrdinaryQuery,
+    GalleryFeedKind.favorites => false,
+  };
+
+  int serverLimit({required bool authenticated, int? accountLevel}) {
+    final level = accountLevel;
+    if (level != null &&
+        unlimitedFromLevel != null &&
+        level >= unlimitedFromLevel!) {
+      return 6;
+    }
+    if (level != null && level >= 30 && goldLimit != null) {
+      return goldLimit!;
+    }
+    if (authenticated && authenticatedLimit != null) {
+      return authenticatedLimit!;
+    }
+    return anonymousLimit;
+  }
+}
+
 class GallerySourceCapabilities {
   const GallerySourceCapabilities({
     required this.supportsSearch,
@@ -44,6 +109,10 @@ class GallerySourceCapabilities {
     required this.supportsDetails,
     required this.supportsMultipleMedia,
     required this.randomFeeds,
+    this.tagSearch = const GalleryTagSearchCapabilities(
+      strategy: GalleryTagSearchStrategy.native,
+      anonymousLimit: 6,
+    ),
   });
 
   final bool supportsSearch;
@@ -62,12 +131,24 @@ class GallerySourceCapabilities {
   final bool supportsDetails;
   final bool supportsMultipleMedia;
   final Set<GalleryFeedKind> randomFeeds;
+  final GalleryTagSearchCapabilities tagSearch;
 
   bool get supportsRanking => rankingKinds.isNotEmpty;
 
   bool supportsRandomFeed(GalleryFeedKind feed) => randomFeeds.contains(feed);
 }
 
+/// Search capability evidence (verified 2026-08-25):
+/// - Danbooru tiers: https://danbooru.donmai.us/wiki_pages/help:users
+/// - Safebooru anonymous API limit response:
+///   https://safebooru.donmai.us/posts.json?limit=1&tags=1girl+solo+smile
+/// - Gelbooru API contract: https://gelbooru.com/index.php?page=wiki&s=view&id=18780
+///   and a live six-tag HTML query:
+///   https://gelbooru.com/index.php?page=post&s=list&tags=1girl+solo+smile+long_hair+looking_at_viewer+blue_eyes
+/// - AI TAG live config/search contracts: https://aitag.win/api/config and
+///   https://aitag.win/api/ai_works_search?page=1&page_size=60&q=1girl
+/// - QuickTagCloud fixed codex format:
+///   https://github.com/AgIzT/NovelAI-Tag
 const Map<GallerySourceId, GallerySourceCapabilities>
 gallerySourceCapabilities = {
   GallerySourceId.danbooru: GallerySourceCapabilities(
@@ -94,6 +175,14 @@ gallerySourceCapabilities = {
       GalleryFeedKind.ranking,
       GalleryFeedKind.favorites,
     },
+    tagSearch: GalleryTagSearchCapabilities(
+      strategy: GalleryTagSearchStrategy.accountTierSeedResidual,
+      anonymousLimit: 2,
+      authenticatedLimit: 2,
+      goldLimit: 6,
+      unlimitedFromLevel: 31,
+      searchMetatagPrefixes: danbooruGalleryMetatagPrefixes,
+    ),
   ),
   GallerySourceId.safebooru: GallerySourceCapabilities(
     supportsSearch: true,
@@ -113,6 +202,11 @@ gallerySourceCapabilities = {
     supportsDetails: true,
     supportsMultipleMedia: false,
     randomFeeds: {GalleryFeedKind.search, GalleryFeedKind.ranking},
+    tagSearch: GalleryTagSearchCapabilities(
+      strategy: GalleryTagSearchStrategy.fixedSeedResidual,
+      anonymousLimit: 2,
+      searchMetatagPrefixes: danbooruGalleryMetatagPrefixes,
+    ),
   ),
   GallerySourceId.gelbooru: GallerySourceCapabilities(
     supportsSearch: true,
@@ -128,6 +222,12 @@ gallerySourceCapabilities = {
     supportsDetails: true,
     supportsMultipleMedia: false,
     randomFeeds: {GalleryFeedKind.search, GalleryFeedKind.favorites},
+    tagSearch: GalleryTagSearchCapabilities(
+      strategy: GalleryTagSearchStrategy.native,
+      anonymousLimit: 6,
+      authenticatedLimit: 6,
+      searchMetatagPrefixes: gelbooruGalleryMetatagPrefixes,
+    ),
   ),
   GallerySourceId.aiTag: GallerySourceCapabilities(
     supportsSearch: true,
@@ -142,6 +242,14 @@ gallerySourceCapabilities = {
     supportsDetails: true,
     supportsMultipleMedia: true,
     randomFeeds: {GalleryFeedKind.search, GalleryFeedKind.ranking},
+    tagSearch: GalleryTagSearchCapabilities(
+      strategy: GalleryTagSearchStrategy.fixedSeedResidual,
+      anonymousLimit: 1,
+      listTagsComplete: false,
+      supportsNegativePushdown: false,
+      rankingAppliesOrdinaryQuery: true,
+      validatesPushdownLocally: true,
+    ),
   ),
   GallerySourceId.quickTagCloud: GallerySourceCapabilities(
     supportsSearch: true,
@@ -157,6 +265,10 @@ gallerySourceCapabilities = {
     supportsDetails: true,
     supportsMultipleMedia: true,
     randomFeeds: {GalleryFeedKind.search, GalleryFeedKind.favorites},
+    tagSearch: GalleryTagSearchCapabilities(
+      strategy: GalleryTagSearchStrategy.localPredicate,
+      anonymousLimit: 6,
+    ),
   ),
 };
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1171,11 +1171,29 @@
     }
   },
   "onlineGallery_searchTags": "Search tags...",
+  "onlineGallery_maxTagsExceeded": "You can combine up to {max} tags in one search",
+  "@onlineGallery_maxTagsExceeded": {
+    "placeholders": {
+      "max": {"type": "int"}
+    }
+  },
+  "onlineGallery_tagDetailsIncomplete": "Some complete tag lists could not be loaded. Unverified works were excluded; retry to complete the results.",
+  "onlineGallery_unsupportedMetatag": "This source or mode does not support metatag syntax. Use ordinary tags or switch to the source search.",
+  "onlineGallery_multiTagScanning": "Combining tags: requested {requests} pages and checked {candidates} candidate works",
+  "onlineGallery_scanPaused": "Several candidate pages were checked without enough matches. You can continue scanning later pages.",
+  "onlineGallery_continueScanning": "Continue scanning",
+  "@onlineGallery_multiTagScanning": {
+    "placeholders": {
+      "requests": {"type": "int"},
+      "candidates": {"type": "int"}
+    }
+  },
   "onlineGallery_refresh": "Refresh",
   "onlineGallery_random": "Random",
   "onlineGallery_randomRedraw": "Draw again",
   "onlineGallery_randomDrawing": "Drawing…",
   "onlineGallery_randomExhausted": "No more unseen images in this range",
+  "onlineGallery_randomDrawNoMatch": "This draw found no matching images. You can draw again.",
   "onlineGallery_randomRestart": "Start over",
   "onlineGallery_login": "Login",
   "onlineGallery_logout": "Logout",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1159,11 +1159,29 @@
     }
   },
   "onlineGallery_searchTags": "タグを検索...",
+  "onlineGallery_maxTagsExceeded": "一度に組み合わせて検索できるタグは最大 {max} 個です",
+  "@onlineGallery_maxTagsExceeded": {
+    "placeholders": {
+      "max": {"type": "int"}
+    }
+  },
+  "onlineGallery_tagDetailsIncomplete": "一部の作品で完全なタグ一覧を取得できませんでした。未確認の作品は除外されています。再試行してください。",
+  "onlineGallery_unsupportedMetatag": "このソースまたはモードではメタタグ構文を使用できません。通常のタグを使うか、ソース検索に切り替えてください。",
+  "onlineGallery_multiTagScanning": "タグを組み合わせて検索中：{requests} ページを取得し、{candidates} 件の候補を確認しました",
+  "onlineGallery_scanPaused": "複数ページの候補を確認しましたが、十分な結果が見つかりませんでした。後続ページの検索を続けられます。",
+  "onlineGallery_continueScanning": "検索を続ける",
+  "@onlineGallery_multiTagScanning": {
+    "placeholders": {
+      "requests": {"type": "int"},
+      "candidates": {"type": "int"}
+    }
+  },
   "onlineGallery_refresh": "更新",
   "onlineGallery_random": "ランダム",
   "onlineGallery_randomRedraw": "もう一度抽選",
   "onlineGallery_randomDrawing": "抽選中…",
   "onlineGallery_randomExhausted": "この範囲に未表示の画像はありません",
+  "onlineGallery_randomDrawNoMatch": "今回は条件に合う画像を取得できませんでした。続けて抽選できます。",
   "onlineGallery_randomRestart": "最初から",
   "onlineGallery_login": "ログイン",
   "onlineGallery_logout": "ログアウト",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4563,6 +4563,42 @@ abstract class AppLocalizations {
   /// **'Search tags...'**
   String get onlineGallery_searchTags;
 
+  /// No description provided for @onlineGallery_maxTagsExceeded.
+  ///
+  /// In en, this message translates to:
+  /// **'You can combine up to {max} tags in one search'**
+  String onlineGallery_maxTagsExceeded(int max);
+
+  /// No description provided for @onlineGallery_tagDetailsIncomplete.
+  ///
+  /// In en, this message translates to:
+  /// **'Some complete tag lists could not be loaded. Unverified works were excluded; retry to complete the results.'**
+  String get onlineGallery_tagDetailsIncomplete;
+
+  /// No description provided for @onlineGallery_unsupportedMetatag.
+  ///
+  /// In en, this message translates to:
+  /// **'This source or mode does not support metatag syntax. Use ordinary tags or switch to the source search.'**
+  String get onlineGallery_unsupportedMetatag;
+
+  /// No description provided for @onlineGallery_multiTagScanning.
+  ///
+  /// In en, this message translates to:
+  /// **'Combining tags: requested {requests} pages and checked {candidates} candidate works'**
+  String onlineGallery_multiTagScanning(int requests, int candidates);
+
+  /// No description provided for @onlineGallery_scanPaused.
+  ///
+  /// In en, this message translates to:
+  /// **'Several candidate pages were checked without enough matches. You can continue scanning later pages.'**
+  String get onlineGallery_scanPaused;
+
+  /// No description provided for @onlineGallery_continueScanning.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue scanning'**
+  String get onlineGallery_continueScanning;
+
   /// No description provided for @onlineGallery_refresh.
   ///
   /// In en, this message translates to:
@@ -4592,6 +4628,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No more unseen images in this range'**
   String get onlineGallery_randomExhausted;
+
+  /// No description provided for @onlineGallery_randomDrawNoMatch.
+  ///
+  /// In en, this message translates to:
+  /// **'This draw found no matching images. You can draw again.'**
+  String get onlineGallery_randomDrawNoMatch;
 
   /// No description provided for @onlineGallery_randomRestart.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2524,6 +2524,31 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onlineGallery_searchTags => 'Search tags...';
 
   @override
+  String onlineGallery_maxTagsExceeded(int max) {
+    return 'You can combine up to $max tags in one search';
+  }
+
+  @override
+  String get onlineGallery_tagDetailsIncomplete =>
+      'Some complete tag lists could not be loaded. Unverified works were excluded; retry to complete the results.';
+
+  @override
+  String get onlineGallery_unsupportedMetatag =>
+      'This source or mode does not support metatag syntax. Use ordinary tags or switch to the source search.';
+
+  @override
+  String onlineGallery_multiTagScanning(int requests, int candidates) {
+    return 'Combining tags: requested $requests pages and checked $candidates candidate works';
+  }
+
+  @override
+  String get onlineGallery_scanPaused =>
+      'Several candidate pages were checked without enough matches. You can continue scanning later pages.';
+
+  @override
+  String get onlineGallery_continueScanning => 'Continue scanning';
+
+  @override
   String get onlineGallery_refresh => 'Refresh';
 
   @override
@@ -2538,6 +2563,10 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get onlineGallery_randomExhausted =>
       'No more unseen images in this range';
+
+  @override
+  String get onlineGallery_randomDrawNoMatch =>
+      'This draw found no matching images. You can draw again.';
 
   @override
   String get onlineGallery_randomRestart => 'Start over';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2471,6 +2471,31 @@ class AppLocalizationsJa extends AppLocalizations {
   String get onlineGallery_searchTags => 'タグを検索...';
 
   @override
+  String onlineGallery_maxTagsExceeded(int max) {
+    return '一度に組み合わせて検索できるタグは最大 $max 個です';
+  }
+
+  @override
+  String get onlineGallery_tagDetailsIncomplete =>
+      '一部の作品で完全なタグ一覧を取得できませんでした。未確認の作品は除外されています。再試行してください。';
+
+  @override
+  String get onlineGallery_unsupportedMetatag =>
+      'このソースまたはモードではメタタグ構文を使用できません。通常のタグを使うか、ソース検索に切り替えてください。';
+
+  @override
+  String onlineGallery_multiTagScanning(int requests, int candidates) {
+    return 'タグを組み合わせて検索中：$requests ページを取得し、$candidates 件の候補を確認しました';
+  }
+
+  @override
+  String get onlineGallery_scanPaused =>
+      '複数ページの候補を確認しましたが、十分な結果が見つかりませんでした。後続ページの検索を続けられます。';
+
+  @override
+  String get onlineGallery_continueScanning => '検索を続ける';
+
+  @override
   String get onlineGallery_refresh => '更新';
 
   @override
@@ -2484,6 +2509,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get onlineGallery_randomExhausted => 'この範囲に未表示の画像はありません';
+
+  @override
+  String get onlineGallery_randomDrawNoMatch =>
+      '今回は条件に合う画像を取得できませんでした。続けて抽選できます。';
 
   @override
   String get onlineGallery_randomRestart => '最初から';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2433,6 +2433,30 @@ class AppLocalizationsZh extends AppLocalizations {
   String get onlineGallery_searchTags => '搜索标签...';
 
   @override
+  String onlineGallery_maxTagsExceeded(int max) {
+    return '最多可组合搜索 $max 个标签';
+  }
+
+  @override
+  String get onlineGallery_tagDetailsIncomplete =>
+      '部分作品的完整标签获取失败，未验证的作品已排除；请重试以补全结果。';
+
+  @override
+  String get onlineGallery_unsupportedMetatag =>
+      '当前来源或模式不支持元标签语法，请改用普通标签或切换到来源搜索。';
+
+  @override
+  String onlineGallery_multiTagScanning(int requests, int candidates) {
+    return '正在组合检索：已请求 $requests 页，检查 $candidates 个候选作品';
+  }
+
+  @override
+  String get onlineGallery_scanPaused => '已分批检查多页候选，尚未找到足够结果。可继续扫描后续页面。';
+
+  @override
+  String get onlineGallery_continueScanning => '继续扫描';
+
+  @override
   String get onlineGallery_refresh => '刷新';
 
   @override
@@ -2446,6 +2470,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get onlineGallery_randomExhausted => '当前范围暂无更多未见图片';
+
+  @override
+  String get onlineGallery_randomDrawNoMatch => '本次未抽中符合条件的图片，可以继续抽取。';
 
   @override
   String get onlineGallery_randomRestart => '重新开始';
@@ -14675,6 +14702,30 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get onlineGallery_searchTags => '搜尋標籤...';
 
   @override
+  String onlineGallery_maxTagsExceeded(int max) {
+    return '最多可組合搜尋 $max 個標籤';
+  }
+
+  @override
+  String get onlineGallery_tagDetailsIncomplete =>
+      '部分作品的完整標籤取得失敗，未驗證的作品已排除；請重試以補齊結果。';
+
+  @override
+  String get onlineGallery_unsupportedMetatag =>
+      '目前來源或模式不支援元標籤語法，請改用一般標籤或切換至來源搜尋。';
+
+  @override
+  String onlineGallery_multiTagScanning(int requests, int candidates) {
+    return '正在組合搜尋：已請求 $requests 頁，檢查 $candidates 個候選作品';
+  }
+
+  @override
+  String get onlineGallery_scanPaused => '已分批檢查多頁候選，尚未找到足夠結果。可繼續掃描後續頁面。';
+
+  @override
+  String get onlineGallery_continueScanning => '繼續掃描';
+
+  @override
   String get onlineGallery_refresh => '重新整理';
 
   @override
@@ -14688,6 +14739,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get onlineGallery_randomExhausted => '當前範圍暫無更多未見圖片';
+
+  @override
+  String get onlineGallery_randomDrawNoMatch => '本次未抽中符合條件的圖片，可以繼續抽取。';
 
   @override
   String get onlineGallery_randomRestart => '重新開始';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1078,11 +1078,29 @@
     }
   },
   "onlineGallery_searchTags": "搜索标签...",
+  "onlineGallery_maxTagsExceeded": "最多可组合搜索 {max} 个标签",
+  "@onlineGallery_maxTagsExceeded": {
+    "placeholders": {
+      "max": {"type": "int"}
+    }
+  },
+  "onlineGallery_tagDetailsIncomplete": "部分作品的完整标签获取失败，未验证的作品已排除；请重试以补全结果。",
+  "onlineGallery_unsupportedMetatag": "当前来源或模式不支持元标签语法，请改用普通标签或切换到来源搜索。",
+  "onlineGallery_multiTagScanning": "正在组合检索：已请求 {requests} 页，检查 {candidates} 个候选作品",
+  "onlineGallery_scanPaused": "已分批检查多页候选，尚未找到足够结果。可继续扫描后续页面。",
+  "onlineGallery_continueScanning": "继续扫描",
+  "@onlineGallery_multiTagScanning": {
+    "placeholders": {
+      "requests": {"type": "int"},
+      "candidates": {"type": "int"}
+    }
+  },
   "onlineGallery_refresh": "刷新",
   "onlineGallery_random": "随机",
   "onlineGallery_randomRedraw": "再抽一组",
   "onlineGallery_randomDrawing": "抽取中…",
   "onlineGallery_randomExhausted": "当前范围暂无更多未见图片",
+  "onlineGallery_randomDrawNoMatch": "本次未抽中符合条件的图片，可以继续抽取。",
   "onlineGallery_randomRestart": "重新开始",
   "onlineGallery_login": "登录",
   "onlineGallery_logout": "退出登录",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1093,11 +1093,29 @@
     }
   },
   "onlineGallery_searchTags": "搜尋標籤...",
+  "onlineGallery_maxTagsExceeded": "最多可組合搜尋 {max} 個標籤",
+  "@onlineGallery_maxTagsExceeded": {
+    "placeholders": {
+      "max": {"type": "int"}
+    }
+  },
+  "onlineGallery_tagDetailsIncomplete": "部分作品的完整標籤取得失敗，未驗證的作品已排除；請重試以補齊結果。",
+  "onlineGallery_unsupportedMetatag": "目前來源或模式不支援元標籤語法，請改用一般標籤或切換至來源搜尋。",
+  "onlineGallery_multiTagScanning": "正在組合搜尋：已請求 {requests} 頁，檢查 {candidates} 個候選作品",
+  "onlineGallery_scanPaused": "已分批檢查多頁候選，尚未找到足夠結果。可繼續掃描後續頁面。",
+  "onlineGallery_continueScanning": "繼續掃描",
+  "@onlineGallery_multiTagScanning": {
+    "placeholders": {
+      "requests": {"type": "int"},
+      "candidates": {"type": "int"}
+    }
+  },
   "onlineGallery_refresh": "重新整理",
   "onlineGallery_random": "隨機",
   "onlineGallery_randomRedraw": "再抽一組",
   "onlineGallery_randomDrawing": "抽取中…",
   "onlineGallery_randomExhausted": "當前範圍暫無更多未見圖片",
+  "onlineGallery_randomDrawNoMatch": "本次未抽中符合條件的圖片，可以繼續抽取。",
   "onlineGallery_randomRestart": "重新開始",
   "onlineGallery_login": "登入",
   "onlineGallery_logout": "退出登入",

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -8,8 +8,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../core/autocomplete/tag_catalog_repository.dart';
 import '../../core/cache/online_gallery_detail_coordinator.dart';
 import '../../core/constants/storage_keys.dart';
+import '../../core/online_gallery/gallery_tag_query.dart';
 import '../../core/network/online_gallery_retry_interceptor.dart';
 import '../../core/storage/local_storage_service.dart';
 import '../../core/utils/app_logger.dart';
@@ -88,6 +90,9 @@ List<GalleryItem> parsePostsInIsolate(Map<String, dynamic> data) {
 enum GalleryViewMode { search, popular, favorites }
 
 enum OnlineGalleryErrorCode {
+  tooManySearchTags,
+  tagDetailsIncomplete,
+  unsupportedMetatag,
   credentialsRequired,
   credentialsInvalid,
   rateLimited,
@@ -111,9 +116,18 @@ enum OnlineGalleryErrorCode {
   artistHuntDetailFailed,
 }
 
-enum OnlineGalleryNotice { gelbooruCredentialsInvalid }
+enum OnlineGalleryNotice {
+  gelbooruCredentialsInvalid,
+  tagDetailsIncomplete,
+  randomDrawNoMatch,
+}
 
 String onlineGalleryPostKey(GalleryItem item) => item.stableKey;
+
+String _galleryRawPageIdentity(List<GalleryItem> items) {
+  final keys = items.map((item) => item.stableKey).toSet().toList()..sort();
+  return keys.join('\u0000');
+}
 
 @Riverpod(keepAlive: true)
 Dio onlineGalleryHttpClient(Ref ref) {
@@ -127,6 +141,20 @@ Dio onlineGalleryHttpClient(Ref ref) {
   dio.interceptors.add(OnlineGalleryRetryInterceptor(dio: dio));
   return dio;
 }
+
+typedef GalleryTagMetadataLoader =
+    Future<Map<String, TagCatalogRecord>> Function(Iterable<String> terms);
+
+final onlineGalleryTagCatalogProvider = Provider<TagCatalogRepository>((ref) {
+  final repository = TagCatalogRepository();
+  ref.onDispose(repository.dispose);
+  return repository;
+});
+
+final onlineGalleryTagMetadataLoaderProvider =
+    Provider<GalleryTagMetadataLoader>((ref) {
+      return ref.watch(onlineGalleryTagCatalogProvider).resolveExactTags;
+    });
 
 final quickTagCloudGallerySourceAdapterProvider =
     Provider<QuickTagCloudGallerySourceAdapter>((ref) {
@@ -164,7 +192,6 @@ Map<GallerySourceId, GallerySourceAdapter> onlineGallerySourceAdapters(
     GallerySourceId.safebooru: DonmaiGallerySourceAdapter(
       sourceId: GallerySourceId.safebooru,
       dio: dio,
-      authHeader: () => ref.read(danbooruAuthProvider.notifier).getAuthHeader(),
     ),
     GallerySourceId.gelbooru: GelbooruGallerySourceAdapter(
       dio: dio,
@@ -253,6 +280,12 @@ class ModeCache {
     this.artistHuntCandidateCount = 0,
     this.artistHuntResolvedCount = 0,
     this.artistHuntFailureCount = 0,
+    this.queryRequestCount = 0,
+    this.queryCandidateCount = 0,
+    this.queryFilterMicros = 0,
+    this.queryDetailFailureCount = 0,
+    this.lastRawPageIdentity,
+    this.queryScanPaused = false,
   });
 
   final List<GalleryItem> posts;
@@ -279,6 +312,12 @@ class ModeCache {
   final int artistHuntCandidateCount;
   final int artistHuntResolvedCount;
   final int artistHuntFailureCount;
+  final int queryRequestCount;
+  final int queryCandidateCount;
+  final int queryFilterMicros;
+  final int queryDetailFailureCount;
+  final String? lastRawPageIdentity;
+  final bool queryScanPaused;
 
   ModeCache copyWith({
     List<GalleryItem>? posts,
@@ -305,6 +344,13 @@ class ModeCache {
     int? artistHuntCandidateCount,
     int? artistHuntResolvedCount,
     int? artistHuntFailureCount,
+    int? queryRequestCount,
+    int? queryCandidateCount,
+    int? queryFilterMicros,
+    int? queryDetailFailureCount,
+    String? lastRawPageIdentity,
+    bool clearLastRawPageIdentity = false,
+    bool? queryScanPaused,
   }) {
     return ModeCache(
       posts: posts ?? this.posts,
@@ -343,6 +389,15 @@ class ModeCache {
           artistHuntResolvedCount ?? this.artistHuntResolvedCount,
       artistHuntFailureCount:
           artistHuntFailureCount ?? this.artistHuntFailureCount,
+      queryRequestCount: queryRequestCount ?? this.queryRequestCount,
+      queryCandidateCount: queryCandidateCount ?? this.queryCandidateCount,
+      queryFilterMicros: queryFilterMicros ?? this.queryFilterMicros,
+      queryDetailFailureCount:
+          queryDetailFailureCount ?? this.queryDetailFailureCount,
+      lastRawPageIdentity: clearLastRawPageIdentity
+          ? null
+          : (lastRawPageIdentity ?? this.lastRawPageIdentity),
+      queryScanPaused: queryScanPaused ?? this.queryScanPaused,
     );
   }
 }
@@ -416,6 +471,8 @@ class OnlineGalleryState {
     this.randomSession = const RandomGallerySession(),
     this.artistHuntEnabled = false,
     this.blacklistRevision = 0,
+    this.danbooruAuthScope = 'anonymous',
+    this.gelbooruAuthScope = 'anonymous',
   });
 
   final bool isLoading;
@@ -453,6 +510,8 @@ class OnlineGalleryState {
   final RandomGallerySession randomSession;
   final bool artistHuntEnabled;
   final int blacklistRevision;
+  final String danbooruAuthScope;
+  final String gelbooruAuthScope;
 
   GallerySourceId get activeSourceId => switch (viewMode) {
     GalleryViewMode.search => sourceId,
@@ -480,9 +539,9 @@ class OnlineGalleryState {
   String get currentCacheKey {
     switch (viewMode) {
       case GalleryViewMode.search:
-        return 'search:${sourceId.key}:${searchQuery.trim()}|${promptQuery.trim()}|$fuzzySearchEnabled|${_ratingsKey(selectedRatings)}|${dateRangeStart?.toIso8601String() ?? ''}|${dateRangeEnd?.toIso8601String() ?? ''}|$aiTagTimeRange|artistHunt:${sourceId == GallerySourceId.aiTag && artistHuntEnabled}|codex:${sourceId == GallerySourceId.quickTagCloud ? quickTagCloudFilterKey : ''}|blacklist:$blacklistRevision';
+        return 'search:${sourceId.key}:${searchQuery.trim()}|${promptQuery.trim()}|$fuzzySearchEnabled|${_ratingsKey(selectedRatings)}|${dateRangeStart?.toIso8601String() ?? ''}|${dateRangeEnd?.toIso8601String() ?? ''}|$aiTagTimeRange|artistHunt:${sourceId == GallerySourceId.aiTag && artistHuntEnabled}|codex:${sourceId == GallerySourceId.quickTagCloud ? quickTagCloudFilterKey : ''}|blacklist:$blacklistRevision|auth:${_authScopeFor(sourceId)}';
       case GalleryViewMode.popular:
-        return 'popular:${popularSourceId.key}:${popularScale.name}|${popularDate?.toIso8601String() ?? ''}|$aiTagPopularPeriod|${popularQuery.trim()}|${popularPromptQuery.trim()}|${_ratingsKey(selectedRatings)}|artistHunt:${popularSourceId == GallerySourceId.aiTag && artistHuntEnabled}|blacklist:$blacklistRevision';
+        return 'popular:${popularSourceId.key}:${popularScale.name}|${popularDate?.toIso8601String() ?? ''}|$aiTagPopularPeriod|${popularQuery.trim()}|${popularPromptQuery.trim()}|${_ratingsKey(selectedRatings)}|artistHunt:${popularSourceId == GallerySourceId.aiTag && artistHuntEnabled}|blacklist:$blacklistRevision|auth:${_authScopeFor(popularSourceId)}';
       case GalleryViewMode.favorites:
         return 'favorites:${favoritesSourceId.key}|${favoriteSearchQuery.trim()}|${_ratingsKey(selectedRatings)}|codex:${favoritesSourceId == GallerySourceId.quickTagCloud ? quickTagCloudFilterKey : ''}|blacklist:$blacklistRevision';
     }
@@ -563,6 +622,8 @@ class OnlineGalleryState {
     RandomGallerySession? randomSession,
     bool? artistHuntEnabled,
     int? blacklistRevision,
+    String? danbooruAuthScope,
+    String? gelbooruAuthScope,
   }) {
     return OnlineGalleryState(
       isLoading: isLoading ?? this.isLoading,
@@ -613,6 +674,8 @@ class OnlineGalleryState {
       randomSession: randomSession ?? this.randomSession,
       artistHuntEnabled: artistHuntEnabled ?? this.artistHuntEnabled,
       blacklistRevision: blacklistRevision ?? this.blacklistRevision,
+      danbooruAuthScope: danbooruAuthScope ?? this.danbooruAuthScope,
+      gelbooruAuthScope: gelbooruAuthScope ?? this.gelbooruAuthScope,
     );
   }
 
@@ -657,6 +720,12 @@ class OnlineGalleryState {
       caches.remove(oldestEvictable);
     }
   }
+
+  String _authScopeFor(GallerySourceId sourceId) => switch (sourceId) {
+    GallerySourceId.danbooru => danbooruAuthScope,
+    GallerySourceId.gelbooru => gelbooruAuthScope,
+    _ => 'public',
+  };
 
   static String _ratingsKey(Set<String> ratings) {
     final sorted = ratings.toList()..sort();
@@ -897,6 +966,7 @@ DateTime? _decodeDate(Object? value) {
 @riverpod
 class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   static const int _pageSize = 60;
+  static const int _residualScanPageBudget = 8;
 
   CancelToken? _cancelToken;
   int _requestGeneration = 0;
@@ -907,8 +977,17 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   int? _pendingRestoredPage;
   Future<void> _persistenceQueue = Future<void>.value();
   Timer? _blacklistRefreshDebounce;
+  Timer? _authenticationChangeTimer;
+  final Map<GallerySourceId, bool> _pendingAuthenticationChanges = {};
+  bool _disposed = false;
+  bool _danbooruAuthReady = false;
+  bool _gelbooruAuthReady = false;
   Set<String> _localFavoriteKeys = const {};
   final Set<String> _remoteFavoriteKeys = <String>{};
+  final LinkedHashMap<String, Set<String>> _normalizedTagSets =
+      LinkedHashMap<String, Set<String>>();
+  final LinkedHashMap<String, GalleryTagQueryPlan> _tagQueryPlans =
+      LinkedHashMap<String, GalleryTagQueryPlan>();
 
   OnlineGalleryDetailCoordinator get _details =>
       _detailCoordinator ??= OnlineGalleryDetailCoordinator(
@@ -920,18 +999,25 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   OnlineGalleryState build() {
     ref.keepAlive();
     ref.onDispose(() {
+      _disposed = true;
       _blacklistRefreshDebounce?.cancel();
+      _authenticationChangeTimer?.cancel();
       _requestGeneration++;
       if (_cancelToken != null && !_cancelToken!.isCancelled) {
         _cancelToken!.cancel('Online gallery notifier disposed');
       }
       _detailCoordinator?.clear();
+      _normalizedTagSets.clear();
     });
     final storage = ref.read(localStorageServiceProvider);
     final persistedSession = storage.getSetting<String>(
       StorageKeys.onlineGalleryBrowsingSessionV1,
     );
-    final restored = decodeOnlineGalleryBrowsingSession(persistedSession);
+    var restored = decodeOnlineGalleryBrowsingSession(persistedSession);
+    restored = restored.copyWith(
+      danbooruAuthScope: _currentDanbooruAuthScope,
+      gelbooruAuthScope: _currentGelbooruAuthScope,
+    );
     if (!restored.randomEnabled &&
         persistedSession != null &&
         restored.currentCache.page > 1) {
@@ -944,7 +1030,14 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     if (restored.randomEnabled) {
       _normalRestorePoint = restored.copyWith(randomEnabled: false);
     }
-    listenSelf((_, next) => _persistBrowsingSession(storage, next));
+    listenSelf((previous, next) {
+      _persistBrowsingSession(storage, next);
+      final wasLoading =
+          previous?.isLoading == true || previous?.isLoadingMore == true;
+      if (wasLoading && !next.isLoading && !next.isLoadingMore) {
+        Future.microtask(_flushAuthenticationChanges);
+      }
+    });
     if (Hive.isBoxOpen(StorageKeys.localFavoritesBox)) {
       Future.microtask(() async {
         await ref
@@ -961,16 +1054,35 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         ),
       );
     }
-    ref.listen<String?>(
-      danbooruAuthProvider.select((value) => value.user?.name),
-      (_, _) => _handleAccountIdentityChanged(GallerySourceId.danbooru),
-    );
-    ref.listen<String?>(
-      gelbooruAuthProvider.select(
-        (value) => value.credentials?.userId.toString(),
+    ref.listen<(String?, String?, int?, bool)>(
+      danbooruAuthProvider.select(
+        (value) => (
+          value.credentials?.username,
+          value.user?.name,
+          value.user?.level,
+          value.isLoggedIn,
+        ),
       ),
-      (_, _) => _handleAccountIdentityChanged(GallerySourceId.gelbooru),
+      (_, _) {
+        if (_danbooruAuthReady) {
+          _queueAuthenticationChange(GallerySourceId.danbooru);
+        }
+      },
     );
+    ref.listen<(String?, GelbooruAuthStatus)>(
+      gelbooruAuthProvider.select(
+        (value) => (value.credentials?.userId.toString(), value.status),
+      ),
+      (_, next) {
+        if (_gelbooruAuthReady) {
+          _queueAuthenticationChange(
+            GallerySourceId.gelbooru,
+            deferWhileLoading: next.$2 == GelbooruAuthStatus.invalid,
+          );
+        }
+      },
+    );
+    unawaited(Future<void>(_initializeAuthenticationScopes));
     ref.listen<int>(
       onlineGalleryBlacklistNotifierProvider.select((value) => value.revision),
       (_, _) => _handleBlacklistChanged(),
@@ -1049,34 +1161,164 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     });
   }
 
-  void _handleAccountIdentityChanged(GallerySourceId sourceId) {
+  Future<void> _initializeAuthenticationScopes() async {
+    if (_disposed) return;
+    try {
+      await Future.wait([
+        ref.read(danbooruAuthProvider.notifier).ensureInitialized(),
+        ref.read(gelbooruAuthProvider.notifier).ensureInitialized(),
+      ]);
+    } catch (error) {
+      if (_disposed) return;
+      AppLogger.w(
+        'Failed to initialize online gallery authentication scopes: $error',
+        'OnlineGallery',
+      );
+    }
+    if (_disposed) return;
+    final initializeDanbooru = !_danbooruAuthReady;
+    final initializeGelbooru = !_gelbooruAuthReady;
+    _danbooruAuthReady = true;
+    _gelbooruAuthReady = true;
+    if (initializeDanbooru || initializeGelbooru) {
+      state = state.copyWith(
+        danbooruAuthScope: initializeDanbooru
+            ? _currentDanbooruAuthScope
+            : state.danbooruAuthScope,
+        gelbooruAuthScope: initializeGelbooru
+            ? _currentGelbooruAuthScope
+            : state.gelbooruAuthScope,
+      );
+    }
+  }
+
+  Future<void> _ensureAuthenticationReady(GallerySourceId sourceId) async {
+    switch (sourceId) {
+      case GallerySourceId.danbooru:
+        try {
+          await ref.read(danbooruAuthProvider.notifier).ensureInitialized();
+        } catch (error) {
+          AppLogger.w(
+            'Failed to initialize Danbooru authentication: $error',
+            'OnlineGallery',
+          );
+        }
+        if (_disposed) return;
+        _danbooruAuthReady = true;
+        final scope = _currentDanbooruAuthScope;
+        if (scope != state.danbooruAuthScope) {
+          state = state.copyWith(danbooruAuthScope: scope);
+        }
+        return;
+      case GallerySourceId.gelbooru:
+        try {
+          await ref.read(gelbooruAuthProvider.notifier).ensureInitialized();
+        } catch (error) {
+          AppLogger.w(
+            'Failed to initialize Gelbooru authentication: $error',
+            'OnlineGallery',
+          );
+        }
+        if (_disposed) return;
+        _gelbooruAuthReady = true;
+        final scope = _currentGelbooruAuthScope;
+        if (scope != state.gelbooruAuthScope) {
+          state = state.copyWith(gelbooruAuthScope: scope);
+        }
+        return;
+      case GallerySourceId.safebooru:
+      case GallerySourceId.aiTag:
+      case GallerySourceId.quickTagCloud:
+        return;
+    }
+  }
+
+  void _queueAuthenticationChange(
+    GallerySourceId sourceId, {
+    bool deferWhileLoading = false,
+  }) {
+    final existing = _pendingAuthenticationChanges[sourceId];
+    _pendingAuthenticationChanges[sourceId] = existing == null
+        ? deferWhileLoading
+        : existing && deferWhileLoading;
+    _authenticationChangeTimer ??= Timer(
+      Duration.zero,
+      _flushAuthenticationChanges,
+    );
+  }
+
+  void _flushAuthenticationChanges() {
+    _authenticationChangeTimer = null;
+    if (_disposed || _pendingAuthenticationChanges.isEmpty) return;
+    final requestActive = state.isLoading || state.isLoadingMore;
+    final ready = _pendingAuthenticationChanges.entries
+        .where((entry) => !requestActive || !entry.value)
+        .map((entry) => entry.key)
+        .toList(growable: false);
+    for (final sourceId in ready) {
+      _pendingAuthenticationChanges.remove(sourceId);
+      _handleAuthenticationChanged(sourceId);
+    }
+  }
+
+  void _handleAuthenticationChanged(GallerySourceId sourceId) {
+    final nextScope = sourceId == GallerySourceId.danbooru
+        ? _currentDanbooruAuthScope
+        : _currentGelbooruAuthScope;
+    final currentScope = sourceId == GallerySourceId.danbooru
+        ? state.danbooruAuthScope
+        : state.gelbooruAuthScope;
+    if (nextScope == currentScope) return;
+
+    final activeSourceContext = state.activeSourceId == sourceId;
+    if (activeSourceContext) _cancelCurrentRequest();
+    final sourcePrefix = '${sourceId.key}:';
     final retainedCaches = <String, ModeCache>{
       for (final entry in state.caches.entries)
-        if (!entry.key.startsWith('favorites:${sourceId.key}'))
+        if (!_isAuthenticatedSourceCache(entry.key, sourceId))
           entry.key: entry.value,
     };
-    _remoteFavoriteKeys.removeWhere(
-      (key) => key.startsWith('${sourceId.key}:'),
-    );
+    _tagQueryPlans.removeWhere((key, _) => key.startsWith('${sourceId.key}|'));
+    _normalizedTagSets.removeWhere((key, _) => key.startsWith(sourcePrefix));
+    _detailCoordinator?.clear();
+    _remoteFavoriteKeys.removeWhere((key) => key.startsWith(sourcePrefix));
+    if (state.randomEnabled) {
+      // The saved normal-mode snapshot belongs to the previous identity. Using
+      // it after random mode exits would restore cross-account result caches.
+      _normalRestorePoint = null;
+    }
     state = state.copyWith(
       caches: retainedCaches,
+      searchCache: const ModeCache(),
+      popularCache: const ModeCache(),
+      danbooruAuthScope: sourceId == GallerySourceId.danbooru
+          ? nextScope
+          : state.danbooruAuthScope,
+      gelbooruAuthScope: sourceId == GallerySourceId.gelbooru
+          ? nextScope
+          : state.gelbooruAuthScope,
+      randomSession: activeSourceContext && state.randomEnabled
+          ? const RandomGallerySession()
+          : state.randomSession,
       favoritedPostKeys: {..._localFavoriteKeys, ..._remoteFavoriteKeys},
+      localFavoritedPostKeys: _localFavoriteKeys,
       remoteFavoritedPostKeys: _remoteFavoriteKeys,
+      clearError: activeSourceContext,
     );
-    if (state.activeSourceId != sourceId ||
-        (!state.randomEnabled && state.viewMode != GalleryViewMode.favorites)) {
-      return;
-    }
-    _cancelCurrentRequest();
+    if (!activeSourceContext) return;
     if (state.randomEnabled) {
-      state = state.copyWith(
-        randomSession: const RandomGallerySession(),
-        clearError: true,
-      );
       unawaited(_loadRandom(replace: true, restart: true));
-    } else if (state.viewMode == GalleryViewMode.favorites) {
+    } else {
       unawaited(loadPosts(refresh: true));
     }
+  }
+
+  bool _isAuthenticatedSourceCache(String key, GallerySourceId sourceId) {
+    if (key.startsWith('search:${sourceId.key}:') ||
+        key.startsWith('popular:${sourceId.key}:')) {
+      return true;
+    }
+    return key.startsWith('favorites:${sourceId.key}|');
   }
 
   Map<GallerySourceId, GallerySourceAdapter> get _adapters =>
@@ -1085,6 +1327,19 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   DanbooruAuthState get _danbooruAuth => ref.read(danbooruAuthProvider);
   GelbooruApiService get _gelbooruApi => ref.read(gelbooruApiServiceProvider);
   GelbooruAuthState get _gelbooruAuth => ref.read(gelbooruAuthProvider);
+  String get _currentDanbooruAuthScope {
+    final auth = _danbooruAuth;
+    final identity = auth.user?.name ?? auth.credentials?.username;
+    if (identity == null) return 'anonymous';
+    final status = auth.isLoggedIn ? 'authenticated' : 'pending';
+    return '$identity:${auth.user?.level ?? 0}:$status';
+  }
+
+  String get _currentGelbooruAuthScope {
+    final auth = _gelbooruAuth;
+    final userId = auth.credentials?.userId;
+    return '${userId ?? 'anonymous'}:${auth.status.name}';
+  }
 
   int _beginRequest() {
     _requestGeneration++;
@@ -1358,13 +1613,21 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   }
 
   Future<void> searchWithPrompt(String query, {required String prompt}) async {
+    final normalized = query.trim();
+    final parsed = GalleryTagQueryParser.parse(normalized);
     _cancelCurrentRequest();
     state = state.copyWith(
-      searchQuery: query.trim(),
+      searchQuery: normalized,
       promptQuery: prompt.trim(),
       viewMode: GalleryViewMode.search,
       clearError: true,
     );
+    if (!parsed.isValid) {
+      state = state.copyWith(
+        errorCode: OnlineGalleryErrorCode.tooManySearchTags,
+      );
+      return;
+    }
     await loadPosts(refresh: true);
   }
 
@@ -1372,13 +1635,21 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     required String query,
     required String prompt,
   }) async {
+    final normalized = query.trim();
+    final parsed = GalleryTagQueryParser.parse(normalized);
     _cancelCurrentRequest();
     state = state.copyWith(
-      popularQuery: query.trim(),
+      popularQuery: normalized,
       popularPromptQuery: prompt.trim(),
       viewMode: GalleryViewMode.popular,
       clearError: true,
     );
+    if (!parsed.isValid) {
+      state = state.copyWith(
+        errorCode: OnlineGalleryErrorCode.tooManySearchTags,
+      );
+      return;
+    }
     await loadPosts(refresh: true);
   }
 
@@ -1442,6 +1713,9 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         isLoadingMore: false,
         clearError: true,
       );
+      if (restore == null && state.currentCache.posts.isEmpty) {
+        await loadPosts(refresh: true);
+      }
       return;
     }
     if (!state.supportsRandom) return;
@@ -1475,11 +1749,17 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     // Establish latest-call-wins before any initialization await. Otherwise an
     // earlier QuickTagCloud refresh can finish initialization later and cancel
     // the request started by a newer click.
+    final sourceId = state.activeSourceId;
     final generation = _beginRequest();
-    await _ensureQuickTagCloudFilterInitialized();
+    final requestCancelToken = _cancelToken!;
+    await Future.wait([
+      _ensureQuickTagCloudFilterInitialized(),
+      _ensureAuthenticationReady(sourceId),
+    ]);
     if (generation != _requestGeneration ||
         !state.randomEnabled ||
-        !state.supportsRandom) {
+        !state.supportsRandom ||
+        state.activeSourceId != sourceId) {
       return;
     }
     final cacheKey = state.currentCacheKey;
@@ -1489,7 +1769,6 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       clearError: true,
     );
     try {
-      final sourceId = state.activeSourceId;
       await ref
           .read(onlineGalleryBlacklistNotifierProvider.notifier)
           .ensureInitialized();
@@ -1527,16 +1806,38 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       }
 
       final adapter = _adapters[sourceId]!;
-      final request = _randomRequest(session, blacklist);
-      final page = await adapter.random(request, cancelToken: _cancelToken);
+      final rawTagQuery = switch (state.viewMode) {
+        GalleryViewMode.search => state.searchQuery,
+        GalleryViewMode.popular => state.popularQuery,
+        GalleryViewMode.favorites => '',
+      };
+      final tagPlan = await _buildTagQueryPlan(sourceId, rawTagQuery);
+      if (generation != _requestGeneration || !state.randomEnabled) return;
+      final request = _randomRequest(session, blacklist, tagPlan);
+      final page = await adapter.random(
+        request,
+        cancelToken: requestCancelToken,
+      );
       if (generation != _requestGeneration ||
           !state.randomEnabled ||
           state.currentCacheKey != cacheKey) {
         return;
       }
 
-      final eligibleItems = await _filterByBlacklistCompletingDetails(
+      final tagFiltered = await _filterByTagPlan(
         page.items,
+        tagPlan,
+        capabilities: sourceId.capabilities.tagSearch,
+        feedKind: state.activeFeedKind,
+        cancelToken: requestCancelToken,
+      );
+      if (generation != _requestGeneration ||
+          !state.randomEnabled ||
+          state.currentCacheKey != cacheKey) {
+        return;
+      }
+      final blacklistFiltered = await _filterByBlacklistCompletingDetails(
+        tagFiltered.items,
         blacklist,
       );
       if (generation != _requestGeneration ||
@@ -1544,18 +1845,20 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
           state.currentCacheKey != cacheKey) {
         return;
       }
+      final detailFailures =
+          tagFiltered.detailFailures + blacklistFiltered.detailFailures;
       final artistHuntActive = state.isArtistHuntActive;
       final seen = Set<String>.of(session.seenStableKeys);
       final seenCandidates = Set<String>.of(session.seenCandidateStableKeys);
       final candidates = <GalleryItem>[];
-      for (var index = 0; index < eligibleItems.length; index++) {
+      for (var index = 0; index < blacklistFiltered.items.length; index++) {
         if (index > 0 && index % 256 == 0) {
           await Future<void>.delayed(Duration.zero);
           if (generation != _requestGeneration || !state.randomEnabled) {
             return;
           }
         }
-        final item = eligibleItems[index];
+        final item = blacklistFiltered.items[index];
         final identity = artistHuntActive
             ? item.detailStableKey
             : item.stableKey;
@@ -1632,7 +1935,8 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       final misses = unique.isEmpty ? session.consecutiveMisses + 1 : 0;
       final sourceExhausted =
           sourceId == GallerySourceId.quickTagCloud && !page.hasMore;
-      final exhausted = sourceExhausted || misses >= 4 || seen.length >= 20000;
+      // Random remote draws are samples, so misses cannot prove exhaustion.
+      final exhausted = sourceExhausted || seen.length >= 20000;
       final nextSession = RandomGallerySession(
         scopeKey: scopeKey,
         cache: session.cache.copyWith(
@@ -1642,6 +1946,8 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
           hasMore: !exhausted,
           total: artistHuntActive ? null : page.total,
           endedByDuplicatePage: exhausted,
+          queryScanPaused: unique.isEmpty && !exhausted,
+          queryDetailFailureCount: detailFailures,
           artistHuntCandidateCount: candidateCount,
           artistHuntResolvedCount: resolvedCount,
           artistHuntFailureCount: failureCount,
@@ -1657,6 +1963,12 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         isLoading: false,
         isLoadingMore: false,
         randomSession: nextSession,
+        notice: detailFailures > 0
+            ? OnlineGalleryNotice.tagDetailsIncomplete
+            : unique.isEmpty && !exhausted
+            ? OnlineGalleryNotice.randomDrawNoMatch
+            : null,
+        clearNotice: detailFailures == 0 && (unique.isNotEmpty || exhausted),
         clearError: true,
       );
     } catch (error) {
@@ -1774,19 +2086,13 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   GalleryRandomRequest _randomRequest(
     RandomGallerySession session,
     Set<String> blacklist,
+    GalleryTagQueryPlan tagPlan,
   ) {
     switch (state.viewMode) {
       case GalleryViewMode.search:
         return GalleryRandomSearchRequest(
           pageSize: _pageSize,
-          query: state.activeSourceId == GallerySourceId.aiTag
-              ? state.searchQuery.trim()
-              : buildOnlineGallerySearchQuery(
-                  state.searchQuery,
-                  fuzzyMatch:
-                      state.activeSourceId != GallerySourceId.quickTagCloud &&
-                      state.fuzzySearchEnabled,
-                ),
+          query: tagPlan.serverQuery,
           prompt: _effectivePromptQuery(state.promptQuery),
           timeRange: state.aiTagTimeRange,
           ratings: state.selectedRatings,
@@ -1803,7 +2109,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
               : _rankingKind(state.popularScale),
           date: state.popularDate,
           period: state.aiTagPopularPeriod,
-          query: state.popularQuery,
+          query: tagPlan.serverQuery,
           prompt: _effectivePromptQuery(state.popularPromptQuery),
           ratings: state.selectedRatings,
           blacklistTags: blacklist,
@@ -1839,6 +2145,226 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     return state.isArtistHuntActive
         ? ArtistChainParser.withArtistConstraint(prompt)
         : prompt;
+  }
+
+  int _serverOrdinaryTagLimit(GallerySourceId sourceId) {
+    final capability = sourceId.capabilities.tagSearch;
+    final authenticated = switch (sourceId) {
+      GallerySourceId.danbooru => _danbooruAuth.isLoggedIn,
+      GallerySourceId.gelbooru => _gelbooruAuth.isAuthenticated,
+      _ => false,
+    };
+    final accountLevel = sourceId == GallerySourceId.danbooru
+        ? _danbooruAuth.user?.level
+        : null;
+    return capability.serverLimit(
+      authenticated: authenticated,
+      accountLevel: accountLevel,
+    );
+  }
+
+  Future<GalleryTagQueryPlan> _buildTagQueryPlan(
+    GallerySourceId sourceId,
+    String rawQuery,
+  ) async {
+    final serverTagLimit = _serverOrdinaryTagLimit(sourceId);
+    final feedKind = state.activeFeedKind;
+    final cacheKey = [
+      sourceId.key,
+      feedKind.name,
+      serverTagLimit,
+      state.fuzzySearchEnabled,
+      rawQuery.trim(),
+    ].join('|');
+    final cached = _tagQueryPlans.remove(cacheKey);
+    if (cached != null) {
+      _tagQueryPlans[cacheKey] = cached;
+      return cached;
+    }
+
+    var query = GalleryTagQueryParser.parse(rawQuery);
+    if (!query.isValid) {
+      throw GalleryTagQueryLimitException(query.ordinaryTagCount);
+    }
+    final tagCapabilities = sourceId.capabilities.tagSearch;
+    final supportedMetatags = tagCapabilities.metatagPrefixes(feedKind);
+    if (query.metatags.any(
+      (clause) => !supportedMetatags.contains(clause.metatagPrefix),
+    )) {
+      throw GalleryTagMetatagUnsupportedException(
+        sourceKey: sourceId.key,
+        feedKey: feedKind.name,
+      );
+    }
+    final supportsNegativePushdown = tagCapabilities.supportsNegativePushdown;
+    if (query.ordinaryClauses.isEmpty) {
+      return GalleryTagQueryPlanner.plan(
+        query,
+        serverTagLimit: serverTagLimit,
+        allowNegativePushdown: supportsNegativePushdown,
+      );
+    }
+
+    Map<String, TagCatalogRecord> records = const {};
+    final usesDanbooruAliases =
+        sourceId == GallerySourceId.danbooru ||
+        sourceId == GallerySourceId.safebooru;
+    if (usesDanbooruAliases) {
+      final terms = query.ordinaryClauses.map((clause) => clause.value);
+      try {
+        records = await ref.read(onlineGalleryTagMetadataLoaderProvider)(terms);
+      } catch (error) {
+        // The catalog only improves Donmai seed selectivity and alias
+        // resolution; source-native terms remain valid if it is unavailable.
+        AppLogger.w(
+          'Tag metadata unavailable; using source-native query terms: $error',
+          'OnlineGallery',
+        );
+      }
+      query = query.canonicalized({
+        for (final entry in records.entries)
+          entry.key: entry.value.canonicalTag,
+      });
+    }
+    final counts = <String, int>{
+      for (final record in records.values)
+        record.canonicalTag: record.postCount,
+    };
+    if (state.fuzzySearchEnabled && sourceId.capabilities.supportsFuzzySearch) {
+      query = GalleryTagQuery(
+        raw: query.raw,
+        clauses: [
+          for (final clause in query.clauses)
+            clause.kind == GalleryTagClauseKind.positive &&
+                    !clause.value.contains('*') &&
+                    !clause.value.contains(':')
+                ? clause.canonicalized('*${clause.value}*')
+                : clause,
+        ],
+      );
+      counts.addAll({
+        for (final entry in counts.entries) '*${entry.key}*': entry.value,
+      });
+    }
+    final plan = GalleryTagQueryPlanner.plan(
+      query,
+      serverTagLimit: serverTagLimit,
+      postCounts: counts,
+      allowNegativePushdown: supportsNegativePushdown,
+    );
+    _tagQueryPlans[cacheKey] = plan;
+    while (_tagQueryPlans.length > 24) {
+      _tagQueryPlans.remove(_tagQueryPlans.keys.first);
+    }
+    return plan;
+  }
+
+  Future<({List<GalleryItem> items, int detailFailures, int filterMicros})>
+  _filterByTagPlan(
+    List<GalleryItem> candidates,
+    GalleryTagQueryPlan plan, {
+    required GalleryTagSearchCapabilities capabilities,
+    required GalleryFeedKind feedKind,
+    required CancelToken cancelToken,
+  }) async {
+    final feedAppliedQuery = capabilities.appliesOrdinaryQuery(feedKind);
+    final needsLocalValidation =
+        plan.query.ordinaryClauses.isNotEmpty &&
+        (!feedAppliedQuery ||
+            plan.requiresLocalFiltering ||
+            capabilities.validatesPushdownLocally);
+    if (!needsLocalValidation || candidates.isEmpty) {
+      return (items: candidates, detailFailures: 0, filterMicros: 0);
+    }
+    final stopwatch = Stopwatch()..start();
+    final matched = <GalleryItem>[];
+    var detailFailures = 0;
+    const detailConcurrency = 6;
+    for (var start = 0; start < candidates.length; start += detailConcurrency) {
+      if (cancelToken.isCancelled) break;
+      final chunk = candidates.skip(start).take(detailConcurrency).toList();
+      final resolved = await Future.wait([
+        for (final candidate in chunk)
+          _resolveTagsForQuery(candidate, plan: plan, cancelToken: cancelToken),
+      ]);
+      if (cancelToken.isCancelled) break;
+      for (var index = 0; index < chunk.length; index++) {
+        final outcome = resolved[index];
+        if (outcome == null) {
+          detailFailures++;
+          continue;
+        }
+        if (plan.matchesNormalizedTags(outcome.tags)) {
+          matched.add(outcome.item);
+        }
+      }
+      if (start > 0) await Future<void>.delayed(Duration.zero);
+    }
+    stopwatch.stop();
+    return (
+      items: List<GalleryItem>.unmodifiable(matched),
+      detailFailures: detailFailures,
+      filterMicros: stopwatch.elapsedMicroseconds,
+    );
+  }
+
+  Future<({GalleryItem item, Set<String> tags})?> _resolveTagsForQuery(
+    GalleryItem item, {
+    required GalleryTagQueryPlan plan,
+    required CancelToken cancelToken,
+  }) async {
+    var resolvedItem = item;
+    var searchTerms = <String>{...item.tags, ...item.searchTerms};
+    var normalized = normalizeGalleryTagSet(searchTerms);
+    if (item.tagsComplete) {
+      return (item: item, tags: _cacheNormalizedTagSet(item, normalized));
+    }
+
+    // An incomplete document can still prove a positive match or a negative
+    // rejection. Defer detail loading to visible AI TAG cards in that case;
+    // sparse six-tag scans otherwise fan out into hundreds of detail requests.
+    if (plan.matchesAnyNegativeClause(normalized) ||
+        (!plan.hasNegativeClauses && plan.matchesPositiveClauses(normalized))) {
+      return (item: item, tags: Set<String>.unmodifiable(normalized));
+    }
+
+    try {
+      resolvedItem = (await _adapters[item.sourceId]!.detail(
+        item,
+        cancelToken: cancelToken,
+      )).item;
+      searchTerms = <String>{...resolvedItem.tags, ...resolvedItem.searchTerms};
+      normalized = normalizeGalleryTagSet(searchTerms);
+    } catch (error) {
+      if (error is DioException && CancelToken.isCancel(error)) rethrow;
+      return null;
+    }
+    if (searchTerms.isEmpty) return null;
+    if (!resolvedItem.tagsComplete &&
+        !plan.matchesAnyNegativeClause(normalized) &&
+        (plan.hasNegativeClauses || !plan.matchesPositiveClauses(normalized))) {
+      return null;
+    }
+    return (
+      item: resolvedItem,
+      tags: _cacheNormalizedTagSet(resolvedItem, normalized),
+    );
+  }
+
+  Set<String> _cacheNormalizedTagSet(GalleryItem item, Set<String> normalized) {
+    final sourceFingerprint = jsonEncode([item.tags, item.searchTerms]);
+    final cacheKey = '${item.detailStableKey}|$sourceFingerprint';
+    final cached = _normalizedTagSets.remove(cacheKey);
+    if (cached != null) {
+      _normalizedTagSets[cacheKey] = cached;
+      return cached;
+    }
+    final immutable = Set<String>.unmodifiable(normalized);
+    _normalizedTagSets[cacheKey] = immutable;
+    while (_normalizedTagSets.length > 5000) {
+      _normalizedTagSets.remove(_normalizedTagSets.keys.first);
+    }
+    return immutable;
   }
 
   Future<void> loadPosts({bool refresh = false}) async {
@@ -1906,16 +2432,24 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     required bool refresh,
     String? initialCursor,
   }) async {
+    final sourceId = state.viewMode == GalleryViewMode.popular
+        ? state.popularSourceId
+        : state.sourceId;
     final generation = _beginRequest();
-    await _ensureQuickTagCloudFilterInitialized();
-    if (generation != _requestGeneration || state.randomEnabled) return;
+    final requestCancelToken = _cancelToken!;
+    await Future.wait([
+      _ensureQuickTagCloudFilterInitialized(),
+      _ensureAuthenticationReady(sourceId),
+    ]);
+    if (generation != _requestGeneration ||
+        state.randomEnabled ||
+        state.activeSourceId != sourceId) {
+      return;
+    }
 
     final cache = state.currentCache;
     final cursor = initialCursor ?? (refresh ? '1' : cache.nextCursor);
     if (cursor == null) return;
-    final sourceId = state.viewMode == GalleryViewMode.popular
-        ? state.popularSourceId
-        : state.sourceId;
     final adapter = _adapters[sourceId]!;
     final cacheKey = state.currentCacheKey;
     final isAppend = !refresh && cache.posts.isNotEmpty;
@@ -1934,9 +2468,20 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
           .ensureInitialized();
       if (!_isCurrentRequest(generation, cacheKey)) return;
       final blacklist = ref.read(onlineGalleryBlacklistNotifierProvider).tags;
+      final rawTagQuery = state.viewMode == GalleryViewMode.popular
+          ? state.popularQuery
+          : state.searchQuery;
+      final tagPlan = await _buildTagQueryPlan(sourceId, rawTagQuery);
+      if (!_isCurrentRequest(generation, cacheKey)) return;
+      final tagCapabilities = sourceId.capabilities.tagSearch;
+      final requiresLocalQueryValidation =
+          tagPlan.query.ordinaryClauses.isNotEmpty &&
+          (!tagCapabilities.appliesOrdinaryQuery(state.activeFeedKind) ||
+              tagPlan.requiresLocalFiltering ||
+              tagCapabilities.validatesPushdownLocally);
       AiTagSourceConfig? aiTagConfig;
       if (adapter is AiTagGallerySourceAdapter) {
-        aiTagConfig = await adapter.getConfig(cancelToken: _cancelToken);
+        aiTagConfig = await adapter.getConfig(cancelToken: requestCancelToken);
         if (!_isCurrentRequest(generation, cacheKey)) return;
       }
       final artistHuntActive = state.isArtistHuntActive;
@@ -1953,13 +2498,21 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       var resolvedCount = refresh ? 0 : cache.artistHuntResolvedCount;
       var failureCount = refresh ? 0 : cache.artistHuntFailureCount;
       var matchedItemCount = 0;
+      var queryRequestCount = refresh ? 0 : cache.queryRequestCount;
+      var queryCandidateCount = refresh ? 0 : cache.queryCandidateCount;
+      var queryFilterMicros = refresh ? 0 : cache.queryFilterMicros;
+      var queryDetailFailureCount = refresh ? 0 : cache.queryDetailFailureCount;
       var requestCursor = cursor;
       var pagesFetched = 0;
       var stalledCursor = false;
+      var repeatedRawPage = false;
+      var scanBudgetReached = false;
+      var previousRawPageIdentity = refresh ? null : cache.lastRawPageIdentity;
       final visitedCursors = <String>{};
       late GalleryPage page;
       while (true) {
         pagesFetched++;
+        queryRequestCount++;
         visitedCursors.add(requestCursor);
         if (state.viewMode == GalleryViewMode.popular) {
           page = await adapter.ranking(
@@ -1973,29 +2526,21 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
                   : _rankingKind(state.popularScale),
               date: state.popularDate,
               period: state.aiTagPopularPeriod,
-              query: state.popularQuery,
+              query: tagPlan.serverQuery,
               prompt: _effectivePromptQuery(state.popularPromptQuery),
               ratings: state.selectedRatings,
               blacklistTags: blacklist,
             ),
-            cancelToken: _cancelToken,
+            cancelToken: requestCancelToken,
           );
         } else {
-          final query = sourceId == GallerySourceId.aiTag
-              ? state.searchQuery.trim()
-              : buildOnlineGallerySearchQuery(
-                  state.searchQuery,
-                  fuzzyMatch:
-                      sourceId != GallerySourceId.quickTagCloud &&
-                      state.fuzzySearchEnabled,
-                );
           page = await adapter.search(
             GallerySearchRequest(
               cursor: requestCursor,
               pageSize: sourceId == GallerySourceId.aiTag
                   ? (aiTagConfig?.pageSize ?? 60)
                   : _pageSize,
-              query: query,
+              query: tagPlan.serverQuery,
               prompt: _effectivePromptQuery(state.promptQuery),
               timeRange: state.aiTagTimeRange,
               ratings: state.selectedRatings,
@@ -2003,13 +2548,40 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
               dateEnd: state.dateRangeEnd,
               blacklistTags: blacklist,
             ),
-            cancelToken: _cancelToken,
+            cancelToken: requestCancelToken,
           );
         }
         if (!_isCurrentRequest(generation, cacheKey)) return;
 
-        List<GalleryItem> visiblePageItems =
-            await _filterByBlacklistCompletingDetails(page.items, blacklist);
+        final rawPageIdentity =
+            page.rawPageIdentity ??
+            (page.items.isNotEmpty
+                ? _galleryRawPageIdentity(page.items)
+                : null);
+        if (rawPageIdentity != null && rawPageIdentity.isNotEmpty) {
+          if (rawPageIdentity == previousRawPageIdentity) {
+            repeatedRawPage = true;
+            break;
+          }
+          previousRawPageIdentity = rawPageIdentity;
+        }
+        queryCandidateCount += page.items.length;
+        final tagFiltered = await _filterByTagPlan(
+          page.items,
+          tagPlan,
+          capabilities: sourceId.capabilities.tagSearch,
+          feedKind: state.activeFeedKind,
+          cancelToken: requestCancelToken,
+        );
+        queryFilterMicros += tagFiltered.filterMicros;
+        queryDetailFailureCount += tagFiltered.detailFailures;
+        if (!_isCurrentRequest(generation, cacheKey)) return;
+        final blacklistFiltered = await _filterByBlacklistCompletingDetails(
+          tagFiltered.items,
+          blacklist,
+        );
+        queryDetailFailureCount += blacklistFiltered.detailFailures;
+        List<GalleryItem> visiblePageItems = blacklistFiltered.items;
         if (!_isCurrentRequest(generation, cacheKey)) return;
         if (artistHuntActive) {
           candidateCount += visiblePageItems.length;
@@ -2052,22 +2624,46 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         final filteredPage =
             page.rawItemCount > 0 &&
             visiblePageItems.length < page.rawItemCount;
+        final needsMoreCandidates =
+            filteredPage || requiresLocalQueryValidation;
         stalledCursor =
-            filteredPage &&
+            needsMoreCandidates &&
             nextCursor != null &&
             visitedCursors.contains(nextCursor);
         final shouldContinue =
-            filteredPage &&
+            needsMoreCandidates &&
             matchedItemCount < _pageSize &&
             page.hasMore &&
             nextCursor != null &&
             !stalledCursor;
-        if (!shouldContinue) break;
+        scanBudgetReached =
+            shouldContinue &&
+            requiresLocalQueryValidation &&
+            pagesFetched >= _residualScanPageBudget;
+        if (!shouldContinue || scanBudgetReached) break;
         requestCursor = nextCursor;
+        final progressCache = cache.copyWith(
+          posts: merged,
+          nextCursor: nextCursor,
+          hasMore: true,
+          scrollOffset: refresh ? 0 : cache.scrollOffset,
+          queryRequestCount: queryRequestCount,
+          queryCandidateCount: queryCandidateCount,
+          queryFilterMicros: queryFilterMicros,
+          queryDetailFailureCount: queryDetailFailureCount,
+          lastRawPageIdentity: previousRawPageIdentity,
+          queryScanPaused: false,
+          clearAppendError: true,
+        );
+        state = state.updateCurrentCache(progressCache);
+        if (queryRequestCount.isEven) {
+          await Future<void>.delayed(Duration.zero);
+        }
       }
       final duplicatePage =
           !refresh && matchedItemCount > 0 && merged.length == baseItems.length;
-      final endedByDuplicatePage = duplicatePage || stalledCursor;
+      final endedByDuplicatePage =
+          duplicatePage || stalledCursor || repeatedRawPage;
       final isInitialLoad =
           !refresh && cache.posts.isEmpty && cache.page == 1 && cursor == '1';
       final firstRequestedPage = refresh || isInitialLoad
@@ -2089,6 +2685,12 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         artistHuntCandidateCount: candidateCount,
         artistHuntResolvedCount: resolvedCount,
         artistHuntFailureCount: failureCount,
+        queryRequestCount: queryRequestCount,
+        queryCandidateCount: queryCandidateCount,
+        queryFilterMicros: queryFilterMicros,
+        queryDetailFailureCount: queryDetailFailureCount,
+        lastRawPageIdentity: previousRawPageIdentity,
+        queryScanPaused: scanBudgetReached,
       );
       final gelbooruCredentialsBecameInvalid =
           sourceId == GallerySourceId.gelbooru &&
@@ -2100,7 +2702,12 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
             aiTagConfig: aiTagConfig,
             notice: gelbooruCredentialsBecameInvalid
                 ? OnlineGalleryNotice.gelbooruCredentialsInvalid
+                : queryDetailFailureCount > 0
+                ? OnlineGalleryNotice.tagDetailsIncomplete
                 : null,
+            clearNotice:
+                !gelbooruCredentialsBecameInvalid &&
+                queryDetailFailureCount == 0,
             clearError: true,
           )
           .updateCurrentCache(nextCache);
@@ -2137,12 +2744,9 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
 
   Future<void> _loadFavorites({required bool refresh, int? targetPage}) async {
     final sourceId = state.favoritesSourceId;
-    if (sourceId == GallerySourceId.danbooru) {
-      await ref.read(danbooruAuthProvider.notifier).ensureInitialized();
-    } else if (sourceId == GallerySourceId.gelbooru) {
-      await ref.read(gelbooruAuthProvider.notifier).ensureInitialized();
-    }
-    if (state.viewMode != GalleryViewMode.favorites ||
+    await _ensureAuthenticationReady(sourceId);
+    if (_disposed ||
+        state.viewMode != GalleryViewMode.favorites ||
         state.favoritesSourceId != sourceId) {
       return;
     }
@@ -2174,6 +2778,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
 
     Object? localError;
     Object? remoteError;
+    var blacklistDetailFailures = 0;
     try {
       await ref
           .read(onlineGalleryBlacklistNotifierProvider.notifier)
@@ -2279,11 +2884,13 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
             raw,
             const {},
           ).where(_matchesFavoriteSearch).toList(growable: false);
-          final remoteItems = await _filterByBlacklistCompletingDetails(
+          final remoteResult = await _filterByBlacklistCompletingDetails(
             matching,
             blacklist,
           );
           if (!_isCurrentRequest(generation, cacheKey)) return;
+          blacklistDetailFailures += remoteResult.detailFailures;
+          final remoteItems = remoteResult.items;
           final upstreamEnded = rawCount < _pageSize;
           final nextRequestPage = requestPage + 1;
           final loadedRemoteItemKeys = remoteItems
@@ -2402,6 +3009,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
             ? _errorCode(remoteError ?? localError)
             : null,
         clearAppendError: !allAvailableBranchesFailed || !isAppend,
+        queryDetailFailureCount: blacklistDetailFailures,
       );
       state = state
           .copyWith(
@@ -2413,6 +3021,10 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
             favoritedPostKeys: {..._localFavoriteKeys, ..._remoteFavoriteKeys},
             localFavoritedPostKeys: _localFavoriteKeys,
             remoteFavoritedPostKeys: _remoteFavoriteKeys,
+            notice: blacklistDetailFailures > 0
+                ? OnlineGalleryNotice.tagDetailsIncomplete
+                : null,
+            clearNotice: blacklistDetailFailures == 0,
             clearError: !allAvailableBranchesFailed || isAppend,
           )
           .updateCurrentCache(cache);
@@ -2610,16 +3222,21 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         .toInt();
   }
 
-  Future<List<GalleryItem>> _filterByBlacklistCompletingDetails(
+  Future<({List<GalleryItem> items, int detailFailures})>
+  _filterByBlacklistCompletingDetails(
     List<GalleryItem> items,
     Set<String> blacklist,
   ) async {
-    if (blacklist.isEmpty) return items;
-    final normalizedBlacklist = blacklist;
+    if (blacklist.isEmpty) return (items: items, detailFailures: 0);
+    final normalizedBlacklist = blacklist
+        .map(_normalizeGalleryPolicyTag)
+        .whereType<String>()
+        .toSet();
     final allowed = <String, bool>{};
     final incomplete = <GalleryItem>[];
+    var detailFailures = 0;
     for (final item in items) {
-      if (item.tags.isEmpty) {
+      if (!item.tagsComplete) {
         incomplete.add(item);
       } else {
         allowed[item.stableKey] = !item.tags.any(
@@ -2634,13 +3251,29 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       final end = min(offset + batchSize, incomplete.length);
       final batch = incomplete.sublist(offset, end);
       final details = await Future.wait(
-        batch.map(
-          (item) =>
-              _details.request(item, priority: GalleryDetailPriority.visible),
-        ),
+        batch.map((item) async {
+          try {
+            return await _details.request(
+              item,
+              priority: GalleryDetailPriority.visible,
+            );
+          } catch (error) {
+            AppLogger.w(
+              'Failed to complete gallery tags for blacklist filtering: '
+                  '${item.stableKey}: $error',
+              'OnlineGallery',
+            );
+            return null;
+          }
+        }),
       );
       for (var index = 0; index < details.length; index++) {
         final detail = details[index];
+        if (detail == null || !detail.item.tagsComplete) {
+          detailFailures++;
+          allowed[batch[index].stableKey] = false;
+          continue;
+        }
         final policyTags = <String>{
           ...detail.item.tags,
           ...detail.rawTags,
@@ -2660,9 +3293,12 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         );
       }
     }
-    return items
-        .where((item) => allowed[item.stableKey] ?? false)
-        .toList(growable: false);
+    return (
+      items: items
+          .where((item) => allowed[item.stableKey] ?? false)
+          .toList(growable: false),
+      detailFailures: detailFailures,
+    );
   }
 
   List<GalleryItem> _filterLocal(
@@ -3047,6 +3683,12 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   }
 
   OnlineGalleryErrorCode _errorCode(Object error) {
+    if (error is GalleryTagQueryLimitException) {
+      return OnlineGalleryErrorCode.tooManySearchTags;
+    }
+    if (error is GalleryTagMetatagUnsupportedException) {
+      return OnlineGalleryErrorCode.unsupportedMetatag;
+    }
     if (error is _ArtistHuntDetailException) {
       return OnlineGalleryErrorCode.artistHuntDetailFailed;
     }

--- a/lib/presentation/screens/online_gallery/online_gallery_screen.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen.dart
@@ -15,6 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../../core/cache/gallery_image_request.dart';
 import '../../../core/cache/online_gallery_image_cache_manager.dart';
 import '../../../core/cache/online_gallery_detail_coordinator.dart';
+import '../../../core/online_gallery/gallery_tag_query.dart';
 import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
 import '../../../core/cache/online_gallery_preload_policy.dart';
 import '../../../core/services/date_formatting_service.dart';
@@ -214,7 +215,12 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         _scheduleVisiblePrefetch();
       });
     }
-    if (_isWithinLoadAhead(_scrollController.position)) {
+    final galleryState = ref.read(onlineGalleryNotifierProvider);
+    final activeCache = galleryState.randomEnabled
+        ? galleryState.randomSession.cache
+        : galleryState.currentCache;
+    if (!activeCache.queryScanPaused &&
+        _isWithinLoadAhead(_scrollController.position)) {
       _galleryNotifier.loadMore();
     }
   }
@@ -232,6 +238,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         state.isLoadingMore ||
         state.hasError ||
         !state.hasMore ||
+        activeCache.queryScanPaused ||
         activeCache.appendErrorCode != null ||
         _scheduledAutoLoadCacheKey == state.currentCacheKey) {
       return;
@@ -254,6 +261,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
           latest.isLoadingMore ||
           latest.hasError ||
           !latest.hasMore ||
+          latestCache.queryScanPaused ||
           latestCache.appendErrorCode != null) {
         return;
       }
@@ -426,6 +434,13 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
             context,
             context.l10n.onlineGallery_gelbooruCredentialsInvalid,
           );
+        } else if (next == OnlineGalleryNotice.tagDetailsIncomplete) {
+          AppToast.warning(
+            context,
+            context.l10n.onlineGallery_tagDetailsIncomplete,
+          );
+        } else if (next == OnlineGalleryNotice.randomDrawNoMatch) {
+          AppToast.info(context, context.l10n.onlineGallery_randomDrawNoMatch);
         }
         _galleryNotifier.clearNotice();
       },
@@ -957,7 +972,19 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
     if (activeSource == GallerySourceId.quickTagCloud) {
       return _buildCodexSearchField(theme);
     }
-    if (activeSource != GallerySourceId.aiTag) return _buildSearchField(theme);
+    if (activeSource != GallerySourceId.aiTag) {
+      return _buildSearchField(
+        theme,
+        controller: isPopular ? _popularSearchController : _searchController,
+        focusNode: isPopular ? _popularSearchFocusNode : _searchFocusNode,
+        onSubmitted: isPopular
+            ? (value) => _galleryNotifier.searchPopular(
+                query: value,
+                prompt: state.popularPromptQuery,
+              )
+            : _galleryNotifier.search,
+      );
+    }
     final queryController = isPopular
         ? _popularSearchController
         : _searchController;
@@ -969,6 +996,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         ? _popularPromptSearchFocusNode
         : _promptSearchFocusNode;
     void submit() {
+      if (!_validateTagQuery(queryController.text)) return;
       if (isPopular) {
         _galleryNotifier.searchPopular(
           query: queryController.text,
@@ -994,6 +1022,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
               hintText: context.l10n.onlineGallery_aiTagQuery,
               icon: Icons.manage_search,
               treatSpacesAsSeparators: true,
+              showTagCount: true,
               onSubmitted: submit,
             ),
           ),
@@ -1021,6 +1050,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
     required IconData icon,
     required VoidCallback onSubmitted,
     bool treatSpacesAsSeparators = false,
+    bool showTagCount = false,
   }) {
     return AutocompleteWrapper(
       controller: controller,
@@ -1053,7 +1083,16 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
                 fontSize: 13,
               ),
               prefixIcon: Icon(icon, size: 18),
-              suffixIcon: value.text.isEmpty
+              suffixIcon: showTagCount
+                  ? _buildTagCountSuffix(
+                      theme,
+                      controller,
+                      onClear: () {
+                        controller.clear();
+                        focusNode.requestFocus();
+                      },
+                    )
+                  : value.text.isEmpty
                   ? null
                   : IconButton(
                       tooltip: context.l10n.common_clear,
@@ -1106,30 +1145,81 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
               size: 18,
               color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
             ),
-            suffixIcon: value.text.isEmpty
-                ? null
-                : IconButton(
-                    tooltip: context.l10n.common_clear,
-                    icon: const Icon(Icons.close, size: 16),
-                    onPressed: () {
-                      _searchController.clear();
-                      _galleryNotifier.search('');
-                    },
-                  ),
+            suffixIcon: _buildTagCountSuffix(
+              theme,
+              _searchController,
+              onClear: () {
+                _searchController.clear();
+                _galleryNotifier.search('');
+              },
+            ),
             border: InputBorder.none,
             contentPadding: const EdgeInsets.symmetric(vertical: 8),
             isDense: true,
           ),
-          onSubmitted: _galleryNotifier.search,
+          onSubmitted: (value) =>
+              _submitTagSearch(value, onValid: _galleryNotifier.search),
         ),
       ),
     );
   }
 
-  Widget _buildSearchField(ThemeData theme) {
+  bool _validateTagQuery(String value) {
+    if (GalleryTagQueryParser.parse(value).isValid) return true;
+    AppToast.warning(
+      context,
+      context.l10n.onlineGallery_maxTagsExceeded(maxGallerySearchTags),
+    );
+    return false;
+  }
+
+  void _submitTagSearch(String value, {required ValueChanged<String> onValid}) {
+    if (_validateTagQuery(value)) onValid(value);
+  }
+
+  Widget _buildTagCountSuffix(
+    ThemeData theme,
+    TextEditingController controller, {
+    required VoidCallback onClear,
+  }) {
+    final count = GalleryTagQueryParser.parse(controller.text).ordinaryTagCount;
+    final exceeded = count > maxGallerySearchTags;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '$count/$maxGallerySearchTags',
+          key: const ValueKey('online-gallery-tag-count'),
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: exceeded
+                ? theme.colorScheme.error
+                : theme.colorScheme.onSurfaceVariant,
+            fontFeatures: const [FontFeature.tabularFigures()],
+          ),
+        ),
+        if (controller.text.isNotEmpty)
+          IconButton(
+            tooltip: context.l10n.common_clear,
+            icon: Icon(
+              Icons.close,
+              size: 16,
+              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
+            ),
+            onPressed: onClear,
+          ),
+      ],
+    );
+  }
+
+  Widget _buildSearchField(
+    ThemeData theme, {
+    required TextEditingController controller,
+    required FocusNode focusNode,
+    required ValueChanged<String> onSubmitted,
+  }) {
     return AutocompleteWrapper(
-      controller: _searchController,
-      focusNode: _searchFocusNode,
+      controller: controller,
+      focusNode: focusNode,
       config: const AutocompleteConfig(
         autoInsertComma: false,
         treatSpacesAsSeparators: true,
@@ -1137,7 +1227,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
       onSuggestionSelected: (value) {
         // 选择补全建议后立即触发搜索
         _searchDebounceTimer?.cancel();
-        _galleryNotifier.search(value);
+        _submitTagSearch(value, onValid: onSubmitted);
       },
       child: Container(
         height: 36,
@@ -1149,8 +1239,8 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
           borderRadius: BorderRadius.circular(18),
         ),
         child: TextField(
-          controller: _searchController,
-          focusNode: _searchFocusNode,
+          controller: controller,
+          focusNode: focusNode,
           style: theme.textTheme.bodyMedium,
           decoration: InputDecoration(
             hintText: context.l10n.onlineGallery_searchTags,
@@ -1163,23 +1253,16 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
               size: 18,
               color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
             ),
-            suffixIcon: _searchController.text.isNotEmpty
-                ? IconButton(
-                    tooltip: context.l10n.common_clear,
-                    icon: Icon(
-                      Icons.close,
-                      size: 16,
-                      color: theme.colorScheme.onSurfaceVariant.withValues(
-                        alpha: 0.6,
-                      ),
-                    ),
-                    onPressed: () {
-                      _searchController.clear();
-                      _galleryNotifier.search('');
-                      setState(() {});
-                    },
-                  )
-                : null,
+            suffixIcon: _buildTagCountSuffix(
+              theme,
+              controller,
+              onClear: () {
+                controller.clear();
+                onSubmitted('');
+                setState(() {});
+              },
+            ),
+            suffixIconConstraints: const BoxConstraints(minWidth: 64),
             border: InputBorder.none,
             contentPadding: const EdgeInsets.symmetric(vertical: 8),
             isDense: true,
@@ -1187,7 +1270,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
           onChanged: (value) {
             setState(() {}); // 仅更新清除按钮可见性，不触发搜索
           },
-          onSubmitted: _galleryNotifier.search,
+          onSubmitted: (value) => _submitTagSearch(value, onValid: onSubmitted),
         ),
       ),
     );
@@ -2519,6 +2602,12 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
 
   String _localizedError(OnlineGalleryErrorCode? errorCode) {
     switch (errorCode) {
+      case OnlineGalleryErrorCode.tooManySearchTags:
+        return context.l10n.onlineGallery_maxTagsExceeded(maxGallerySearchTags);
+      case OnlineGalleryErrorCode.tagDetailsIncomplete:
+        return context.l10n.onlineGallery_tagDetailsIncomplete;
+      case OnlineGalleryErrorCode.unsupportedMetatag:
+        return context.l10n.onlineGallery_unsupportedMetatag;
       case OnlineGalleryErrorCode.gelbooruCredentialsRequired:
         return context.l10n.onlineGallery_gelbooruCredentialsRequired;
       case OnlineGalleryErrorCode.gelbooruCredentialsInvalid:
@@ -2596,7 +2685,38 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
           ),
           const SizedBox(height: 12),
           Text(message, style: theme.textTheme.titleMedium),
-          if (artistHuntEmpty && activeCache.artistHuntFailureCount > 0) ...[
+          if (activeCache.queryScanPaused) ...[
+            const SizedBox(height: 8),
+            Text(
+              context.l10n.onlineGallery_scanPaused,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            TextButton.icon(
+              onPressed: _galleryNotifier.loadMore,
+              icon: const Icon(Icons.manage_search, size: 18),
+              label: Text(context.l10n.onlineGallery_continueScanning),
+            ),
+          ] else if (activeCache.queryDetailFailureCount > 0) ...[
+            const SizedBox(height: 8),
+            Text(
+              context.l10n.onlineGallery_tagDetailsIncomplete,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            TextButton.icon(
+              onPressed: _galleryNotifier.refresh,
+              icon: const Icon(Icons.refresh, size: 18),
+              label: Text(context.l10n.common_retry),
+            ),
+          ] else if (artistHuntEmpty &&
+              activeCache.artistHuntFailureCount > 0) ...[
             const SizedBox(height: 8),
             Text(
               context.l10n.onlineGallery_artistHuntPartialFailure(
@@ -2935,6 +3055,27 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         ),
       );
     }
+    if (activeCache.queryScanPaused) {
+      return Center(
+        child: TextButton.icon(
+          onPressed: _galleryNotifier.loadMore,
+          icon: const Icon(Icons.manage_search),
+          label: Text(context.l10n.onlineGallery_continueScanning),
+        ),
+      );
+    }
+    if (activeCache.queryDetailFailureCount > 0) {
+      return Center(
+        child: TextButton.icon(
+          onPressed: _galleryNotifier.refresh,
+          icon: Icon(Icons.refresh, color: theme.colorScheme.error),
+          label: Text(
+            context.l10n.onlineGallery_tagDetailsIncomplete,
+            style: TextStyle(color: theme.colorScheme.error),
+          ),
+        ),
+      );
+    }
     if (!state.hasMore) {
       return Center(
         child: Padding(
@@ -2961,7 +3102,33 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
   /// 构建页面显示内容（加载中、错误、空状态、网格）
   Widget _buildPageContent(ThemeData theme, OnlineGalleryState state) {
     if (state.isLoading && state.posts.isEmpty) {
-      return const Center(child: CircularProgressIndicator());
+      final cache = state.currentCache;
+      final tagCount = GalleryTagQueryParser.parse(
+        state.viewMode == GalleryViewMode.popular
+            ? state.popularQuery
+            : state.searchQuery,
+      ).ordinaryTagCount;
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            if (tagCount > 1 && cache.queryRequestCount > 0) ...[
+              const SizedBox(height: 12),
+              Text(
+                context.l10n.onlineGallery_multiTagScanning(
+                  cache.queryRequestCount,
+                  cache.queryCandidateCount,
+                ),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ],
+        ),
+      );
     }
     if (state.hasError && state.posts.isEmpty) {
       return _buildErrorState(theme, state);

--- a/test/core/autocomplete/tag_catalog_repository_test.dart
+++ b/test/core/autocomplete/tag_catalog_repository_test.dart
@@ -76,6 +76,21 @@ void main() {
     },
   );
 
+  test('resolves canonical and alias metadata in one bounded query', () async {
+    final records = await repository.resolveExactTags([
+      'blue_hair',
+      'aqua eyes',
+      'missing',
+      'BLUE_HAIR',
+    ]);
+
+    expect(records.keys, {'blue_hair', 'aqua_eyes'});
+    expect(records['blue_hair']?.canonicalTag, 'blue_hair');
+    expect(records['blue_hair']?.postCount, 2000);
+    expect(records['aqua_eyes']?.canonicalTag, 'blue_eyes');
+    expect(records['aqua_eyes']?.postCount, 1000);
+  });
+
   test('maps e621 source categories without dropping their tags', () async {
     final general = await repository.search(_query('anthro'));
     final species = await repository.search(_query('species_wolf'));

--- a/test/core/online_gallery/gallery_tag_query_test.dart
+++ b/test/core/online_gallery/gallery_tag_query_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/online_gallery/gallery_tag_query.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_source.dart';
+
+void main() {
+  group('GalleryTagQueryParser', () {
+    test('counts positive and negative ordinary tags together', () {
+      final query = GalleryTagQueryParser.parse(
+        'cat_girl, blue-hair smile -watermark rating:safe order:score',
+      );
+
+      expect(query.isValid, isTrue);
+      expect(query.ordinaryTagCount, 4);
+      expect(query.ordinaryClauses.map((clause) => clause.value), [
+        'cat_girl',
+        'blue-hair',
+        'smile',
+        'watermark',
+      ]);
+      expect(query.negativeClauses.single.value, 'watermark');
+      expect(query.metatags.map((clause) => clause.value), [
+        'rating:safe',
+        'order:score',
+      ]);
+    });
+
+    test('rejects a seventh ordinary tag including negative tags', () {
+      final query = GalleryTagQueryParser.parse(
+        'a b c d e f rating:g -watermark',
+      );
+
+      expect(query.ordinaryTagCount, 7);
+      expect(query.isValid, isFalse);
+    });
+
+    test('recognizes category, relationship, and source metatags', () {
+      final query = GalleryTagQueryParser.parse(
+        'cat tagcount:3 child:none has:source source:https://example.com sort:score:desc',
+      );
+
+      expect(query.ordinaryClauses.single.value, 'cat');
+      expect(query.metatags.map((clause) => clause.value), [
+        'tagcount:3',
+        'child:none',
+        'has:source',
+        'source:https://example.com',
+        'sort:score:desc',
+      ]);
+    });
+
+    test('does not misclassify a legal colon tag as an unknown metatag', () {
+      final query = GalleryTagQueryParser.parse('artist:name status:active');
+
+      expect(query.ordinaryClauses.single.value, 'artist:name');
+      expect(query.metatags.single.value, 'status:active');
+    });
+  });
+
+  group('GalleryTagQueryPlanner', () {
+    test('uses the rarest supported combination and filters the residual', () {
+      final query = GalleryTagQueryParser.parse(
+        'common rare medium extra -watermark rating:g',
+      );
+      final plan = GalleryTagQueryPlanner.plan(
+        query,
+        serverTagLimit: 2,
+        postCounts: const {
+          'common': 1000000,
+          'rare': 10,
+          'medium': 1000,
+          'extra': 100,
+          'watermark': 500000,
+        },
+      );
+
+      expect(plan.seedClauses.map((clause) => clause.value), ['rare', 'extra']);
+      expect(plan.serverQuery, 'rare extra rating:g');
+      expect(plan.residualClauses.map((clause) => clause.value), [
+        'common',
+        'medium',
+        'watermark',
+      ]);
+      expect(plan.matchesTags(['rare', 'extra', 'common', 'medium']), isTrue);
+      expect(
+        plan.matchesTags(['rare', 'extra', 'common', 'medium', 'watermark']),
+        isFalse,
+      );
+    });
+
+    test('canonicalizes aliases before planning and matching', () {
+      final query = GalleryTagQueryParser.parse('kitty blue_hair');
+      final canonical = query.canonicalized(const {'kitty': 'cat'});
+      final plan = GalleryTagQueryPlanner.plan(
+        canonical,
+        serverTagLimit: 1,
+        postCounts: const {'cat': 20, 'blue_hair': 100},
+      );
+
+      expect(plan.serverQuery, 'cat');
+      expect(plan.matchesTags(['CAT', 'blue hair']), isTrue);
+    });
+
+    test('deduplicates aliases that resolve to the same canonical tag', () {
+      final query = GalleryTagQueryParser.parse('kitty cat blue_hair');
+      final canonical = query.canonicalized(const {'kitty': 'cat'});
+      final plan = GalleryTagQueryPlanner.plan(canonical, serverTagLimit: 2);
+
+      expect(canonical.ordinaryTagCount, 2);
+      expect(plan.serverQuery.split(' '), containsAll(['cat', 'blue_hair']));
+      expect(plan.requiresLocalFiltering, isFalse);
+    });
+
+    test(
+      'keeps negative clauses local when a source cannot push them down',
+      () {
+        final plan = GalleryTagQueryPlanner.plan(
+          GalleryTagQueryParser.parse('cat -watermark'),
+          serverTagLimit: 1,
+          allowNegativePushdown: false,
+        );
+
+        expect(plan.serverQuery, 'cat');
+        expect(plan.residualClauses.map((clause) => clause.searchToken), [
+          '-watermark',
+        ]);
+        expect(plan.matchesTags(['cat']), isTrue);
+        expect(plan.matchesTags(['cat', 'watermark']), isFalse);
+      },
+    );
+
+    test('supports fuzzy positive predicates without quadratic matching', () {
+      const query = GalleryTagQuery(
+        raw: 'hair smile',
+        clauses: [
+          GalleryTagClause(
+            kind: GalleryTagClauseKind.positive,
+            raw: 'hair',
+            value: '*hair*',
+          ),
+          GalleryTagClause(
+            kind: GalleryTagClauseKind.positive,
+            raw: 'smile',
+            value: 'smile',
+          ),
+        ],
+      );
+      final plan = GalleryTagQueryPlanner.plan(query, serverTagLimit: 1);
+
+      expect(plan.matchesTags(['long_hair', 'smile']), isTrue);
+      expect(plan.matchesTags(['long_hair']), isFalse);
+    });
+  });
+
+  group('performance', () {
+    test('compiled six-tag predicate scans 100k normalized works linearly', () {
+      final plan = GalleryTagQueryPlanner.plan(
+        GalleryTagQueryParser.parse('a b c d e -blocked'),
+        serverTagLimit: 2,
+      );
+      final matching = <String>{'a', 'b', 'c', 'd', 'e'};
+      final nonMatching = <String>{'a', 'b', 'c', 'd'};
+      final stopwatch = Stopwatch()..start();
+      var matches = 0;
+      for (var index = 0; index < 100000; index++) {
+        if (plan.matchesNormalizedTags(index.isEven ? matching : nonMatching)) {
+          matches++;
+        }
+      }
+      stopwatch.stop();
+
+      expect(matches, 50000);
+      expect(
+        stopwatch.elapsed,
+        lessThan(const Duration(seconds: 2)),
+        reason: 'elapsed=${stopwatch.elapsedMicroseconds}µs',
+      );
+    });
+  });
+
+  group('source capability matrix', () {
+    test('every source exposes a complete six-tag execution strategy', () {
+      for (final source in GallerySourceId.values) {
+        final capability = gallerySourceCapabilities[source]!.tagSearch;
+        expect(capability.strategy, isNotNull, reason: source.key);
+        expect(capability.anonymousLimit, inInclusiveRange(0, 6));
+        expect(
+          capability.listTagsComplete,
+          source != GallerySourceId.aiTag,
+          reason: source.key,
+        );
+      }
+    });
+
+    test('Danbooru follows anonymous, Basic, Gold and Platinum limits', () {
+      final capability =
+          gallerySourceCapabilities[GallerySourceId.danbooru]!.tagSearch;
+
+      expect(capability.serverLimit(authenticated: false), 2);
+      expect(capability.serverLimit(authenticated: true, accountLevel: 20), 2);
+      expect(capability.serverLimit(authenticated: true, accountLevel: 30), 6);
+      expect(capability.serverLimit(authenticated: true, accountLevel: 31), 6);
+    });
+
+    test('metatag and ranking query support is explicit per feed', () {
+      final danbooru =
+          gallerySourceCapabilities[GallerySourceId.danbooru]!.tagSearch;
+      final aiTag = gallerySourceCapabilities[GallerySourceId.aiTag]!.tagSearch;
+
+      expect(
+        danbooru.metatagPrefixes(GalleryFeedKind.search),
+        contains('order'),
+      );
+      expect(danbooru.metatagPrefixes(GalleryFeedKind.ranking), isEmpty);
+      expect(danbooru.appliesOrdinaryQuery(GalleryFeedKind.ranking), isFalse);
+      expect(aiTag.metatagPrefixes(GalleryFeedKind.search), isEmpty);
+      expect(aiTag.appliesOrdinaryQuery(GalleryFeedKind.ranking), isTrue);
+      expect(aiTag.validatesPushdownLocally, isTrue);
+    });
+
+    test('other source limits select their native or residual strategy', () {
+      expect(
+        gallerySourceCapabilities[GallerySourceId.safebooru]!.tagSearch
+            .serverLimit(authenticated: false),
+        2,
+      );
+      expect(
+        gallerySourceCapabilities[GallerySourceId.gelbooru]!.tagSearch
+            .serverLimit(authenticated: false),
+        6,
+      );
+      expect(
+        gallerySourceCapabilities[GallerySourceId.gelbooru]!.tagSearch
+            .serverLimit(authenticated: true),
+        6,
+      );
+      expect(
+        gallerySourceCapabilities[GallerySourceId.aiTag]!.tagSearch.serverLimit(
+          authenticated: false,
+        ),
+        1,
+      );
+      expect(
+        gallerySourceCapabilities[GallerySourceId.quickTagCloud]!.tagSearch
+            .serverLimit(authenticated: false),
+        6,
+      );
+    });
+  });
+}

--- a/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
+++ b/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
@@ -431,7 +431,7 @@ void main() {
         final http = _RecordingHttpAdapter((request) {
           if (request.uri.path == '/api/config') return _configJson;
           expect(request.uri.path, '/api/ai_works_search');
-          expect(request.queryParameters['q'], 'artist name');
+          expect(request.queryParameters['q'], 'artist::1 name::1');
           expect(request.queryParameters['prompt'], '::artist:');
           expect(request.queryParameters['time_range'], 'q2026Q2');
           expect(request.queryParameters['page'], 2);
@@ -473,6 +473,22 @@ void main() {
           containsAll(['all', 'y2026', 'q2026Q2', 'older']),
         );
         expect(page.items.map((item) => item.id), [100]);
+        expect(page.items.single.tags, ['tag one', 'tag_two']);
+        expect(
+          page.items.single.searchTerms,
+          containsAll([
+            'tag one',
+            'tag_two',
+            'Work 100',
+            'Work',
+            'Alice',
+            'Hello',
+            'World',
+            'SD',
+          ]),
+        );
+        expect(page.items.single.tags, isNot(containsAll(['Hello', 'World'])));
+        expect(page.items.single.tagsComplete, isFalse);
         expect(page.hasMore, isTrue);
         expect(page.nextCursor, '3');
       },
@@ -545,7 +561,7 @@ void main() {
         expect(rankRequests[1].queryParameters['month'], '2026-07');
         expect(rankRequests[2].queryParameters['month'], 'older');
         expect(
-          rankRequests.every((r) => r.queryParameters['q'] == 'NAI'),
+          rankRequests.every((r) => r.queryParameters['q'] == 'NAI::1'),
           isTrue,
         );
         expect(
@@ -637,7 +653,57 @@ void main() {
       expect(detail.media[2].prompt, 'comfy positive');
       expect(detail.media[2].negativePrompt, 'comfy negative');
       expect(detail.item.mediaCount, 4);
+      expect(detail.item.tags, containsAll(['tag one', 'tag_two', '1girl']));
+      expect(detail.item.tags, isNot(containsAll(['Hello', 'World'])));
+      expect(
+        detail.item.searchTerms,
+        containsAll(['Alice', 'Hello', 'World', '1girl']),
+      );
+      expect(detail.item.tagsComplete, isFalse);
     });
+
+    test(
+      'normalizes NovelAI and SD prompt weights into searchable tags',
+      () async {
+        final http = _RecordingHttpAdapter((request) {
+          if (request.uri.path == '/api/config') return _configJson;
+          if (request.uri.path == '/api/work/502') {
+            return {
+              'work': _aiWork(502),
+              'images': [_weightedAiImage('502_p0')],
+            };
+          }
+          throw StateError('Unexpected request ${request.uri}');
+        });
+        final adapter = AiTagGallerySourceAdapter(
+          dio: Dio()..httpClientAdapter = http,
+        );
+        const item = GalleryItem(
+          id: 502,
+          sourceId: GallerySourceId.aiTag,
+          createdAt: '',
+          uploaderId: 9,
+          cover: GalleryMedia(
+            id: 'pending',
+            previewUrl: '',
+            displayUrl: '',
+            downloadUrl: '',
+          ),
+        );
+
+        final detail = await adapter.detail(item);
+
+        expect(
+          detail.item.tags,
+          containsAll(['cat girl', 'blue hair', 'smile', 'fox_ears']),
+        );
+        expect(
+          detail.item.searchTerms,
+          containsAll(['blue hair', 'blue', 'hair']),
+        );
+        expect(detail.item.tagsComplete, isTrue);
+      },
+    );
   });
 }
 
@@ -709,6 +775,18 @@ Map<String, Object?> _comfyAiImage(String fileName) => {
       'class_type': 'CLIPTextEncode',
       'inputs': {'text': 'comfy negative'},
     },
+  }),
+};
+
+Map<String, Object?> _weightedAiImage(String fileName) => {
+  'id': fileName.hashCode,
+  'work_id': 502,
+  'author_id': 9,
+  'image_type': 'SD',
+  'file_name': fileName,
+  'ai_json': jsonEncode({
+    'parameters':
+        '1.5::cat girl::, (blue hair:0.8), {smile}, fox_ears::1.2\nNegative prompt: lowres\nSteps: 24, Sampler: Euler a, CFG scale: 6, Seed: 42, Size: 768x1152',
   }),
 };
 

--- a/test/data/datasources/remote/online_gallery/quick_tag_cloud_gallery_source_adapter_test.dart
+++ b/test/data/datasources/remote/online_gallery/quick_tag_cloud_gallery_source_adapter_test.dart
@@ -90,6 +90,28 @@ void main() {
     ]);
   });
 
+  test('多标签搜索仅返回完整 Tag 集满足 AND 条件的词条', () async {
+    final matched = await adapter.search(
+      const GallerySearchRequest(
+        query: 'hero cinematic_lighting -abstract',
+        cursor: '1',
+        pageSize: 20,
+        ratings: {'g'},
+      ),
+    );
+    final missing = await adapter.search(
+      const GallerySearchRequest(
+        query: 'hero abstract',
+        cursor: '1',
+        pageSize: 20,
+        ratings: {'g'},
+      ),
+    );
+
+    expect(matched.items.map((item) => item.sourceWorkId), ['book/book-0001']);
+    expect(missing.items, isEmpty);
+  });
+
   test('取消令牌贯穿目录与法典加载', () async {
     final cancelToken = CancelToken();
 

--- a/test/presentation/providers/online_gallery_pagination_test.dart
+++ b/test/presentation/providers/online_gallery_pagination_test.dart
@@ -6,8 +6,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/storage/local_storage_service.dart';
 import 'package:nai_launcher/data/datasources/remote/online_gallery/gallery_source_adapter.dart';
+import 'package:nai_launcher/data/models/danbooru/danbooru_user.dart';
 import 'package:nai_launcher/data/models/online_gallery/gallery_item.dart';
 import 'package:nai_launcher/data/models/online_gallery/gallery_source.dart';
+import 'package:nai_launcher/data/services/danbooru_auth_service.dart';
 import 'package:nai_launcher/presentation/providers/online_gallery_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -64,6 +66,39 @@ void main() {
       expect(adapter.searchCursors, ['1', '2']);
       expect(state.posts.map((item) => item.id), [101, 202]);
       expect(state.posts.map((item) => item.stableKey).toSet(), hasLength(2));
+    },
+  );
+
+  test(
+    'popular ranking validates a query that the ranking feed ignores',
+    () async {
+      var requestCount = 0;
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async {
+          requestCount++;
+          return switch (requestCount) {
+            1 => _page(request.cursor, const [], nextCursor: null),
+            2 => _page(request.cursor, [
+              _item(1, tags: const ['other']),
+            ], nextCursor: '2'),
+            _ => _page(request.cursor, [
+              _item(2, tags: const ['target']),
+            ], nextCursor: null),
+          };
+        },
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.switchToPopular();
+      await notifier.searchPopular(query: 'target', prompt: '');
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.searchCursors, ['1', '1', '2']);
+      expect(state.posts.map((item) => item.id), [2]);
+      expect(state.hasMore, isFalse);
     },
   );
 
@@ -362,6 +397,680 @@ void main() {
   });
 
   test(
+    'a single residual negative clause is always filtered locally',
+    () async {
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async => _page(request.cursor, [
+          _item(1, tags: const ['a', 'b', 'blocked']),
+          _item(2, tags: const ['a', 'b']),
+        ], nextCursor: null),
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+
+      await container
+          .read(onlineGalleryNotifierProvider.notifier)
+          .search('a b -blocked');
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.searchQueries.single, 'a b');
+      expect(state.posts.map((item) => item.id), [2]);
+    },
+  );
+
+  test(
+    'six-tag residual filtering consumes empty pages until matching work arrives',
+    () async {
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async {
+          return switch (request.cursor) {
+            '1' => _page('1', [
+              _item(1, tags: const ['a', 'b', 'c']),
+              _item(2, tags: const ['a', 'b', 'd']),
+            ], nextCursor: '2'),
+            '2' => _page('2', [
+              _item(3, tags: const ['a', 'b', 'c', 'd', 'e', 'f']),
+            ], nextCursor: '3'),
+            _ => _page('3', const [], nextCursor: null),
+          };
+        },
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+
+      await container
+          .read(onlineGalleryNotifierProvider.notifier)
+          .search('a b c d e f');
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.searchCursors, ['1', '2', '3']);
+      expect(adapter.searchQueries.toSet(), {'a b'});
+      expect(state.posts.map((item) => item.id), [3]);
+      expect(state.currentCache.queryRequestCount, 3);
+      expect(state.currentCache.queryCandidateCount, 3);
+      expect(state.hasMore, isFalse);
+    },
+  );
+
+  test(
+    'residual scans pause at the page budget and resume from the cursor',
+    () async {
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async {
+          final page = int.parse(request.cursor);
+          return _page(request.cursor, [
+            _item(
+              page,
+              tags: page == 9 ? const ['a', 'b', 'c'] : const ['a', 'b'],
+            ),
+          ], nextCursor: page < 9 ? '${page + 1}' : null);
+        },
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.search('a b c');
+      var state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.searchCursors, [
+        for (var page = 1; page <= 8; page++) '$page',
+      ]);
+      expect(state.posts, isEmpty);
+      expect(state.hasMore, isTrue);
+      expect(state.currentCache.nextCursor, '9');
+      expect(state.currentCache.queryScanPaused, isTrue);
+
+      await notifier.loadMore();
+      state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.searchCursors.last, '9');
+      expect(state.posts.single.id, 9);
+      expect(state.hasMore, isFalse);
+      expect(state.currentCache.queryScanPaused, isFalse);
+    },
+  );
+
+  test('raw-page repetition is detected across scan-budget resumes', () async {
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async {
+        final page = int.parse(request.cursor);
+        return _page(
+          request.cursor,
+          [
+            _item(page, tags: const ['a', 'b']),
+          ],
+          nextCursor: '${page + 1}',
+          rawPageIdentity: page <= 8 ? 'raw-$page' : 'raw-8',
+        );
+      },
+    );
+    final container = _container(danbooru: adapter);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.search('a b c');
+    expect(
+      container
+          .read(onlineGalleryNotifierProvider)
+          .currentCache
+          .queryScanPaused,
+      isTrue,
+    );
+
+    await notifier.loadMore();
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(adapter.searchCursors, [
+      for (var page = 1; page <= 9; page++) '$page',
+    ]);
+    expect(state.currentCache.endedByDuplicatePage, isTrue);
+    expect(state.hasMore, isFalse);
+  });
+
+  test('advancing cursors with the same raw page terminate the scan', () async {
+    final repeated = _item(1, tags: const ['a', 'b']);
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async => _page(request.cursor, [
+        repeated,
+      ], nextCursor: request.cursor == '1' ? '2' : '3'),
+    );
+    final container = _container(danbooru: adapter);
+    addTearDown(container.dispose);
+
+    await container
+        .read(onlineGalleryNotifierProvider.notifier)
+        .search('a b c');
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(adapter.searchCursors, ['1', '2']);
+    expect(state.posts, isEmpty);
+    expect(state.currentCache.endedByDuplicatePage, isTrue);
+    expect(state.hasMore, isFalse);
+  });
+
+  test(
+    'different raw pages are not collapsed after adapter filtering',
+    () async {
+      final repeatedVisible = _item(1, tags: const ['a', 'b']);
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async {
+          if (request.cursor == '3') {
+            return _page(
+              request.cursor,
+              [
+                _item(3, tags: const ['a', 'b', 'c']),
+              ],
+              nextCursor: null,
+              rawPageIdentity: 'raw-3',
+            );
+          }
+          return _page(
+            request.cursor,
+            [repeatedVisible],
+            nextCursor: request.cursor == '1' ? '2' : '3',
+            rawPageIdentity: 'raw-${request.cursor}',
+          );
+        },
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+
+      await container
+          .read(onlineGalleryNotifierProvider.notifier)
+          .search('a b c');
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.searchCursors, ['1', '2', '3']);
+      expect(state.posts.single.id, 3);
+      expect(state.currentCache.endedByDuplicatePage, isFalse);
+    },
+  );
+
+  test(
+    'incomplete list tags are completed by detail before matching',
+    () async {
+      final incomplete = _item(8, tags: const ['a'], tagsComplete: false);
+      final complete = _item(8, tags: const ['a', 'b', 'c']);
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async =>
+            _page(request.cursor, [incomplete], nextCursor: null),
+        onDetail: (item, _) async =>
+            GalleryDetail(item: complete, media: [complete.cover]),
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+
+      await container
+          .read(onlineGalleryNotifierProvider.notifier)
+          .search('a b c');
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.detailRequests, 1);
+      expect(state.posts.map((item) => item.id), [8]);
+      expect(state.notice, isNull);
+    },
+  );
+
+  test('source changes cancel in-flight tag detail completion', () async {
+    final pendingDetail = Completer<GalleryDetail>();
+    CancelToken? detailCancelToken;
+    final incomplete = _item(8, tags: const ['a'], tagsComplete: false);
+    final danbooru = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async =>
+          _page(request.cursor, [incomplete], nextCursor: null),
+      onDetail: (item, cancelToken) {
+        detailCancelToken = cancelToken;
+        return pendingDetail.future;
+      },
+    );
+    final safebooru = _FakeGalleryAdapter(
+      GallerySourceId.safebooru,
+      onSearch: (request, _) async => _page(request.cursor, [
+        _item(
+          22,
+          source: GallerySourceId.safebooru,
+          tags: const ['a', 'b', 'c'],
+        ),
+      ], nextCursor: null),
+    );
+    final container = _container(danbooru: danbooru, safebooru: safebooru);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    final staleSearch = notifier.search('a b c');
+    while (danbooru.detailRequests == 0) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    await notifier.setSource(GallerySourceId.safebooru);
+
+    expect(detailCancelToken?.isCancelled, isTrue);
+    pendingDetail.complete(
+      GalleryDetail(item: incomplete, media: [incomplete.cover]),
+    );
+    await staleSearch;
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(state.sourceId, GallerySourceId.safebooru);
+    expect(state.posts.single.id, 22);
+  });
+
+  test('AI TAG keeps source-native terms and skips Danbooru aliases', () async {
+    var metadataLoads = 0;
+    final danbooru = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async =>
+          _page(request.cursor, const [], nextCursor: null),
+    );
+    final aiTag = _FakeGalleryAdapter(
+      GallerySourceId.aiTag,
+      onSearch: (request, _) async => _page(
+        request.cursor,
+        request.query.isEmpty
+            ? const []
+            : [
+                _item(
+                  30,
+                  source: GallerySourceId.aiTag,
+                  tags: const ['kitty'],
+                  tagsComplete: false,
+                ),
+              ],
+        nextCursor: null,
+      ),
+      onDetail: (item, _) async {
+        final complete = item.copyWith(
+          searchTerms: const ['kitty', 'Alice', 'portrait'],
+          tagsComplete: true,
+        );
+        return GalleryDetail(item: complete, media: [complete.cover]);
+      },
+    );
+    final container = _container(
+      danbooru: danbooru,
+      aiTag: aiTag,
+      metadataLoader: (terms) async {
+        metadataLoads++;
+        return const {};
+      },
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.setSource(GallerySourceId.aiTag);
+    await notifier.search('alice');
+
+    expect(metadataLoads, 0);
+    expect(aiTag.searchQueries.last, 'alice');
+    expect(container.read(onlineGalleryNotifierProvider).posts.single.id, 30);
+  });
+
+  test('unsupported metatags fail before issuing a source request', () async {
+    final danbooru = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async =>
+          _page(request.cursor, const [], nextCursor: null),
+    );
+    final aiTag = _FakeGalleryAdapter(
+      GallerySourceId.aiTag,
+      onSearch: (request, _) async =>
+          _page(request.cursor, const [], nextCursor: null),
+    );
+    final container = _container(danbooru: danbooru, aiTag: aiTag);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.setSource(GallerySourceId.aiTag);
+    final aiRequests = aiTag.searchQueries.length;
+    await notifier.search('rating:g');
+    var state = container.read(onlineGalleryNotifierProvider);
+    expect(aiTag.searchQueries, hasLength(aiRequests));
+    expect(state.errorCode, OnlineGalleryErrorCode.unsupportedMetatag);
+
+    await notifier.setSource(GallerySourceId.danbooru);
+    await notifier.switchToPopular();
+    final rankingRequests = danbooru.searchQueries.length;
+    await notifier.searchPopular(query: 'order:score', prompt: '');
+    state = container.read(onlineGalleryNotifierProvider);
+    expect(danbooru.searchQueries, hasLength(rankingRequests));
+    expect(state.errorCode, OnlineGalleryErrorCode.unsupportedMetatag);
+  });
+
+  test(
+    'Gelbooru accepts sort but rejects Danbooru-only order syntax',
+    () async {
+      final gelbooru = _FakeGalleryAdapter(
+        GallerySourceId.gelbooru,
+        onSearch: (request, _) async =>
+            _page(request.cursor, const [], nextCursor: null),
+      );
+      final container = _container(
+        danbooru: _emptyAdapter(GallerySourceId.danbooru),
+        gelbooru: gelbooru,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.setSource(GallerySourceId.gelbooru);
+      await notifier.search('a b c d e f sort:score:desc');
+      expect(gelbooru.searchQueries.last, contains('sort:score:desc'));
+      expect(container.read(onlineGalleryNotifierProvider).errorCode, isNull);
+
+      final requestCount = gelbooru.searchQueries.length;
+      await notifier.search('order:score');
+      expect(gelbooru.searchQueries, hasLength(requestCount));
+      expect(
+        container.read(onlineGalleryNotifierProvider).errorCode,
+        OnlineGalleryErrorCode.unsupportedMetatag,
+      );
+    },
+  );
+
+  test(
+    'account changes invalidate source caches and reload active results',
+    () async {
+      var requestCount = 0;
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async {
+          requestCount++;
+          return _page(request.cursor, [_item(requestCount)], nextCursor: null);
+        },
+      );
+      final container = _container(
+        danbooru: adapter,
+        danbooruAuthBuilder: _MutableDanbooruAuth.new,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.loadPosts();
+      final auth =
+          container.read(danbooruAuthProvider.notifier) as _MutableDanbooruAuth;
+      auth.authenticate(name: 'alice', level: 30);
+      while (adapter.searchCursors.length < 2) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(state.danbooruAuthScope, 'alice:30:authenticated');
+      expect(state.posts.single.id, 2);
+      expect(
+        state.caches.keys.where((key) => key.startsWith('search:danbooru:')),
+        everyElement(contains('auth:alice:30:authenticated')),
+      );
+    },
+  );
+
+  test('account changes cancel an in-flight source request', () async {
+    var requestCount = 0;
+    CancelToken? firstToken;
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, cancelToken) async {
+        requestCount++;
+        if (requestCount == 1) {
+          final token = cancelToken!;
+          firstToken = token;
+          await token.whenCancel;
+          throw token.cancelError!;
+        }
+        return _page(request.cursor, [_item(2)], nextCursor: null);
+      },
+    );
+    final container = _container(
+      danbooru: adapter,
+      danbooruAuthBuilder: _MutableDanbooruAuth.new,
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    final firstLoad = notifier.loadPosts();
+    while (firstToken == null) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    final auth =
+        container.read(danbooruAuthProvider.notifier) as _MutableDanbooruAuth;
+    auth.authenticate(name: 'alice', level: 30);
+    while (requestCount < 2) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    await firstLoad;
+
+    expect(firstToken!.isCancelled, isTrue);
+    expect(container.read(onlineGalleryNotifierProvider).posts.single.id, 2);
+  });
+
+  test(
+    'authentication scopes isolate search but not unified favorites keys',
+    () {
+      const state = OnlineGalleryState(
+        danbooruAuthScope: 'alice:20:authenticated',
+        gelbooruAuthScope: '100:valid',
+      );
+      expect(state.currentCacheKey, contains('auth:alice:20:authenticated'));
+      expect(
+        state
+            .copyWith(danbooruAuthScope: 'bob:30:authenticated')
+            .currentCacheKey,
+        isNot(state.currentCacheKey),
+      );
+
+      final unifiedFavorites = state.copyWith(
+        viewMode: GalleryViewMode.favorites,
+      );
+      expect(
+        unifiedFavorites.currentCacheKey,
+        startsWith('favorites:danbooru|'),
+      );
+      expect(
+        unifiedFavorites
+            .copyWith(danbooruAuthScope: 'bob:30:authenticated')
+            .currentCacheKey,
+        unifiedFavorites.currentCacheKey,
+      );
+    },
+  );
+
+  test(
+    'account changes during random mode cannot restore the old normal cache',
+    () async {
+      var requestCount = 0;
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async {
+          requestCount++;
+          return _page(request.cursor, [_item(requestCount)], nextCursor: null);
+        },
+      );
+      final container = _container(
+        danbooru: adapter,
+        danbooruAuthBuilder: _MutableDanbooruAuth.new,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.loadPosts();
+      await notifier.setRandomEnabled(true);
+      final auth =
+          container.read(danbooruAuthProvider.notifier) as _MutableDanbooruAuth;
+      auth.authenticate(name: 'alice', level: 30);
+      while (requestCount < 3) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      await notifier.setRandomEnabled(false);
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(state.randomEnabled, isFalse);
+      expect(state.danbooruAuthScope, 'alice:30:authenticated');
+      expect(state.posts.single.id, 4);
+      expect(
+        state.caches.keys.where((key) => key.startsWith('search:danbooru:')),
+        everyElement(contains('auth:alice:30:authenticated')),
+      );
+    },
+  );
+
+  test('incomplete positive AI TAG terms avoid eager detail fan-out', () async {
+    final aiTag = _FakeGalleryAdapter(
+      GallerySourceId.aiTag,
+      onSearch: (request, _) async => _page(request.cursor, [
+        _item(
+          1,
+          source: GallerySourceId.aiTag,
+          searchTerms: const ['blue'],
+          tagsComplete: false,
+        ),
+      ], nextCursor: null),
+    );
+    final container = _container(
+      danbooru: _emptyAdapter(GallerySourceId.danbooru),
+      aiTag: aiTag,
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.setSource(GallerySourceId.aiTag);
+    await notifier.search('blue');
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(state.posts.single.id, 1);
+    expect(aiTag.detailRequests, 0);
+  });
+
+  test(
+    'incomplete AI TAG detail can prove a positive match without all media',
+    () async {
+      final aiTag = _FakeGalleryAdapter(
+        GallerySourceId.aiTag,
+        onSearch: (request, _) async => _page(request.cursor, [
+          _item(
+            2,
+            source: GallerySourceId.aiTag,
+            tags: const [],
+            tagsComplete: false,
+          ),
+        ], nextCursor: null),
+        onDetail: (item, _) async => GalleryDetail(
+          item: _item(
+            2,
+            source: GallerySourceId.aiTag,
+            searchTerms: const ['blue'],
+            tagsComplete: false,
+          ),
+          media: [item.cover],
+        ),
+      );
+      final container = _container(
+        danbooru: _emptyAdapter(GallerySourceId.danbooru),
+        aiTag: aiTag,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.setSource(GallerySourceId.aiTag);
+      await notifier.search('blue');
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(state.posts.single.id, 2);
+      expect(state.currentCache.queryDetailFailureCount, 0);
+      expect(aiTag.detailRequests, 1);
+    },
+  );
+
+  test(
+    'incomplete AI TAG detail cannot guess that a negative tag is absent',
+    () async {
+      final aiTag = _FakeGalleryAdapter(
+        GallerySourceId.aiTag,
+        onSearch: (request, _) async => _page(request.cursor, [
+          _item(
+            3,
+            source: GallerySourceId.aiTag,
+            searchTerms: const ['blue'],
+            tagsComplete: false,
+          ),
+        ], nextCursor: null),
+        onDetail: (item, _) async => GalleryDetail(
+          item: _item(
+            3,
+            source: GallerySourceId.aiTag,
+            searchTerms: const ['blue'],
+            tagsComplete: false,
+          ),
+          media: [item.cover],
+        ),
+      );
+      final container = _container(
+        danbooru: _emptyAdapter(GallerySourceId.danbooru),
+        aiTag: aiTag,
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.setSource(GallerySourceId.aiTag);
+      await notifier.search('blue -red');
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(state.posts, isEmpty);
+      expect(state.currentCache.queryDetailFailureCount, 1);
+      expect(aiTag.detailRequests, 1);
+    },
+  );
+
+  test('normalized tag cache does not outlive changed source tags', () async {
+    var revised = false;
+    final safebooru = _FakeGalleryAdapter(
+      GallerySourceId.safebooru,
+      onSearch: (request, _) async => _page(request.cursor, [
+        _item(
+          1,
+          source: GallerySourceId.safebooru,
+          tags: revised
+              ? const ['cat', 'bird', 'fox']
+              : const ['cat', 'dog', 'fox'],
+        ),
+      ], nextCursor: null),
+    );
+    final container = _container(
+      danbooru: _emptyAdapter(GallerySourceId.danbooru),
+      safebooru: safebooru,
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.setSource(GallerySourceId.safebooru);
+    await notifier.search('cat dog fox');
+    expect(container.read(onlineGalleryNotifierProvider).posts, hasLength(1));
+
+    revised = true;
+    await notifier.refresh();
+    expect(container.read(onlineGalleryNotifierProvider).posts, isEmpty);
+  });
+
+  test('a seventh tag fails before issuing an upstream request', () async {
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async =>
+          _page(request.cursor, const [], nextCursor: null),
+    );
+    final container = _container(danbooru: adapter);
+    addTearDown(container.dispose);
+
+    await container
+        .read(onlineGalleryNotifierProvider.notifier)
+        .search('a b c d e f g');
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(adapter.searchCursors, isEmpty);
+    expect(state.errorCode, OnlineGalleryErrorCode.tooManySearchTags);
+  });
+
+  test(
     'append failure retains existing posts and can retry in place',
     () async {
       var pageTwoAttempts = 0;
@@ -406,9 +1115,20 @@ void main() {
   );
 }
 
+_FakeGalleryAdapter _emptyAdapter(GallerySourceId sourceId) =>
+    _FakeGalleryAdapter(
+      sourceId,
+      onSearch: (request, _) async =>
+          _page(request.cursor, const [], nextCursor: null),
+    );
+
 ProviderContainer _container({
   required _FakeGalleryAdapter danbooru,
   _FakeGalleryAdapter? safebooru,
+  _FakeGalleryAdapter? gelbooru,
+  _FakeGalleryAdapter? aiTag,
+  GalleryTagMetadataLoader? metadataLoader,
+  DanbooruAuth Function()? danbooruAuthBuilder,
 }) {
   final safe =
       safebooru ??
@@ -417,27 +1137,52 @@ ProviderContainer _container({
         onSearch: (request, _) async =>
             _page(request.cursor, const [], nextCursor: null),
       );
-  final gelbooru = _FakeGalleryAdapter(
-    GallerySourceId.gelbooru,
-    onSearch: (request, _) async =>
-        _page(request.cursor, const [], nextCursor: null),
-  );
-  final aiTag = _FakeGalleryAdapter(
-    GallerySourceId.aiTag,
-    onSearch: (request, _) async =>
-        _page(request.cursor, const [], nextCursor: null),
-  );
+  final gelbooruAdapter =
+      gelbooru ??
+      _FakeGalleryAdapter(
+        GallerySourceId.gelbooru,
+        onSearch: (request, _) async =>
+            _page(request.cursor, const [], nextCursor: null),
+      );
+  final aiTagAdapter =
+      aiTag ??
+      _FakeGalleryAdapter(
+        GallerySourceId.aiTag,
+        onSearch: (request, _) async =>
+            _page(request.cursor, const [], nextCursor: null),
+      );
   return ProviderContainer(
     overrides: [
       localStorageServiceProvider.overrideWithValue(_MemoryStorage()),
+      if (danbooruAuthBuilder != null)
+        danbooruAuthProvider.overrideWith(danbooruAuthBuilder),
+      onlineGalleryTagMetadataLoaderProvider.overrideWithValue(
+        metadataLoader ?? (terms) async => const {},
+      ),
       onlineGallerySourceAdaptersProvider.overrideWithValue({
         GallerySourceId.danbooru: danbooru,
         GallerySourceId.safebooru: safe,
-        GallerySourceId.gelbooru: gelbooru,
-        GallerySourceId.aiTag: aiTag,
+        GallerySourceId.gelbooru: gelbooruAdapter,
+        GallerySourceId.aiTag: aiTagAdapter,
       }),
     ],
   );
+}
+
+class _MutableDanbooruAuth extends DanbooruAuth {
+  @override
+  DanbooruAuthState build() => const DanbooruAuthState();
+
+  @override
+  Future<void> ensureInitialized() async {}
+
+  void authenticate({required String name, required int level}) {
+    state = DanbooruAuthState(
+      credentials: DanbooruCredentials(username: name, apiKey: 'test-key'),
+      user: DanbooruUser(id: 1, name: name, level: level),
+      lastVerifiedAt: DateTime.now(),
+    );
+  }
 }
 
 class _MemoryStorage extends LocalStorageService {
@@ -463,6 +1208,7 @@ GalleryPage _page(
   List<GalleryItem> items, {
   required String? nextCursor,
   int? rawItemCount,
+  String? rawPageIdentity,
 }) {
   return GalleryPage(
     items: items,
@@ -470,10 +1216,17 @@ GalleryPage _page(
     nextCursor: nextCursor,
     hasMore: nextCursor != null,
     rawItemCount: rawItemCount ?? items.length,
+    rawPageIdentity: rawPageIdentity,
   );
 }
 
-GalleryItem _item(int id, {GallerySourceId source = GallerySourceId.danbooru}) {
+GalleryItem _item(
+  int id, {
+  GallerySourceId source = GallerySourceId.danbooru,
+  List<String> tags = const ['1girl'],
+  List<String> searchTerms = const [],
+  bool tagsComplete = true,
+}) {
   return GalleryItem(
     id: id,
     sourceId: source,
@@ -482,7 +1235,9 @@ GalleryItem _item(int id, {GallerySourceId source = GallerySourceId.danbooru}) {
     width: 768,
     height: 1024,
     rating: 'g',
-    tags: const ['1girl'],
+    tags: tags,
+    searchTerms: searchTerms,
+    tagsComplete: tagsComplete,
     cover: GalleryMedia(
       id: '$id',
       previewUrl: 'https://example.test/${source.key}/$id-preview.webp',
@@ -496,7 +1251,7 @@ GalleryItem _item(int id, {GallerySourceId source = GallerySourceId.danbooru}) {
 }
 
 class _FakeGalleryAdapter implements GallerySourceAdapter {
-  _FakeGalleryAdapter(this.sourceId, {required this.onSearch});
+  _FakeGalleryAdapter(this.sourceId, {required this.onSearch, this.onDetail});
 
   @override
   final GallerySourceId sourceId;
@@ -505,8 +1260,15 @@ class _FakeGalleryAdapter implements GallerySourceAdapter {
     CancelToken? cancelToken,
   )
   onSearch;
+  final Future<GalleryDetail> Function(
+    GalleryItem item,
+    CancelToken? cancelToken,
+  )?
+  onDetail;
   final List<String> searchCursors = [];
   final List<int> searchPageSizes = [];
+  final List<String> searchQueries = [];
+  int detailRequests = 0;
 
   @override
   Random get randomGenerator => Random(1);
@@ -522,6 +1284,7 @@ class _FakeGalleryAdapter implements GallerySourceAdapter {
   }) {
     searchCursors.add(request.cursor);
     searchPageSizes.add(request.pageSize);
+    searchQueries.add(request.query);
     return onSearch(request, cancelToken);
   }
 
@@ -552,6 +1315,9 @@ class _FakeGalleryAdapter implements GallerySourceAdapter {
     GalleryItem item, {
     CancelToken? cancelToken,
   }) async {
+    detailRequests++;
+    final handler = onDetail;
+    if (handler != null) return handler(item, cancelToken);
     return GalleryDetail(item: item, media: [item.cover]);
   }
 }

--- a/test/presentation/providers/online_gallery_random_mode_test.dart
+++ b/test/presentation/providers/online_gallery_random_mode_test.dart
@@ -76,9 +76,15 @@ void main() {
 
   test('random search preserves fuzzy matching and resets its scope', () async {
     final adapter = _RandomFakeAdapter([
-      [_item(1)],
-      [_item(2)],
-      [_item(3)],
+      [
+        _item(1).copyWith(tags: const ['cat', 'dog']),
+      ],
+      [
+        _item(2).copyWith(tags: const ['cat', 'dog']),
+      ],
+      [
+        _item(3).copyWith(tags: const ['cat', 'dog']),
+      ],
     ]);
     final container = _container(adapter);
     addTearDown(container.dispose);
@@ -141,7 +147,9 @@ void main() {
         const OnlineGalleryState(sourceId: GallerySourceId.quickTagCloud),
       ),
     );
-    final item = _quickItem('blocked').copyWith(tags: const []);
+    final item = _quickItem(
+      'blocked',
+    ).copyWith(tags: const [], tagsComplete: false);
     final adapter = _QueryRecordingAdapter(
       GallerySourceId.quickTagCloud,
       randomItems: [item],
@@ -169,6 +177,52 @@ void main() {
 
     final request = adapter.lastRandomRequest as GalleryRandomSearchRequest;
     expect(request.blacklistTags, {'blocked_tag'});
+    expect(container.read(onlineGalleryNotifierProvider).posts, isEmpty);
+  });
+
+  test('AI TAG random completes tags before applying the blacklist', () async {
+    final storage = _MemoryStorage();
+    await storage.setSetting(
+      StorageKeys.onlineGalleryBrowsingSessionV1,
+      encodeOnlineGalleryBrowsingSession(
+        const OnlineGalleryState(sourceId: GallerySourceId.aiTag),
+      ),
+    );
+    final incomplete = _quickItem('ai-blocked').copyWith(
+      sourceId: GallerySourceId.aiTag,
+      tags: const ['visible'],
+      tagsComplete: false,
+    );
+    final complete = incomplete.copyWith(
+      tags: const ['visible', 'blocked_tag'],
+      tagsComplete: true,
+    );
+    final adapter = _QueryRecordingAdapter(
+      GallerySourceId.aiTag,
+      randomItems: [incomplete],
+      detailItem: complete,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        localStorageServiceProvider.overrideWithValue(storage),
+        onlineGallerySourceAdaptersProvider.overrideWithValue({
+          for (final source in GallerySourceId.values)
+            source: source == GallerySourceId.aiTag
+                ? adapter
+                : _EmptyAdapter(source),
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container
+        .read(onlineGalleryBlacklistNotifierProvider.notifier)
+        .addLocalTag('blocked_tag');
+
+    await container
+        .read(onlineGalleryNotifierProvider.notifier)
+        .setRandomEnabled(true);
+
+    expect(adapter.detailRequests, 1);
     expect(container.read(onlineGalleryNotifierProvider).posts, isEmpty);
   });
 
@@ -369,35 +423,39 @@ void main() {
     expect(state.randomSession.exhausted, isTrue);
   });
 
-  test('four empty unique draws exhaust until explicit restart', () async {
-    final adapter = _RandomFakeAdapter([
-      const [],
-      const [],
-      const [],
-      const [],
-      [_item(7)],
-    ]);
-    final container = _container(adapter);
-    addTearDown(container.dispose);
-    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+  test(
+    'empty filtered draws remain retryable until the source exhausts',
+    () async {
+      final adapter = _RandomFakeAdapter([
+        const [],
+        const [],
+        const [],
+        const [],
+        [_item(7)],
+      ]);
+      final container = _container(adapter);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
 
-    await notifier.setRandomEnabled(true);
-    for (var i = 0; i < 3; i++) {
+      await notifier.setRandomEnabled(true);
+      for (var i = 0; i < 3; i++) {
+        await notifier.loadMore();
+      }
+      var state = container.read(onlineGalleryNotifierProvider);
+      expect(state.randomSession.consecutiveMisses, 4);
+      expect(state.randomSession.exhausted, isFalse);
+      expect(state.notice, OnlineGalleryNotice.randomDrawNoMatch);
+      expect(state.randomSession.cache.queryScanPaused, isTrue);
+
       await notifier.loadMore();
-    }
-    var state = container.read(onlineGalleryNotifierProvider);
-    expect(state.randomSession.consecutiveMisses, 4);
-    expect(state.randomSession.exhausted, isTrue);
-
-    await notifier.loadMore();
-    expect(adapter.randomCalls, 4);
-
-    await notifier.restartRandom();
-    state = container.read(onlineGalleryNotifierProvider);
-    expect(state.posts.single.id, 7);
-    expect(state.randomSession.seenStableKeys, {'danbooru:7'});
-    expect(state.randomSession.exhausted, isFalse);
-  });
+      expect(adapter.randomCalls, 5);
+      state = container.read(onlineGalleryNotifierProvider);
+      expect(state.posts.single.id, 7);
+      expect(state.randomSession.seenStableKeys, {'danbooru:7'});
+      expect(state.randomSession.exhausted, isFalse);
+      expect(state.randomSession.cache.queryScanPaused, isFalse);
+    },
+  );
 
   test(
     'source switch starts the new random request without awaiting the old one',
@@ -731,15 +789,18 @@ class _QueryRecordingAdapter extends GallerySourceAdapter {
     this.sourceId, {
     this.randomItems = const [],
     this.detailTags = const [],
+    this.detailItem,
   });
 
   @override
   final GallerySourceId sourceId;
   final List<GalleryItem> randomItems;
   final List<String> detailTags;
+  final GalleryItem? detailItem;
 
   GallerySearchRequest? lastSearchRequest;
   GalleryRandomRequest? lastRandomRequest;
+  int detailRequests = 0;
 
   @override
   Future<GalleryPage> search(
@@ -763,10 +824,13 @@ class _QueryRecordingAdapter extends GallerySourceAdapter {
   Future<GalleryDetail> detail(
     GalleryItem item, {
     CancelToken? cancelToken,
-  }) async => GalleryDetail(
-    item: item.copyWith(tags: detailTags),
-    media: [item.cover],
-  );
+  }) async {
+    detailRequests++;
+    final resolved =
+        detailItem ??
+        item.copyWith(tags: detailTags, tagsComplete: detailTags.isNotEmpty);
+    return GalleryDetail(item: resolved, media: [resolved.cover]);
+  }
 }
 
 class _EmptyAdapter implements GallerySourceAdapter {

--- a/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
@@ -756,6 +756,38 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('paused random miss requires an explicit continue action', (
+    tester,
+  ) async {
+    _PausedRandomGalleryNotifier.loadMoreCalls = 0;
+    await _setViewSize(tester, 1200);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          onlineGalleryNotifierProvider.overrideWith(
+            _PausedRandomGalleryNotifier.new,
+          ),
+          danbooruAuthProvider.overrideWith(_LoggedOutDanbooruAuth.new),
+          gelbooruAuthProvider.overrideWith(_UnconfiguredGelbooruAuth.new),
+          danbooruSuggestionNotifierProvider.overrideWith(
+            _EmptyDanbooruSuggestionNotifier.new,
+          ),
+        ],
+        child: const _TestApp(),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(_PausedRandomGalleryNotifier.loadMoreCalls, 0);
+    expect(find.text('Continue scanning'), findsOneWidget);
+
+    await tester.tap(find.text('Continue scanning'));
+    await tester.pump();
+    expect(_PausedRandomGalleryNotifier.loadMoreCalls, 1);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('page replacement renders the second page URL with stable keys', (
     tester,
   ) async {
@@ -935,81 +967,117 @@ void main() {
   });
 
   for (final width in [700.0, 840.0, 1180.0, 1600.0]) {
-    testWidgets('QuickTagCloud Chinese toolbar stays aligned at width $width', (
-      tester,
-    ) async {
-      await _setViewSize(tester, width);
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            onlineGalleryNotifierProvider.overrideWith(
-              _QuickTagCloudGalleryNotifier.new,
-            ),
-            quickTagCloudGallerySourceAdapterProvider.overrideWithValue(
-              _TrackingQuickTagCloudAdapter(),
-            ),
-            quickTagCloudCatalogProvider.overrideWith(
-              (ref) async => _quickTagCloudCatalog(),
-            ),
-            quickTagCloudFilterProvider.overrideWith(
-              _QuickTagCloudFilterNotifier.new,
-            ),
-            danbooruAuthProvider.overrideWith(_LoggedOutDanbooruAuth.new),
-            gelbooruAuthProvider.overrideWith(_UnconfiguredGelbooruAuth.new),
-            danbooruSuggestionNotifierProvider.overrideWith(
-              _EmptyDanbooruSuggestionNotifier.new,
-            ),
-          ],
-          child: const _TestApp(locale: Locale('zh')),
-        ),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
-
-      if (width >= 1400) {
-        for (final icon in const [
-          Icons.shuffle,
-          Icons.refresh,
-          Icons.checklist,
-        ]) {
-          expect(find.byIcon(icon), findsOneWidget);
-        }
-      }
-      final searchRect = tester.getRect(
-        find.byKey(const ValueKey('online-gallery-primary-search')),
-      );
-      final blacklistRect = tester.getRect(
-        find.byKey(const ValueKey('online-gallery-blacklist')),
-      );
-      final accountRect = tester.getRect(
-        find.byKey(const ValueKey('online-gallery-account-avatar')),
-      );
-      final primaryRect = tester.getRect(
-        find.byKey(const ValueKey('online-gallery-toolbar-primary-row')),
-      );
-      expect(searchRect.width, greaterThanOrEqualTo(280));
-      expect(blacklistRect.left - searchRect.right, closeTo(8, 0.1));
-      expect(accountRect.right, greaterThanOrEqualTo(primaryRect.right - 0.1));
-      for (final key in const [
-        'online-gallery-primary-search',
-        'online-gallery-blacklist',
-        'online-gallery-output-filter',
-        'online-gallery-random-toggle',
-        'online-gallery-refresh',
-        'online-gallery-multi-select',
-        'online-gallery-account-avatar',
-      ]) {
-        final rect = tester.getRect(find.byKey(ValueKey(key)));
-        expect(
-          (rect.center.dy - primaryRect.center.dy).abs(),
-          lessThan(1),
-          reason: '$key must stay in the primary row at width $width',
+    testWidgets(
+      'QuickTagCloud toolbar keeps every global control in row one at $width',
+      (tester) async {
+        await _setViewSize(tester, width);
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              onlineGalleryNotifierProvider.overrideWith(
+                _QuickTagCloudGalleryNotifier.new,
+              ),
+              quickTagCloudGallerySourceAdapterProvider.overrideWithValue(
+                _TrackingQuickTagCloudAdapter(),
+              ),
+              quickTagCloudCatalogProvider.overrideWith(
+                (ref) async => _quickTagCloudCatalog(),
+              ),
+              quickTagCloudFilterProvider.overrideWith(
+                _QuickTagCloudFilterNotifier.new,
+              ),
+              danbooruAuthProvider.overrideWith(_LoggedOutDanbooruAuth.new),
+              gelbooruAuthProvider.overrideWith(_UnconfiguredGelbooruAuth.new),
+              danbooruSuggestionNotifierProvider.overrideWith(
+                _EmptyDanbooruSuggestionNotifier.new,
+              ),
+            ],
+            child: const _TestApp(locale: Locale('zh')),
+          ),
         );
-      }
-      expect(find.text('Leaf category'), findsOneWidget);
-      expect(find.text('Fallback codex title'), findsNothing);
-      expect(tester.takeException(), isNull);
-    });
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        if (width >= 1400) {
+          for (final icon in const [
+            Icons.shuffle,
+            Icons.refresh,
+            Icons.checklist,
+          ]) {
+            expect(find.byIcon(icon), findsOneWidget);
+          }
+        }
+        for (final key in const [
+          'online-gallery-source-selector',
+          'online-gallery-mode-search',
+          'online-gallery-rating-filter',
+          'online-gallery-primary-search',
+          'online-gallery-blacklist',
+          'online-gallery-output-filter',
+          'online-gallery-random-toggle',
+          'online-gallery-refresh',
+          'online-gallery-multi-select',
+          'online-gallery-account-avatar',
+        ]) {
+          expect(find.byKey(ValueKey(key)), findsOneWidget);
+        }
+        final searchRect = tester.getRect(
+          find.byKey(const ValueKey('online-gallery-primary-search')),
+        );
+        final counterRect = tester.getRect(
+          find.byKey(const ValueKey('online-gallery-tag-count')),
+        );
+        final blacklistRect = tester.getRect(
+          find.byKey(const ValueKey('online-gallery-blacklist')),
+        );
+        final accountRect = tester.getRect(
+          find.byKey(const ValueKey('online-gallery-account-avatar')),
+        );
+        final primaryRect = tester.getRect(
+          find.byKey(const ValueKey('online-gallery-toolbar-primary-row')),
+        );
+        expect(searchRect.width, greaterThanOrEqualTo(280));
+        expect(counterRect.center.dy, closeTo(searchRect.center.dy, 0.1));
+        expect(blacklistRect.left - searchRect.right, closeTo(8, 0.1));
+        expect(
+          accountRect.right,
+          greaterThanOrEqualTo(primaryRect.right - 0.1),
+        );
+        for (final key in const [
+          'online-gallery-primary-search',
+          'online-gallery-blacklist',
+          'online-gallery-output-filter',
+          'online-gallery-random-toggle',
+          'online-gallery-refresh',
+          'online-gallery-multi-select',
+          'online-gallery-account-avatar',
+        ]) {
+          final rect = tester.getRect(find.byKey(ValueKey(key)));
+          expect(
+            (rect.center.dy - primaryRect.center.dy).abs(),
+            lessThan(1),
+            reason: '$key must stay in the primary row at width $width',
+          );
+        }
+        if (width == 1600) {
+          expect(accountRect.right, closeTo(primaryRect.right, 0.1));
+          final searchField = find.descendant(
+            of: find.byKey(const ValueKey('online-gallery-primary-search')),
+            matching: find.byType(TextField),
+          );
+          await tester.enterText(searchField, 'a b c d e f g');
+          await tester.pump();
+          expect(find.text('7/6'), findsOneWidget);
+          await tester.testTextInput.receiveAction(TextInputAction.search);
+          await tester.pump();
+          expect(find.text('最多可组合搜索 6 个标签'), findsOneWidget);
+          await tester.pump(const Duration(seconds: 4));
+        }
+        expect(find.text('Leaf category'), findsOneWidget);
+        expect(find.text('Fallback codex title'), findsNothing);
+        expect(tester.takeException(), isNull);
+      },
+    );
   }
 
   testWidgets('QuickTagCloud reuses rating filter and refresh update check', (
@@ -1559,6 +1627,32 @@ class _UnderfilledGalleryNotifier extends OnlineGalleryNotifier {
   }
 }
 
+class _PausedRandomGalleryNotifier extends OnlineGalleryNotifier {
+  static int loadMoreCalls = 0;
+
+  @override
+  OnlineGalleryState build() {
+    return const OnlineGalleryState(
+      randomEnabled: true,
+      randomSession: RandomGallerySession(
+        cache: ModeCache(
+          nextCursor: 'random',
+          hasMore: true,
+          queryScanPaused: true,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Future<void> loadPosts({bool refresh = false}) async {}
+
+  @override
+  Future<void> loadMore() async {
+    loadMoreCalls++;
+  }
+}
+
 class _PagedGalleryNotifier extends OnlineGalleryNotifier {
   @override
   OnlineGalleryState build() {
@@ -1642,6 +1736,9 @@ class _UnconfiguredGelbooruAuth extends GelbooruAuth {
   @override
   GelbooruAuthState build() =>
       const GelbooruAuthState(status: GelbooruAuthStatus.unconfigured);
+
+  @override
+  Future<void> ensureInitialized() async {}
 }
 
 class _AuthenticatedGelbooruAuth extends GelbooruAuth {
@@ -1650,6 +1747,9 @@ class _AuthenticatedGelbooruAuth extends GelbooruAuth {
     credentials: GelbooruCredentials(userId: 99, apiKey: 'key'),
     status: GelbooruAuthStatus.authenticated,
   );
+
+  @override
+  Future<void> ensureInitialized() async {}
 }
 
 class _TestReplicationQueueNotifier extends ReplicationQueueNotifier {


### PR DESCRIPTION
## 变更内容
- 为 Danbooru、Safebooru、Gelbooru、AI TAG 与 QuickTagCloud 提供最多 6 个 AND Tag 的统一搜索体验
- 按来源服务端能力拆分查询，Danbooru 匿名/Basic 严格只下推 2 个 Tag，其余条件在本地高性能过滤
- 使用标签统计选择高区分度服务端候选，并通过连续分页填满结果，避免组合爆炸请求
- 增加取消、查询代次隔离、去重、边界提示及多语言支持
- 保持随机、排名、收藏、黑名单及来源专属筛选行为

## 验证
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1`：711 项通过，3 项跳过
- `flutter test test/l10n/i18n_regression_test.dart`：17 项通过
- 目标 `flutter analyze`：通过
- `git diff --check origin/main...HEAD`：通过
