### PR TITLE
Add independent negative prompts for characters

### DIFF
--- a/lib/core/autocomplete/prompt_token_parser.dart
+++ b/lib/core/autocomplete/prompt_token_parser.dart
@@ -1,4 +1,5 @@
 import '../utils/alias_parser.dart';
+import '../utils/character_prompt_block_parser.dart';
 import 'completion_models.dart';
 
 class PromptTokenParser {
@@ -20,6 +21,25 @@ class PromptTokenParser {
     bool splitOnSpaces = false,
   }) {
     final cursor = cursorPosition.clamp(0, text.length);
+    final syntax = CharacterPromptBlockParser.parse(text);
+    final negativeBlock = syntax.blockContaining(cursor, contentOnly: true);
+    if (syntax.hasNegativeBlock &&
+        negativeBlock == null &&
+        syntax.blockContaining(cursor) != null) {
+      return CompletionQuery(
+        fullText: text,
+        cursorPosition: cursor,
+        token: '',
+        replacementRange: TextReplacementRange(start: cursor, end: cursor),
+        existingTags: _existingTags(
+          syntax,
+          token: '',
+          splitOnSpaces: splitOnSpaces,
+        ),
+        limit: limit.clamp(1, CompletionResultLimits.all),
+        locale: locale,
+      );
+    }
     final (isTypingAlias, partialAlias, aliasStart) =
         AliasParser.detectPartialAlias(text, cursor);
     if (isTypingAlias) {
@@ -45,14 +65,16 @@ class PromptTokenParser {
       );
     }
 
-    var start = cursor;
-    var end = cursor;
+    final lowerBound = negativeBlock?.contentRange.start ?? 0;
+    final upperBound = negativeBlock?.contentRange.end ?? text.length;
+    var start = cursor.clamp(lowerBound, upperBound);
+    var end = start;
 
-    while (start > 0 &&
+    while (start > lowerBound &&
         !_isSeparator(text.codeUnitAt(start - 1), splitOnSpaces)) {
       start--;
     }
-    while (end < text.length &&
+    while (end < upperBound &&
         !_isSeparator(text.codeUnitAt(end), splitOnSpaces)) {
       end++;
     }
@@ -82,14 +104,11 @@ class PromptTokenParser {
         .replaceAll(' ', '_')
         .toLowerCase();
 
-    final existingTags = <String>{};
-    final tagSeparator = splitOnSpaces ? RegExp(r'[,\n\s]+') : RegExp(r'[,\n]');
-    for (final segment in text.split(tagSeparator)) {
-      final normalized = _normalizeExistingTag(segment);
-      if (normalized.isNotEmpty && normalized != token) {
-        existingTags.add(normalized);
-      }
-    }
+    final existingTags = _existingTags(
+      syntax,
+      token: token,
+      splitOnSpaces: splitOnSpaces,
+    );
 
     return CompletionQuery(
       fullText: text,
@@ -140,14 +159,20 @@ class PromptTokenParser {
     if (parsed.token.length < 2) return null;
 
     var insertionPosition = parsed.replacementRange.end;
-    while (insertionPosition < text.length &&
+    final syntax = CharacterPromptBlockParser.parse(text);
+    final negativeBlock = syntax.blockContaining(
+      parsed.cursorPosition,
+      contentOnly: true,
+    );
+    final upperBound = negativeBlock?.contentRange.end ?? text.length;
+    while (insertionPosition < upperBound &&
         !_isSeparator(text.codeUnitAt(insertionPosition), splitOnSpaces)) {
       insertionPosition++;
     }
-    if (insertionPosition < text.length &&
+    if (insertionPosition < upperBound &&
         text.codeUnitAt(insertionPosition) == 0x2c) {
       insertionPosition++;
-      while (insertionPosition < text.length &&
+      while (insertionPosition < upperBound &&
           (text.codeUnitAt(insertionPosition) == 0x20 ||
               text.codeUnitAt(insertionPosition) == 0x09)) {
         insertionPosition++;
@@ -272,6 +297,11 @@ class PromptTokenParser {
     final range = query.replacementRange;
     final before = text.substring(0, range.start);
     var after = text.substring(range.end);
+    final parsedSyntax = CharacterPromptBlockParser.parse(text);
+    final negativeBlock = parsedSyntax.blockContaining(
+      range.start,
+      contentOnly: true,
+    );
 
     if (query.relatedTag != null && range.start == range.end) {
       final alreadySeparated =
@@ -279,7 +309,10 @@ class PromptTokenParser {
           before.trimRight().endsWith('\n') ||
           before.trimRight().endsWith('\r');
       final prefix = before.isEmpty || alreadySeparated ? '' : ', ';
-      final hasFollowingTag = after.trimLeft().isNotEmpty;
+      final contentAfter = negativeBlock == null
+          ? after
+          : text.substring(range.end, negativeBlock.contentRange.end);
+      final hasFollowingTag = contentAfter.trimLeft().isNotEmpty;
       final suffix = autoInsertComma || hasFollowingTag ? ', ' : '';
       final insertion = '$prefix$tag$suffix';
       final result = '$before$insertion$after';
@@ -288,9 +321,12 @@ class PromptTokenParser {
 
     var insertion = tag;
     if (autoInsertComma) {
+      final syntaxEnd = negativeBlock == null
+          ? after.length
+          : (negativeBlock.contentRange.end - range.end).clamp(0, after.length);
       final syntaxSuffix = RegExp(
         r'^(?::\s*-?\d+(?:\.\d+)?)?[\}\]\)]*',
-      ).firstMatch(after)!.group(0)!;
+      ).firstMatch(after.substring(0, syntaxEnd))!.group(0)!;
       final contentAfterSyntax = after.substring(syntaxSuffix.length);
       final existingComma = RegExp(r'^\s*,\s*').firstMatch(contentAfterSyntax);
       if (existingComma == null) {
@@ -312,8 +348,9 @@ class PromptTokenParser {
     bool splitOnSpaces,
   ) {
     List<String> tags(String text) {
+      final parsed = CharacterPromptBlockParser.parse(text);
       final separator = splitOnSpaces ? RegExp(r'[,\n\s]+') : RegExp(r'[,\n]');
-      return text
+      return _semanticText(parsed)
           .split(separator)
           .map(_normalizeExistingTag)
           .where((tag) => tag.isNotEmpty)
@@ -343,4 +380,23 @@ class PromptTokenParser {
     value = value.replaceFirst(_artistCategoryPrefix, '');
     return value.trim().replaceAll(' ', '_').toLowerCase();
   }
+
+  static Set<String> _existingTags(
+    CharacterPromptBlockParseResult parsed, {
+    required String token,
+    required bool splitOnSpaces,
+  }) {
+    final tags = <String>{};
+    final separator = splitOnSpaces ? RegExp(r'[,\n\s]+') : RegExp(r'[,\n]');
+    for (final segment in _semanticText(parsed).split(separator)) {
+      final normalized = _normalizeExistingTag(segment);
+      if (normalized.isNotEmpty && normalized != token) tags.add(normalized);
+    }
+    return tags;
+  }
+
+  static String _semanticText(CharacterPromptBlockParseResult parsed) => [
+    parsed.positivePrompt,
+    parsed.negativePrompt,
+  ].where((part) => part.isNotEmpty).join(', ');
 }

--- a/lib/core/services/character_conversion_service.dart
+++ b/lib/core/services/character_conversion_service.dart
@@ -1,6 +1,7 @@
 import '../../data/models/character/character_prompt.dart' as ui_character;
 import '../../data/models/image/image_params.dart';
 import '../utils/app_logger.dart';
+import '../utils/character_prompt_block_parser.dart';
 
 /// 角色转换结果
 ///
@@ -70,9 +71,14 @@ class CharacterConversionService {
     ui_character.CharacterPromptConfig config, {
     bool resolveAliases = true,
   }) {
-    // 过滤出启用且有提示词的角色
+    // 仅负向角色也是有效角色，NovelAI 会把它映射到独立角色 UC。
     final enabledCharacters = config.characters
-        .where((c) => c.enabled && c.prompt.isNotEmpty)
+        .where(
+          (character) =>
+              character.enabled &&
+              (character.prompt.isNotEmpty ||
+                  character.negativePrompt.isNotEmpty),
+        )
         .toList();
 
     if (enabledCharacters.isEmpty) {
@@ -90,8 +96,9 @@ class CharacterConversionService {
         positionY = position.row;
       }
 
-      // 解析角色提示词中的别名
-      String resolvedPrompt = uiChar.prompt;
+      // 先展开别名，再由共享解析器拆分角色词库扩展语法。这样通过
+      // `<词库名>` 添加的角色也不会把 `negative` 标记发送给 NovelAI。
+      String resolvedPromptSource = uiChar.prompt;
       String resolvedNegativePrompt = uiChar.negativePrompt;
 
       if (resolveAliases) {
@@ -102,15 +109,20 @@ class CharacterConversionService {
 
           if (promptWithAliases != uiChar.prompt ||
               negativeWithAliases != uiChar.negativePrompt) {
-            resolvedPrompt = promptWithAliases;
+            resolvedPromptSource = promptWithAliases;
             resolvedNegativePrompt = negativeWithAliases;
             aliasesWereResolved = true;
           }
         }
       }
 
+      final parsed = CharacterPromptBlockParser.parse(resolvedPromptSource);
+      resolvedNegativePrompt = parsed.mergeNegativePrompt(
+        resolvedNegativePrompt,
+      );
+
       return CharacterPrompt(
-        prompt: resolvedPrompt,
+        prompt: parsed.positivePrompt,
         negativePrompt: resolvedNegativePrompt,
         positionX: positionX,
         positionY: positionY,
@@ -151,7 +163,11 @@ class CharacterConversionService {
   ///
   /// [config] UI 层的角色提示词配置
   bool hasEnabledCharacters(ui_character.CharacterPromptConfig config) {
-    return config.characters.any((c) => c.enabled && c.prompt.isNotEmpty);
+    return config.characters.any(
+      (character) =>
+          character.enabled &&
+          (character.prompt.isNotEmpty || character.negativePrompt.isNotEmpty),
+    );
   }
 
   /// 获取启用的角色数量
@@ -159,7 +175,12 @@ class CharacterConversionService {
   /// [config] UI 层的角色提示词配置
   int getEnabledCharacterCount(ui_character.CharacterPromptConfig config) {
     return config.characters
-        .where((c) => c.enabled && c.prompt.isNotEmpty)
+        .where(
+          (character) =>
+              character.enabled &&
+              (character.prompt.isNotEmpty ||
+                  character.negativePrompt.isNotEmpty),
+        )
         .length;
   }
 }

--- a/lib/core/utils/character_prompt_block_parser.dart
+++ b/lib/core/utils/character_prompt_block_parser.dart
@@ -1,0 +1,278 @@
+/// Source range in a character-library prompt.
+class CharacterPromptSourceRange {
+  const CharacterPromptSourceRange(this.start, this.end);
+
+  final int start;
+  final int end;
+
+  bool contains(int offset, {bool includeEnd = false}) =>
+      offset >= start && (includeEnd ? offset <= end : offset < end);
+}
+
+enum CharacterPromptBlockIssue { unclosedBlock, repeatedBlock, emptyBlock }
+
+/// A complete top-level `negative(...)` block.
+class CharacterNegativeBlock {
+  const CharacterNegativeBlock({
+    required this.range,
+    required this.keywordRange,
+    required this.openingBoundaryRange,
+    required this.contentRange,
+    required this.closingBoundaryRange,
+  });
+
+  final CharacterPromptSourceRange range;
+  final CharacterPromptSourceRange keywordRange;
+  final CharacterPromptSourceRange openingBoundaryRange;
+  final CharacterPromptSourceRange contentRange;
+  final CharacterPromptSourceRange closingBoundaryRange;
+}
+
+class CharacterPromptBlockParseResult {
+  const CharacterPromptBlockParseResult({
+    required this.source,
+    required this.positivePrompt,
+    required this.negativePrompt,
+    required this.blocks,
+    required this.issues,
+  });
+
+  final String source;
+  final String positivePrompt;
+  final String negativePrompt;
+  final List<CharacterNegativeBlock> blocks;
+  final Set<CharacterPromptBlockIssue> issues;
+
+  bool get hasNegativeBlock => blocks.isNotEmpty;
+  bool get isValid => issues.isEmpty;
+
+  String mergeNegativePrompt(String existingPrompt) {
+    final seen = <String>{};
+    return [negativePrompt, existingPrompt]
+        .map((part) => part.trim())
+        .where((part) => part.isNotEmpty && seen.add(part))
+        .join(', ');
+  }
+
+  CharacterNegativeBlock? blockContaining(
+    int offset, {
+    bool contentOnly = false,
+  }) {
+    for (final block in blocks) {
+      final range = contentOnly ? block.contentRange : block.range;
+      if (range.contains(offset, includeEnd: contentOnly)) return block;
+    }
+    return null;
+  }
+}
+
+/// The single parser for the character-library `negative(...)` extension.
+///
+/// A block is reserved only at a top-level tag boundary. Parentheses escaped
+/// with a backslash and parentheses inside the block are preserved as content.
+abstract final class CharacterPromptBlockParser {
+  static const _keyword = 'negative';
+
+  /// Serializes separate character prompts back to the character-library
+  /// extension without creating a second syntax representation.
+  static String compose({
+    required String positivePrompt,
+    required String negativePrompt,
+  }) {
+    final parsedPositive = parse(positivePrompt.trim());
+    final positive = parsedPositive.positivePrompt;
+    final negative = parsedPositive.mergeNegativePrompt(negativePrompt);
+
+    if (negative.isEmpty) return positive;
+    if (positive.isEmpty) return '$_keyword($negative)';
+    return '$positive, $_keyword($negative)';
+  }
+
+  static CharacterPromptBlockParseResult parse(String source) {
+    if (source.isEmpty) {
+      return const CharacterPromptBlockParseResult(
+        source: '',
+        positivePrompt: '',
+        negativePrompt: '',
+        blocks: [],
+        issues: {},
+      );
+    }
+
+    final blocks = <CharacterNegativeBlock>[];
+    final issues = <CharacterPromptBlockIssue>{};
+    var braceDepth = 0;
+    var bracketDepth = 0;
+    var parenDepth = 0;
+    var index = 0;
+
+    while (index < source.length) {
+      if (_isEscaped(source, index)) {
+        index++;
+        continue;
+      }
+
+      if (braceDepth == 0 &&
+          bracketDepth == 0 &&
+          parenDepth == 0 &&
+          _startsReservedBlock(source, index)) {
+        final close = _findClosingParen(source, index + _keyword.length);
+        if (close == null) {
+          issues.add(CharacterPromptBlockIssue.unclosedBlock);
+          index += _keyword.length + 1;
+          continue;
+        }
+        if (!_hasClosingBoundary(source, close + 1)) {
+          index++;
+          continue;
+        }
+
+        final contentStart = index + _keyword.length + 1;
+        final block = CharacterNegativeBlock(
+          range: CharacterPromptSourceRange(index, close + 1),
+          keywordRange: CharacterPromptSourceRange(
+            index,
+            index + _keyword.length,
+          ),
+          openingBoundaryRange: CharacterPromptSourceRange(
+            index + _keyword.length,
+            index + _keyword.length + 1,
+          ),
+          contentRange: CharacterPromptSourceRange(contentStart, close),
+          closingBoundaryRange: CharacterPromptSourceRange(close, close + 1),
+        );
+        blocks.add(block);
+        if (source.substring(contentStart, close).trim().isEmpty) {
+          issues.add(CharacterPromptBlockIssue.emptyBlock);
+        }
+        index = close + 1;
+        continue;
+      }
+
+      switch (source[index]) {
+        case '{':
+          braceDepth++;
+        case '}':
+          if (braceDepth > 0) braceDepth--;
+        case '[':
+          bracketDepth++;
+        case ']':
+          if (bracketDepth > 0) bracketDepth--;
+        case '(':
+          parenDepth++;
+        case ')':
+          if (parenDepth > 0) parenDepth--;
+      }
+      index++;
+    }
+
+    if (blocks.length > 1) {
+      issues.add(CharacterPromptBlockIssue.repeatedBlock);
+    }
+
+    final negativeParts = blocks
+        .map(
+          (block) => source
+              .substring(block.contentRange.start, block.contentRange.end)
+              .trim(),
+        )
+        .where((part) => part.isNotEmpty)
+        .toList(growable: false);
+
+    return CharacterPromptBlockParseResult(
+      source: source,
+      positivePrompt: _removeBlocks(source, blocks),
+      negativePrompt: negativeParts.join(', '),
+      blocks: List.unmodifiable(blocks),
+      issues: Set.unmodifiable(issues),
+    );
+  }
+
+  static bool _startsReservedBlock(String source, int index) {
+    final openingParen = index + _keyword.length;
+    if (openingParen >= source.length ||
+        !source.startsWith('$_keyword(', index)) {
+      return false;
+    }
+
+    var previous = index - 1;
+    while (previous >= 0 && _isHorizontalWhitespace(source[previous])) {
+      previous--;
+    }
+    return previous < 0 ||
+        source[previous] == ',' ||
+        source[previous] == '\n' ||
+        source[previous] == '\r';
+  }
+
+  static bool _hasClosingBoundary(String source, int index) {
+    while (index < source.length && _isHorizontalWhitespace(source[index])) {
+      index++;
+    }
+    return index == source.length ||
+        source[index] == ',' ||
+        source[index] == '\n' ||
+        source[index] == '\r';
+  }
+
+  static int? _findClosingParen(String source, int openingParen) {
+    var depth = 1;
+    for (var index = openingParen + 1; index < source.length; index++) {
+      if (_isEscaped(source, index)) continue;
+      if (source[index] == '(') {
+        depth++;
+      } else if (source[index] == ')') {
+        depth--;
+        if (depth == 0) return index;
+      }
+    }
+    return null;
+  }
+
+  static String _removeBlocks(
+    String source,
+    List<CharacterNegativeBlock> blocks,
+  ) {
+    if (blocks.isEmpty) return source;
+
+    var result = source;
+    for (final block in blocks.reversed) {
+      var start = block.range.start;
+      var end = block.range.end;
+
+      while (start > 0 && _isHorizontalWhitespace(result[start - 1])) {
+        start--;
+      }
+      if (start > 0 && result[start - 1] == ',') {
+        start--;
+      } else {
+        while (end < result.length && _isHorizontalWhitespace(result[end])) {
+          end++;
+        }
+        if (end < result.length && result[end] == ',') {
+          end++;
+          while (end < result.length && _isHorizontalWhitespace(result[end])) {
+            end++;
+          }
+        }
+      }
+      result = result.replaceRange(start, end, '');
+    }
+    return result.trim();
+  }
+
+  static bool _isEscaped(String source, int index) {
+    var backslashes = 0;
+    for (
+      var cursor = index - 1;
+      cursor >= 0 && source[cursor] == r'\';
+      cursor--
+    ) {
+      backslashes++;
+    }
+    return backslashes.isOdd;
+  }
+
+  static bool _isHorizontalWhitespace(String value) =>
+      value == ' ' || value == '\t' || value == '\f' || value == '\u00a0';
+}

--- a/lib/core/utils/nai_prompt_formatter.dart
+++ b/lib/core/utils/nai_prompt_formatter.dart
@@ -1,3 +1,4 @@
+import 'character_prompt_block_parser.dart';
 import 'text_space_converter.dart';
 
 /// NAI 提示词格式化工具
@@ -21,6 +22,26 @@ class NaiPromptFormatter {
   static String format(String prompt) {
     if (prompt.isEmpty) return prompt;
 
+    // Format block contents through the same path as positive tags while the
+    // shared parser protects the reserved keyword and matching boundaries.
+    var prepared = prompt;
+    final parsed = CharacterPromptBlockParser.parse(prompt);
+    for (final block in parsed.blocks.reversed) {
+      final content = prepared.substring(
+        block.contentRange.start,
+        block.contentRange.end,
+      );
+      prepared = prepared.replaceRange(
+        block.contentRange.start,
+        block.contentRange.end,
+        _formatPromptText(content),
+      );
+    }
+
+    return _formatPromptText(prepared);
+  }
+
+  static String _formatPromptText(String prompt) {
     return prompt.splitMapJoin(
       _lineBreakPattern,
       onMatch: (match) => match.group(0)!,

--- a/lib/data/models/character/character_prompt.dart
+++ b/lib/data/models/character/character_prompt.dart
@@ -463,6 +463,7 @@ class CharacterPromptConfig with _$CharacterPromptConfig {
     String? name,
     CharacterGender gender = CharacterGender.female,
     String? prompt,
+    String? negativePrompt,
     String? thumbnailPath,
   }) {
     // 根据性别设置初始提示词（如果未指定）
@@ -481,6 +482,7 @@ class CharacterPromptConfig with _$CharacterPromptConfig {
       name: name ?? getNextCharacterName(),
       gender: gender,
       prompt: initialPrompt,
+      negativePrompt: negativePrompt ?? 'lowres, aliasing, ',
       positionMode: CharacterPositionMode.custom,
       customPosition: defaultPosition,
       thumbnailPath: thumbnailPath,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3317,6 +3317,7 @@
   "tagLibrary_tagsHelper": "Tags are used for filtering and searching",
   "tagLibrary_content": "Prompt Content",
   "tagLibrary_contentHint": "Enter prompt content, supports autocomplete",
+  "tagLibrary_characterNegativeSyntaxHelp": "Character entries can store independent Undesired Content with negative(...), for example: girl, blue eyes, negative(red hair, glasses)",
 
   "settings_network": "Network",
   "settings_enableProxy": "Enable Proxy",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3252,6 +3252,7 @@
   "tagLibrary_tagsHelper": "タグはフィルタリングと検索に使用されます",
   "tagLibrary_content": "プロンプトの内容",
   "tagLibrary_contentHint": "プロンプトの内容を入力し、オートコンプリートをサポートします",
+  "tagLibrary_characterNegativeSyntaxHelp": "キャラクター項目では negative(...) で個別の除外プロンプトを保存できます。例：girl, blue eyes, negative(red hair, glasses)",
   "settings_network": "ネットワーク",
   "settings_enableProxy": "プロキシを有効にする",
   "settings_proxyEnabled": "有効",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12569,6 +12569,12 @@ abstract class AppLocalizations {
   /// **'Enter prompt content, supports autocomplete'**
   String get tagLibrary_contentHint;
 
+  /// No description provided for @tagLibrary_characterNegativeSyntaxHelp.
+  ///
+  /// In en, this message translates to:
+  /// **'Character entries can store independent Undesired Content with negative(...), for example: girl, blue eyes, negative(red hair, glasses)'**
+  String get tagLibrary_characterNegativeSyntaxHelp;
+
   /// No description provided for @settings_network.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7088,6 +7088,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enter prompt content, supports autocomplete';
 
   @override
+  String get tagLibrary_characterNegativeSyntaxHelp =>
+      'Character entries can store independent Undesired Content with negative(...), for example: girl, blue eyes, negative(red hair, glasses)';
+
+  @override
   String get settings_network => 'Network';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -6920,6 +6920,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get tagLibrary_contentHint => 'プロンプトの内容を入力し、オートコンプリートをサポートします';
 
   @override
+  String get tagLibrary_characterNegativeSyntaxHelp =>
+      'キャラクター項目では negative(...) で個別の除外プロンプトを保存できます。例：girl, blue eyes, negative(red hair, glasses)';
+
+  @override
   String get settings_network => 'ネットワーク';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6804,6 +6804,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get tagLibrary_contentHint => '输入提示词内容，支持智能补全';
 
   @override
+  String get tagLibrary_characterNegativeSyntaxHelp =>
+      '角色词库可用 negative(...) 保存独立负面提示词，例如：girl, blue eyes, negative(red hair, glasses)';
+
+  @override
   String get settings_network => '网络';
 
   @override
@@ -19002,6 +19006,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get tagLibrary_contentHint => '輸入提示詞內容，支援智慧補全';
+
+  @override
+  String get tagLibrary_characterNegativeSyntaxHelp =>
+      '角色詞庫可用 negative(...) 儲存獨立負面提示詞，例如：girl, blue eyes, negative(red hair, glasses)';
 
   @override
   String get settings_network => '網路';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3330,6 +3330,7 @@
   "tagLibrary_tagsHelper": "标签用于筛选和搜索",
   "tagLibrary_content": "提示词内容",
   "tagLibrary_contentHint": "输入提示词内容，支持智能补全",
+  "tagLibrary_characterNegativeSyntaxHelp": "角色词库可用 negative(...) 保存独立负面提示词，例如：girl, blue eyes, negative(red hair, glasses)",
 
   "settings_network": "网络",
   "settings_enableProxy": "启用代理",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3339,6 +3339,7 @@
   "tagLibrary_tagsHelper": "標籤用於篩選和搜尋",
   "tagLibrary_content": "提示詞內容",
   "tagLibrary_contentHint": "輸入提示詞內容，支援智慧補全",
+  "tagLibrary_characterNegativeSyntaxHelp": "角色詞庫可用 negative(...) 儲存獨立負面提示詞，例如：girl, blue eyes, negative(red hair, glasses)",
   "settings_network": "網路",
   "settings_enableProxy": "啟用代理",
   "settings_proxyEnabled": "已啟用",

--- a/lib/presentation/providers/character_prompt_provider.dart
+++ b/lib/presentation/providers/character_prompt_provider.dart
@@ -54,6 +54,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
   /// [gender] 角色性别
   /// [name] 角色名称，为空时自动生成
   /// [prompt] 正向提示词，为空时根据性别生成默认值
+  /// [negativePrompt] 角色独立负向提示词；null 时保留旧版默认值
   /// [thumbnailPath] 缩略图路径（词库导入时）
   ///
   /// Requirements: 1.2, 1.3
@@ -61,6 +62,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
     CharacterGender gender, {
     String? name,
     String? prompt,
+    String? negativePrompt,
     String? thumbnailPath,
   }) {
     if (isAtCharacterLimit) {
@@ -76,6 +78,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
       gender: gender,
       name: name,
       prompt: prompt,
+      negativePrompt: negativePrompt,
       thumbnailPath: thumbnailPath,
     );
     _saveConfig();

--- a/lib/presentation/providers/generation/generation_request_preparation_service.dart
+++ b/lib/presentation/providers/generation/generation_request_preparation_service.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import '../../../core/utils/character_prompt_block_parser.dart';
 import '../../../core/utils/prompt_preset_resolution.dart';
 import '../../../data/models/image/image_params.dart';
 
@@ -107,13 +108,19 @@ class GenerationRequestPreparationService {
       if (prompt.isNotEmpty) effective = effective.copyWith(prompt: prompt);
     }
 
+    final resolvedPrompt = CharacterPromptBlockParser.parse(
+      promptPreparation.resolveAliases(effective.prompt),
+    ).positivePrompt;
+    final promptWithFixedTags = promptPreparation.applyFixedPositiveTags(
+      resolvedPrompt,
+    );
+    final negativePromptWithFixedTags = promptPreparation
+        .applyFixedNegativeTags(
+          promptPreparation.resolveAliases(effective.negativePrompt),
+        );
     effective = effective.copyWith(
-      prompt: promptPreparation.applyFixedPositiveTags(
-        promptPreparation.resolveAliases(effective.prompt),
-      ),
-      negativePrompt: promptPreparation.applyFixedNegativeTags(
-        promptPreparation.resolveAliases(effective.negativePrompt),
-      ),
+      prompt: promptWithFixedTags,
+      negativePrompt: negativePromptWithFixedTags,
     );
     final presets = promptPreparation.resolvePresets(effective);
     final characters = dependencies.characters.read(effective.model);
@@ -143,8 +150,11 @@ class GenerationRequestPreparationService {
     );
     if (prompt.isEmpty) return currentParams;
 
-    var preparedPrompt = promptPreparation.applyFixedPositiveTags(
+    final resolvedPrompt = CharacterPromptBlockParser.parse(
       promptPreparation.resolveAliases(prompt),
+    ).positivePrompt;
+    var preparedPrompt = promptPreparation.applyFixedPositiveTags(
+      resolvedPrompt,
     );
     preparedPrompt = promptPreparation
         .resolvePresets(

--- a/lib/presentation/providers/prompt_token_counter_provider.dart
+++ b/lib/presentation/providers/prompt_token_counter_provider.dart
@@ -6,6 +6,7 @@ import '../../core/constants/model_capabilities.dart';
 import '../../core/services/prompt_token_counter_service.dart';
 import '../../core/utils/novelai_auto_text.dart';
 import '../../core/utils/prompt_preset_resolution.dart';
+import '../../core/utils/character_prompt_block_parser.dart';
 import '../../core/utils/prompt_semantics_utils.dart';
 import '../../data/models/character/character_prompt.dart' as ui_character;
 import '../../data/models/image/image_params.dart';
@@ -217,7 +218,9 @@ PromptTokenCountPayload _buildPositiveTokenCountPayload({
   String qualityTier = QualityTags.standardTier,
   bool useCoords = false,
 }) {
-  final resolvedPrompt = resolveAliases(prompt).trim();
+  final resolvedPrompt = CharacterPromptBlockParser.parse(
+    resolveAliases(prompt),
+  ).positivePrompt.trim();
   final resolvedNegativePrompt = resolveAliases(negativePrompt).trim();
   final promptWithFixedTags = fixedTagsState
       .applyToPrompt(resolvedPrompt)
@@ -242,13 +245,20 @@ PromptTokenCountPayload _buildPositiveTokenCountPayload({
     useCustomUcPreset: useCustomUcPreset,
   );
   final enabledCharacters = characters
-      .where((character) => character.enabled && character.prompt.isNotEmpty)
+      .where(
+        (character) =>
+            character.enabled &&
+            (character.prompt.isNotEmpty ||
+                character.negativePrompt.isNotEmpty),
+      )
       .toList(growable: false);
   final resolvedCharacters = <NovelAiAutoTextCharacter>[];
   final extraTexts = <String>[];
   for (var index = 0; index < enabledCharacters.length; index++) {
     final character = enabledCharacters[index];
-    final resolvedPrompt = resolveAliases(character.prompt).trim();
+    final resolvedPrompt = CharacterPromptBlockParser.parse(
+      resolveAliases(character.prompt),
+    ).positivePrompt.trim();
     final customPosition = character.customPosition;
     final position =
         character.positionMode == ui_character.CharacterPositionMode.custom &&
@@ -376,7 +386,14 @@ PromptTokenCountPayload _buildNegativeTokenCountPayload({
 
   final extraTexts = characters
       .where((character) => character.enabled)
-      .map((character) => resolveAliases(character.negativePrompt).trim())
+      .map((character) {
+        final parsedPrompt = CharacterPromptBlockParser.parse(
+          resolveAliases(character.prompt),
+        );
+        return parsedPrompt.mergeNegativePrompt(
+          resolveAliases(character.negativePrompt),
+        );
+      })
       .where((text) => text.isNotEmpty)
       .toList(growable: false);
   final negativeFixedTagTexts = [

--- a/lib/presentation/screens/generation/widgets/image_preview.dart
+++ b/lib/presentation/screens/generation/widgets/image_preview.dart
@@ -10,10 +10,12 @@ import 'package:path/path.dart' as p;
 import '../../../../core/enums/precise_ref_type.dart';
 import '../../../../core/platform/platform_capabilities.dart';
 import '../../../../core/services/android_media_store_service.dart';
+import '../../../../core/services/character_conversion_service.dart';
 import '../../../../core/shortcuts/default_shortcuts.dart';
 import '../../../../core/shortcuts/shortcut_config.dart';
 import '../../../../core/shortcuts/shortcut_manager.dart';
 import '../../../../core/utils/app_logger.dart';
+import '../../../../core/utils/character_prompt_block_parser.dart';
 import '../../../../core/utils/file_explorer_utils.dart';
 import '../../../../core/utils/image_save_utils.dart';
 import '../../../../core/utils/localization_extension.dart';
@@ -1109,7 +1111,7 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
           params.negativePrompt,
         );
         final promptWithFixedTags = fixedTagsState.applyToPrompt(
-          resolvedPrompt,
+          CharacterPromptBlockParser.parse(resolvedPrompt).positivePrompt,
         );
         final negativePromptWithFixedTags = fixedTagsState
             .applyToNegativePrompt(resolvedNegative);
@@ -1135,17 +1137,18 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
         final charCaptions = <Map<String, dynamic>>[];
         final charNegCaptions = <Map<String, dynamic>>[];
 
-        for (final char in characterConfig.characters.where(
-          (c) => c.enabled && c.prompt.isNotEmpty,
-        )) {
+        final convertedCharacters = CharacterConversionService(
+          aliasResolver: aliasResolver.resolveAliases,
+        ).convert(characterConfig);
+        for (final char in convertedCharacters.characters) {
           charCaptions.add({
-            'char_caption': aliasResolver.resolveAliases(char.prompt),
+            'char_caption': char.prompt,
             'centers': [
               {'x': 0.5, 'y': 0.5},
             ],
           });
           charNegCaptions.add({
-            'char_caption': aliasResolver.resolveAliases(char.negativePrompt),
+            'char_caption': char.negativePrompt,
             'centers': [
               {'x': 0.5, 'y': 0.5},
             ],

--- a/lib/presentation/screens/generation/widgets/prompt_input_coordinator.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_input_coordinator.dart
@@ -45,11 +45,19 @@ class PromptInputCoordinator {
       final prompt = _normalize(sourcePrompt);
       switch (target) {
         case SendTargetType.smartDecompose:
-          _applySmartDecompose(prompt);
+          _applySmartDecompose(prompt, negativePrompt: consumed.negativePrompt);
         case SendTargetType.replaceCharacter:
-          _applyToCharacterPrompt(prompt, clearExisting: true);
+          _applyToCharacterPrompt(
+            prompt,
+            negativePrompt: consumed.negativePrompt,
+            clearExisting: true,
+          );
         case SendTargetType.appendCharacter:
-          _applyToCharacterPrompt(prompt, clearExisting: false);
+          _applyToCharacterPrompt(
+            prompt,
+            negativePrompt: consumed.negativePrompt,
+            clearExisting: false,
+          );
         case SendTargetType.mainPrompt:
         case SendTargetType.fixedTag:
         case null:
@@ -75,9 +83,16 @@ class PromptInputCoordinator {
     updatePrompt(prompt);
   }
 
-  void _applyToCharacterPrompt(String prompt, {required bool clearExisting}) {
+  void _applyToCharacterPrompt(
+    String prompt, {
+    String? negativePrompt,
+    required bool clearExisting,
+  }) {
     final notifier = _ref.read(characterPromptNotifierProvider.notifier);
     if (clearExisting) notifier.clearAllCharacters();
+    final normalizedNegative = negativePrompt == null
+        ? null
+        : _normalize(negativePrompt);
 
     if (PipeParser.isPipeFormat(prompt)) {
       final result = PipeParser.parse(prompt);
@@ -85,6 +100,7 @@ class PromptInputCoordinator {
         notifier.addCharacter(
           _inferGender(result.globalPrompt),
           prompt: result.globalPrompt,
+          negativePrompt: normalizedNegative,
         );
       }
       for (final character in result.characters) {
@@ -92,11 +108,16 @@ class PromptInputCoordinator {
           notifier.addCharacter(
             character.inferredGender ?? CharacterGender.other,
             prompt: character.prompt,
+            negativePrompt: normalizedNegative,
           );
         }
       }
     } else {
-      notifier.addCharacter(_inferGender(prompt), prompt: prompt);
+      notifier.addCharacter(
+        _inferGender(prompt),
+        prompt: prompt,
+        negativePrompt: normalizedNegative,
+      );
     }
 
     if (_mounted()) {
@@ -125,9 +146,12 @@ class PromptInputCoordinator {
     return CharacterGender.other;
   }
 
-  void _applySmartDecompose(String prompt) {
+  void _applySmartDecompose(String prompt, {String? negativePrompt}) {
     final result = PipeParser.parse(prompt);
     if (result.globalPrompt.isNotEmpty) applyToMainPrompt(result.globalPrompt);
+    final normalizedNegative = negativePrompt == null
+        ? null
+        : _normalize(negativePrompt);
 
     final notifier = _ref.read(characterPromptNotifierProvider.notifier);
     notifier.clearAllCharacters();
@@ -136,6 +160,7 @@ class PromptInputCoordinator {
         notifier.addCharacter(
           character.inferredGender ?? CharacterGender.other,
           prompt: character.prompt,
+          negativePrompt: normalizedNegative,
         );
       }
     }

--- a/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
+++ b/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
@@ -3,10 +3,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../core/utils/localization_extension.dart';
-import '../../../core/utils/comfyui_prompt_parser/pipe_parser.dart';
-import '../../../core/utils/sd_to_nai_converter.dart';
 import '../../../core/shortcuts/default_shortcuts.dart';
+import '../../../core/utils/character_prompt_block_parser.dart';
+import '../../../core/utils/comfyui_prompt_parser/pipe_parser.dart';
+import '../../../core/utils/localization_extension.dart';
+import '../../../core/utils/sd_to_nai_converter.dart';
 import '../../../data/models/tag_library/tag_library_entry.dart';
 import '../../adaptive/adaptive_presenter.dart';
 import '../../providers/fixed_tags_provider.dart';
@@ -190,7 +191,11 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
     }
 
     // 多个选中项：直接拼接内容发送到主提示词
-    final content = selectedEntries.map((e) => e.content).join(', ');
+    final content = selectedEntries
+        .map((entry) => CharacterPromptBlockParser.parse(entry.content))
+        .map((parsed) => parsed.positivePrompt)
+        .where((prompt) => prompt.isNotEmpty)
+        .join(', ');
 
     // 设置待填充提示词
     ref
@@ -814,9 +819,10 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
     TagLibraryEntry entry,
     bool sendAsAlias,
   ) async {
+    final parsed = CharacterPromptBlockParser.parse(entry.content);
     final content = sendAsAlias
         ? '<${entry.name}>'
-        : SdToNaiConverter.convert(entry.content);
+        : SdToNaiConverter.convert(parsed.positivePrompt);
 
     await ref
         .read(fixedTagsNotifierProvider.notifier)
@@ -837,11 +843,19 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
     SendOptions sendOptions,
   ) async {
     final content = _prepareContentForHome(entry, sendOptions);
+    final parsed = CharacterPromptBlockParser.parse(entry.content);
+    final sendsToCharacter =
+        sendOptions.targetType == SendTargetType.replaceCharacter ||
+        sendOptions.targetType == SendTargetType.appendCharacter ||
+        sendOptions.targetType == SendTargetType.smartDecompose;
 
     ref
         .read(pendingPromptNotifierProvider.notifier)
         .set(
           prompt: content,
+          negativePrompt: sendsToCharacter && parsed.hasNegativeBlock
+              ? parsed.negativePrompt
+              : null,
           targetType: sendOptions.targetType,
           clearOnConsume: true,
         );
@@ -865,20 +879,23 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
     }
 
     // 检查是否为竖线格式且需要提取角色部分
-    final isPipeFormat = PipeParser.isPipeFormat(entry.content);
+    final positivePrompt = CharacterPromptBlockParser.parse(
+      entry.content,
+    ).positivePrompt;
+    final isPipeFormat = PipeParser.isPipeFormat(positivePrompt);
     final needsCharacterExtract =
         isPipeFormat &&
         (options.targetType == SendTargetType.replaceCharacter ||
             options.targetType == SendTargetType.appendCharacter);
 
     if (needsCharacterExtract) {
-      final result = PipeParser.parse(entry.content);
+      final result = PipeParser.parse(positivePrompt);
       if (result.characters.isNotEmpty) {
         return result.characters.map((c) => c.prompt).join('\n| ');
       }
     }
 
-    return entry.content;
+    return positivePrompt;
   }
 
   /// 获取发送成功提示消息

--- a/lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart
@@ -346,12 +346,12 @@ class _EntryAddDialogState extends ConsumerState<EntryAddDialog> {
                     Padding(
                       padding: const EdgeInsets.only(left: 12),
                       child: Text(
-                        context.l10n.fixedTags_syntaxHelp,
+                        context.l10n.tagLibrary_characterNegativeSyntaxHelp,
                         style: TextStyle(
                           fontSize: 12,
                           color: theme.colorScheme.outline,
                         ),
-                        maxLines: 2,
+                        maxLines: 3,
                       ),
                     ),
 

--- a/lib/presentation/screens/tag_library_page/widgets/send_to_home_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/send_to_home_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/utils/character_prompt_block_parser.dart';
 import '../../../../core/utils/comfyui_prompt_parser/pipe_parser.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../core/utils/sd_to_nai_converter.dart';
@@ -56,7 +57,11 @@ class _SendToHomeDialogState extends ConsumerState<SendToHomeDialog> {
   }
 
   /// 检测是否为竖线格式
-  bool get _isPipeFormat => PipeParser.isPipeFormat(widget.entry.content);
+  CharacterPromptBlockParseResult get _promptParts =>
+      CharacterPromptBlockParser.parse(widget.entry.content);
+
+  bool get _isPipeFormat =>
+      PipeParser.isPipeFormat(_promptParts.positivePrompt);
 
   /// 获取发送内容
   /// 如果 sendAsAlias 为 true，返回 <条目名> 形式
@@ -67,7 +72,7 @@ class _SendToHomeDialogState extends ConsumerState<SendToHomeDialog> {
       return '<${widget.entry.name}>';
     }
     // 应用 SD→NAI 转换和格式化
-    return SdToNaiConverter.convert(widget.entry.content);
+    return SdToNaiConverter.convert(_promptParts.positivePrompt);
   }
 
   /// 解析竖线格式结果
@@ -404,10 +409,25 @@ class _SendToHomeDialogState extends ConsumerState<SendToHomeDialog> {
     final label = hasCharacters
         ? context.l10n.sendToHome_characterPromptCount(parsed.characters.length)
         : context.l10n.sendToHome_characterPrompt;
-    return _PreviewItem(
-      label: label,
-      content: content,
-      color: Theme.of(context).colorScheme.tertiary,
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _PreviewItem(
+          label: label,
+          content: content,
+          color: theme.colorScheme.tertiary,
+        ),
+        if (_promptParts.hasNegativeBlock &&
+            _promptParts.negativePrompt.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _PreviewItem(
+            label: context.l10n.prompt_negativePrompt,
+            content: _promptParts.negativePrompt,
+            color: theme.colorScheme.error,
+          ),
+        ],
+      ],
     );
   }
 }

--- a/lib/presentation/widgets/character/add_character_buttons.dart
+++ b/lib/presentation/widgets/character/add_character_buttons.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/utils/character_prompt_block_parser.dart';
 import '../../../data/models/character/character_prompt.dart';
 import '../../providers/character_prompt_provider.dart';
 import '../../providers/tag_library_page_provider.dart';
@@ -67,6 +68,7 @@ class AddCharacterButtons extends ConsumerWidget {
     );
 
     if (entry != null) {
+      final parsed = CharacterPromptBlockParser.parse(entry.content);
       // 记录使用
       ref.read(tagLibraryPageNotifierProvider.notifier).recordUsage(entry.id);
 
@@ -76,7 +78,10 @@ class AddCharacterButtons extends ConsumerWidget {
           .addCharacter(
             CharacterGender.female, // 默认女性
             name: entry.displayName,
-            prompt: entry.content,
+            prompt: parsed.positivePrompt,
+            negativePrompt: parsed.hasNegativeBlock
+                ? parsed.negativePrompt
+                : null,
             thumbnailPath: entry.thumbnail,
           );
     }

--- a/lib/presentation/widgets/character/character_prompt_button.dart
+++ b/lib/presentation/widgets/character/character_prompt_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/utils/character_prompt_block_parser.dart';
 import '../../../data/models/character/character_prompt.dart';
 import '../../providers/character_prompt_provider.dart';
 import '../../providers/tag_library_page_provider.dart';
@@ -182,11 +183,13 @@ class _AddCharacterMenu extends ConsumerWidget {
       builder: (context) => const TagLibraryPickerDialog(),
     );
     if (entry != null) {
+      final parsed = CharacterPromptBlockParser.parse(entry.content);
       ref.read(tagLibraryPageNotifierProvider.notifier).recordUsage(entry.id);
       notifier.addCharacter(
         CharacterGender.female,
         name: entry.displayName,
-        prompt: entry.content,
+        prompt: parsed.positivePrompt,
+        negativePrompt: parsed.hasNegativeBlock ? parsed.negativePrompt : null,
         thumbnailPath: entry.thumbnail,
       );
       _selectLast(ref);

--- a/lib/presentation/widgets/character/inline_character_card.dart
+++ b/lib/presentation/widgets/character/inline_character_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/utils/character_prompt_block_parser.dart';
 import '../../../data/models/character/character_prompt.dart';
 import '../../providers/character_position_canvas_provider.dart';
 import '../../providers/character_prompt_provider.dart';
@@ -331,7 +332,10 @@ class _InlineCharacterCardState extends ConsumerState<InlineCharacterCard> {
           () => AddToLibraryDialog.show(
             context,
             name: widget.character.name,
-            content: widget.character.prompt,
+            content: CharacterPromptBlockParser.compose(
+              positivePrompt: widget.character.prompt,
+              negativePrompt: widget.character.negativePrompt,
+            ),
           ),
         );
       case _CharacterCardAction.delete:

--- a/lib/presentation/widgets/character/inline_character_row.dart
+++ b/lib/presentation/widgets/character/inline_character_row.dart
@@ -3,6 +3,7 @@ import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/constants/api_constants.dart';
+import '../../../core/utils/character_prompt_block_parser.dart';
 import '../../../data/models/character/character_prompt.dart';
 import '../../providers/character_position_canvas_provider.dart';
 import '../../providers/character_prompt_provider.dart';
@@ -368,7 +369,10 @@ class _RowEditorPanelState extends ConsumerState<_RowEditorPanel> {
                       () => AddToLibraryDialog.show(
                         context,
                         name: widget.character.name,
-                        content: widget.character.prompt,
+                        content: CharacterPromptBlockParser.compose(
+                          positivePrompt: widget.character.prompt,
+                          negativePrompt: widget.character.negativePrompt,
+                        ),
                       ),
                     ),
                   ),
@@ -579,11 +583,13 @@ class _AddCharacterChip extends ConsumerWidget {
       builder: (context) => const TagLibraryPickerDialog(),
     );
     if (entry != null) {
+      final parsed = CharacterPromptBlockParser.parse(entry.content);
       ref.read(tagLibraryPageNotifierProvider.notifier).recordUsage(entry.id);
       notifier.addCharacter(
         CharacterGender.female,
         name: entry.displayName,
-        prompt: entry.content,
+        prompt: parsed.positivePrompt,
+        negativePrompt: parsed.hasNegativeBlock ? parsed.negativePrompt : null,
         thumbnailPath: entry.thumbnail,
       );
       _selectLast(ref);

--- a/lib/presentation/widgets/common/weight_adjust_toolbar.dart
+++ b/lib/presentation/widgets/common/weight_adjust_toolbar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:nai_launcher/core/utils/localization_extension.dart';
 
+import '../../../core/utils/character_prompt_block_parser.dart';
 import '../../themes/core/input_surface_style.dart';
 
 /// 权重调整工具条包装器
@@ -188,6 +189,9 @@ class _WeightAdjustToolbarWrapperState
   }
 
   void _adjustWeightByStep(double step) {
+    if (!_WeightSelectionEditor.protectNegativeBlockSyntax(widget.controller)) {
+      return;
+    }
     final result = _WeightSelectionEditor.parseSelection(widget.controller);
     _WeightSelectionEditor.applyWeight(
       widget.controller,
@@ -201,7 +205,8 @@ class _WeightAdjustToolbarWrapperState
         event.scrollDelta.dy == 0 ||
         !widget.enabled ||
         !widget.enableWheelAdjustment ||
-        !_WeightSelectionEditor.hasSelection(widget.controller)) {
+        !_WeightSelectionEditor.hasSelection(widget.controller) ||
+        !_WeightSelectionEditor.protectNegativeBlockSyntax(widget.controller)) {
       return;
     }
 
@@ -235,6 +240,45 @@ class _WeightParseResult {
 }
 
 class _WeightSelectionEditor {
+  static bool protectNegativeBlockSyntax(TextEditingController controller) {
+    final selection = controller.selection;
+    if (!selection.isValid || selection.isCollapsed) return false;
+
+    final parsed = CharacterPromptBlockParser.parse(controller.text);
+    for (final block in parsed.blocks) {
+      final overlapsBlock =
+          selection.start < block.range.end &&
+          selection.end > block.range.start;
+      if (!overlapsBlock) continue;
+
+      final insideContent =
+          selection.start >= block.contentRange.start &&
+          selection.end <= block.contentRange.end;
+      final containsWholeBlock =
+          selection.start == block.range.start &&
+          selection.end == block.range.end;
+      if (!insideContent && !containsWholeBlock) return false;
+
+      final start = selection.start.clamp(
+        block.contentRange.start,
+        block.contentRange.end,
+      );
+      final end = selection.end.clamp(
+        block.contentRange.start,
+        block.contentRange.end,
+      );
+      if (start >= end) return false;
+      if (start != selection.start || end != selection.end) {
+        controller.selection = TextSelection(
+          baseOffset: start,
+          extentOffset: end,
+        );
+      }
+      return true;
+    }
+    return true;
+  }
+
   static bool hasSelection(TextEditingController controller) {
     final selection = controller.selection;
     return selection.isValid &&

--- a/lib/presentation/widgets/prompt/nai_syntax_controller.dart
+++ b/lib/presentation/widgets/prompt/nai_syntax_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../core/utils/alias_parser.dart';
+import '../../../core/utils/character_prompt_block_parser.dart';
 
 /// NAI 语法高亮控制器
 /// 继承 TextEditingController，重写 buildTextSpan 实现语法着色
@@ -211,6 +212,7 @@ class NaiSyntaxController extends TextEditingController {
 
     final backgroundMarks = List<_HighlightMark?>.filled(text.length, null);
     final pipeMarks = List<_PipeMark?>.filled(text.length, null);
+    final negativeMarks = List<_NegativeMark?>.filled(text.length, null);
     final errors = <String>[];
 
     if (includeEmphasis) {
@@ -218,6 +220,7 @@ class NaiSyntaxController extends TextEditingController {
       _applyAliasHighlights(text, backgroundMarks);
     }
     _applyOfficialPipeHighlights(text, pipeMarks);
+    _applyCharacterNegativeHighlights(text, negativeMarks, errors);
     _syntaxErrors = errors;
 
     return _buildHighlightedSpans(
@@ -226,7 +229,64 @@ class NaiSyntaxController extends TextEditingController {
       colors,
       backgroundMarks,
       pipeMarks,
+      negativeMarks,
     );
+  }
+
+  void _applyCharacterNegativeHighlights(
+    String text,
+    List<_NegativeMark?> marks,
+    List<String> errors,
+  ) {
+    final parsed = CharacterPromptBlockParser.parse(text);
+    for (final block in parsed.blocks) {
+      _fillNegativeMarks(
+        marks,
+        block.contentRange.start,
+        block.contentRange.end,
+        _NegativeMark.content,
+      );
+      _fillNegativeMarks(
+        marks,
+        block.keywordRange.start,
+        block.keywordRange.end,
+        _NegativeMark.keyword,
+      );
+      _fillNegativeMarks(
+        marks,
+        block.openingBoundaryRange.start,
+        block.openingBoundaryRange.end,
+        _NegativeMark.boundary,
+      );
+      _fillNegativeMarks(
+        marks,
+        block.closingBoundaryRange.start,
+        block.closingBoundaryRange.end,
+        _NegativeMark.boundary,
+      );
+    }
+    if (parsed.issues.contains(CharacterPromptBlockIssue.unclosedBlock)) {
+      errors.add('negative(...) 块未闭合');
+    }
+    if (parsed.issues.contains(CharacterPromptBlockIssue.repeatedBlock)) {
+      errors.add('只能使用一个 negative(...) 块');
+    }
+    if (parsed.issues.contains(CharacterPromptBlockIssue.emptyBlock)) {
+      errors.add('negative(...) 块不能为空');
+    }
+  }
+
+  void _fillNegativeMarks(
+    List<_NegativeMark?> marks,
+    int start,
+    int end,
+    _NegativeMark mark,
+  ) {
+    final safeStart = start.clamp(0, marks.length);
+    final safeEnd = end.clamp(safeStart, marks.length);
+    for (var index = safeStart; index < safeEnd; index++) {
+      marks[index] = mark;
+    }
   }
 
   /// 官网按字符执行权重动作；括号不要求成对，`::` 会重置全部状态。
@@ -381,15 +441,24 @@ class NaiSyntaxController extends TextEditingController {
     NaiSyntaxColors colors,
     List<_HighlightMark?> backgroundMarks,
     List<_PipeMark?> pipeMarks,
+    List<_NegativeMark?> negativeMarks,
   ) {
     final spans = <TextSpan>[];
     var start = 0;
-    var decoration = _SpanDecoration(backgroundMarks[0], pipeMarks[0]);
+    var decoration = _SpanDecoration(
+      backgroundMarks[0],
+      pipeMarks[0],
+      negativeMarks[0],
+    );
 
     for (var index = 1; index <= text.length; index++) {
       final nextDecoration = index == text.length
           ? null
-          : _SpanDecoration(backgroundMarks[index], pipeMarks[index]);
+          : _SpanDecoration(
+              backgroundMarks[index],
+              pipeMarks[index],
+              negativeMarks[index],
+            );
       if (nextDecoration == decoration) continue;
 
       spans.add(
@@ -410,6 +479,8 @@ enum _HighlightTone { high, low, mid, alias }
 
 enum _PipeMark { single, double }
 
+enum _NegativeMark { keyword, boundary, content }
+
 class _HighlightMark {
   final _HighlightTone tone;
   final double opacity;
@@ -427,17 +498,19 @@ class _HighlightMark {
 class _SpanDecoration {
   final _HighlightMark? background;
   final _PipeMark? pipe;
+  final _NegativeMark? negative;
 
-  const _SpanDecoration(this.background, this.pipe);
+  const _SpanDecoration(this.background, this.pipe, this.negative);
 
   @override
   bool operator ==(Object other) =>
       other is _SpanDecoration &&
       other.background == background &&
-      other.pipe == pipe;
+      other.pipe == pipe &&
+      other.negative == negative;
 
   @override
-  int get hashCode => Object.hash(background, pipe);
+  int get hashCode => Object.hash(background, pipe, negative);
 }
 
 /// 官网强调高亮的默认主题色。
@@ -447,6 +520,7 @@ class NaiSyntaxColors {
   final Color lowIntensityColor;
   final Color midIntensityColor;
   final Color pipeColor;
+  final Color negativeColor;
 
   const NaiSyntaxColors._({
     required this.isDark,
@@ -454,6 +528,7 @@ class NaiSyntaxColors {
     required this.lowIntensityColor,
     required this.midIntensityColor,
     required this.pipeColor,
+    required this.negativeColor,
   });
 
   factory NaiSyntaxColors.fromTheme(ThemeData theme) {
@@ -463,6 +538,10 @@ class NaiSyntaxColors {
       lowIntensityColor: const Color(0xFF079CED),
       midIntensityColor: const Color(0xFF7ACC29),
       pipeColor: theme.colorScheme.onSurface,
+      negativeColor: Color.alphaBlend(
+        theme.colorScheme.error.withValues(alpha: 0.58),
+        theme.colorScheme.onSurfaceVariant,
+      ),
     );
   }
 
@@ -472,6 +551,7 @@ class NaiSyntaxColors {
     lowIntensityColor,
     midIntensityColor,
     pipeColor,
+    negativeColor,
   );
 
   TextStyle _applyDecoration(TextStyle baseStyle, _SpanDecoration decoration) {
@@ -480,8 +560,19 @@ class NaiSyntaxColors {
     if (mark != null) {
       style = style.copyWith(backgroundColor: _getBackgroundColor(mark));
     }
+    if (decoration.negative != null) {
+      style = style.copyWith(
+        color: negativeColor,
+        fontWeight: decoration.negative == _NegativeMark.content
+            ? style.fontWeight
+            : FontWeight.w600,
+      );
+    }
     if (decoration.pipe != null) {
-      style = style.copyWith(color: pipeColor, fontWeight: FontWeight.w800);
+      style = style.copyWith(
+        color: decoration.negative == null ? pipeColor : negativeColor,
+        fontWeight: FontWeight.w800,
+      );
     }
     return style;
   }

--- a/test/core/autocomplete/prompt_token_parser_test.dart
+++ b/test/core/autocomplete/prompt_token_parser_test.dart
@@ -248,6 +248,62 @@ void main() {
         expect(result.cursorPosition, result.text.length);
       },
     );
+
+    test('queries and replaces tags inside a character negative block', () {
+      const text = 'girl, negative(red ha, glasses)';
+      final query = PromptTokenParser.parse(
+        text: text,
+        cursorPosition: text.indexOf('red ha') + 'red ha'.length,
+        limit: 20,
+        locale: 'en',
+      );
+
+      expect(query.token, 'red_ha');
+      expect(query.existingTags, containsAll(['girl', 'glasses']));
+      expect(query.existingTags, isNot(contains('negative(red_ha')));
+
+      final result = PromptTokenParser.apply(
+        text: text,
+        query: query,
+        canonicalTag: 'red_hair',
+        autoInsertComma: true,
+        replaceUnderscores: false,
+      );
+      expect(result.text, 'girl, negative(red_hair, glasses)');
+    });
+
+    test('inserts related tags before the negative block closing boundary', () {
+      const text = 'girl, negative(red hair)';
+      final query = PromptTokenParser.parseRelated(
+        text: text,
+        cursorPosition: text.indexOf('red hair') + 3,
+        limit: 20,
+        locale: 'en',
+      )!;
+
+      final result = PromptTokenParser.apply(
+        text: text,
+        query: query,
+        canonicalTag: 'glasses',
+        autoInsertComma: false,
+        replaceUnderscores: true,
+      );
+      expect(result.text, 'girl, negative(red hair, glasses)');
+    });
+
+    test('does not query the reserved keyword or its boundaries', () {
+      const text = 'girl, negative(red hair)';
+      final query = PromptTokenParser.parse(
+        text: text,
+        cursorPosition: text.indexOf('negative') + 3,
+        limit: 20,
+        locale: 'en',
+      );
+
+      expect(query.token, isEmpty);
+      expect(query.replacementRange.start, text.indexOf('negative') + 3);
+      expect(query.existingTags, containsAll(['girl', 'red_hair']));
+    });
   });
 
   group('PromptTokenParser.editChangesActiveToken', () {

--- a/test/core/services/character_conversion_service_test.dart
+++ b/test/core/services/character_conversion_service_test.dart
@@ -4,6 +4,35 @@ import 'package:nai_launcher/data/models/character/character_prompt.dart'
     as ui_character;
 
 void main() {
+  group('CharacterPromptConfig.addCharacter', () {
+    test('preserves the legacy default UC when no block was supplied', () {
+      const config = ui_character.CharacterPromptConfig();
+
+      final character = config
+          .addCharacter(prompt: 'girl, blue eyes')
+          .characters
+          .single;
+
+      expect(character.prompt, 'girl, blue eyes');
+      expect(character.negativePrompt, 'lowres, aliasing, ');
+    });
+
+    test('stores an explicitly parsed independent UC', () {
+      const config = ui_character.CharacterPromptConfig();
+
+      final character = config
+          .addCharacter(
+            prompt: 'girl, blue eyes',
+            negativePrompt: 'red hair, glasses',
+          )
+          .characters
+          .single;
+
+      expect(character.prompt, 'girl, blue eyes');
+      expect(character.negativePrompt, 'red hair, glasses');
+    });
+  });
+
   group('CharacterConversionService', () {
     test('custom mode resolves all six missing positions continuously', () {
       final characters = List<ui_character.CharacterPrompt>.generate(
@@ -63,6 +92,94 @@ void main() {
       expect(result.characters.single.positionX, 0.0);
       expect(result.characters.single.positionY, 1.0);
       expect(result.aliasesResolved, isTrue);
+    });
+
+    test('maps a library negative block to independent character UC', () {
+      const config = ui_character.CharacterPromptConfig(
+        characters: [
+          ui_character.CharacterPrompt(
+            id: 'alice',
+            name: 'Alice',
+            prompt:
+                r'girl, alice \(wonderland\), blue eyes, negative(red hair, glasses)',
+            negativePrompt: '',
+          ),
+        ],
+      );
+
+      final result = CharacterConversionService().convert(config);
+      final character = result.characters.single;
+
+      expect(character.prompt, r'girl, alice \(wonderland\), blue eyes');
+      expect(character.negativePrompt, 'red hair, glasses');
+      expect(character.prompt, isNot(contains('negative(')));
+      expect(character.negativePrompt, isNot(contains('negative(')));
+    });
+
+    test('splits negative syntax after resolving a library alias', () {
+      const config = ui_character.CharacterPromptConfig(
+        characters: [
+          ui_character.CharacterPrompt(
+            id: 'alice',
+            name: 'Alice',
+            prompt: '<alice>',
+            negativePrompt: 'lowres',
+          ),
+        ],
+      );
+
+      final result = CharacterConversionService(
+        aliasResolver: (text) => text == '<alice>'
+            ? 'girl, blue eyes, negative(red hair, glasses)'
+            : text,
+      ).convert(config);
+      final character = result.characters.single;
+
+      expect(character.prompt, 'girl, blue eyes');
+      expect(character.negativePrompt, 'red hair, glasses, lowres');
+      expect(result.aliasesResolved, isTrue);
+    });
+
+    test('does not duplicate UC already projected from the same alias', () {
+      const config = ui_character.CharacterPromptConfig(
+        characters: [
+          ui_character.CharacterPrompt(
+            id: 'alice',
+            name: 'Alice',
+            prompt: '<alice>',
+            negativePrompt: 'red hair, glasses',
+          ),
+        ],
+      );
+
+      final character = CharacterConversionService(
+        aliasResolver: (text) =>
+            text == '<alice>' ? 'girl, negative(red hair, glasses)' : text,
+      ).convert(config).characters.single;
+
+      expect(character.prompt, 'girl');
+      expect(character.negativePrompt, 'red hair, glasses');
+    });
+
+    test('keeps negative-only characters in the API mapping', () {
+      const config = ui_character.CharacterPromptConfig(
+        characters: [
+          ui_character.CharacterPrompt(
+            id: 'negative-only',
+            name: 'Negative only',
+            prompt: 'negative(red hair)',
+            negativePrompt: '',
+          ),
+        ],
+      );
+
+      final service = CharacterConversionService();
+      final result = service.convert(config);
+
+      expect(result.characters.single.prompt, isEmpty);
+      expect(result.characters.single.negativePrompt, 'red hair');
+      expect(service.hasEnabledCharacters(config), isTrue);
+      expect(service.getEnabledCharacterCount(config), 1);
     });
   });
 }

--- a/test/core/utils/character_prompt_block_parser_test.dart
+++ b/test/core/utils/character_prompt_block_parser_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/utils/character_prompt_block_parser.dart';
+
+void main() {
+  group('CharacterPromptBlockParser', () {
+    test('splits the approved syntax without changing escaped parentheses', () {
+      const source =
+          r'girl, alice \(wonderland\), blonde hair, blue eyes, negative(red hair, glasses, hat)';
+
+      final result = CharacterPromptBlockParser.parse(source);
+
+      expect(
+        result.positivePrompt,
+        r'girl, alice \(wonderland\), blonde hair, blue eyes',
+      );
+      expect(result.negativePrompt, 'red hair, glasses, hat');
+      expect(result.blocks, hasLength(1));
+      expect(result.issues, isEmpty);
+    });
+
+    test('supports nested and escaped parentheses inside the block', () {
+      final result = CharacterPromptBlockParser.parse(
+        r'girl, negative(red hair, smile \(evil\), (round face))',
+      );
+
+      expect(result.positivePrompt, 'girl');
+      expect(result.negativePrompt, r'red hair, smile \(evil\), (round face)');
+    });
+
+    test('preserves NovelAI weight syntax in both prompt parts', () {
+      final result = CharacterPromptBlockParser.parse(
+        'girl, {blue eyes}, 1.2::smile::, '
+        'negative([red hair], 0.8::glasses::)',
+      );
+
+      expect(result.positivePrompt, 'girl, {blue eyes}, 1.2::smile::');
+      expect(result.negativePrompt, '[red hair], 0.8::glasses::');
+    });
+
+    test('recognizes a block between positive tags', () {
+      final result = CharacterPromptBlockParser.parse(
+        'girl, negative(red hair), blue eyes',
+      );
+
+      expect(result.positivePrompt, 'girl, blue eyes');
+      expect(result.negativePrompt, 'red hair');
+    });
+
+    test('supports a negative-only entry', () {
+      final result = CharacterPromptBlockParser.parse(
+        'negative(red hair, glasses)',
+      );
+
+      expect(result.positivePrompt, isEmpty);
+      expect(result.negativePrompt, 'red hair, glasses');
+      expect(result.isValid, isTrue);
+    });
+
+    test('reports an empty block without losing its boundaries', () {
+      final result = CharacterPromptBlockParser.parse('girl, negative(  )');
+
+      expect(result.positivePrompt, 'girl');
+      expect(result.negativePrompt, isEmpty);
+      expect(result.blocks, hasLength(1));
+      expect(result.issues, contains(CharacterPromptBlockIssue.emptyBlock));
+    });
+
+    test('reports an unclosed reserved block and keeps legacy text intact', () {
+      const source = 'girl, negative(red hair, glasses';
+      final result = CharacterPromptBlockParser.parse(source);
+
+      expect(result.positivePrompt, source);
+      expect(result.negativePrompt, isEmpty);
+      expect(result.blocks, isEmpty);
+      expect(result.issues, contains(CharacterPromptBlockIssue.unclosedBlock));
+    });
+
+    test('reports repeated blocks and safely removes every marker', () {
+      final result = CharacterPromptBlockParser.parse(
+        'girl, negative(red hair), negative(glasses)',
+      );
+
+      expect(result.positivePrompt, 'girl');
+      expect(result.negativePrompt, 'red hair, glasses');
+      expect(result.blocks, hasLength(2));
+      expect(result.issues, contains(CharacterPromptBlockIssue.repeatedBlock));
+    });
+
+    test('does not reserve negative text outside a top-level tag boundary', () {
+      for (final source in [
+        'notnegative(red hair)',
+        'some negative(red hair)',
+        '{negative(red hair)}',
+        '1.2::negative(red hair)::',
+        'negative(red hair) suffix',
+      ]) {
+        final result = CharacterPromptBlockParser.parse(source);
+        expect(result.hasNegativeBlock, isFalse, reason: source);
+        expect(result.positivePrompt, source, reason: source);
+      }
+    });
+
+    test('finds content context at the closing-caret boundary', () {
+      const source = 'girl, negative(red hair)';
+      final result = CharacterPromptBlockParser.parse(source);
+      final close = source.lastIndexOf(')');
+
+      expect(result.blockContaining(close, contentOnly: true), isNotNull);
+      expect(result.blockContaining(close + 1, contentOnly: true), isNull);
+    });
+
+    test('composes separate character fields into one canonical block', () {
+      final content = CharacterPromptBlockParser.compose(
+        positivePrompt: 'girl, blue eyes',
+        negativePrompt: 'red hair, glasses',
+      );
+      final parsed = CharacterPromptBlockParser.parse(content);
+
+      expect(content, 'girl, blue eyes, negative(red hair, glasses)');
+      expect(parsed.positivePrompt, 'girl, blue eyes');
+      expect(parsed.negativePrompt, 'red hair, glasses');
+      expect(parsed.blocks, hasLength(1));
+    });
+
+    test('compose canonicalizes an existing block without duplication', () {
+      expect(
+        CharacterPromptBlockParser.compose(
+          positivePrompt: 'girl, negative(red hair)',
+          negativePrompt: 'glasses',
+        ),
+        'girl, negative(red hair, glasses)',
+      );
+      expect(
+        CharacterPromptBlockParser.compose(
+          positivePrompt: '',
+          negativePrompt: 'red hair',
+        ),
+        'negative(red hair)',
+      );
+    });
+  });
+}

--- a/test/core/utils/nai_prompt_formatter_test.dart
+++ b/test/core/utils/nai_prompt_formatter_test.dart
@@ -26,5 +26,15 @@ void main() {
 
       expect(NaiPromptFormatter.format(prompt), 'first_tag\n  \nsecond_tag');
     });
+
+    test('格式化正负标签但不破坏 negative 块边界', () {
+      const prompt =
+          r'girl, alice \(wonderland\), negative(red hair, 1.2::blue eyes::)';
+
+      expect(
+        NaiPromptFormatter.format(prompt),
+        r'girl, alice_\(wonderland\), negative(red_hair, 1.2::blue_eyes::)',
+      );
+    });
   });
 }

--- a/test/presentation/agent_chat/services/prompt_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/prompt_toolbox_test.dart
@@ -151,6 +151,7 @@ class _DuplicateNameCharacterNotifier extends CharacterPromptNotifier {
     CharacterGender gender, {
     String? name,
     String? prompt,
+    String? negativePrompt,
     String? thumbnailPath,
   }) {
     state = state.copyWith(
@@ -160,6 +161,7 @@ class _DuplicateNameCharacterNotifier extends CharacterPromptNotifier {
           id: 'new-character',
           name: name ?? '',
           prompt: prompt ?? '',
+          negativePrompt: negativePrompt ?? '',
           gender: gender,
         ),
       ],

--- a/test/presentation/providers/generation/generation_request_preparation_service_test.dart
+++ b/test/presentation/providers/generation/generation_request_preparation_service_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/utils/prompt_preset_resolution.dart';
+import 'package:nai_launcher/data/models/image/image_params.dart';
+import 'package:nai_launcher/presentation/providers/generation/generation_request_preparation_service.dart';
+
+void main() {
+  test(
+    'ordinary library alias insertion submits only its positive portion',
+    () async {
+      final service = GenerationRequestPreparationService(
+        GenerationPreparationDependencies(
+          prompt: GenerationPromptPreparation(
+            randomModeEnabled: false,
+            queueExecuting: false,
+            generateAndApplyRandomPrompt: (_) async => '',
+            resolveAliases: (prompt) => prompt == '<alice>'
+                ? 'girl, blue eyes, negative(red hair, glasses)'
+                : prompt,
+            applyFixedPositiveTags: (prompt) =>
+                '$prompt, negative(fixed literal)',
+            applyFixedNegativeTags: (prompt) => prompt,
+            resolvePresets: (params) => PromptPresetResolution(
+              prompt: params.prompt,
+              negativePrompt: params.negativePrompt,
+              qualityToggle: params.qualityToggle,
+              ucPreset: params.ucPreset,
+              omitQualityTagHint: params.omitQualityTagHint,
+              omitUcPresetTagHint: params.omitUcPresetTagHint,
+            ),
+          ),
+          characters: GenerationCharacterPreparation(
+            read: (_) => const CharacterPreparationSnapshot(
+              characters: [],
+              useCoords: false,
+            ),
+          ),
+          vibes: GenerationVibePreparation(prepare: (params) async => params),
+          focused: GenerationFocusedPreparation(
+            read: () => const GenerationFocusedSnapshot(
+              enabled: false,
+              minimumContextMegaPixels: 0,
+            ),
+          ),
+        ),
+      );
+
+      final result = await service.prepareInitial(
+        const ImageParams(prompt: '<alice>', negativePrompt: 'global uc'),
+      );
+
+      expect(result.params.prompt, 'girl, blue eyes, negative(fixed literal)');
+      expect(result.params.negativePrompt, 'global uc');
+      expect(result.params.prompt, isNot(contains('red hair')));
+      expect(result.params.prompt, isNot(contains('glasses')));
+    },
+  );
+}

--- a/test/presentation/providers/prompt_token_counter_provider_test.dart
+++ b/test/presentation/providers/prompt_token_counter_provider_test.dart
@@ -163,6 +163,56 @@ void main() {
       },
     );
 
+    test('character negative blocks follow request prompt partitioning', () {
+      String resolveNegativeAlias(String text) =>
+          text == '<alice>' ? 'girl, blue eyes, negative(red hair)' : text;
+      final fixedTags = FixedTagsState(
+        entries: [
+          FixedTagEntry.create(
+            name: 'literal fixed tag',
+            content: 'negative(fixed literal)',
+            position: FixedTagPosition.suffix,
+          ),
+        ],
+      );
+      const characters = [
+        CharacterPrompt(
+          id: 'alice',
+          name: 'Alice',
+          prompt: '<alice>',
+          negativePrompt: 'red hair',
+        ),
+      ];
+
+      final positive = buildPromptTokenCountPayload(
+        target: PromptTokenCountTarget.positive,
+        prompt: '<alice>',
+        negativePrompt: 'global uc',
+        model: api.ImageModels.animeDiffusionV45Full,
+        fixedTagsState: fixedTags,
+        qualityToggle: false,
+        ucPreset: api.UcPresets.noneApiValue,
+        characters: characters,
+        resolveAliases: resolveNegativeAlias,
+      );
+      final negative = buildPromptTokenCountPayload(
+        target: PromptTokenCountTarget.negative,
+        prompt: '<alice>',
+        negativePrompt: 'global uc',
+        model: api.ImageModels.animeDiffusionV45Full,
+        fixedTagsState: fixedTags,
+        qualityToggle: false,
+        ucPreset: api.UcPresets.noneApiValue,
+        characters: characters,
+        resolveAliases: resolveNegativeAlias,
+      );
+
+      expect(positive.mainText, 'girl, blue eyes, negative(fixed literal)');
+      expect(positive.extraTexts, ['girl, blue eyes']);
+      expect(negative.mainText, 'global uc');
+      expect(negative.extraTexts, ['red hair']);
+    });
+
     test('positive V5 payload should count the generated text block', () {
       final payload = buildPromptTokenCountPayload(
         target: PromptTokenCountTarget.positive,

--- a/test/presentation/screens/generation/widgets/prompt_input_test.dart
+++ b/test/presentation/screens/generation/widgets/prompt_input_test.dart
@@ -971,12 +971,14 @@ class _TestCharacterPromptNotifier extends CharacterPromptNotifier {
     CharacterGender gender, {
     String? name,
     String? prompt,
+    String? negativePrompt,
     String? thumbnailPath,
   }) {
     state = state.addCharacter(
       gender: gender,
       name: name,
       prompt: prompt,
+      negativePrompt: negativePrompt,
       thumbnailPath: thumbnailPath,
     );
   }

--- a/test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart
@@ -27,6 +27,7 @@ void main() {
     expect(find.text('添加条目'), findsOneWidget);
     expect(find.text('预览图'), findsOneWidget);
     expect(find.text('名称'), findsOneWidget);
+    expect(find.textContaining('negative(...) 保存独立负面提示词'), findsOneWidget);
 
     final thumbnailTop = tester.getTopLeft(find.text('预览图')).dy;
     final nameTop = tester.getTopLeft(find.text('名称')).dy;

--- a/test/presentation/widgets/character/character_add_from_library_test.dart
+++ b/test/presentation/widgets/character/character_add_from_library_test.dart
@@ -6,8 +6,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:nai_launcher/core/constants/storage_keys.dart';
 import 'package:nai_launcher/data/models/character/character_prompt.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
 import 'package:nai_launcher/data/repositories/character_prompt_repository.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/providers/character_prompt_provider.dart';
+import 'package:nai_launcher/presentation/providers/tag_library_page_provider.dart';
 import 'package:nai_launcher/presentation/widgets/character/character_prompt_button.dart';
 import 'package:nai_launcher/presentation/widgets/character/inline_character_row.dart';
 import 'package:nai_launcher/presentation/widgets/tag_library/tag_library_picker_dialog.dart';
@@ -39,8 +42,9 @@ void main() {
     ).put(StorageKeys.enableAutocomplete, false);
   });
 
-  Widget buildTestApp(Widget child) {
+  Widget buildTestApp(Widget child, {List<Override> overrides = const []}) {
     return ProviderScope(
+      overrides: overrides,
       child: MaterialApp(
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -107,4 +111,78 @@ void main() {
     await tester.tap(find.text('Cancel'));
     await tester.pumpAndSettle();
   });
+
+  testWidgets('library negative block populates independent character UC', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final entry = TagLibraryEntry.create(
+      name: 'Alice negative',
+      content: 'girl, blue eyes, negative(red hair, glasses)',
+    );
+    final characterNotifier = _TestCharacterPromptNotifier();
+
+    await tester.pumpWidget(
+      buildTestApp(
+        const CharacterPromptButton(),
+        overrides: [
+          tagLibraryPageNotifierProvider.overrideWith(
+            () => _TestTagLibraryPageNotifier([entry]),
+          ),
+          characterPromptNotifierProvider.overrideWith(() => characterNotifier),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Characters'));
+    await tester.pumpAndSettle();
+    await openLibraryMenuItem(tester);
+    await tester.tap(find.text('Alice negative'));
+    await tester.pumpAndSettle();
+
+    final character = characterNotifier.current.characters.single;
+    expect(character.prompt, 'girl, blue eyes');
+    expect(character.negativePrompt, 'red hair, glasses');
+  });
+}
+
+class _TestTagLibraryPageNotifier extends TagLibraryPageNotifier {
+  _TestTagLibraryPageNotifier(this.entries);
+
+  final List<TagLibraryEntry> entries;
+
+  @override
+  TagLibraryPageState build() => TagLibraryPageState(entries: entries);
+
+  @override
+  Future<void> recordUsage(String id) async {}
+}
+
+class _TestCharacterPromptNotifier extends CharacterPromptNotifier {
+  CharacterPromptConfig get current => state;
+
+  @override
+  CharacterPromptConfig build() => const CharacterPromptConfig();
+
+  @override
+  void addCharacter(
+    CharacterGender gender, {
+    String? name,
+    String? prompt,
+    String? negativePrompt,
+    String? thumbnailPath,
+  }) {
+    state = state.addCharacter(
+      gender: gender,
+      name: name,
+      prompt: prompt,
+      negativePrompt: negativePrompt,
+      thumbnailPath: thumbnailPath,
+    );
+  }
 }

--- a/test/presentation/widgets/character/inline_character_card_test.dart
+++ b/test/presentation/widgets/character/inline_character_card_test.dart
@@ -143,5 +143,29 @@ void main() {
       expect(find.text(l10n.common_delete), findsOneWidget);
       expect(tester.takeException(), isNull);
     });
+
+    testWidgets('添加到词库时将角色独立 UC 编码为 negative 块', (tester) async {
+      const target = CharacterPrompt(
+        id: 'char-negative',
+        name: 'Alice',
+        prompt: 'girl, blue eyes',
+        negativePrompt: 'red hair, glasses',
+      );
+      await tester.pumpWidget(buildTestApp(target: target));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('character-actions-menu')));
+      await tester.pumpAndSettle();
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(InlineCharacterCard)),
+      )!;
+      await tester.tap(find.text(l10n.tagLibrary_addToLibrary));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('girl, blue eyes, negative(red hair, glasses)'),
+        findsOneWidget,
+      );
+    });
   });
 }

--- a/test/presentation/widgets/character/inline_character_section_test.dart
+++ b/test/presentation/widgets/character/inline_character_section_test.dart
@@ -26,12 +26,14 @@ class _TestCharacterPromptNotifier extends CharacterPromptNotifier {
     CharacterGender gender, {
     String? name,
     String? prompt,
+    String? negativePrompt,
     String? thumbnailPath,
   }) {
     state = state.addCharacter(
       gender: gender,
       name: name,
       prompt: prompt,
+      negativePrompt: negativePrompt,
       thumbnailPath: thumbnailPath,
     );
   }

--- a/test/presentation/widgets/common/weight_adjust_toolbar_test.dart
+++ b/test/presentation/widgets/common/weight_adjust_toolbar_test.dart
@@ -76,6 +76,64 @@ void main() {
     expect(platformDefaultAllowed, isFalse);
   });
 
+  testWidgets('wheel weighting never wraps negative block boundaries', (
+    tester,
+  ) async {
+    const text = 'girl, negative(red hair, glasses)';
+    final prompt = TextEditingController(text: text);
+    final focus = FocusNode();
+    final page = ScrollController(initialScrollOffset: 100);
+    _registerCleanup(tester, prompt, focus, page);
+
+    await _pumpHarness(
+      tester,
+      prompt: prompt,
+      focus: focus,
+      page: page,
+      enableWheelAdjustment: true,
+    );
+    focus.requestFocus();
+    prompt.selection = TextSelection(
+      baseOffset: text.indexOf('negative'),
+      extentOffset: text.length,
+    );
+    await tester.pump();
+
+    await _sendWheel(tester);
+
+    expect(prompt.text, 'girl, negative(0.95::red hair, glasses::)');
+  });
+
+  testWidgets('wheel weighting rejects a selection crossing block boundaries', (
+    tester,
+  ) async {
+    const text = 'girl, negative(red hair, glasses)';
+    final prompt = TextEditingController(text: text);
+    final focus = FocusNode();
+    final page = ScrollController(initialScrollOffset: 100);
+    _registerCleanup(tester, prompt, focus, page);
+
+    await _pumpHarness(
+      tester,
+      prompt: prompt,
+      focus: focus,
+      page: page,
+      enableWheelAdjustment: true,
+    );
+    focus.requestFocus();
+    prompt.selection = const TextSelection(
+      baseOffset: 0,
+      extentOffset: text.length,
+    );
+    await tester.pump();
+    final pageOffsetBefore = page.offset;
+
+    await _sendWheel(tester);
+
+    expect(prompt.text, text);
+    expect(page.offset, greaterThan(pageOffsetBefore));
+  });
+
   testWidgets('disabled wheel adjustment leaves page scrolling available', (
     tester,
   ) async {

--- a/test/presentation/widgets/prompt/nai_syntax_controller_test.dart
+++ b/test/presentation/widgets/prompt/nai_syntax_controller_test.dart
@@ -152,6 +152,59 @@ void main() {
         isTrue,
       );
     });
+
+    testWidgets('tints the complete negative block without hiding weights', (
+      tester,
+    ) async {
+      final controller = NaiSyntaxController(
+        text: 'girl, negative({red hair}, 1.2::glasses::)',
+      );
+      addTearDown(controller.dispose);
+
+      final children = await _buildTextSpanChildren(tester, controller);
+      final negativeSpans = children
+          .where((span) => span.style?.color != null)
+          .toList();
+
+      expect(
+        negativeSpans.map((span) => span.text).join(),
+        'negative({red hair}, 1.2::glasses::)',
+      );
+      expect(
+        negativeSpans.any((span) => span.style?.backgroundColor != null),
+        isTrue,
+      );
+      expect(controller.syntaxErrors, isEmpty);
+    });
+
+    testWidgets('keeps negative semantics when search highlighting overlaps', (
+      tester,
+    ) async {
+      final controller = NaiSyntaxController(text: 'girl, negative(red hair)')
+        ..updateSearchHighlights(
+          matches: const [TextRange(start: 15, end: 23)],
+          activeMatchIndex: 0,
+        );
+      addTearDown(controller.dispose);
+
+      final children = await _buildTextSpanChildren(tester, controller);
+      final match = children.singleWhere((span) => span.text == 'red hair');
+
+      expect(match.style?.color, isNotNull);
+      expect(match.style?.backgroundColor, isNotNull);
+    });
+
+    testWidgets('reports malformed negative block syntax', (tester) async {
+      final controller = NaiSyntaxController(
+        text: 'negative(), negative(red hair',
+      );
+      addTearDown(controller.dispose);
+
+      await _buildTextSpanChildren(tester, controller);
+
+      expect(controller.syntaxErrors, contains('negative(...) 块未闭合'));
+      expect(controller.syntaxErrors, contains('negative(...) 块不能为空'));
+    });
   });
 }
 


### PR DESCRIPTION
## Problem
Character library entries could not store separate negative prompts. Negative syntax could also interfere with autocomplete, formatting, generation, and editing.

## Solution
Add support for `negative(...)` blocks in character prompts and map their contents to each character's independent negative prompt.

- Added a shared parser for character negative blocks, including validation and escaped or nested parentheses.
- Updated character conversion, generation preparation, token counting, autocomplete, formatting, and library flows.
- Added syntax highlighting, boundary-safe weight editing, localized help text, and support for negative-only characters.
- Added unit and widget coverage for parsing, conversion, generation, autocomplete, formatting, UI flows, and editing behavior.