### PR TITLE
fix(navigation): 修复侧边栏展开收起卡顿

### DIFF
--- a/lib/presentation/providers/layout_state_provider.dart
+++ b/lib/presentation/providers/layout_state_provider.dart
@@ -77,6 +77,8 @@ class LayoutState {
 /// UI布局状态 Notifier
 @riverpod
 class LayoutStateNotifier extends _$LayoutStateNotifier {
+  Future<void> _mainNavRailPersistence = Future<void>.value();
+
   @override
   LayoutState build() {
     // 从本地存储加载布局状态
@@ -168,7 +170,16 @@ class LayoutStateNotifier extends _$LayoutStateNotifier {
     state = state.copyWith(mainNavRailExpanded: expanded);
 
     final storage = ref.read(localStorageServiceProvider);
-    await storage.setMainNavRailExpanded(expanded);
+    final write = _mainNavRailPersistence.then(
+      (_) => storage.setMainNavRailExpanded(expanded),
+    );
+    // A failed write must not block later clicks; this invocation still
+    // awaits `write` directly so its storage error remains observable.
+    _mainNavRailPersistence = write.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    await write;
   }
 
   /// 切换桌面主导航栏展开状态

--- a/lib/presentation/router/desktop_shell.dart
+++ b/lib/presentation/router/desktop_shell.dart
@@ -34,27 +34,23 @@ class DesktopShell extends ConsumerWidget {
             },
           ),
           Expanded(
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                return Stack(
-                  clipBehavior: Clip.none,
-                  children: [
-                    content,
-                    const Positioned(
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      child: GlobalStatusBanners(),
-                    ),
-                    QueueShellOverlay(
-                      isVisible: isQueueVisible,
-                      desktop: true,
-                      onQueueStarted: () =>
-                          navigationShell.goBranch(AppBranch.generation.index),
-                    ),
-                  ],
-                );
-              },
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                content,
+                const Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  child: GlobalStatusBanners(),
+                ),
+                QueueShellOverlay(
+                  isVisible: isQueueVisible,
+                  desktop: true,
+                  onQueueStarted: () =>
+                      navigationShell.goBranch(AppBranch.generation.index),
+                ),
+              ],
             ),
           ),
         ],

--- a/lib/presentation/widgets/navigation/main_nav_rail.dart
+++ b/lib/presentation/widgets/navigation/main_nav_rail.dart
@@ -17,15 +17,27 @@ import '../../providers/replication_queue_provider.dart';
 import '../../providers/update_provider.dart';
 import '../../router/app_branch.dart';
 import '../../router/app_routes.dart';
+import '../../themes/theme_extension.dart';
 import '../auth/account_avatar.dart';
 import '../auth/login_form_container.dart';
 
 import '../common/app_toast.dart';
 
