### PR TITLE
fix(agent): 统一工具权限与 Anlas 确认决策

### DIFF
--- a/lib/core/agent/permissions/agent_permission.dart
+++ b/lib/core/agent/permissions/agent_permission.dart
@@ -29,7 +29,6 @@ enum AgentPermissionOperation {
   overwrite,
   move,
   execute,
-  charge,
 }
 
 /// Action the caller must take before invoking a tool.
@@ -51,14 +50,6 @@ class AgentPermissionPolicy {
     AgentPermissionDomain domain,
     AgentPermissionOperation operation,
   ) {
-    // These gates describe the operation itself. Dispatchers still enforce
-    // the domain access mode before presenting or honoring confirmation.
-    if (operation == AgentPermissionOperation.charge) {
-      return AgentPermissionDecision.confirmCharge;
-    }
-    if (_destructiveOperations.contains(operation)) {
-      return AgentPermissionDecision.ask;
-    }
     final mode = modeFor(domain);
     if (mode == AgentAccessMode.blocked) {
       return AgentPermissionDecision.block;
@@ -66,6 +57,12 @@ class AgentPermissionPolicy {
     if (mode == AgentAccessMode.readOnly &&
         operation != AgentPermissionOperation.read) {
       return AgentPermissionDecision.block;
+    }
+    // Destructive actions retain an explicit confirmation even in full-access
+    // mode. Billing is evaluated separately from the operation because a tool
+    // that can consume Anlas may have an exact zero-cost invocation.
+    if (_destructiveOperations.contains(operation)) {
+      return AgentPermissionDecision.ask;
     }
     return switch (mode) {
       AgentAccessMode.blocked => AgentPermissionDecision.block,

--- a/lib/core/agent/permissions/tool_permission_catalog.dart
+++ b/lib/core/agent/permissions/tool_permission_catalog.dart
@@ -5,11 +5,13 @@ class AgentToolPermissionDescriptor {
     required this.toolName,
     required this.domain,
     required this.operation,
+    this.mayConsumeAnlas = false,
   });
 
   final String toolName;
   final AgentPermissionDomain domain;
   final AgentPermissionOperation operation;
+  final bool mayConsumeAnlas;
 }
 
 /// Complete, immutable permission metadata for a known set of tools.
@@ -34,9 +36,19 @@ class AgentToolPermissionCatalog {
   AgentPermissionDecision decide({
     required String toolName,
     required AgentPermissionPolicy policy,
+    int? estimatedAnlas,
   }) {
     final descriptor = descriptorFor(toolName);
-    return policy.decide(descriptor.domain, descriptor.operation);
+    final ordinaryDecision = policy.decide(
+      descriptor.domain,
+      descriptor.operation,
+    );
+    if (ordinaryDecision == AgentPermissionDecision.block ||
+        !descriptor.mayConsumeAnlas ||
+        (estimatedAnlas != null && estimatedAnlas <= 0)) {
+      return ordinaryDecision;
+    }
+    return AgentPermissionDecision.confirmCharge;
   }
 
   static Map<String, AgentToolPermissionDescriptor> _build(
@@ -208,9 +220,7 @@ AgentToolPermissionDescriptor describeAgentToolPermission(String toolName) {
       toolName.startsWith('remove_') ||
       toolName.startsWith('clear_') ||
       toolName.startsWith('cancel_');
-  final operation = charged.contains(toolName)
-      ? AgentPermissionOperation.charge
-      : isDelete
+  final operation = isDelete
       ? AgentPermissionOperation.delete
       : isRead
       ? AgentPermissionOperation.read
@@ -223,6 +233,7 @@ AgentToolPermissionDescriptor describeAgentToolPermission(String toolName) {
     toolName: toolName,
     domain: domain,
     operation: operation,
+    mayConsumeAnlas: charged.contains(toolName),
   );
 }
 

--- a/lib/core/windowing/agent_window_shell.dart
+++ b/lib/core/windowing/agent_window_shell.dart
@@ -354,8 +354,10 @@ class _AgentWindowBridgeShellState extends State<_AgentWindowBridgeShell> {
     if (approval != null)
       AgentWindowApprovalBar(
         approval: approval,
-        resolve: (value) =>
-            bridge.sendCommand('resolveApproval', {'value': value}),
+        resolve: (value) => bridge.sendCommand('resolveApproval', {
+          'toolCallId': approval['toolCallId'],
+          'value': value,
+        }),
       ),
     if (resources.isNotEmpty)
       AgentWindowResourceList(

--- a/lib/core/windowing/agent_window_shell_widgets.dart
+++ b/lib/core/windowing/agent_window_shell_widgets.dart
@@ -22,7 +22,7 @@ class AgentWindowPermissionModeButton extends StatelessWidget {
     final current = payload['permissionMode'] as String? ?? 'safe';
     final label = switch (current) {
       'fullAccess' => l10n.agentChat_permissionFull,
-      'ask' => l10n.agentChat_permissionAsk,
+      'askBeforeSensitiveActions' => l10n.agentChat_permissionAsk,
       _ => l10n.agentChat_permissionSafe,
     };
     return PopupMenuButton<String>(
@@ -33,7 +33,10 @@ class AgentWindowPermissionModeButton extends StatelessWidget {
           value: 'safe',
           child: Text(l10n.agentChat_permissionSafe),
         ),
-        PopupMenuItem(value: 'ask', child: Text(l10n.agentChat_permissionAsk)),
+        PopupMenuItem(
+          value: 'askBeforeSensitiveActions',
+          child: Text(l10n.agentChat_permissionAsk),
+        ),
         PopupMenuItem(
           value: 'fullAccess',
           child: Text(l10n.agentChat_permissionFull),

--- a/lib/presentation/agent_chat/providers/agent_chat_notifier.dart
+++ b/lib/presentation/agent_chat/providers/agent_chat_notifier.dart
@@ -312,8 +312,8 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
     AbortSignal? signal,
   ) => _permissionController!.beforeToolCall(context, signal);
 
-  void resolveToolApproval(bool approved) =>
-      _permissionController?.resolveApproval(approved);
+  bool resolveToolApproval(String toolCallId, bool approved) =>
+      _permissionController?.resolveApproval(toolCallId, approved) ?? false;
 
   Future<void> setPermissionMode(AgentPermissionMode mode) async {
     if (!canManageAgentChatSessions(state)) {
@@ -1133,7 +1133,7 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
     }
     state = state.copyWith(workPhase: AgentChatWorkPhase.stopping);
     agent.abort();
-    resolveToolApproval(false);
+    _permissionController?.cancelApproval();
     _client.cancel('agent_chat');
     await agent.waitForIdle();
   }

--- a/lib/presentation/agent_chat/services/agent_tool_permission_controller.dart
+++ b/lib/presentation/agent_chat/services/agent_tool_permission_controller.dart
@@ -72,17 +72,21 @@ class AgentToolPermissionController {
     final args = context.args is Map<String, dynamic>
         ? Map<String, dynamic>.from(context.args as Map<String, dynamic>)
         : const <String, dynamic>{};
-    final catalogDecision = catalog.decide(
-      toolName: context.toolCall.name,
-      policy: permissionPolicy,
-    );
     final isNonBillingPreparation =
         (context.toolCall.name == 'generate_image' ||
             context.toolCall.name == 'queue_image_task') &&
         args['preparation_id'] is! String;
+    int? estimatedAnlas;
+    if (!isNonBillingPreparation && descriptor.mayConsumeAnlas) {
+      estimatedAnlas = await _estimateAnlas(context.toolCall.name, args);
+    }
     final decision = isNonBillingPreparation
         ? AgentPermissionDecision.allow
-        : catalogDecision;
+        : catalog.decide(
+            toolName: context.toolCall.name,
+            policy: permissionPolicy,
+            estimatedAnlas: estimatedAnlas,
+          );
     _toolDecisions[context.toolCall.id] = decision;
     await writeAudit(
       id: '${context.toolCall.id}.decision',
@@ -106,7 +110,8 @@ class AgentToolPermissionController {
     }
     final completer = Completer<bool>();
     _approvalCompleter = completer;
-    final estimatedAnlas = await _estimateAnlas(context.toolCall.name, args);
+    _activeApprovalToolCallId = context.toolCall.id;
+    estimatedAnlas ??= await _estimateAnlas(context.toolCall.name, args);
     _onApprovalChanged(
       AgentToolApprovalRequest(
         toolCallId: context.toolCall.id,
@@ -127,6 +132,7 @@ class AgentToolPermissionController {
     signal?.removeListener(onAbort);
     if (identical(_approvalCompleter, completer)) {
       _approvalCompleter = null;
+      _activeApprovalToolCallId = null;
       if (_isMounted()) {
         _onApprovalChanged(null);
       }
@@ -147,11 +153,22 @@ class AgentToolPermissionController {
           );
   }
 
-  void resolveApproval(bool approved) {
+  bool resolveApproval(String toolCallId, bool approved) {
     final completer = _approvalCompleter;
-    if (completer != null && !completer.isCompleted) {
-      completer.complete(approved);
+    if (completer == null ||
+        completer.isCompleted ||
+        _activeApprovalToolCallId != toolCallId) {
+      return false;
     }
+    completer.complete(approved);
+    return true;
+  }
+
+  String? _activeApprovalToolCallId;
+
+  void cancelApproval() {
+    final toolCallId = _activeApprovalToolCallId;
+    if (toolCallId != null) resolveApproval(toolCallId, false);
   }
 
   AgentPermissionDecision takeDecision(String toolCallId) =>
@@ -178,5 +195,5 @@ class AgentToolPermissionController {
     }
   }
 
-  void dispose() => resolveApproval(false);
+  void dispose() => cancelApproval();
 }

--- a/lib/presentation/agent_chat/services/agent_window_bridge_adapter.dart
+++ b/lib/presentation/agent_chat/services/agent_window_bridge_adapter.dart
@@ -238,10 +238,13 @@ final class AgentWindowBridgeAdapter {
             .setWebAccessEnabled(value);
       case 'resolveApproval':
         final value = payload['value'];
-        if (value is! bool) {
-          throw const FormatException('resolveApproval requires bool value');
+        final toolCallId = payload['toolCallId'];
+        if (value is! bool || toolCallId is! String || toolCallId.isEmpty) {
+          throw const FormatException(
+            'resolveApproval requires toolCallId and bool value',
+          );
         }
-        notifier.resolveToolApproval(value);
+        return {'ok': notifier.resolveToolApproval(toolCallId, value)};
       default:
         throw UnsupportedError('Unsupported Agent window command: $name');
     }

--- a/lib/presentation/agent_chat/services/manual_inpaint_toolbox.dart
+++ b/lib/presentation/agent_chat/services/manual_inpaint_toolbox.dart
@@ -10,7 +10,6 @@ import '../../../core/agent/harness/env/dart_io_execution_env.dart';
 import '../../../core/agent/harness/harness_result.dart';
 import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
 import '../../../core/agent/resources/agent_chat_resource_reference.dart';
-import '../../../core/services/anlas_calculator.dart';
 import '../../../core/utils/app_logger.dart';
 import '../../../core/utils/localization_extension.dart';
 import '../../../data/models/image/image_params.dart';
@@ -22,6 +21,7 @@ import '../../providers/image_generation_provider.dart';
 import '../../widgets/image_editor/image_editor_screen.dart';
 import 'agent_resource_resolver.dart';
 import 'defined_agent_tool.dart';
+import 'generation_anlas_estimator.dart';
 import 'manual_inpaint_tool_definitions.dart';
 import 'manual_inpaint_toolbox_serialization.dart';
 
@@ -37,6 +37,8 @@ typedef ManualInpaintDraftListener =
     FutureOr<void> Function(String sessionId, InpaintDraft draft);
 typedef ManualInpaintResourceLoader =
     Future<Uint8List?> Function(AgentChatResourceReference reference);
+typedef ManualInpaintAnlasEstimator =
+    int Function(ImageParams params, int batchSize);
 
 class ManualInpaintEditorSession {
   const ManualInpaintEditorSession({required this.result, required this.close});
@@ -70,6 +72,7 @@ class ManualInpaintToolbox {
     String Function()? activeSessionId,
     ManualInpaintDraftListener? onDraftChanged,
     ManualInpaintResourceLoader? resourceLoader,
+    ManualInpaintAnlasEstimator? anlasEstimator,
   }) : _repository =
            repository ??
            InpaintDraftFileRepository(
@@ -87,7 +90,12 @@ class ManualInpaintToolbox {
        _navigator = navigator,
        _activeSessionId = activeSessionId,
        _onDraftChanged = onDraftChanged,
-       _resourceLoader = resourceLoader;
+       _resourceLoader = resourceLoader,
+       _estimateAnlas =
+           anlasEstimator ??
+           ((params, batchSize) => GenerationAnlasEstimator(
+             _ref,
+           ).estimate(params, requestCount: 1, batchSize: batchSize));
 
   final Ref _ref;
   final InpaintDraftRepository _repository;
@@ -97,6 +105,7 @@ class ManualInpaintToolbox {
   final NavigatorState? Function()? _navigator;
   final String Function()? _activeSessionId;
   final ManualInpaintDraftListener? _onDraftChanged;
+  final ManualInpaintAnlasEstimator _estimateAnlas;
   final Map<String, ManualInpaintEditorSession> _sessions = {};
   final Map<String, String> _draftSessionIds = {};
   ManualInpaintResourceLoader? _resourceLoader;
@@ -118,7 +127,18 @@ class ManualInpaintToolbox {
 
   Future<int?> estimateAnlasForDraft(String draftId) async {
     final draft = await _repository.get(draftId);
-    return draft?.estimatedAnlas.toInt();
+    if (draft == null) return null;
+    final snapshot = draft.parameterSnapshot;
+    final storedBatchSize = snapshot['_agentBatchSize'];
+    final batchSize = storedBatchSize is int && storedBatchSize > 0
+        ? storedBatchSize
+        : _ref.read(imagesPerRequestProvider);
+    return _estimateAnlas(
+      ImageParams.fromJson(snapshot).copyWith(
+        action: ImageGenerationAction.infill,
+      ),
+      batchSize,
+    );
   }
 
   List<AgentTool> tools() => buildManualInpaintToolDefinitions(
@@ -262,10 +282,9 @@ class ManualInpaintToolbox {
       final prepared = await _repository.prepare(
         sourceBytes: source,
         parameterSnapshot: snapshot,
-        estimatedAnlas: AnlasCalculator.calculate(
+        estimatedAnlas: _estimateAnlas(
           params.copyWith(action: ImageGenerationAction.infill),
-          isOpus: true,
-          batchSize: batchSize,
+          batchSize,
         ),
       );
       createdDraftId = prepared.id;

--- a/lib/presentation/agent_chat/widgets/agent_chat_panel_view_data.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_panel_view_data.dart
@@ -96,7 +96,7 @@ class AgentChatPanelCommands {
   final VoidCallback stop;
   final VoidCallback dismissError;
   final Future<void> Function() retryLastMessage;
-  final void Function(bool approved) resolveApproval;
+  final bool Function(String toolCallId, bool approved) resolveApproval;
   final void Function(String suggestion) useSuggestion;
   final Future<void> Function(UserMessage message) copyUserMessage;
   final Future<void> Function(AssistantMessage message) copyAssistantMessage;

--- a/lib/presentation/agent_chat/widgets/agent_chat_status.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_status.dart
@@ -93,7 +93,8 @@ class AgentChatStatus extends StatelessWidget {
             toolName: request.toolName,
             args: request.args,
             estimatedAnlas: request.estimatedAnlas,
-            onResolve: commands.resolveApproval,
+            onResolve: (approved) =>
+                commands.resolveApproval(request.toolCallId, approved),
           ),
         if (state.routeReady)
           Padding(

--- a/test/core/agent/permissions/agent_permission_test.dart
+++ b/test/core/agent/permissions/agent_permission_test.dart
@@ -67,8 +67,11 @@ void main() {
       );
     });
 
-    test('always confirms destructive and charged operations', () {
-      for (final mode in AgentAccessMode.values) {
+    test('always confirms destructive operations in non-blocked domains', () {
+      for (final mode in const {
+        AgentAccessMode.askBeforeWrite,
+        AgentAccessMode.allowWrite,
+      }) {
         final policy = AgentPermissionPolicy({
           AgentPermissionDomain.generationQueue: mode,
         });
@@ -82,13 +85,6 @@ void main() {
             AgentPermissionDecision.ask,
           );
         }
-        expect(
-          policy.decide(
-            AgentPermissionDomain.generationQueue,
-            AgentPermissionOperation.charge,
-          ),
-          AgentPermissionDecision.confirmCharge,
-        );
       }
     });
   });
@@ -102,7 +98,8 @@ void main() {
     const generate = AgentToolPermissionDescriptor(
       toolName: 'generate',
       domain: AgentPermissionDomain.generation,
-      operation: AgentPermissionOperation.charge,
+      operation: AgentPermissionOperation.execute,
+      mayConsumeAnlas: true,
     );
 
     test('looks up and evaluates registered tool names', () {
@@ -112,16 +109,88 @@ void main() {
       );
 
       expect(catalog.descriptorFor('read_status'), same(read));
+      final policy = AgentPermissionPolicy(const {
+        AgentPermissionDomain.generation: AgentAccessMode.allowWrite,
+      });
       expect(
-        catalog.decide(
-          toolName: 'generate',
-          policy: AgentPermissionPolicy(const {
-            AgentPermissionDomain.generation: AgentAccessMode.allowWrite,
-          }),
-        ),
+        catalog.decide(toolName: 'generate', policy: policy),
         AgentPermissionDecision.confirmCharge,
       );
+      expect(
+        catalog.decide(toolName: 'generate', policy: policy, estimatedAnlas: 0),
+        AgentPermissionDecision.allow,
+      );
       expect(() => catalog.descriptorFor('unknown'), throwsStateError);
+    });
+
+    test('applies the permission mode by operation before billing', () {
+      const mutation = AgentToolPermissionDescriptor(
+        toolName: 'mutate',
+        domain: AgentPermissionDomain.prompt,
+        operation: AgentPermissionOperation.update,
+      );
+      const deletion = AgentToolPermissionDescriptor(
+        toolName: 'delete',
+        domain: AgentPermissionDomain.prompt,
+        operation: AgentPermissionOperation.delete,
+      );
+      final catalog = AgentToolPermissionCatalog(
+        toolNames: const ['read_status', 'mutate', 'delete', 'generate'],
+        descriptors: const [read, mutation, deletion, generate],
+      );
+
+      AgentPermissionPolicy policy(AgentAccessMode mode) =>
+          AgentPermissionPolicy({
+            AgentPermissionDomain.status: mode,
+            AgentPermissionDomain.prompt: mode,
+            AgentPermissionDomain.generation: mode,
+          });
+
+      final expected = {
+        AgentAccessMode.readOnly: const [
+          AgentPermissionDecision.allow,
+          AgentPermissionDecision.block,
+          AgentPermissionDecision.block,
+          AgentPermissionDecision.block,
+          AgentPermissionDecision.block,
+        ],
+        AgentAccessMode.askBeforeWrite: const [
+          AgentPermissionDecision.allow,
+          AgentPermissionDecision.ask,
+          AgentPermissionDecision.ask,
+          AgentPermissionDecision.ask,
+          AgentPermissionDecision.confirmCharge,
+        ],
+        AgentAccessMode.allowWrite: const [
+          AgentPermissionDecision.allow,
+          AgentPermissionDecision.allow,
+          AgentPermissionDecision.ask,
+          AgentPermissionDecision.allow,
+          AgentPermissionDecision.confirmCharge,
+        ],
+      };
+      for (final entry in expected.entries) {
+        final current = policy(entry.key);
+        expect(
+          [
+            catalog.decide(toolName: 'read_status', policy: current),
+            catalog.decide(toolName: 'mutate', policy: current),
+            catalog.decide(toolName: 'delete', policy: current),
+            catalog.decide(
+              toolName: 'generate',
+              policy: current,
+              estimatedAnlas: 0,
+            ),
+            catalog.decide(
+              toolName: 'generate',
+              policy: current,
+              estimatedAnlas: 3,
+            ),
+          ],
+          entry.value,
+          reason: entry.key.name,
+        );
+      }
     });
 
     test('rejects missing, duplicate, and unknown descriptors', () {

--- a/test/core/windowing/agent_window_shell_test.dart
+++ b/test/core/windowing/agent_window_shell_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/windowing/agent_window_protocol.dart';
 import 'package:nai_launcher/core/windowing/agent_window_shell.dart';
+import 'package:nai_launcher/core/windowing/agent_window_shell_widgets.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 
 void main() {
@@ -134,6 +135,81 @@ void main() {
       ),
       isTrue,
     );
+  });
+
+  testWidgets('secondary uses canonical ask permission mode value', (
+    tester,
+  ) async {
+    final commands = <(String, Map<String, Object?>)>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: AgentWindowPermissionModeButton(
+            payload: const {'permissionMode': 'askBeforeSensitiveActions'},
+            sendCommand: (name, payload) async {
+              commands.add((name, payload));
+              return null;
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Ask'), findsOneWidget);
+    await tester.tap(find.text('Ask'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Ask').last);
+    await tester.pumpAndSettle();
+
+    expect(commands, hasLength(1));
+    expect(commands.single.$1, 'setPermissionMode');
+    expect(commands.single.$2, {'value': 'askBeforeSensitiveActions'});
+  });
+
+  testWidgets('secondary approval response carries its tool call id', (
+    tester,
+  ) async {
+    final bridge = _FakeBridge()
+      ..snapshot = const AgentWindowSnapshot(
+        revision: 4,
+        payload: {
+          'ready': true,
+          'initialized': true,
+          'routeReady': true,
+          'sessions': [],
+          'messages': [],
+          'activities': [],
+          'resources': [],
+          'composerText': '',
+          'routeLabel': 'Default',
+          'permissionMode': 'fullAccess',
+          'webAccessEnabled': false,
+          'approval': {
+            'toolCallId': 'charge-1',
+            'toolName': 'submit_generation',
+            'estimatedAnlas': 3,
+          },
+        },
+      );
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => buildAgentWindowBridgeShell(context, bridge),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Allow once'));
+    await tester.pump();
+
+    final approval = bridge.commands.singleWhere(
+      (entry) => entry.$1 == 'resolveApproval',
+    );
+    expect(approval.$2, {'toolCallId': 'charge-1', 'value': true});
   });
 
   testWidgets('secondary shell renders user images and survives corrupt data', (

--- a/test/data/models/agent/agent_settings_test.dart
+++ b/test/data/models/agent/agent_settings_test.dart
@@ -32,6 +32,22 @@ void main() {
       );
     });
 
+    test('round-trips every permission mode using its canonical name', () {
+      for (final mode in AgentPermissionMode.values) {
+        final settings = AgentSettings(
+          chat: AgentChatConfig(permissionMode: mode),
+        );
+
+        final encoded = settings.toJson();
+        final chat = encoded['chat']! as Map<String, dynamic>;
+        expect(chat['permissionMode'], mode.name);
+        expect(
+          AgentSettings.decode(jsonEncode(encoded)).chat.permissionMode,
+          mode,
+        );
+      }
+    });
+
     test('schema 3 settings migrate to append mode', () {
       final raw = const AgentSettings(
         chat: AgentChatConfig(customSystemPrompt: 'Keep this behavior.'),

--- a/test/presentation/agent_chat/services/agent_tool_permission_controller_test.dart
+++ b/test/presentation/agent_chat/services/agent_tool_permission_controller_test.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/agent.dart';
+import 'package:nai_launcher/core/agent/audit/audit_sink.dart';
+import 'package:nai_launcher/core/agent/permissions/permissions.dart';
+import 'package:nai_launcher/presentation/agent_chat/providers/agent_chat_state.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_tool_permission_controller.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_tool_registry_builder.dart';
+
+void main() {
+  group('AgentToolPermissionController billing decisions', () {
+    test(
+      'full access automatically allows an exact zero-cost submit',
+      () async {
+        AgentToolApprovalRequest? approval;
+        final controller = _controller(
+          mode: AgentAccessMode.allowWrite,
+          estimate: 0,
+          onApproval: (value) => approval = value,
+        );
+
+        final result = await controller.beforeToolCall(
+          _context('zero-cost'),
+          null,
+        );
+
+        expect(result, isNull);
+        expect(approval, isNull);
+      },
+    );
+
+    test('positive cost requires approval even with full access', () async {
+      AgentToolApprovalRequest? approval;
+      final controller = _controller(
+        mode: AgentAccessMode.allowWrite,
+        estimate: 4,
+        onApproval: (value) => approval = value,
+      );
+
+      final pending = controller.beforeToolCall(_context('positive'), null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(approval?.estimatedAnlas, 4);
+      expect(controller.resolveApproval('positive', true), isTrue);
+      expect(await pending, isNull);
+    });
+
+    test('ask mode still asks for a zero-cost mutation', () async {
+      AgentToolApprovalRequest? approval;
+      final controller = _controller(
+        mode: AgentAccessMode.askBeforeWrite,
+        estimate: 0,
+        onApproval: (value) => approval = value,
+      );
+
+      final pending = controller.beforeToolCall(_context('ask-zero'), null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(approval?.estimatedAnlas, 0);
+      controller.resolveApproval('ask-zero', false);
+      expect((await pending)?.block, isTrue);
+    });
+
+    test('safe mode blocks submit without presenting approval', () async {
+      AgentToolApprovalRequest? approval;
+      final controller = _controller(
+        mode: AgentAccessMode.readOnly,
+        estimate: 0,
+        onApproval: (value) => approval = value,
+      );
+
+      final result = await controller.beforeToolCall(_context('blocked'), null);
+
+      expect(result?.block, isTrue);
+      expect(approval, isNull);
+    });
+
+    test('stale window response cannot resolve a newer approval', () async {
+      final controller = _controller(
+        mode: AgentAccessMode.allowWrite,
+        estimate: 2,
+        onApproval: (_) {},
+      );
+      final pending = controller.beforeToolCall(_context('current'), null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.resolveApproval('stale', true), isFalse);
+      var completed = false;
+      unawaited(pending.then((_) => completed = true));
+      await Future<void>.delayed(Duration.zero);
+      expect(completed, isFalse);
+
+      expect(controller.resolveApproval('current', false), isTrue);
+      expect((await pending)?.block, isTrue);
+    });
+  });
+}
+
+AgentToolPermissionController _controller({
+  required AgentAccessMode mode,
+  required int? estimate,
+  required void Function(AgentToolApprovalRequest?) onApproval,
+}) {
+  final descriptor = describeAgentToolPermission('submit_generation');
+  final catalog = AgentToolPermissionCatalog(
+    toolNames: const ['submit_generation'],
+    descriptors: [descriptor],
+  );
+  final controller = AgentToolPermissionController(
+    auditSink: MemoryAgentAuditSink(),
+    estimateAnlas: (_, _) async => estimate,
+    onApprovalChanged: onApproval,
+    isMounted: () => true,
+  );
+  controller.configure(
+    AgentToolRegistry(
+      tools: const [],
+      catalog: catalog,
+      policy: AgentPermissionPolicy({descriptor.domain: mode}),
+    ),
+  );
+  return controller;
+}
+
+BeforeToolCallContext _context(String id) {
+  final toolCall = ToolCallContent(
+    id: id,
+    name: 'submit_generation',
+    arguments: const {'preparation_id': 'prepared', 'confirmed': true},
+  );
+  final assistant = AssistantMessage(
+    content: [toolCall],
+    stopReason: StopReason.toolUse,
+  );
+  return BeforeToolCallContext(
+    assistantMessage: assistant,
+    toolCall: toolCall,
+    args: toolCall.arguments,
+    context: AgentContext(
+      systemPrompt: '',
+      messages: [assistant],
+      tools: const [],
+    ),
+  );
+}

--- a/test/presentation/agent_chat/services/generation_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/generation_toolbox_test.dart
@@ -523,6 +523,13 @@ void main() {
       expect(imageSource.mimeType, 'image/png');
       expect(imageSource.base64Data, isNotEmpty);
       expect(submitted.details['files'], ['saved.png']);
+
+      final replayed = await submit.execute('submit-replayed', {
+        'preparation_id': payload['preparation_id'],
+        'confirmed': true,
+      });
+      expect(replayed.isError, isTrue);
+      expect(fake.generateCalls, 1);
     },
   );
 

--- a/test/presentation/agent_chat/services/manual_inpaint_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/manual_inpaint_toolbox_test.dart
@@ -55,6 +55,7 @@ void main() {
       final toolbox = ManualInpaintToolbox(
         container.read(_refProvider),
         supportDirectory: root,
+        anlasEstimator: (_, _) => 7,
         workspaceDir: root.path,
         repository: repository,
         editorLauncher: (_, __, ___) => ManualInpaintEditorSession(
@@ -89,6 +90,8 @@ void main() {
         (await repository.get(id))!.parameterSnapshot['prompt'],
         'repair face',
       );
+      expect((await repository.get(id))!.estimatedAnlas, 7);
+      expect(await toolbox.estimateAnlasForDraft(id), 7);
 
       editorResult.complete(
         ImageEditorResult(
@@ -149,6 +152,7 @@ void main() {
     final toolbox = ManualInpaintToolbox(
       container.read(_refProvider),
       supportDirectory: root,
+      anlasEstimator: (_, _) => 0,
       workspaceDir: root.path,
       repository: repository,
       editorLauncher: (_, __, ___) => ManualInpaintEditorSession(
@@ -190,6 +194,7 @@ void main() {
     final toolbox = ManualInpaintToolbox(
       container.read(_refProvider),
       supportDirectory: root,
+      anlasEstimator: (_, _) => 0,
       repository: repository,
       resourceLoader: (value) async => value == reference ? source : null,
       editorLauncher: (_, __, ___) =>


### PR DESCRIPTION
## 根因

- 工具目录把“可能消耗 Anlas”编码成了独立 `charge` 操作，权限策略因此在获得真实估算前无条件返回计费确认；即使准确估算为 `0`，全开放模式也无法自动放行。
- runtime 在普通权限决策之后才估算费用，权限模式与计费规则没有形成同一条可测试的决策链；手动局部重绘还使用了硬编码 Opus 计费状态。
- detached secondary-engine 的批准命令只携带布尔值，没有关联 `toolCallId`，延迟响应可能误解锁后续请求；Ask 模式还发送了旧枚举字符串。

## 修复

- 工具声明拆分为普通操作类别（read/create/update/delete/execute）与 `mayConsumeAnlas` 风险元数据，由共享 catalog 统一执行“域权限 → 精确费用”决策。
- 全开放模式自动放行普通 read/mutation 和准确估算为 0 Anlas 的操作；delete 仍需确认。
- 任何估算为正数或暂时未知的 Anlas 操作均显示独立费用确认，全开放模式不能绕过；Ask 模式的正数费用确认同时明确覆盖本次 mutation。
- generation preparation 继续只准备、不执行；携带有效 `preparation_id` 的 confirmed submit 进入统一计费决策，已消费 preparation 无法重放。
- 手动局部重绘改用共享 `GenerationAnlasEstimator` 与当前订阅状态，并在提交确认前重新估算。
- 主窗口保持唯一 runtime/state owner；secondary 仅通过现有 IPC 返回带 `toolCallId` 的结果，过期/重复响应会被拒绝。

## 行为矩阵

| 权限模式 | read | mutation | delete | 计费工具 = 0 Anlas | 计费工具 > 0 / 未知 |
| --- | --- | --- | --- | --- | --- |
| 安全/只读 | 放行 | 拒绝 | 拒绝 | 拒绝 | 拒绝 |
| 每次询问 | 放行 | 普通确认 | 普通确认 | 普通确认 | 明确费用确认 |
| 全开放 | 放行 | 放行 | 普通确认 | 放行 | 明确费用确认 |

## 验证

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1 -Path "lib/core/agent/permissions/agent_permission.dart,lib/core/agent/permissions/tool_permission_catalog.dart,lib/presentation/agent_chat/services/agent_tool_permission_controller.dart,lib/presentation/agent_chat/providers/agent_chat_notifier.dart,lib/presentation/agent_chat/services/agent_window_bridge_adapter.dart,lib/core/windowing/agent_window_shell.dart,lib/core/windowing/agent_window_shell_widgets.dart,lib/presentation/agent_chat/services/manual_inpaint_toolbox.dart" -Include "test/presentation/agent_chat/services/agent_tool_permission_controller_test.dart,test/core/windowing/agent_window_shell_test.dart,test/presentation/agent_chat/services/generation_toolbox_test.dart,test/presentation/agent_chat/services/manual_inpaint_toolbox_test.dart" -TimeoutSeconds 180`（65 tests passed）
- `timeout 60s flutter test test/data/models/agent/agent_settings_test.dart --plain-name 'round-trips every permission mode using its canonical name' --reporter=compact`
- `dart analyze lib/core/agent/permissions`
- `dart analyze lib/core/windowing`
- `dart analyze lib/presentation/agent_chat/services`
- `dart analyze lib/presentation/agent_chat/widgets`
- `dart analyze lib/presentation/agent_chat/providers/agent_chat_notifier.dart`
- `git diff --check`

未执行真实生成，未消耗 Anlas，未运行会抢占键鼠的自动化。