### PR TITLE
refactor(shell): 拆分壳层并明确系统字体能力

### DIFF
--- a/lib/core/platform/platform_capabilities.dart
+++ b/lib/core/platform/platform_capabilities.dart
@@ -64,6 +64,7 @@ class PlatformCapabilities {
   bool get supportsComfyUiIntegration => isDesktop;
   bool get supportsDesktopOverlayInteractions => isDesktop;
   bool get supportsKritaBridge => isDesktop;
+  bool get supportsSystemFontEnumeration => isWindows;
   bool get supportsNativeShare => isMobile || isMacOS;
   bool get supportsSystemGalleryExport => isAndroid;
   bool get supportsDocumentFileExport => isAndroid;

--- a/lib/core/services/system_font_service.dart
+++ b/lib/core/services/system_font_service.dart
@@ -2,21 +2,29 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../platform/platform_capabilities.dart';
+
 part 'system_font_service.g.dart';
 
 /// 系统字体服务 - 通过 MethodChannel 获取系统字体列表
 class SystemFontService {
-  static const _channel = MethodChannel('com.nailauncher/system_fonts');
+  SystemFontService({
+    MethodChannel channel = const MethodChannel('com.nailauncher/system_fonts'),
+    PlatformCapabilities? capabilities,
+  }) : _channel = channel,
+       _capabilities = capabilities ?? PlatformCapabilities.current;
+
+  final MethodChannel _channel;
+  final PlatformCapabilities _capabilities;
 
   /// 获取系统字体列表
   Future<List<String>> getSystemFonts() async {
-    try {
-      final List<dynamic> fonts = await _channel.invokeMethod('getSystemFonts');
-      return fonts.cast<String>();
-    } catch (e) {
-      // 如果获取失败，返回空列表
-      return [];
+    if (!_capabilities.supportsSystemFontEnumeration) {
+      throw UnsupportedError('System font enumeration is not supported');
     }
+
+    final List<dynamic> fonts = await _channel.invokeMethod('getSystemFonts');
+    return fonts.cast<String>();
   }
 }
 

--- a/lib/presentation/providers/font_provider.dart
+++ b/lib/presentation/providers/font_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../core/platform/platform_capabilities.dart';
 import '../../core/services/system_font_service.dart';
 import '../../core/storage/local_storage_service.dart';
 
@@ -208,12 +209,14 @@ Future<List<FontConfig>> systemFontList(Ref ref) async {
 /// 所有可用字体列表 Provider
 @riverpod
 Future<Map<String, List<FontConfig>>> allFonts(Ref ref) async {
-  final systemFonts = await ref.watch(systemFontListProvider.future);
-  final googleFonts = GoogleFontPresets.all;
-
-  return {
+  final fontGroups = <String, List<FontConfig>>{
     '应用默认': [FontConfig.defaultFont],
-    'Google Fonts': googleFonts,
-    '系统字体': systemFonts,
+    'Google Fonts': GoogleFontPresets.all,
   };
+
+  if (PlatformCapabilities.current.supportsSystemFontEnumeration) {
+    fontGroups['系统字体'] = await ref.watch(systemFontListProvider.future);
+  }
+
+  return fontGroups;
 }

--- a/lib/presentation/router/app_branch.dart
+++ b/lib/presentation/router/app_branch.dart
@@ -13,6 +13,14 @@ enum AppBranch {
   preciseRefLibrary,
 }
 
+/// Branches whose widget state remains mounted while another branch is active.
+const Set<AppBranch> keptAliveAppBranches = {
+  AppBranch.localGallery,
+  AppBranch.onlineGallery,
+  AppBranch.vibeLibrary,
+  AppBranch.preciseRefLibrary,
+};
+
 /// Global navigation shortcuts and their destination branches.
 const Map<String, AppBranch> globalNavigationShortcutBranches = {
   ShortcutIds.navigateToGeneration: AppBranch.generation,

--- a/lib/presentation/router/app_shell.dart
+++ b/lib/presentation/router/app_shell.dart
@@ -1,40 +1,31 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:url_launcher/url_launcher.dart';
 
-import '../../core/constants/community_links.dart';
 import '../../core/platform/platform_capabilities.dart';
-import '../../core/services/auth_error_service.dart';
 import '../../core/shortcuts/default_shortcuts.dart';
 import '../../core/utils/localization_extension.dart';
-import '../adaptive/adaptive_presenter.dart';
 import '../adaptive/window_size_class.dart';
 import '../providers/auth_provider.dart';
-import '../providers/mobile_shell_overlay_provider.dart';
 import '../providers/prompt_maximize_provider.dart';
-import '../providers/replication_queue_provider.dart';
-import '../providers/update_provider.dart';
 import '../widgets/app_branch_visibility.dart';
-import '../widgets/common/app_toast.dart';
-import '../widgets/common/update_notice_banner.dart';
 import '../widgets/drop/global_drop_handler.dart';
-import '../widgets/navigation/main_nav_rail.dart';
-import '../widgets/queue/queue_management_page.dart';
 import '../widgets/shortcuts/shortcut_aware_widget.dart';
 import '../widgets/shortcuts/shortcut_help_dialog.dart';
 import 'app_branch.dart';
 import 'app_routes.dart';
+import 'desktop_shell.dart';
+import 'mobile_shell.dart';
+import 'queue_shell_overlay.dart';
 
-/// 队列管理面板显示状态 Provider
-final queueManagementVisibleProvider = StateProvider<bool>((ref) => false);
+export 'desktop_shell.dart' show DesktopShell;
+export 'mobile_shell.dart' show MobileShell;
+export 'queue_shell_overlay.dart' show queueManagementVisibleProvider;
 
 /// 主布局 Shell - 包含导航 (StatefulShellRoute 版本)
 ///
-/// 使用混合保活策略：
-/// - 画廊页面（索引 1, 2）使用 Offstage 保活
-/// - Vibe库页面（索引 7）使用 Offstage 保活
-/// - 其他页面不保活
+/// 使用混合保活策略：画廊、Vibe 库和精准参考库分支使用 Offstage
+/// 保活，其他分支离开时销毁。
 class MainShell extends ConsumerStatefulWidget {
   final StatefulNavigationShell navigationShell;
   final List<Widget> children;
@@ -98,29 +89,23 @@ class _MainShellState extends ConsumerState<MainShell> {
   Widget build(BuildContext context) {
     final currentIndex = widget.navigationShell.currentIndex;
 
-    // 构建混合保活内容栈
-    // - 索引 1 (localGallery) 和 2 (onlineGallery) 使用 Offstage 保活
-    // - 索引 7 (vibeLibrary) 和 8 (preciseRefLibrary) 使用 Offstage 保活
-    // - 其他索引不保活，切换时销毁重建
     final contentStack = IndexedStack(
       index: currentIndex,
       children: widget.children.asMap().entries.map((entry) {
         final index = entry.key;
         final child = entry.value;
         final isActive = index == currentIndex;
+        final branch = AppBranch.values[index];
         final branchNavigator =
             widget.navigationShell.route.branches[index].navigatorKey;
 
         Widget branchContent;
-        // 保活页面：画廊（1, 2）、Vibe 库（7）和精准参考库（8）
-        // 始终保持在树中，通过 TickerMode 控制动画
-        if (index == 1 || index == 2 || index == 7 || index == 8) {
+        if (keptAliveAppBranches.contains(branch)) {
           branchContent = AppBranchVisibility(
             isVisible: isActive,
             child: TickerMode(enabled: isActive, child: child),
           );
         } else if (!isActive) {
-          // 其他索引：非活动时显示空容器（不保活）
           branchContent = const SizedBox.shrink();
         } else {
           branchContent = AppBranchVisibility(isVisible: true, child: child);
@@ -144,22 +129,18 @@ class _MainShellState extends ConsumerState<MainShell> {
         ? GlobalDropHandler(child: contentStack)
         : contentStack;
 
-    // 定义全局快捷键动作映射（使用 ShortcutIds 常量）
     final globalShortcuts = <String, VoidCallback>{
       for (final entry in globalNavigationShortcutBranches.entries)
         entry.key: () => widget.navigationShell.goBranch(entry.value.index),
-      // 显示快捷键帮助
       ShortcutIds.showShortcutHelp: () {
         ShortcutHelpDialog.show(context);
       },
-      // 显示/隐藏队列
       ShortcutIds.toggleQueue: () {
         final isVisible = ref.read(queueManagementVisibleProvider);
         ref.read(queueManagementVisibleProvider.notifier).state = !isVisible;
       },
     };
 
-    // 使用 ShortcutAwareWidget 包装全局快捷键
     final shortcutEnabledContent = ShortcutAwareWidget(
       contextType: ShortcutContext.global,
       shortcuts: globalShortcuts,
@@ -234,619 +215,5 @@ class _MainShellState extends ConsumerState<MainShell> {
         });
       }
     }
-  }
-}
-
-class _GlobalStatusBanners extends StatelessWidget {
-  const _GlobalStatusBanners();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [UpdateNoticeBanner(), _AuthRecoveryBanner()],
-    );
-  }
-}
-
-class _AuthRecoveryBanner extends ConsumerWidget {
-  const _AuthRecoveryBanner();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final authState = ref.watch(authNotifierProvider);
-    final errorCode = authState.errorCode;
-    if (authState.status != AuthStatus.error || errorCode == null) {
-      return const SizedBox.shrink();
-    }
-
-    final message = AuthErrorService().getErrorText(
-      context.l10n,
-      errorCode,
-      authState.httpStatusCode,
-    );
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final authNotifier = ref.read(authNotifierProvider.notifier);
-
-    return SafeArea(
-      bottom: false,
-      child: Align(
-        alignment: Alignment.topCenter,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 440),
-            child: Material(
-              key: const ValueKey('auth-recovery-banner'),
-              color: colorScheme.surfaceContainerHigh,
-              elevation: 4,
-              shadowColor: colorScheme.shadow.withValues(alpha: 0.22),
-              borderRadius: BorderRadius.circular(14),
-              clipBehavior: Clip.antiAlias,
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  final compact = MediaQuery.sizeOf(context).width < 520;
-                  final messageRow = Row(
-                    children: [
-                      Icon(
-                        Icons.error_outline_rounded,
-                        size: 20,
-                        color: colorScheme.error,
-                      ),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: Text(
-                          message,
-                          maxLines: compact ? 2 : 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                      if (compact)
-                        IconButton(
-                          key: const ValueKey('auth-recovery-dismiss'),
-                          onPressed: () => authNotifier.clearError(delayMs: 0),
-                          icon: const Icon(Icons.close_rounded),
-                          tooltip: MaterialLocalizations.of(
-                            context,
-                          ).closeButtonTooltip,
-                          visualDensity: VisualDensity.compact,
-                        ),
-                    ],
-                  );
-                  final actions = [
-                    TextButton.icon(
-                      key: const ValueKey('auth-recovery-retry'),
-                      onPressed: authNotifier.retryAutoLogin,
-                      icon: const Icon(Icons.refresh_rounded, size: 18),
-                      label: Text(context.l10n.common_retry),
-                    ),
-                    FilledButton.tonalIcon(
-                      key: const ValueKey('auth-recovery-login'),
-                      onPressed: () => context.push(AppRoutes.login),
-                      icon: const Icon(Icons.login_rounded, size: 18),
-                      label: Text(context.l10n.settings_goToLogin),
-                    ),
-                  ];
-
-                  if (compact) {
-                    return Padding(
-                      padding: const EdgeInsets.fromLTRB(12, 6, 8, 8),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          messageRow,
-                          Align(
-                            alignment: Alignment.centerRight,
-                            child: Wrap(spacing: 8, children: actions),
-                          ),
-                        ],
-                      ),
-                    );
-                  }
-
-                  return Padding(
-                    padding: const EdgeInsets.fromLTRB(14, 6, 8, 6),
-                    child: Row(
-                      children: [
-                        Expanded(child: messageRow),
-                        const SizedBox(width: 8),
-                        ...actions,
-                        IconButton(
-                          key: const ValueKey('auth-recovery-dismiss'),
-                          onPressed: () => authNotifier.clearError(delayMs: 0),
-                          icon: const Icon(Icons.close_rounded),
-                          tooltip: MaterialLocalizations.of(
-                            context,
-                          ).closeButtonTooltip,
-                          visualDensity: VisualDensity.compact,
-                        ),
-                      ],
-                    ),
-                  );
-                },
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// 桌面端布局
-class DesktopShell extends ConsumerWidget {
-  final StatefulNavigationShell navigationShell;
-  final Widget content;
-
-  const DesktopShell({
-    super.key,
-    required this.navigationShell,
-    required this.content,
-  });
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final isQueueVisible = ref.watch(queueManagementVisibleProvider);
-
-    return Scaffold(
-      body: Row(
-        children: [
-          MainNavRail(
-            navigationShell: navigationShell,
-            isQueueVisible: isQueueVisible,
-            onQueueVisibilityChanged: (isVisible) {
-              ref.read(queueManagementVisibleProvider.notifier).state =
-                  isVisible;
-            },
-          ),
-          Expanded(
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                return Stack(
-                  clipBehavior: Clip.none,
-                  children: [
-                    content,
-                    const Positioned(
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      child: _GlobalStatusBanners(),
-                    ),
-                    _QueuePanel(
-                      isVisible: isQueueVisible,
-                      desktop: true,
-                      onQueueStarted: () =>
-                          navigationShell.goBranch(AppBranch.generation.index),
-                    ),
-                  ],
-                );
-              },
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Compact touch-first shell. Secondary destinations remain explicit in the
-/// labelled “more” panel instead of disappearing behind desktop-only routes.
-class MobileShell extends ConsumerWidget {
-  final StatefulNavigationShell navigationShell;
-  final Widget content;
-
-  const MobileShell({
-    super.key,
-    required this.navigationShell,
-    required this.content,
-  });
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final isQueueVisible = ref.watch(queueManagementVisibleProvider);
-    final showUpdateBadge = ref.watch(
-      updateStateProvider.select((state) => state.hasNewVersion),
-    );
-    final queueCount = ref.watch(
-      replicationQueueNotifierProvider.select((state) => state.count),
-    );
-    final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
-    final shellOverlayActive = ref.watch(
-      mobileShellOverlayNotifierProvider.select(
-        (overlays) => overlays.isNotEmpty,
-      ),
-    );
-
-    return PopScope<void>(
-      canPop: !isQueueVisible,
-      onPopInvokedWithResult: (didPop, _) {
-        if (!didPop && isQueueVisible) {
-          ref.read(queueManagementVisibleProvider.notifier).state = false;
-        }
-      },
-      child: Scaffold(
-        body: SafeArea(
-          bottom: false,
-          child: Stack(
-            clipBehavior: Clip.none,
-            children: [
-              content,
-              const Positioned(
-                top: 0,
-                left: 0,
-                right: 0,
-                child: _GlobalStatusBanners(),
-              ),
-              _QueuePanel(
-                isVisible: isQueueVisible,
-                desktop: false,
-                onQueueStarted: () =>
-                    navigationShell.goBranch(AppBranch.generation.index),
-              ),
-            ],
-          ),
-        ),
-        bottomNavigationBar: keyboardVisible || shellOverlayActive
-            ? null
-            : NavigationBar(
-                selectedIndex: isQueueVisible
-                    ? mobileMoreNavigationIndex
-                    : mobileNavigationIndexForBranch(
-                        navigationShell.currentIndex,
-                      ),
-                onDestinationSelected: (index) =>
-                    _onNavigate(context, index, ref),
-                destinations: [
-                  NavigationDestination(
-                    icon: const Icon(Icons.auto_awesome_outlined),
-                    selectedIcon: const Icon(Icons.auto_awesome),
-                    label: context.l10n.nav_generate,
-                  ),
-                  NavigationDestination(
-                    icon: const Icon(Icons.photo_library_outlined),
-                    selectedIcon: const Icon(Icons.photo_library),
-                    label: context.l10n.nav_gallery,
-                  ),
-                  NavigationDestination(
-                    icon: const Icon(Icons.travel_explore_outlined),
-                    selectedIcon: const Icon(Icons.travel_explore),
-                    label: context.l10n.nav_explore,
-                  ),
-                  NavigationDestination(
-                    icon: const Icon(Icons.library_books_outlined),
-                    selectedIcon: const Icon(Icons.library_books),
-                    label: context.l10n.nav_dictionary,
-                  ),
-                  NavigationDestination(
-                    icon: Badge(
-                      isLabelVisible: queueCount > 0 || showUpdateBadge,
-                      label: queueCount > 0
-                          ? Text(
-                              queueCount > 99 ? '99+' : queueCount.toString(),
-                            )
-                          : null,
-                      smallSize: 7,
-                      child: const Icon(Icons.apps_outlined),
-                    ),
-                    selectedIcon: Badge(
-                      isLabelVisible: queueCount > 0 || showUpdateBadge,
-                      label: queueCount > 0
-                          ? Text(
-                              queueCount > 99 ? '99+' : queueCount.toString(),
-                            )
-                          : null,
-                      smallSize: 7,
-                      child: const Icon(Icons.apps),
-                    ),
-                    label: context.l10n.nav_more,
-                  ),
-                ],
-              ),
-      ),
-    );
-  }
-
-  void _onNavigate(BuildContext context, int mobileIndex, WidgetRef ref) {
-    if (mobileIndex == mobileMoreNavigationIndex) {
-      ref.read(queueManagementVisibleProvider.notifier).state = false;
-      _showMorePanel(context, ref);
-      return;
-    }
-
-    ref.read(queueManagementVisibleProvider.notifier).state = false;
-    if (mobileIndex < 0 || mobileIndex >= mobileNavigationBranches.length) {
-      return;
-    }
-    navigationShell.goBranch(mobileNavigationBranches[mobileIndex].index);
-  }
-
-  Future<void> _showMorePanel(BuildContext context, WidgetRef ref) {
-    final queueCount = ref.read(replicationQueueNotifierProvider).count;
-    final hasUpdate = ref.read(updateStateProvider).hasNewVersion;
-
-    return AdaptivePresenter.showPanel<void>(
-      context: context,
-      initialChildSize: 0.68,
-      minChildSize: 0.52,
-      titleBuilder: (context) => Text(
-        context.l10n.nav_more,
-        style: Theme.of(context).textTheme.titleLarge,
-      ),
-      builder: (panelContext, scrollController) => ListView(
-        controller: scrollController,
-        padding: const EdgeInsets.fromLTRB(8, 8, 8, 24),
-        children: [
-          _MobileMoreDestination(
-            icon: Icons.playlist_play_rounded,
-            label: panelContext.l10n.queue_management,
-            badgeCount: queueCount,
-            onTap: () {
-              Navigator.of(panelContext).pop();
-              ref.read(queueManagementVisibleProvider.notifier).state = true;
-            },
-          ),
-          const Divider(indent: 16, endIndent: 16),
-          _MobileMoreDestination(
-            icon: Icons.style_outlined,
-            label: panelContext.l10n.vibeLibrary_title,
-            onTap: () => _selectBranch(panelContext, AppBranch.vibeLibrary),
-          ),
-          _MobileMoreDestination(
-            icon: Icons.center_focus_strong_outlined,
-            label: panelContext.l10n.nav_preciseRefLibrary,
-            onTap: () =>
-                _selectBranch(panelContext, AppBranch.preciseRefLibrary),
-          ),
-          _MobileMoreDestination(
-            icon: Icons.casino_outlined,
-            label: panelContext.l10n.nav_randomConfig,
-            onTap: () => _selectBranch(panelContext, AppBranch.promptConfig),
-          ),
-          _MobileMoreDestination(
-            icon: Icons.insights_outlined,
-            label: panelContext.l10n.statistics_title,
-            onTap: () => _selectBranch(panelContext, AppBranch.statistics),
-          ),
-          const Divider(indent: 16, endIndent: 16),
-          _MobileMoreDestination(
-            icon: Icons.settings_outlined,
-            label: panelContext.l10n.settings_title,
-            showBadge: hasUpdate,
-            onTap: () => _selectBranch(panelContext, AppBranch.settings),
-          ),
-          const Divider(indent: 16, endIndent: 16),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(8, 4, 8, 0),
-            child: Row(
-              children: [
-                Expanded(
-                  child: _MobileCommunityButton(
-                    key: const ValueKey('mobile-more-discord'),
-                    icon: const Icon(Icons.discord, size: 20),
-                    label: panelContext.l10n.nav_joinDiscord,
-                    backgroundColor: const Color(0xFF5865F2),
-                    onPressed: () => _openCommunityLink(
-                      panelContext,
-                      CommunityLinks.discord,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: _MobileCommunityButton(
-                    key: const ValueKey('mobile-more-github'),
-                    icon: const GitHubLogo(color: Colors.white, size: 20),
-                    label: panelContext.l10n.nav_projectRepository,
-                    backgroundColor: const Color(0xFF2D333B),
-                    onPressed: () =>
-                        _openCommunityLink(panelContext, CommunityLinks.github),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _openCommunityLink(BuildContext panelContext, String url) async {
-    var opened = false;
-    try {
-      opened = await launchUrl(
-        Uri.parse(url),
-        mode: LaunchMode.externalApplication,
-      );
-    } catch (_) {
-      opened = false;
-    }
-    if (!opened && panelContext.mounted) {
-      AppToast.error(panelContext, panelContext.l10n.cannotOpenUrl);
-    }
-  }
-
-  void _selectBranch(BuildContext panelContext, AppBranch branch) {
-    Navigator.of(panelContext).pop();
-    navigationShell.goBranch(branch.index);
-  }
-}
-
-class _MobileCommunityButton extends StatelessWidget {
-  const _MobileCommunityButton({
-    super.key,
-    required this.icon,
-    required this.label,
-    required this.backgroundColor,
-    required this.onPressed,
-  });
-
-  final Widget icon;
-  final String label;
-  final Color backgroundColor;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return FilledButton.tonalIcon(
-      onPressed: onPressed,
-      style: FilledButton.styleFrom(
-        backgroundColor: backgroundColor,
-        foregroundColor: Colors.white,
-        minimumSize: const Size.fromHeight(56),
-        padding: const EdgeInsets.symmetric(horizontal: 10),
-      ),
-      icon: icon,
-      label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
-    );
-  }
-}
-
-class _MobileMoreDestination extends StatelessWidget {
-  const _MobileMoreDestination({
-    required this.icon,
-    required this.label,
-    required this.onTap,
-    this.badgeCount = 0,
-    this.showBadge = false,
-  });
-
-  final IconData icon;
-  final String label;
-  final VoidCallback onTap;
-  final int badgeCount;
-  final bool showBadge;
-
-  @override
-  Widget build(BuildContext context) {
-    final hasCount = badgeCount > 0;
-    return ListTile(
-      minTileHeight: 56,
-      leading: Badge(
-        isLabelVisible: hasCount || showBadge,
-        label: hasCount
-            ? Text(badgeCount > 99 ? '99+' : badgeCount.toString())
-            : null,
-        smallSize: 7,
-        child: Icon(icon),
-      ),
-      title: Text(label),
-      trailing: const Icon(Icons.chevron_right),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      onTap: onTap,
-    );
-  }
-}
-
-// ============================================
-// 队列面板组件
-// ============================================
-
-/// 队列管理面板组件
-///
-/// 带背景遮罩、滑动动画和队列管理页面
-class _QueuePanel extends ConsumerWidget {
-  final bool isVisible;
-  final bool desktop;
-  final VoidCallback onQueueStarted;
-
-  const _QueuePanel({
-    required this.isVisible,
-    required this.desktop,
-    required this.onQueueStarted,
-  });
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final reduceMotion = MediaQuery.disableAnimationsOf(context);
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return Stack(
-          children: [
-            // 背景遮罩
-            if (isVisible)
-              Positioned.fill(
-                child: GestureDetector(
-                  onTap: () =>
-                      ref.read(queueManagementVisibleProvider.notifier).state =
-                          false,
-                  child: ColoredBox(
-                    color: theme.colorScheme.scrim.withValues(
-                      alpha: desktop ? 0.28 : 0.36,
-                    ),
-                  ),
-                ),
-              ),
-            TweenAnimationBuilder<Offset>(
-              tween: Tween(
-                begin: desktop ? const Offset(1, 0) : const Offset(0, 1),
-                end: isVisible
-                    ? Offset.zero
-                    : (desktop ? const Offset(1, 0) : const Offset(0, 1)),
-              ),
-              duration: reduceMotion
-                  ? Duration.zero
-                  : const Duration(milliseconds: 220),
-              curve: Curves.easeOutCubic,
-              builder: (context, offset, child) {
-                final hidden = desktop ? offset.dx >= 0.5 : offset.dy >= 0.5;
-                return ExcludeSemantics(
-                  excluding: hidden,
-                  child: IgnorePointer(
-                    ignoring: hidden,
-                    child: FractionalTranslation(
-                      translation: offset,
-                      child: child,
-                    ),
-                  ),
-                );
-              },
-              child: Align(
-                alignment: desktop
-                    ? Alignment.centerRight
-                    : Alignment.bottomCenter,
-                child: SizedBox(
-                  width: desktop ? 460 : constraints.maxWidth,
-                  child: Material(
-                    color: theme.scaffoldBackgroundColor,
-                    elevation: 18,
-                    shadowColor: Colors.black.withValues(alpha: 0.28),
-                    borderRadius: desktop
-                        ? const BorderRadius.horizontal(
-                            left: Radius.circular(16),
-                          )
-                        : const BorderRadius.vertical(top: Radius.circular(16)),
-                    clipBehavior: Clip.antiAlias,
-                    child: SafeArea(
-                      top: false,
-                      child: SizedBox(
-                        height: desktop
-                            ? constraints.maxHeight
-                            : constraints.maxHeight * 0.85,
-                        child: QueueManagementPage(
-                          onClose: () =>
-                              ref
-                                      .read(
-                                        queueManagementVisibleProvider.notifier,
-                                      )
-                                      .state =
-                                  false,
-                          onQueueStarted: onQueueStarted,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        );
-      },
-    );
   }
 }

--- a/lib/presentation/router/desktop_shell.dart
+++ b/lib/presentation/router/desktop_shell.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../widgets/navigation/main_nav_rail.dart';
+import 'app_branch.dart';
+import 'global_status_banners.dart';
+import 'queue_shell_overlay.dart';
+
+/// 桌面端布局
+class DesktopShell extends ConsumerWidget {
+  final StatefulNavigationShell navigationShell;
+  final Widget content;
+
+  const DesktopShell({
+    super.key,
+    required this.navigationShell,
+    required this.content,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isQueueVisible = ref.watch(queueManagementVisibleProvider);
+
+    return Scaffold(
+      body: Row(
+        children: [
+          MainNavRail(
+            navigationShell: navigationShell,
+            isQueueVisible: isQueueVisible,
+            onQueueVisibilityChanged: (isVisible) {
+              ref.read(queueManagementVisibleProvider.notifier).state =
+                  isVisible;
+            },
+          ),
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                return Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    content,
+                    const Positioned(
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      child: GlobalStatusBanners(),
+                    ),
+                    QueueShellOverlay(
+                      isVisible: isQueueVisible,
+                      desktop: true,
+                      onQueueStarted: () =>
+                          navigationShell.goBranch(AppBranch.generation.index),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/router/global_status_banners.dart
+++ b/lib/presentation/router/global_status_banners.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/services/auth_error_service.dart';
+import '../../core/utils/localization_extension.dart';
+import '../providers/auth_provider.dart';
+import '../widgets/common/update_notice_banner.dart';
+import 'app_routes.dart';
+
+class GlobalStatusBanners extends StatelessWidget {
+  const GlobalStatusBanners({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [UpdateNoticeBanner(), _AuthRecoveryBanner()],
+    );
+  }
+}
+
+class _AuthRecoveryBanner extends ConsumerWidget {
+  const _AuthRecoveryBanner();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authNotifierProvider);
+    final errorCode = authState.errorCode;
+    if (authState.status != AuthStatus.error || errorCode == null) {
+      return const SizedBox.shrink();
+    }
+
+    final message = AuthErrorService().getErrorText(
+      context.l10n,
+      errorCode,
+      authState.httpStatusCode,
+    );
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final authNotifier = ref.read(authNotifierProvider.notifier);
+
+    return SafeArea(
+      bottom: false,
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 440),
+            child: Material(
+              key: const ValueKey('auth-recovery-banner'),
+              color: colorScheme.surfaceContainerHigh,
+              elevation: 4,
+              shadowColor: colorScheme.shadow.withValues(alpha: 0.22),
+              borderRadius: BorderRadius.circular(14),
+              clipBehavior: Clip.antiAlias,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final compact = MediaQuery.sizeOf(context).width < 520;
+                  final messageRow = Row(
+                    children: [
+                      Icon(
+                        Icons.error_outline_rounded,
+                        size: 20,
+                        color: colorScheme.error,
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Text(
+                          message,
+                          maxLines: compact ? 2 : 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                      if (compact)
+                        IconButton(
+                          key: const ValueKey('auth-recovery-dismiss'),
+                          onPressed: () => authNotifier.clearError(delayMs: 0),
+                          icon: const Icon(Icons.close_rounded),
+                          tooltip: MaterialLocalizations.of(
+                            context,
+                          ).closeButtonTooltip,
+                          visualDensity: VisualDensity.compact,
+                        ),
+                    ],
+                  );
+                  final actions = [
+                    TextButton.icon(
+                      key: const ValueKey('auth-recovery-retry'),
+                      onPressed: authNotifier.retryAutoLogin,
+                      icon: const Icon(Icons.refresh_rounded, size: 18),
+                      label: Text(context.l10n.common_retry),
+                    ),
+                    FilledButton.tonalIcon(
+                      key: const ValueKey('auth-recovery-login'),
+                      onPressed: () => context.push(AppRoutes.login),
+                      icon: const Icon(Icons.login_rounded, size: 18),
+                      label: Text(context.l10n.settings_goToLogin),
+                    ),
+                  ];
+
+                  if (compact) {
+                    return Padding(
+                      padding: const EdgeInsets.fromLTRB(12, 6, 8, 8),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          messageRow,
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: Wrap(spacing: 8, children: actions),
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  return Padding(
+                    padding: const EdgeInsets.fromLTRB(14, 6, 8, 6),
+                    child: Row(
+                      children: [
+                        Expanded(child: messageRow),
+                        const SizedBox(width: 8),
+                        ...actions,
+                        IconButton(
+                          key: const ValueKey('auth-recovery-dismiss'),
+                          onPressed: () => authNotifier.clearError(delayMs: 0),
+                          icon: const Icon(Icons.close_rounded),
+                          tooltip: MaterialLocalizations.of(
+                            context,
+                          ).closeButtonTooltip,
+                          visualDensity: VisualDensity.compact,
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/router/mobile_more_panel.dart
+++ b/lib/presentation/router/mobile_more_panel.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../core/constants/community_links.dart';
+import '../../core/utils/localization_extension.dart';
+import '../adaptive/adaptive_presenter.dart';
+import '../providers/replication_queue_provider.dart';
+import '../providers/update_provider.dart';
+import '../widgets/common/app_toast.dart';
+import '../widgets/navigation/main_nav_rail.dart';
+import 'app_branch.dart';
+import 'queue_shell_overlay.dart';
+
+Future<void> showMobileMorePanel({
+  required BuildContext context,
+  required WidgetRef ref,
+  required StatefulNavigationShell navigationShell,
+}) {
+  final queueCount = ref.read(replicationQueueNotifierProvider).count;
+  final hasUpdate = ref.read(updateStateProvider).hasNewVersion;
+
+  return AdaptivePresenter.showPanel<void>(
+    context: context,
+    initialChildSize: 0.68,
+    minChildSize: 0.52,
+    titleBuilder: (context) => Text(
+      context.l10n.nav_more,
+      style: Theme.of(context).textTheme.titleLarge,
+    ),
+    builder: (panelContext, scrollController) => ListView(
+      controller: scrollController,
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 24),
+      children: [
+        _MobileMoreDestination(
+          icon: Icons.playlist_play_rounded,
+          label: panelContext.l10n.queue_management,
+          badgeCount: queueCount,
+          onTap: () {
+            Navigator.of(panelContext).pop();
+            ref.read(queueManagementVisibleProvider.notifier).state = true;
+          },
+        ),
+        const Divider(indent: 16, endIndent: 16),
+        _MobileMoreDestination(
+          icon: Icons.style_outlined,
+          label: panelContext.l10n.vibeLibrary_title,
+          onTap: () => _selectBranch(
+            panelContext,
+            navigationShell,
+            AppBranch.vibeLibrary,
+          ),
+        ),
+        _MobileMoreDestination(
+          icon: Icons.center_focus_strong_outlined,
+          label: panelContext.l10n.nav_preciseRefLibrary,
+          onTap: () => _selectBranch(
+            panelContext,
+            navigationShell,
+            AppBranch.preciseRefLibrary,
+          ),
+        ),
+        _MobileMoreDestination(
+          icon: Icons.casino_outlined,
+          label: panelContext.l10n.nav_randomConfig,
+          onTap: () => _selectBranch(
+            panelContext,
+            navigationShell,
+            AppBranch.promptConfig,
+          ),
+        ),
+        _MobileMoreDestination(
+          icon: Icons.insights_outlined,
+          label: panelContext.l10n.statistics_title,
+          onTap: () => _selectBranch(
+            panelContext,
+            navigationShell,
+            AppBranch.statistics,
+          ),
+        ),
+        const Divider(indent: 16, endIndent: 16),
+        _MobileMoreDestination(
+          icon: Icons.settings_outlined,
+          label: panelContext.l10n.settings_title,
+          showBadge: hasUpdate,
+          onTap: () =>
+              _selectBranch(panelContext, navigationShell, AppBranch.settings),
+        ),
+        const Divider(indent: 16, endIndent: 16),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(8, 4, 8, 0),
+          child: Row(
+            children: [
+              Expanded(
+                child: _MobileCommunityButton(
+                  key: const ValueKey('mobile-more-discord'),
+                  icon: const Icon(Icons.discord, size: 20),
+                  label: panelContext.l10n.nav_joinDiscord,
+                  backgroundColor: const Color(0xFF5865F2),
+                  onPressed: () =>
+                      _openCommunityLink(panelContext, CommunityLinks.discord),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _MobileCommunityButton(
+                  key: const ValueKey('mobile-more-github'),
+                  icon: const GitHubLogo(color: Colors.white, size: 20),
+                  label: panelContext.l10n.nav_projectRepository,
+                  backgroundColor: const Color(0xFF2D333B),
+                  onPressed: () =>
+                      _openCommunityLink(panelContext, CommunityLinks.github),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+Future<void> _openCommunityLink(BuildContext panelContext, String url) async {
+  var opened = false;
+  try {
+    opened = await launchUrl(
+      Uri.parse(url),
+      mode: LaunchMode.externalApplication,
+    );
+  } catch (_) {
+    opened = false;
+  }
+  if (!opened && panelContext.mounted) {
+    AppToast.error(panelContext, panelContext.l10n.cannotOpenUrl);
+  }
+}
+
+void _selectBranch(
+  BuildContext panelContext,
+  StatefulNavigationShell navigationShell,
+  AppBranch branch,
+) {
+  Navigator.of(panelContext).pop();
+  navigationShell.goBranch(branch.index);
+}
+
+class _MobileCommunityButton extends StatelessWidget {
+  const _MobileCommunityButton({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.backgroundColor,
+    required this.onPressed,
+  });
+
+  final Widget icon;
+  final String label;
+  final Color backgroundColor;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.tonalIcon(
+      onPressed: onPressed,
+      style: FilledButton.styleFrom(
+        backgroundColor: backgroundColor,
+        foregroundColor: Colors.white,
+        minimumSize: const Size.fromHeight(56),
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+      ),
+      icon: icon,
+      label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+    );
+  }
+}
+
+class _MobileMoreDestination extends StatelessWidget {
+  const _MobileMoreDestination({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.badgeCount = 0,
+    this.showBadge = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final int badgeCount;
+  final bool showBadge;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasCount = badgeCount > 0;
+    return ListTile(
+      minTileHeight: 56,
+      leading: Badge(
+        isLabelVisible: hasCount || showBadge,
+        label: hasCount
+            ? Text(badgeCount > 99 ? '99+' : badgeCount.toString())
+            : null,
+        smallSize: 7,
+        child: Icon(icon),
+      ),
+      title: Text(label),
+      trailing: const Icon(Icons.chevron_right),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/presentation/router/mobile_shell.dart
+++ b/lib/presentation/router/mobile_shell.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/utils/localization_extension.dart';
+import '../providers/mobile_shell_overlay_provider.dart';
+import '../providers/replication_queue_provider.dart';
+import '../providers/update_provider.dart';
+import 'app_branch.dart';
+import 'global_status_banners.dart';
+import 'mobile_more_panel.dart';
+import 'queue_shell_overlay.dart';
+
+/// Compact touch-first shell. Secondary destinations remain explicit in the
+/// labelled “more” panel instead of disappearing behind desktop-only routes.
+class MobileShell extends ConsumerWidget {
+  final StatefulNavigationShell navigationShell;
+  final Widget content;
+
+  const MobileShell({
+    super.key,
+    required this.navigationShell,
+    required this.content,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isQueueVisible = ref.watch(queueManagementVisibleProvider);
+    final showUpdateBadge = ref.watch(
+      updateStateProvider.select((state) => state.hasNewVersion),
+    );
+    final queueCount = ref.watch(
+      replicationQueueNotifierProvider.select((state) => state.count),
+    );
+    final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
+    final shellOverlayActive = ref.watch(
+      mobileShellOverlayNotifierProvider.select(
+        (overlays) => overlays.isNotEmpty,
+      ),
+    );
+
+    return PopScope<void>(
+      canPop: !isQueueVisible,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && isQueueVisible) {
+          ref.read(queueManagementVisibleProvider.notifier).state = false;
+        }
+      },
+      child: Scaffold(
+        body: SafeArea(
+          bottom: false,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              content,
+              const Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: GlobalStatusBanners(),
+              ),
+              QueueShellOverlay(
+                isVisible: isQueueVisible,
+                desktop: false,
+                onQueueStarted: () =>
+                    navigationShell.goBranch(AppBranch.generation.index),
+              ),
+            ],
+          ),
+        ),
+        bottomNavigationBar: keyboardVisible || shellOverlayActive
+            ? null
+            : NavigationBar(
+                selectedIndex: isQueueVisible
+                    ? mobileMoreNavigationIndex
+                    : mobileNavigationIndexForBranch(
+                        navigationShell.currentIndex,
+                      ),
+                onDestinationSelected: (index) =>
+                    _onNavigate(context, index, ref),
+                destinations: [
+                  NavigationDestination(
+                    icon: const Icon(Icons.auto_awesome_outlined),
+                    selectedIcon: const Icon(Icons.auto_awesome),
+                    label: context.l10n.nav_generate,
+                  ),
+                  NavigationDestination(
+                    icon: const Icon(Icons.photo_library_outlined),
+                    selectedIcon: const Icon(Icons.photo_library),
+                    label: context.l10n.nav_gallery,
+                  ),
+                  NavigationDestination(
+                    icon: const Icon(Icons.travel_explore_outlined),
+                    selectedIcon: const Icon(Icons.travel_explore),
+                    label: context.l10n.nav_explore,
+                  ),
+                  NavigationDestination(
+                    icon: const Icon(Icons.library_books_outlined),
+                    selectedIcon: const Icon(Icons.library_books),
+                    label: context.l10n.nav_dictionary,
+                  ),
+                  NavigationDestination(
+                    icon: Badge(
+                      isLabelVisible: queueCount > 0 || showUpdateBadge,
+                      label: queueCount > 0
+                          ? Text(
+                              queueCount > 99 ? '99+' : queueCount.toString(),
+                            )
+                          : null,
+                      smallSize: 7,
+                      child: const Icon(Icons.apps_outlined),
+                    ),
+                    selectedIcon: Badge(
+                      isLabelVisible: queueCount > 0 || showUpdateBadge,
+                      label: queueCount > 0
+                          ? Text(
+                              queueCount > 99 ? '99+' : queueCount.toString(),
+                            )
+                          : null,
+                      smallSize: 7,
+                      child: const Icon(Icons.apps),
+                    ),
+                    label: context.l10n.nav_more,
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  void _onNavigate(BuildContext context, int mobileIndex, WidgetRef ref) {
+    if (mobileIndex == mobileMoreNavigationIndex) {
+      ref.read(queueManagementVisibleProvider.notifier).state = false;
+      showMobileMorePanel(
+        context: context,
+        ref: ref,
+        navigationShell: navigationShell,
+      );
+      return;
+    }
+
+    ref.read(queueManagementVisibleProvider.notifier).state = false;
+    if (mobileIndex < 0 || mobileIndex >= mobileNavigationBranches.length) {
+      return;
+    }
+    navigationShell.goBranch(mobileNavigationBranches[mobileIndex].index);
+  }
+}

--- a/lib/presentation/router/queue_shell_overlay.dart
+++ b/lib/presentation/router/queue_shell_overlay.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../widgets/queue/queue_management_page.dart';
+
+/// 队列管理面板显示状态 Provider
+final queueManagementVisibleProvider = StateProvider<bool>((ref) => false);
+
+/// 带背景遮罩、滑动动画和队列管理页面的 Shell 级队列面板。
+class QueueShellOverlay extends ConsumerWidget {
+  final bool isVisible;
+  final bool desktop;
+  final VoidCallback onQueueStarted;
+
+  const QueueShellOverlay({
+    super.key,
+    required this.isVisible,
+    required this.desktop,
+    required this.onQueueStarted,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Stack(
+          children: [
+            if (isVisible)
+              Positioned.fill(
+                child: GestureDetector(
+                  onTap: () =>
+                      ref.read(queueManagementVisibleProvider.notifier).state =
+                          false,
+                  child: ColoredBox(
+                    color: theme.colorScheme.scrim.withValues(
+                      alpha: desktop ? 0.28 : 0.36,
+                    ),
+                  ),
+                ),
+              ),
+            TweenAnimationBuilder<Offset>(
+              tween: Tween(
+                begin: desktop ? const Offset(1, 0) : const Offset(0, 1),
+                end: isVisible
+                    ? Offset.zero
+                    : (desktop ? const Offset(1, 0) : const Offset(0, 1)),
+              ),
+              duration: reduceMotion
+                  ? Duration.zero
+                  : const Duration(milliseconds: 220),
+              curve: Curves.easeOutCubic,
+              builder: (context, offset, child) {
+                final hidden = desktop ? offset.dx >= 0.5 : offset.dy >= 0.5;
+                return ExcludeSemantics(
+                  excluding: hidden,
+                  child: IgnorePointer(
+                    ignoring: hidden,
+                    child: FractionalTranslation(
+                      translation: offset,
+                      child: child,
+                    ),
+                  ),
+                );
+              },
+              child: Align(
+                alignment: desktop
+                    ? Alignment.centerRight
+                    : Alignment.bottomCenter,
+                child: SizedBox(
+                  width: desktop ? 460 : constraints.maxWidth,
+                  child: Material(
+                    color: theme.scaffoldBackgroundColor,
+                    elevation: 18,
+                    shadowColor: Colors.black.withValues(alpha: 0.28),
+                    borderRadius: desktop
+                        ? const BorderRadius.horizontal(
+                            left: Radius.circular(16),
+                          )
+                        : const BorderRadius.vertical(top: Radius.circular(16)),
+                    clipBehavior: Clip.antiAlias,
+                    child: SafeArea(
+                      top: false,
+                      child: SizedBox(
+                        height: desktop
+                            ? constraints.maxHeight
+                            : constraints.maxHeight * 0.85,
+                        child: QueueManagementPage(
+                          onClose: () =>
+                              ref
+                                      .read(
+                                        queueManagementVisibleProvider.notifier,
+                                      )
+                                      .state =
+                                  false,
+                          onQueueStarted: onQueueStarted,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/test/core/platform/platform_capabilities_test.dart
+++ b/test/core/platform/platform_capabilities_test.dart
@@ -18,6 +18,7 @@ void main() {
       expect(capabilities.supportsComfyUiIntegration, isFalse);
       expect(capabilities.supportsDesktopOverlayInteractions, isFalse);
       expect(capabilities.supportsKritaBridge, isFalse);
+      expect(capabilities.supportsSystemFontEnumeration, isFalse);
       expect(capabilities.supportsInAppPackageInstall, isTrue);
       expect(capabilities.requiresExternalInstallerFlow, isTrue);
     });
@@ -35,6 +36,7 @@ void main() {
       expect(capabilities.supportsComfyUiIntegration, isTrue);
       expect(capabilities.supportsDesktopOverlayInteractions, isTrue);
       expect(capabilities.supportsKritaBridge, isTrue);
+      expect(capabilities.supportsSystemFontEnumeration, isTrue);
       expect(capabilities.supportsInAppPackageInstall, isTrue);
       expect(capabilities.requiresExternalInstallerFlow, isFalse);
     });

--- a/test/core/services/system_font_service_test.dart
+++ b/test/core/services/system_font_service_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/platform/platform_capabilities.dart';
+import 'package:nai_launcher/core/services/system_font_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.nailauncher/system_fonts');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('Windows invokes the native font enumeration contract', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, 'getSystemFonts');
+      return ['Segoe UI', 'Arial'];
+    });
+    final service = SystemFontService(
+      channel: channel,
+      capabilities: PlatformCapabilities.forPlatform(TargetPlatform.windows),
+    );
+
+    await expectLater(
+      service.getSystemFonts(),
+      completion(['Segoe UI', 'Arial']),
+    );
+  });
+
+  test('unsupported platforms reject without invoking the channel', () async {
+    var invocationCount = 0;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      invocationCount++;
+      return ['Should not be returned'];
+    });
+    final service = SystemFontService(
+      channel: channel,
+      capabilities: PlatformCapabilities.forPlatform(TargetPlatform.android),
+    );
+
+    await expectLater(
+      service.getSystemFonts(),
+      throwsA(isA<UnsupportedError>()),
+    );
+    expect(invocationCount, 0);
+  });
+
+  test('Windows native bridge failures remain observable', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      throw PlatformException(code: 'enumeration_failed', message: 'failed');
+    });
+    final service = SystemFontService(
+      channel: channel,
+      capabilities: PlatformCapabilities.forPlatform(TargetPlatform.windows),
+    );
+
+    await expectLater(
+      service.getSystemFonts(),
+      throwsA(
+        isA<PlatformException>().having(
+          (error) => error.code,
+          'code',
+          'enumeration_failed',
+        ),
+      ),
+    );
+  });
+}

--- a/test/presentation/providers/font_provider_test.dart
+++ b/test/presentation/providers/font_provider_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/platform/platform_capabilities.dart';
+import 'package:nai_launcher/presentation/providers/font_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.nailauncher/system_fonts');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    PlatformCapabilities.debugOverride = null;
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test(
+    'unsupported platforms omit the system font group and channel call',
+    () async {
+      PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+        TargetPlatform.android,
+      );
+      var invocationCount = 0;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        invocationCount++;
+        return ['Should not be returned'];
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final groups = await container.read(allFontsProvider.future);
+
+      expect(groups.keys, ['应用默认', 'Google Fonts']);
+      expect(groups, isNot(contains('系统字体')));
+      expect(invocationCount, 0);
+    },
+  );
+
+  test('Windows exposes sorted system fonts', () async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    messenger.setMockMethodCallHandler(
+      channel,
+      (call) async => ['Segoe UI', 'Arial'],
+    );
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final groups = await container.read(allFontsProvider.future);
+
+    expect(groups['系统字体']?.map((font) => font.displayName), [
+      'Arial',
+      'Segoe UI',
+    ]);
+  });
+
+  test('Windows bridge failures propagate through the font provider', () async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      throw PlatformException(code: 'enumeration_failed');
+    });
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container.read(allFontsProvider.future),
+      throwsA(
+        isA<PlatformException>().having(
+          (error) => error.code,
+          'code',
+          'enumeration_failed',
+        ),
+      ),
+    );
+  });
+}

--- a/test/presentation/router/app_branch_test.dart
+++ b/test/presentation/router/app_branch_test.dart
@@ -16,6 +16,15 @@ void main() {
     });
   });
 
+  test('keep-alive branches use the semantic route contract', () {
+    expect(keptAliveAppBranches, {
+      AppBranch.localGallery,
+      AppBranch.onlineGallery,
+      AppBranch.vibeLibrary,
+      AppBranch.preciseRefLibrary,
+    });
+  });
+
   test(
     'compact navigation keeps core branches visible and routes the rest to more',
     () {

--- a/test/presentation/router/main_shell_auth_prompt_test.dart
+++ b/test/presentation/router/main_shell_auth_prompt_test.dart
@@ -9,6 +9,7 @@ import 'package:nai_launcher/presentation/providers/auth_provider.dart';
 import 'package:nai_launcher/presentation/providers/mobile_shell_overlay_provider.dart';
 import 'package:nai_launcher/presentation/providers/shortcuts_provider.dart';
 import 'package:nai_launcher/presentation/router/app_router.dart';
+import 'package:nai_launcher/presentation/router/queue_shell_overlay.dart';
 
 void main() {
   testWidgets('MainShell 消费启动前 pending 提示并顺序处理后续提示', (tester) async {
@@ -143,6 +144,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    expect(find.byType(DesktopShell), findsOneWidget);
+    expect(find.byType(MobileShell), findsNothing);
     final banner = find.byKey(const ValueKey('auth-recovery-banner'));
     expect(banner, findsOneWidget);
     expect(tester.getSize(banner).width, lessThanOrEqualTo(440));
@@ -151,6 +154,9 @@ void main() {
 
     await tester.binding.setSurfaceSize(const Size(390, 820));
     await tester.pumpAndSettle();
+    expect(find.byType(DesktopShell), findsNothing);
+    expect(find.byType(MobileShell), findsOneWidget);
+    expect(find.byType(NavigationBar), findsOneWidget);
     expect(tester.getSize(banner).width, lessThanOrEqualTo(366));
     expect(tester.getSize(banner).height, lessThan(120));
     expect(tester.takeException(), isNull);
@@ -158,6 +164,43 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('auth-recovery-dismiss')));
     await tester.pumpAndSettle();
     expect(banner, findsNothing);
+
+    final moreDestination = find.byWidgetPredicate(
+      (widget) => widget is NavigationDestination && widget.label == '更多',
+    );
+    await tester.tap(moreDestination);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('mobile-more-discord')), findsOneWidget);
+    expect(find.byKey(const ValueKey('mobile-more-github')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+    router.pop();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('mobile-more-discord')), findsNothing);
+
+    final queueOverlay = find.byType(QueueShellOverlay);
+    expect(queueOverlay, findsOneWidget);
+    container.read(queueManagementVisibleProvider.notifier).state = true;
+    await tester.pumpAndSettle();
+    final queuePointerGate = tester.widget<IgnorePointer>(
+      find
+          .descendant(of: queueOverlay, matching: find.byType(IgnorePointer))
+          .first,
+    );
+    final queueTranslation = tester.widget<FractionalTranslation>(
+      find
+          .descendant(
+            of: queueOverlay,
+            matching: find.byType(FractionalTranslation),
+          )
+          .first,
+    );
+    expect(queuePointerGate.ignoring, isFalse);
+    expect(queueTranslation.translation, Offset.zero);
+    expect(
+      tester.widget<NavigationBar>(find.byType(NavigationBar)).selectedIndex,
+      4,
+    );
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('MainShell 将系统返回交给当前分支的 PopScope', (tester) async {

--- a/test/presentation/router/main_shell_keep_alive_test.dart
+++ b/test/presentation/router/main_shell_keep_alive_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nai_launcher/core/shortcuts/shortcut_config.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/providers/account_manager_provider.dart';
+import 'package:nai_launcher/presentation/providers/auth_provider.dart';
+import 'package:nai_launcher/presentation/providers/shortcuts_provider.dart';
+import 'package:nai_launcher/presentation/router/app_router.dart';
+
+void main() {
+  testWidgets('MainShell keeps only the semantic keep-alive branches mounted', (
+    tester,
+  ) async {
+    final lifecycle = <AppBranch, _BranchLifecycle>{
+      for (final branch in AppBranch.values) branch: _BranchLifecycle(),
+    };
+    final container = ProviderContainer(
+      overrides: [
+        accountManagerNotifierProvider.overrideWith(
+          _TestAccountManagerNotifier.new,
+        ),
+        authNotifierProvider.overrideWith(_UnauthenticatedAuthNotifier.new),
+        shortcutConfigNotifierProvider.overrideWith(
+          _TestShortcutConfigNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final router = _buildRouter(lifecycle);
+    addTearDown(router.dispose);
+
+    await tester.binding.setSurfaceSize(const Size(390, 820));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          routerConfig: router,
+          locale: const Locale('zh'),
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    for (final branch in keptAliveAppBranches) {
+      router.go('/branch/${branch.index}');
+      await tester.pumpAndSettle();
+      router.go('/branch/${AppBranch.generation.index}');
+      await tester.pumpAndSettle();
+
+      expect(lifecycle[branch]!.created, 1, reason: branch.name);
+      expect(lifecycle[branch]!.disposed, 0, reason: branch.name);
+      final tickerModes = tester.widgetList<TickerMode>(
+        find.ancestor(
+          of: find.byKey(
+            ValueKey('branch-${branch.index}'),
+            skipOffstage: false,
+          ),
+          matching: find.byType(TickerMode, skipOffstage: false),
+        ),
+      );
+      expect(
+        tickerModes.any((tickerMode) => !tickerMode.enabled),
+        isTrue,
+        reason: branch.name,
+      );
+    }
+
+    router.go('/branch/${AppBranch.settings.index}');
+    await tester.pumpAndSettle();
+    router.go('/branch/${AppBranch.generation.index}');
+    await tester.pumpAndSettle();
+
+    expect(lifecycle[AppBranch.settings]!.created, 1);
+    expect(lifecycle[AppBranch.settings]!.disposed, 1);
+    expect(find.byKey(const ValueKey('branch-3')), findsNothing);
+  });
+}
+
+GoRouter _buildRouter(Map<AppBranch, _BranchLifecycle> lifecycle) {
+  return GoRouter(
+    initialLocation: '/branch/0',
+    routes: [
+      StatefulShellRoute(
+        navigatorContainerBuilder: (context, navigationShell, children) {
+          return MainShell(
+            navigationShell: navigationShell,
+            children: children,
+          );
+        },
+        builder: (context, state, navigationShell) => navigationShell,
+        branches: [
+          for (final branch in AppBranch.values)
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/branch/${branch.index}',
+                  builder: (context, state) => _TrackedBranch(
+                    key: ValueKey('branch-${branch.index}'),
+                    lifecycle: lifecycle[branch]!,
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    ],
+  );
+}
+
+class _BranchLifecycle {
+  int created = 0;
+  int disposed = 0;
+}
+
+class _TrackedBranch extends StatefulWidget {
+  const _TrackedBranch({super.key, required this.lifecycle});
+
+  final _BranchLifecycle lifecycle;
+
+  @override
+  State<_TrackedBranch> createState() => _TrackedBranchState();
+}
+
+class _TrackedBranchState extends State<_TrackedBranch> {
+  @override
+  void initState() {
+    super.initState();
+    widget.lifecycle.created++;
+  }
+
+  @override
+  void dispose() {
+    widget.lifecycle.disposed++;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.expand();
+}
+
+class _TestAccountManagerNotifier extends AccountManagerNotifier {
+  @override
+  AccountManagerState build() => const AccountManagerState();
+}
+
+class _UnauthenticatedAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => const AuthState(status: AuthStatus.unauthenticated);
+}
+
+class _TestShortcutConfigNotifier extends ShortcutConfigNotifier {
+  @override
+  Future<ShortcutConfig> build() async => ShortcutConfig.createDefault();
+}

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -26,20 +26,27 @@ int CALLBACK EnumFontFamExProc(
 }
 
 // Get system font list
-std::vector<std::string> GetSystemFonts() {
+std::optional<std::vector<std::string>> GetSystemFonts(
+    std::string* error_message) {
   g_font_names.clear();
 
   HDC hdc = GetDC(NULL);
   if (hdc == NULL) {
-    return {};
+    *error_message = "Failed to acquire the Windows screen device context.";
+    return std::nullopt;
   }
 
   LOGFONTW lf = {};
   lf.lfCharSet = DEFAULT_CHARSET;
   lf.lfFaceName[0] = L'\0';
 
+  // The return value is callback-controlled and does not distinguish an empty
+  // enumeration from failure.
   EnumFontFamiliesExW(hdc, &lf, EnumFontFamExProc, 0, 0);
-  ReleaseDC(NULL, hdc);
+  if (ReleaseDC(NULL, hdc) == 0) {
+    *error_message = "Failed to release the Windows screen device context.";
+    return std::nullopt;
+  }
 
   std::vector<std::string> result;
   for (const auto& name : g_font_names) {
@@ -104,9 +111,14 @@ bool FlutterWindow::OnCreate() {
       [](const flutter::MethodCall<flutter::EncodableValue>& call,
          std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
         if (call.method_name() == "getSystemFonts") {
-          auto fonts = GetSystemFonts();
+          std::string error_message;
+          auto fonts = GetSystemFonts(&error_message);
+          if (!fonts.has_value()) {
+            result->Error("system_font_enumeration_failed", error_message);
+            return;
+          }
           flutter::EncodableList font_list;
-          for (const auto& font : fonts) {
+          for (const auto& font : fonts.value()) {
             font_list.push_back(flutter::EncodableValue(font));
           }
           result->Success(flutter::EncodableValue(font_list));


### PR DESCRIPTION
## 变更

- 将 `app_shell.dart` 拆分为桌面壳层、移动壳层、状态横幅、更多面板和队列覆盖层，保持原路由、响应式、快捷键与交互契约。
- 用 `AppBranch` 语义集合替代保活裸索引，保留本地画廊、在线画廊、Vibe 库和精准参考库生命周期。
- 新增 Windows-only 系统字体枚举 capability；不支持平台不调用 MethodChannel 且不显示空系统字体组。
- Windows 原生桥可检测错误经 MethodChannel/Provider 错误链显式传播，合法空枚举仍成功返回。
- 保留 Shell 与 `GenerationScreen` 各自的 `GlobalDropHandler`。

## 验证

- `dart format`：15 个相关文件，0 change；最终测试文件已格式化。
- `scripts/test_affected.ps1`：8 个文件 / 19 项测试通过；最终 Shell 布局扩展单文件 3 项通过。
- scoped `flutter analyze`：通过，无问题。
- `flutter build windows --debug`：通过。
- 四轮独立多维等价性审查，最终 `CLEAN_GATE_PASS`。

## 运行态说明

按任务约束未启动 Flutter runner、模拟器或真实 GUI。确定性 widget tests 覆盖 desktop/mobile 壳层、banner 尺寸、More panel、queue overlay、返回与保活状态；不声称真实设备像素级或真实 Windows 字体枚举验收。