+Duration _boundedMotionDuration(
+  BuildContext context,
+  Duration source, {
+  required int minMilliseconds,
+  required int maxMilliseconds,
+}) {
+  if (MediaQuery.disableAnimationsOf(context)) return Duration.zero;
+  return Duration(
+    milliseconds: source.inMilliseconds.clamp(minMilliseconds, maxMilliseconds),
+  );
+}
+
 class MainNavRail extends ConsumerWidget {
   static const double collapsedWidth = 60;
   static const double expandedWidth = 196;
-  static const Duration animationDuration = Duration(milliseconds: 240);
 
   static const List<AppBranch> _railBranches = [
     AppBranch.generation,
@@ -72,16 +84,20 @@ class MainNavRail extends ConsumerWidget {
     final selectedIndex = _railBranches.indexWhere(
       (branch) => branch.index == currentIndex,
     );
+    final motion = theme.appTheme;
+    final animationDuration = _boundedMotionDuration(
+      context,
+      motion.slowDuration,
+      minMilliseconds: 200,
+      maxMilliseconds: 280,
+    );
 
     return _NavRailExpansionScope(
       isExpanded: isExpanded,
-      child: AnimatedContainer(
-        key: const Key('main-nav-rail'),
+      child: _NavRailWidthTransition(
+        isExpanded: isExpanded,
         duration: animationDuration,
-        curve: Curves.easeInOutCubic,
-        width: isExpanded ? expandedWidth : collapsedWidth,
-        height: double.infinity,
-        clipBehavior: Clip.hardEdge,
+        curve: isExpanded ? motion.enterCurve : motion.exitCurve,
         decoration: BoxDecoration(
           color: theme.colorScheme.surface,
           border: Border(
@@ -233,6 +249,57 @@ class MainNavRail extends ConsumerWidget {
   }
 }
 
+class _NavRailWidthTransition extends StatelessWidget {
+  const _NavRailWidthTransition({
+    required this.isExpanded,
+    required this.duration,
+    required this.curve,
+    required this.decoration,
+    required this.child,
+  });
+
+  final bool isExpanded;
+  final Duration duration;
+  final Curve curve;
+  final Decoration decoration;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween<double>(end: isExpanded ? 1 : 0),
+      duration: duration,
+      curve: curve,
+      builder: (context, value, child) {
+        final width =
+            MainNavRail.collapsedWidth +
+            (MainNavRail.expandedWidth - MainNavRail.collapsedWidth) * value;
+        return Container(
+          key: const Key('main-nav-rail'),
+          width: width,
+          height: double.infinity,
+          clipBehavior: Clip.hardEdge,
+          decoration: decoration,
+          child: OverflowBox(
+            alignment: Alignment.centerLeft,
+            minWidth: MainNavRail.expandedWidth,
+            maxWidth: MainNavRail.expandedWidth,
+            child: RepaintBoundary(
+              child: SizedBox(
+                key: const Key('main-nav-rail-content'),
+                width: MainNavRail.expandedWidth,
+                height: double.infinity,
+                child: child,
+              ),
+            ),
+          ),
+        );
+      },
+      child: child,
+    );
+  }
+}
+
 class _NavRailExpansionScope extends InheritedWidget {
   const _NavRailExpansionScope({
     required this.isExpanded,
@@ -254,6 +321,31 @@ class _NavRailExpansionScope extends InheritedWidget {
   }
 }
 
+class _ExpandedRailContent extends StatelessWidget {
+  const _ExpandedRailContent({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final isExpanded = _NavRailExpansionScope.isExpandedOf(context);
+    final motion = Theme.of(context).appTheme;
+    final duration = _boundedMotionDuration(
+      context,
+      motion.normalDuration,
+      minMilliseconds: 120,
+      maxMilliseconds: 180,
+    );
+
+    return AnimatedOpacity(
+      opacity: isExpanded ? 1 : 0,
+      duration: duration,
+      curve: isExpanded ? motion.enterCurve : motion.exitCurve,
+      child: child,
+    );
+  }
+}
+
 class _NavRailToggle extends StatelessWidget {
   const _NavRailToggle({required this.isExpanded, required this.onTap});
 
@@ -271,72 +363,58 @@ class _NavRailToggle extends StatelessWidget {
       height: 48,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 6),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            // 侧栏宽度正在动画时提前切换为紧凑按钮，避免展开内容溢出。
-            if (isExpanded && constraints.maxWidth >= 170) {
-              return Row(
-                key: const ValueKey('expanded-nav-toggle'),
+        child: Tooltip(
+          message: label,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: onTap,
+              borderRadius: BorderRadius.circular(8),
+              child: Row(
                 children: [
+                  SizedBox(
+                    key: const Key('main-nav-toggle'),
+                    width: 48,
+                    height: 48,
+                    child: Icon(
+                      isExpanded
+                          ? Icons.keyboard_double_arrow_left
+                          : Icons.keyboard_double_arrow_right,
+                      size: 20,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
                   Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: 6, right: 4),
+                    child: _ExpandedRailContent(
                       child: Text(
-                        'v${AppVersion.versionName}',
-                        key: const Key('main-nav-version'),
+                        label,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant.withValues(
-                            alpha: 0.72,
-                          ),
-                          fontFeatures: const [FontFeature.tabularFigures()],
+                        style: theme.textTheme.labelLarge?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
                         ),
                       ),
                     ),
                   ),
-                  TextButton.icon(
-                    key: const Key('main-nav-toggle'),
-                    onPressed: onTap,
-                    style: TextButton.styleFrom(
-                      foregroundColor: theme.colorScheme.onSurfaceVariant,
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                      minimumSize: const Size(0, 48),
-                      visualDensity: VisualDensity.compact,
+                  _ExpandedRailContent(
+                    child: Text(
+                      'v${AppVersion.versionName}',
+                      key: const Key('main-nav-version'),
+                      maxLines: 1,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant.withValues(
+                          alpha: 0.72,
+                        ),
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
                     ),
-                    icon: const Icon(
-                      Icons.keyboard_double_arrow_left,
-                      size: 18,
-                    ),
-                    label: Text(label),
                   ),
+                  const SizedBox(width: 8),
                 ],
-              );
-            }
-
-            return Center(
-              key: const ValueKey('collapsed-nav-toggle'),
-              child: IconButton(
-                key: const Key('main-nav-toggle'),
-                onPressed: onTap,
-                tooltip: label,
-                visualDensity: VisualDensity.compact,
-                style: IconButton.styleFrom(
-                  foregroundColor: theme.colorScheme.onSurfaceVariant,
-                  hoverColor: theme.colorScheme.surfaceContainerHighest,
-                  highlightColor: theme.colorScheme.primary.withValues(
-                    alpha: 0.1,
-                  ),
-                ),
-                icon: Icon(
-                  isExpanded
-                      ? Icons.keyboard_double_arrow_left
-                      : Icons.keyboard_double_arrow_right,
-                  size: 20,
-                ),
               ),
-            );
-          },
+            ),
+          ),
         ),
       ),
     );
@@ -736,37 +814,25 @@ class _RailLinkItem extends StatelessWidget {
                       : Colors.transparent,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: LayoutBuilder(
-                  builder: (context, constraints) {
-                    final showLabel = constraints.maxWidth > 60;
-                    final labelOpacity = ((constraints.maxWidth - 60) / 48)
-                        .clamp(0.0, 1.0);
-                    return Row(
-                      children: [
-                        SizedBox(
-                          width: constraints.maxWidth.clamp(0.0, 48.0),
-                          height: 48,
-                          child: Center(child: icon),
-                        ),
-                        if (showLabel)
-                          Expanded(
-                            child: Opacity(
-                              opacity: labelOpacity,
-                              child: Text(
-                                label,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: theme.textTheme.bodyMedium?.copyWith(
-                                  color: theme.colorScheme.onSurface,
-                                  fontWeight: FontWeight.w500,
-                                ),
-                              ),
-                            ),
+                child: Row(
+                  children: [
+                    SizedBox(width: 48, height: 48, child: Center(child: icon)),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: _ExpandedRailContent(
+                        child: Text(
+                          label,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurface,
+                            fontWeight: FontWeight.w500,
                           ),
-                        if (showLabel) const SizedBox(width: 12),
-                      ],
-                    );
-                  },
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                  ],
                 ),
               ),
             ),
@@ -846,51 +912,43 @@ class _NavIconState extends State<_NavIcon> {
                   color: backgroundColor,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: LayoutBuilder(
-                  builder: (context, constraints) {
-                    final showLabel = constraints.maxWidth > 60;
-                    final labelOpacity = ((constraints.maxWidth - 60) / 48)
-                        .clamp(0.0, 1.0);
-                    return Row(
-                      children: [
-                        SizedBox(
-                          width: constraints.maxWidth.clamp(0.0, 48.0),
-                          height: 48,
-                          child: Center(
-                            child: Badge(
-                              isLabelVisible:
-                                  widget.showBadge || widget.badgeLabel != null,
-                              smallSize: 7,
-                              label: widget.badgeLabel == null
-                                  ? null
-                                  : Text(widget.badgeLabel!),
-                              child: Icon(widget.icon, color: color, size: 24),
-                            ),
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 48,
+                      height: 48,
+                      child: Center(
+                        child: Badge(
+                          isLabelVisible:
+                              widget.showBadge || widget.badgeLabel != null,
+                          smallSize: 7,
+                          label: widget.badgeLabel == null
+                              ? null
+                              : Text(widget.badgeLabel!),
+                          child: Icon(widget.icon, color: color, size: 24),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: _ExpandedRailContent(
+                        child: Text(
+                          widget.label,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: widget.isSelected
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.onSurface,
+                            fontWeight: widget.isSelected
+                                ? FontWeight.w600
+                                : FontWeight.w500,
                           ),
                         ),
-                        if (showLabel)
-                          Expanded(
-                            child: Opacity(
-                              opacity: labelOpacity,
-                              child: Text(
-                                widget.label,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: theme.textTheme.bodyMedium?.copyWith(
-                                  color: widget.isSelected
-                                      ? theme.colorScheme.primary
-                                      : theme.colorScheme.onSurface,
-                                  fontWeight: widget.isSelected
-                                      ? FontWeight.w600
-                                      : FontWeight.w500,
-                                ),
-                              ),
-                            ),
-                          ),
-                        if (showLabel) const SizedBox(width: 12),
-                      ],
-                    );
-                  },
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                  ],
                 ),
               ),
             ),
@@ -976,49 +1034,31 @@ class _AccountAvatarButtonState extends State<_AccountAvatarButton> {
                     : Colors.transparent,
                 borderRadius: BorderRadius.circular(22),
               ),
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  final showLabel = constraints.maxWidth > 80;
-                  final labelOpacity = ((constraints.maxWidth - 80) / 48).clamp(
-                    0.0,
-                    1.0,
-                  );
-                  return Row(
-                    children: [
-                      SizedBox(
-                        width: constraints.maxWidth.clamp(0.0, 40.0),
-                        height: 48,
-                        child: Center(child: avatar),
+              child: Row(
+                children: [
+                  SizedBox(width: 48, height: 48, child: Center(child: avatar)),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _ExpandedRailContent(
+                      child: Text(
+                        currentAccount?.displayName ?? context.l10n.auth_login,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
                       ),
-                      if (showLabel) ...[
-                        const SizedBox(width: 10),
-                        Expanded(
-                          child: Opacity(
-                            opacity: labelOpacity,
-                            child: Text(
-                              currentAccount?.displayName ??
-                                  context.l10n.auth_login,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: theme.textTheme.bodyMedium?.copyWith(
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                          ),
-                        ),
-                        Opacity(
-                          opacity: labelOpacity,
-                          child: Icon(
-                            Icons.expand_more,
-                            size: 18,
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                        const SizedBox(width: 10),
-                      ],
-                    ],
-                  );
-                },
+                    ),
+                  ),
+                  _ExpandedRailContent(
+                    child: Icon(
+                      Icons.expand_more,
+                      size: 18,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                ],
               ),
             ),
           ),

--- a/test/presentation/providers/layout_state_provider_test.dart
+++ b/test/presentation/providers/layout_state_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/storage/local_storage_service.dart';
@@ -34,6 +36,32 @@ void main() {
           .read(layoutStateNotifierProvider.notifier)
           .setMainNavRailExpanded(false);
 
+      expect(storage.mainNavExpanded, isFalse);
+    });
+
+    test('rapid updates persist in interaction order', () async {
+      final firstWrite = Completer<void>();
+      final storage = _DelayedMainNavStorage(firstWrite.future);
+      final container = ProviderContainer(
+        overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(layoutStateNotifierProvider.notifier);
+
+      final expand = notifier.setMainNavRailExpanded(true);
+      final collapse = notifier.setMainNavRailExpanded(false);
+
+      expect(
+        container.read(layoutStateNotifierProvider).mainNavRailExpanded,
+        isFalse,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(storage.requestedValues, [true]);
+
+      firstWrite.complete();
+      await Future.wait([expand, collapse]);
+
+      expect(storage.requestedValues, [true, false]);
       expect(storage.mainNavExpanded, isFalse);
     });
   });
@@ -253,5 +281,19 @@ class _FakeLayoutStorage extends LocalStorageService {
   @override
   Future<void> setWebLeftPanelExpanded(bool value) async {
     webExpanded = value;
+  }
+}
+
+class _DelayedMainNavStorage extends _FakeLayoutStorage {
+  _DelayedMainNavStorage(this.firstWrite);
+
+  final Future<void> firstWrite;
+  final List<bool> requestedValues = [];
+
+  @override
+  Future<void> setMainNavRailExpanded(bool value) async {
+    requestedValues.add(value);
+    if (requestedValues.length == 1) await firstWrite;
+    mainNavExpanded = value;
   }
 }

--- a/test/presentation/widgets/main_nav_rail_test.dart
+++ b/test/presentation/widgets/main_nav_rail_test.dart
@@ -34,10 +34,7 @@ class _SavedAccountManagerNotifier extends AccountManagerNotifier {
   @override
   AccountManagerState build() => AccountManagerState(
     accounts: [
-      SavedAccount.create(
-        email: 'saved@example.com',
-        nickname: 'Saved Alice',
-      ),
+      SavedAccount.create(email: 'saved@example.com', nickname: 'Saved Alice'),
     ],
   );
 }
@@ -122,7 +119,7 @@ void main() {
       tester.getSize(find.byKey(const Key('main-nav-rail'))).width,
       MainNavRail.collapsedWidth,
     );
-    expect(find.text('画布'), findsNothing);
+    expect(_labelOpacity(tester, '画布'), 0);
 
     await tester.tap(find.byKey(const Key('main-nav-toggle')));
     await tester.pumpAndSettle();
@@ -149,7 +146,73 @@ void main() {
       tester.getSize(find.byKey(const Key('main-nav-rail'))).width,
       MainNavRail.collapsedWidth,
     );
-    expect(find.text('画布'), findsNothing);
+    expect(_labelOpacity(tester, '画布'), 0);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('展开动画保持内容布局稳定且快速反向切换连续', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1000, 760));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final navigationShell = _MockNavigationShell();
+    final storage = _FakeMainNavStorage();
+    when(() => navigationShell.currentIndex).thenReturn(0);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localStorageServiceProvider.overrideWith((ref) => storage),
+          authNotifierProvider.overrideWith(_FakeAuthNotifier.new),
+          accountManagerNotifierProvider.overrideWith(
+            _FakeAccountManagerNotifier.new,
+          ),
+          queueExecutionNotifierProvider.overrideWith(
+            _FakeQueueExecutionNotifier.new,
+          ),
+          replicationQueueNotifierProvider.overrideWith(
+            _FakeReplicationQueueNotifier.new,
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: MainNavRail(navigationShell: navigationShell)),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final collapsedIconCenter = tester.getCenter(find.byIcon(Icons.brush));
+    await tester.tap(find.byKey(const Key('main-nav-toggle')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 80));
+
+    final expandingWidth = _railWidth(tester);
+    expect(
+      expandingWidth,
+      inExclusiveRange(MainNavRail.collapsedWidth, MainNavRail.expandedWidth),
+    );
+    expect(_railContentWidth(tester), MainNavRail.expandedWidth);
+    expect(tester.getCenter(find.byIcon(Icons.brush)), collapsedIconCenter);
+
+    await tester.tap(find.byKey(const Key('main-nav-toggle')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 40));
+    final reversingWidth = _railWidth(tester);
+    expect(reversingWidth, lessThan(expandingWidth));
+
+    await tester.tap(find.byKey(const Key('main-nav-toggle')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 40));
+    expect(_railWidth(tester), greaterThan(reversingWidth));
+    expect(_railContentWidth(tester), MainNavRail.expandedWidth);
+    expect(tester.getCenter(find.byIcon(Icons.brush)), collapsedIconCenter);
+
+    await tester.pumpAndSettle();
+    expect(_railWidth(tester), MainNavRail.expandedWidth);
+    expect(_labelOpacity(tester, '画布'), 1);
+    expect(storage.isExpanded, isTrue);
     expect(tester.takeException(), isNull);
   });
 
@@ -189,13 +252,25 @@ void main() {
     expect(find.text('Saved Alice'), findsNothing);
     expect(find.text('登录'), findsOneWidget);
 
-    await tester.tap(
-      find.byKey(const Key('main-nav-account-menu-button')),
-    );
+    await tester.tap(find.byKey(const Key('main-nav-account-menu-button')));
     await tester.pumpAndSettle();
 
     expect(find.text('Saved Alice'), findsNothing);
     expect(find.text('登录'), findsNWidgets(2));
     expect(find.text('添加账号'), findsNothing);
   });
+}
+
+double _railWidth(WidgetTester tester) =>
+    tester.getSize(find.byKey(const Key('main-nav-rail'))).width;
+
+double _railContentWidth(WidgetTester tester) =>
+    tester.getSize(find.byKey(const Key('main-nav-rail-content'))).width;
+
+double _labelOpacity(WidgetTester tester, String label) {
+  final opacity = find.ancestor(
+    of: find.text(label),
+    matching: find.byType(AnimatedOpacity),
+  );
+  return tester.widget<AnimatedOpacity>(opacity.first).opacity;
 }


### PR DESCRIPTION
## 根因

- 侧栏使用 `AnimatedContainer` 逐帧改变对子树的宽度约束，导航项、账号区和底部开关中的多个 `LayoutBuilder` 因此每帧重新计算布局、创建/移除文字子树并重排图标。
- 桌面壳层在主内容区域额外包了一层不使用 constraints 的 `LayoutBuilder`，侧栏宽度变化时会重复执行 builder 并重建 `Stack`。
- 快速反向点击会并发写入展开状态，较慢的旧写入存在晚于新状态落盘的竞态。

## 用户可见变化

- 侧栏内部始终按完整宽度稳定布局，只动画外层可见宽度；图标位置不再随帧抖动，文字以独立透明度过渡出现/消失。
- 展开、收起和动画中的快速反向切换均从当前宽度连续衔接；开关保持在固定可点击位置，不等待动画结束。
- 动画继续保留完整效果，并遵循主题 motion token、设计时长范围与系统“减少动态效果”；未通过缩短或禁用动画规避问题。
- 快速连续切换按交互顺序串行持久化，最终保存状态与界面状态一致。
- Windows/macOS 桌面侧栏的导航、账号、外链、队列和设置能力保持不变；Android 紧凑导航分支未改动。

## 验证

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1 -Path "lib/presentation/widgets/navigation/main_nav_rail.dart,lib/presentation/router/desktop_shell.dart,lib/presentation/providers/layout_state_provider.dart" -Include "test/presentation/widgets/main_nav_rail_test.dart,test/presentation/providers/layout_state_provider_test.dart"`
  - 36 tests passed
  - 覆盖展开、收起、快速双向反转、固定内部布局/图标位置、最终 UI/持久化状态一致
- `dart analyze lib/presentation/widgets/navigation/main_nav_rail.dart lib/presentation/router/desktop_shell.dart lib/presentation/providers/layout_state_provider.dart test/presentation/widgets/main_nav_rail_test.dart test/presentation/providers/layout_state_provider_test.dart`
  - No issues found
- `git diff --check`
  - passed

## 合并说明

本 PR 仅供审查，**不要自动合并**。
