### PR TITLE
perf(gallery): 优化在线画廊桌面滚动性能

### DIFF
--- a/lib/presentation/agent_chat/widgets/agent_resource_drop_region.dart
+++ b/lib/presentation/agent_chat/widgets/agent_resource_drop_region.dart
@@ -4,6 +4,7 @@ import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 
 import '../../../../core/agent/resources/agent_chat_resource_drag_format.dart';
 import '../../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../../core/platform/platform_capabilities.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../providers/agent_chat_notifier.dart';
 
@@ -86,18 +87,40 @@ class AgentResourceDropRegion extends StatelessWidget {
   }
 }
 
-class AgentResourceDragSource extends ConsumerWidget {
+class AgentResourceDragSource extends ConsumerStatefulWidget {
   const AgentResourceDragSource({
     super.key,
     required this.reference,
     required this.child,
+    this.deferDesktopRegistration = false,
   });
 
   final AgentChatResourceReference reference;
   final Widget child;
 
+  /// Keeps the native drag detector and snapshot layer out of large desktop
+  /// virtualized lists until the pointer reaches this item.
+  ///
+  /// Touch platforms retain eager registration so long-press dragging keeps
+  /// receiving the original pointer sequence.
+  final bool deferDesktopRegistration;
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<AgentResourceDragSource> createState() =>
+      _AgentResourceDragSourceState();
+}
+
+class _AgentResourceDragSourceState
+    extends ConsumerState<AgentResourceDragSource> {
+  final _childKey = GlobalKey();
+  bool _desktopPointerInside = false;
+  bool _desktopPointerDown = false;
+
+  Widget get _preservedChild =>
+      KeyedSubtree(key: _childKey, child: widget.child);
+
+  Widget _buildSource(BuildContext context, WidgetRef ref) {
+    final reference = widget.reference;
     return DragItemWidget(
       allowedOperations: () => [DropOperation.copy],
       dragItemProvider: (_) async {
@@ -117,7 +140,60 @@ class AgentResourceDragSource extends ConsumerWidget {
           position: details.globalPosition,
           reference: reference,
         ),
-        child: DraggableWidget(child: child),
+        child: DraggableWidget(child: _preservedChild),
+      ),
+    );
+  }
+
+  Widget _buildContextMenuTarget(BuildContext context, WidgetRef ref) {
+    return GestureDetector(
+      behavior: HitTestBehavior.deferToChild,
+      onSecondaryTapDown: (details) => showAddAgentResourceMenu(
+        context: context,
+        ref: ref,
+        position: details.globalPosition,
+        reference: widget.reference,
+      ),
+      child: _preservedChild,
+    );
+  }
+
+  void _releaseDesktopPointer() {
+    if (!_desktopPointerDown) return;
+    if (_desktopPointerInside) {
+      _desktopPointerDown = false;
+    } else {
+      setState(() => _desktopPointerDown = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final defersRegistration =
+        widget.deferDesktopRegistration &&
+        PlatformCapabilities.current.hasPrecisePointer;
+    if (!defersRegistration) return _buildSource(context, ref);
+
+    return Listener(
+      onPointerDown: (_) => _desktopPointerDown = true,
+      onPointerUp: (_) => _releaseDesktopPointer(),
+      onPointerCancel: (_) => _releaseDesktopPointer(),
+      child: MouseRegion(
+        onEnter: (_) {
+          if (!_desktopPointerInside) {
+            setState(() => _desktopPointerInside = true);
+          }
+        },
+        onExit: (_) {
+          if (_desktopPointerDown) {
+            _desktopPointerInside = false;
+          } else {
+            setState(() => _desktopPointerInside = false);
+          }
+        },
+        child: _desktopPointerInside || _desktopPointerDown
+            ? _buildSource(context, ref)
+            : _buildContextMenuTarget(context, ref),
       ),
     );
   }

--- a/lib/presentation/screens/online_gallery/gallery_grid_item.dart
+++ b/lib/presentation/screens/online_gallery/gallery_grid_item.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../../core/cache/online_gallery_detail_coordinator.dart';
@@ -19,7 +20,7 @@ class GalleryGridItem extends StatefulWidget {
     required this.index,
     required this.itemWidth,
     required this.columnCount,
-    required this.isScrolling,
+    required this.scrolling,
     required this.anchorKey,
     required this.onVisibilityChanged,
     required this.detailRequestScope,
@@ -31,7 +32,7 @@ class GalleryGridItem extends StatefulWidget {
   final int index;
   final double itemWidth;
   final int columnCount;
-  final bool isScrolling;
+  final ValueListenable<bool> scrolling;
   final GlobalKey? anchorKey;
   final void Function(
     int index,
@@ -119,6 +120,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
     GalleryDetail? detail,
   }) {
     return AgentResourceDragSource(
+      deferDesktopRegistration: true,
       reference: AgentChatResourceReference(
         kind: AgentChatResourceKind.onlineGalleryMedia,
         source: item.sourceId.key,
@@ -152,9 +154,10 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
       child: OnlineGalleryVisibilityDrivenItem(
         key: ValueKey('visible:${post.stableKey}'),
         visibilityKey: post.stableKey,
+        scrolling: widget.scrolling,
         onVisibilityChanged: _handleVisibility,
-        builder: (context, hasBeenVisible) {
-          if (!hasBeenVisible && widget.isScrolling && !_needsDetail) {
+        builder: (context, hasBeenVisible, isScrolling) {
+          if (!hasBeenVisible && isScrolling && !_needsDetail) {
             return SizedBox(
               height: (widget.itemWidth / layoutAspectRatio).clamp(
                 80.0,

--- a/lib/presentation/screens/online_gallery/online_gallery_content.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_content.dart
@@ -39,16 +39,13 @@ class OnlineGalleryContent extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ListenableBuilder(
-      listenable: controller,
-      builder: (context, _) => _OnlineGalleryContentPresenter(
-        context: context,
-        ref: ref,
-        controller: controller,
-        scrollCoordinator: scrollCoordinator,
-        commands: commands,
-      ).build(Theme.of(context), state),
-    );
+    return _OnlineGalleryContentPresenter(
+      context: context,
+      ref: ref,
+      controller: controller,
+      scrollCoordinator: scrollCoordinator,
+      commands: commands,
+    ).build(Theme.of(context), state);
   }
 }
 
@@ -304,7 +301,7 @@ class _OnlineGalleryContentPresenter {
       index: index,
       itemWidth: itemWidth,
       columnCount: columnCount,
-      isScrolling: _controller.isScrolling,
+      scrolling: _controller.scrolling,
       anchorKey: post.stableKey == _controller.pendingAnchorStableKey
           ? _controller.anchorRestoreKey
           : null,

--- a/lib/presentation/screens/online_gallery/online_gallery_grid.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_grid.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:visibility_detector/visibility_detector.dart';
@@ -12,6 +13,13 @@ typedef OnlineGalleryGridItemBuilder =
       int index,
       double itemWidth,
       int columnCount,
+    );
+
+typedef OnlineGalleryVisibilityItemBuilder =
+    Widget Function(
+      BuildContext context,
+      bool hasBeenVisible,
+      bool isScrolling,
     );
 
 /// Responsive masonry grid. Item interaction is supplied as commands so this
@@ -73,13 +81,15 @@ class OnlineGalleryVisibilityDrivenItem extends StatefulWidget {
   const OnlineGalleryVisibilityDrivenItem({
     super.key,
     required this.visibilityKey,
+    required this.scrolling,
     required this.onVisibilityChanged,
     required this.builder,
   });
 
   final String visibilityKey;
+  final ValueListenable<bool> scrolling;
   final void Function(bool visible, double visibleTop) onVisibilityChanged;
-  final Widget Function(BuildContext context, bool hasBeenVisible) builder;
+  final OnlineGalleryVisibilityItemBuilder builder;
 
   @override
   State<OnlineGalleryVisibilityDrivenItem> createState() =>
@@ -90,9 +100,53 @@ class OnlineGalleryVisibilityDrivenItemState
     extends State<OnlineGalleryVisibilityDrivenItem> {
   bool _hasBeenVisible = false;
   bool _isVisible = false;
+  late bool _isScrolling;
+  bool _listensForScrolling = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _isScrolling = widget.scrolling.value;
+    _startListeningForScrolling();
+  }
+
+  @override
+  void didUpdateWidget(covariant OnlineGalleryVisibilityDrivenItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.scrolling == widget.scrolling) return;
+    if (_listensForScrolling) {
+      oldWidget.scrolling.removeListener(_handleScrollingChanged);
+      _listensForScrolling = false;
+    }
+    _isScrolling = widget.scrolling.value;
+    _startListeningForScrolling();
+  }
+
+  void _startListeningForScrolling() {
+    if (_hasBeenVisible || _listensForScrolling) return;
+    widget.scrolling.addListener(_handleScrollingChanged);
+    _listensForScrolling = true;
+  }
+
+  void _stopListeningForScrolling() {
+    if (!_listensForScrolling) return;
+    widget.scrolling.removeListener(_handleScrollingChanged);
+    _listensForScrolling = false;
+  }
+
+  void _handleScrollingChanged() {
+    final value = widget.scrolling.value;
+    if (_isScrolling == value) return;
+    if (!_hasBeenVisible && value && mounted) {
+      setState(() => _isScrolling = value);
+    } else {
+      _isScrolling = value;
+    }
+  }
 
   @override
   void dispose() {
+    _stopListeningForScrolling();
     if (_isVisible) widget.onVisibilityChanged(false, 0);
     super.dispose();
   }
@@ -111,10 +165,11 @@ class OnlineGalleryVisibilityDrivenItemState
         if (_isVisible == visible) return;
         _isVisible = visible;
         if (visible && !_hasBeenVisible && mounted) {
+          _stopListeningForScrolling();
           setState(() => _hasBeenVisible = true);
         }
       },
-      child: widget.builder(context, _hasBeenVisible),
+      child: widget.builder(context, _hasBeenVisible, _isScrolling),
     );
   }
 }

--- a/lib/presentation/screens/online_gallery/online_gallery_screen_controller.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen_controller.dart
@@ -31,6 +31,7 @@ class OnlineGalleryScreenController extends ChangeNotifier {
   final dateRangeLayerLink = LayerLink();
   final anchorRestoreKey = GlobalKey();
   final primarySearchRevealKey = GlobalKey();
+  final scrolling = ValueNotifier<bool>(false);
 
   final Map<int, ({GalleryItem item, double itemWidth, double visibleTop})>
   visibleItems = {};
@@ -46,7 +47,7 @@ class OnlineGalleryScreenController extends ChangeNotifier {
   double lastScrollOffset = 0;
   int scrollDirection = 1;
   int lookaheadItemCount = 12;
-  bool isScrolling = false;
+  bool get isScrolling => scrolling.value;
   bool isEditingPage = false;
   GalleryViewMode? lastViewMode;
   GallerySourceId? lastFavoritesSource;
@@ -71,8 +72,22 @@ class OnlineGalleryScreenController extends ChangeNotifier {
 
   void setScrolling(bool value) {
     if (isScrolling == value) return;
-    isScrolling = value;
-    notifyListeners();
+    scrolling.value = value;
+  }
+
+  bool recordVisibleItem({
+    required int index,
+    required GalleryItem item,
+    required double itemWidth,
+    required double visibleTop,
+  }) {
+    final previous = visibleItems[index];
+    visibleItems[index] = (
+      item: item,
+      itemWidth: itemWidth,
+      visibleTop: visibleTop,
+    );
+    return previous?.item.stableKey != item.stableKey;
   }
 
   void beginPageEditing(int currentPage) {
@@ -134,6 +149,7 @@ class OnlineGalleryScreenController extends ChangeNotifier {
     scrollController.dispose();
     pageController.dispose();
     pageFocusNode.dispose();
+    scrolling.dispose();
     super.dispose();
   }
 }

--- a/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
@@ -174,7 +174,8 @@ class OnlineGalleryScrollPrefetchCoordinator {
       }
       return;
     }
-    controller.visibleItems[index] = (
+    final enteredViewport = controller.recordVisibleItem(
+      index: index,
       item: item,
       itemWidth: itemWidth,
       visibleTop: visibleTop,
@@ -188,6 +189,10 @@ class OnlineGalleryScrollPrefetchCoordinator {
             columnCount: columnCount,
           );
     }
+    // VisibilityDetector also reports position changes for cards that remain
+    // visible. Keep the anchor and viewport sizing current, but do not repeat
+    // image queue and idle-prefetch work until a card actually enters.
+    if (!enteredViewport) return;
     if (item.previewUrl.isNotEmpty) {
       unawaited(
         controller.prefetchCoordinator.submit(

--- a/test/presentation/agent_chat/widgets/agent_resource_drop_region_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_resource_drop_region_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
+import 'package:nai_launcher/core/platform/platform_capabilities.dart';
+import 'package:nai_launcher/presentation/agent_chat/widgets/agent_resource_drop_region.dart';
+import 'package:super_drag_and_drop/super_drag_and_drop.dart';
+
+void main() {
+  tearDown(() => PlatformCapabilities.debugOverride = null);
+
+  testWidgets('desktop deferred drag source registers only while hovered', (
+    tester,
+  ) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    await tester.pumpWidget(_manySourcesApp());
+
+    expect(find.byType(AgentResourceDragSource), findsAtLeastNWidgets(8));
+    expect(find.byType(DragItemWidget), findsNothing);
+    expect(find.byType(DraggableWidget), findsNothing);
+
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(pointer.hover(const Offset(50, 50)));
+    await tester.pump();
+
+    expect(find.byType(DragItemWidget), findsOneWidget);
+    expect(find.byType(DraggableWidget), findsOneWidget);
+
+    await tester.sendEventToBinding(pointer.hover(const Offset(900, 700)));
+    await tester.pump();
+
+    expect(find.byType(DragItemWidget), findsNothing);
+    expect(find.byType(DraggableWidget), findsNothing);
+  });
+
+  testWidgets('desktop hover registration preserves the card state', (
+    tester,
+  ) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    var initializations = 0;
+    var disposals = 0;
+    await tester.pumpWidget(
+      _app(
+        deferDesktopRegistration: true,
+        child: _LifecycleProbe(
+          onInit: () => initializations++,
+          onDispose: () => disposals++,
+        ),
+      ),
+    );
+
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(pointer.hover(const Offset(50, 50)));
+    await tester.pump();
+    await tester.sendEventToBinding(pointer.hover(const Offset(500, 500)));
+    await tester.pump();
+
+    expect(initializations, 1);
+    expect(disposals, 0);
+  });
+
+  testWidgets('desktop drag source stays registered until pointer up', (
+    tester,
+  ) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    await tester.pumpWidget(_app(deferDesktopRegistration: true));
+
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(pointer.hover(const Offset(50, 50)));
+    await tester.pump();
+    await tester.sendEventToBinding(pointer.down(const Offset(50, 50)));
+    await tester.sendEventToBinding(pointer.move(const Offset(500, 500)));
+    await tester.pump();
+
+    expect(find.byType(DragItemWidget), findsOneWidget);
+
+    await tester.sendEventToBinding(pointer.up());
+    await tester.pump();
+
+    expect(find.byType(DragItemWidget), findsNothing);
+  });
+
+  testWidgets('touch platform keeps deferred drag source registered', (
+    tester,
+  ) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.android,
+    );
+    await tester.pumpWidget(_app(deferDesktopRegistration: true));
+
+    expect(find.byType(DragItemWidget), findsOneWidget);
+    expect(find.byType(DraggableWidget), findsOneWidget);
+  });
+}
+
+Widget _manySourcesApp() {
+  return ProviderScope(
+    child: MaterialApp(
+      home: Scaffold(
+        body: GridView.count(
+          crossAxisCount: 4,
+          children: List.generate(
+            24,
+            (index) => AgentResourceDragSource(
+              deferDesktopRegistration: true,
+              reference: AgentChatResourceReference(
+                kind: AgentChatResourceKind.onlineGalleryMedia,
+                source: 'danbooru',
+                resourceId: '$index',
+              ),
+              child: ColoredBox(color: Colors.primaries[index % 18]),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _app({required bool deferDesktopRegistration, Widget? child}) {
+  return ProviderScope(
+    child: MaterialApp(
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 100,
+            height: 100,
+            child: AgentResourceDragSource(
+              deferDesktopRegistration: deferDesktopRegistration,
+              reference: AgentChatResourceReference(
+                kind: AgentChatResourceKind.onlineGalleryMedia,
+                source: 'danbooru',
+                resourceId: '1',
+              ),
+              child: child ?? const ColoredBox(color: Colors.blue),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+class _LifecycleProbe extends StatefulWidget {
+  const _LifecycleProbe({required this.onInit, required this.onDispose});
+
+  final VoidCallback onInit;
+  final VoidCallback onDispose;
+
+  @override
+  State<_LifecycleProbe> createState() => _LifecycleProbeState();
+}
+
+class _LifecycleProbeState extends State<_LifecycleProbe> {
+  @override
+  void initState() {
+    super.initState();
+    widget.onInit();
+  }
+
+  @override
+  void dispose() {
+    widget.onDispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const ColoredBox(color: Colors.blue);
+}

--- a/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
+++ b/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
@@ -195,7 +195,7 @@ Widget _app({
           index: 0,
           itemWidth: 200,
           columnCount: 1,
-          isScrolling: false,
+          scrolling: const AlwaysStoppedAnimation(false),
           anchorKey: null,
           onVisibilityChanged: (_, __, ___, ____, _____, ______) {},
           detailRequestScope: detailRequestScope,

--- a/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
@@ -1,11 +1,129 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/cache/online_gallery_prefetch_coordinator.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_item.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_source.dart';
 import 'package:nai_launcher/presentation/providers/online_gallery_provider.dart';
 import 'package:nai_launcher/presentation/screens/online_gallery/online_gallery_grid.dart';
 import 'package:nai_launcher/presentation/screens/online_gallery/online_gallery_screen_controller.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
 void main() {
+  test('scroll state changes do not notify grid listeners', () {
+    final controller = OnlineGalleryScreenController(
+      prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
+        preloader: (_) async {},
+      ),
+    );
+    addTearDown(controller.dispose);
+    var notifications = 0;
+    var scrollingNotifications = 0;
+    controller.addListener(() => notifications++);
+    controller.scrolling.addListener(() => scrollingNotifications++);
+
+    controller.setScrolling(true);
+    controller.setScrolling(false);
+
+    expect(controller.isScrolling, isFalse);
+    expect(notifications, 0);
+    expect(scrollingNotifications, 2);
+  });
+
+  testWidgets('only unseen items rebuild when scrolling starts', (
+    tester,
+  ) async {
+    final previousUpdateInterval =
+        VisibilityDetectorController.instance.updateInterval;
+    VisibilityDetectorController.instance.updateInterval = Duration.zero;
+    addTearDown(
+      () => VisibilityDetectorController.instance.updateInterval =
+          previousUpdateInterval,
+    );
+    final scrolling = ValueNotifier(false);
+    addTearDown(scrolling.dispose);
+    var builds = 0;
+    var lastHasBeenVisible = false;
+    var lastIsScrolling = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Offstage(
+          child: OnlineGalleryVisibilityDrivenItem(
+            visibilityKey: 'post-1',
+            scrolling: scrolling,
+            onVisibilityChanged: (_, __) {},
+            builder: (context, hasBeenVisible, isScrolling) {
+              builds++;
+              lastHasBeenVisible = hasBeenVisible;
+              lastIsScrolling = isScrolling;
+              return const SizedBox.square(dimension: 100);
+            },
+          ),
+        ),
+      ),
+    );
+    expect((builds, lastHasBeenVisible, lastIsScrolling), (1, false, false));
+
+    scrolling.value = true;
+    await tester.pump();
+    expect((builds, lastHasBeenVisible, lastIsScrolling), (2, false, true));
+
+    scrolling.value = false;
+    await tester.pump();
+    expect(builds, 2);
+
+    final detector = tester.widget<VisibilityDetector>(
+      find.byType(VisibilityDetector, skipOffstage: false),
+    );
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size.square(100),
+        visibleBounds: const Rect.fromLTWH(0, 0, 100, 100),
+      ),
+    );
+    await tester.pump();
+    expect((builds, lastHasBeenVisible, lastIsScrolling), (3, true, false));
+
+    scrolling.value = true;
+    await tester.pump();
+    expect(builds, 3);
+  });
+
+  test('repeated visibility updates only enter the viewport once', () {
+    final controller = OnlineGalleryScreenController(
+      prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
+        preloader: (_) async {},
+      ),
+    );
+    addTearDown(controller.dispose);
+    const item = GalleryItem(
+      id: 1,
+      workId: 'post-1',
+      sourceId: GallerySourceId.danbooru,
+    );
+
+    expect(
+      controller.recordVisibleItem(
+        index: 0,
+        item: item,
+        itemWidth: 200,
+        visibleTop: 12,
+      ),
+      isTrue,
+    );
+    expect(
+      controller.recordVisibleItem(
+        index: 0,
+        item: item,
+        itemWidth: 200,
+        visibleTop: -24,
+      ),
+      isFalse,
+    );
+    expect(controller.visibleItems[0]?.visibleTop, -24);
+  });
+
   testWidgets(
     'derives column count from grid width rather than viewport height',
     (tester) async {

--- a/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
@@ -124,6 +124,59 @@ void main() {
     expect(controller.visibleItems[0]?.visibleTop, -24);
   });
 
+  testWidgets('lazily builds only the viewport and cache neighborhood', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1200, 800);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    final controller = OnlineGalleryScreenController(
+      prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
+        preloader: (_) async {},
+      ),
+    );
+    addTearDown(controller.dispose);
+    final items = List.generate(
+      1000,
+      (index) => GalleryItem(
+        id: index,
+        workId: 'post-$index',
+        sourceId: GallerySourceId.danbooru,
+      ),
+    );
+    final builtIndices = <int>{};
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: OnlineGalleryGrid(
+            state: OnlineGalleryState(searchCache: ModeCache(posts: items)),
+            controller: controller,
+            itemBuilder: (context, index, itemWidth, columnCount) {
+              builtIndices.add(index);
+              return const SizedBox(height: 120);
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(builtIndices, contains(0));
+    expect(builtIndices, isNot(contains(999)));
+    expect(builtIndices.length, lessThan(200));
+    final initialLastIndex = builtIndices.reduce((a, b) => a > b ? a : b);
+
+    await tester.drag(find.byType(OnlineGalleryGrid), const Offset(0, -700));
+    await tester.pump();
+
+    expect(
+      builtIndices.reduce((a, b) => a > b ? a : b),
+      greaterThan(initialLastIndex),
+    );
+    expect(builtIndices.length, lessThan(400));
+  });
+
   testWidgets(
     'derives column count from grid width rather than viewport height',
     (tester) async {


### PR DESCRIPTION
## 根因

历史追溯确认回归是逐步放大的组合路径，而不是 Masonry 虚拟化失效：

- `4b4cf6a5` 引入 `VisibilityDetector`、渐进式图片加载和可见图片预取，使卡片首次进入视口时增加可见性、请求和解码工作。
- `7c9b2f72` 将网格 `cacheExtent` 扩到 `0.75` 个 viewport，并把 idle lookahead 从固定 `8` 扩为动态 `12~48`；这是最明确的历史负载放大点。PC 大窗口列数较多时，缓存范围内会提前构建更多完整卡片。
- `9434018d` 拆分后由 `OnlineGalleryContent` 整体监听 `OnlineGalleryScreenController`；滚动开始/停止的通知会重建内容树。旧实现已有同类 `setState`，因此它不是单独的起点，但会继续放大缓存范围内卡片的重建成本。
- 最新 `e5e4d167` 又将 `AgentResourceDragSource` 常驻到每张卡片，使每个可见及 `cacheExtent` 内卡片都创建 `DragItemWidget`、`WidgetSnapshotter`、`Listener` 与原生拖拽检测链，进一步增加 Element、RenderObject、hit-test 和 snapshot 成本。
- `VisibilityDetector` 对持续可见卡片的位置变化重复进入图片与 idle 预取提交路径，虽有 pending/in-flight 去重，仍产生不必要的 provider 创建、队列与定时器工作。

## 图片、缓存与分页审查

- 网格始终使用各来源归一化后的 preview URL，并按布局宽度与 DPR 设置 `memCacheWidth` / `ResizeImage`；未发现原图误解码或缺少 decode size 限制。
- 磁盘缓存 key、预取 stable key 和统一 cache manager 可稳定复用；未发现同图无限重复下载。
- 分页使用 `ChunkedGalleryItems` 共享旧 chunks，append 不复制完整图片列表；各来源均有 loading/hasMore/error/cursor 防重入。
- 滚动中的 visible thumbnail 预取仍保留一次真实入视口提交，用于当前卡片及时显示；本修复已去除持续可见位置更新造成的重复提交，并阻止 cacheExtent 内未见卡片在滚动中提前构建。
- 顶层 `currentCache` 变化、AI TAG 无预览详情加载只发生在分页/详情状态变化，并非逐像素滚动热路径，未为本次优化扩大业务改造范围。

## 改动

- 保留既有 `cacheExtent` 与预取能力，但滚动期间尚未首次可见的缓存卡片只保留稳定尺寸占位，不提前构建完整图片、Provider 投影和拖拽树；首次真正进入视口时恢复真实卡片。
- 将滚动状态拆为独立 `ValueNotifier`：只让尚未首次可见的缓存卡片局部监听；已可见卡片不监听，滚动停止不再触发整个内容树/网格重建。
- PC 精确指针环境下，在线画廊卡片只在 hover 时注册 `super_drag_and_drop` 源；拖拽按下后保持注册直至释放，并用稳定 `KeyedSubtree` 保留卡片 State。右键添加 Agent 入口保持可用。
- Android/触屏环境继续 eager 注册，保留原有长按拖拽能力。
- 持续可见回调继续更新锚点位置、item 宽度和 viewport lookahead，但仅在卡片真正进入视口时提交可见图片与 idle 预取。
- 未改变画廊来源、布局、筛选、分页、选择、详情、Agent 资源语义、移动端能力或数据。

## 回归证据

- 多个桌面拖拽源未 hover 时 `DragItemWidget` / `DraggableWidget` 数量为 0，hover 时严格为 1。
- 覆盖 hover 分支切换不销毁卡片 State、拖拽离开卡片后保持到 pointer up、触屏仍 eager 注册。
- 覆盖滚动状态不通知整个 controller、仅未见卡片在滚动开始时局部重建、首次可见后移除监听、重复可见更新仅算一次进入且保持锚点位置。
- 使用 1000 项数据验证 Masonry 网格只构建视口及 cache neighborhood，滚动后按需扩展且不会按总数据量一次性构建。

## 验证

- `scripts/test_affected.ps1`（3 个相关测试文件，12 项）：通过
- 变更文件定向 `flutter analyze`（9 项）：通过
- `git diff --check`：通过
- CI `Build Windows debug`：通过
- CI 两次 `Build installable Android APK`（push / PR）：通过
- CI 全量 `flutter analyze`：仅报告未改动的 `test/presentation/screens/generation/widgets/right_panel_test.dart:72-73` 两条 `prefer_const_constructors`
- CI 全量测试：先在未改动的 `test/app_test.dart` 两个 Prompt assistant defaults 用例失败，随后达到仓库 570 秒硬限制；本 PR 相关用例全部通过