### PR TITLE
feat(gallery): 添加无阻塞占位卡片加载

### DIFF
--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -80,9 +80,11 @@ export 'online_gallery_state.dart'
 
 part 'online_gallery_provider.g.dart';
 
+const int onlineGalleryPageSize = 60;
+
 @riverpod
 class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
-  static const int _pageSize = 60;
+  static const int _pageSize = onlineGalleryPageSize;
   final OnlineGalleryLoadCoordinator _loadCoordinator =
       OnlineGalleryLoadCoordinator();
   final OnlineGalleryArtistHuntService _artistHunt =

--- a/lib/presentation/screens/online_gallery/gallery_grid_item.dart
+++ b/lib/presentation/screens/online_gallery/gallery_grid_item.dart
@@ -7,6 +7,7 @@ import '../../../core/utils/localization_extension.dart';
 import '../../../data/models/online_gallery/danbooru_post.dart';
 import 'online_gallery_grid.dart';
 import '../../agent_chat/widgets/agent_resource_drop_region.dart';
+import '../../widgets/online_gallery/online_gallery_image_placeholder.dart';
 
 /// Owns one gallery tile's visibility and detail request lifecycle.
 ///
@@ -55,6 +56,7 @@ class GalleryGridItem extends StatefulWidget {
     GalleryItem item,
     double itemWidth, {
     required double layoutAspectRatio,
+    required bool loadMedia,
     GalleryDetail? detail,
   })
   buildCard;
@@ -117,6 +119,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
     BuildContext context,
     GalleryItem item,
     double layoutAspectRatio, {
+    required bool loadMedia,
     GalleryDetail? detail,
   }) {
     return AgentResourceDragSource(
@@ -137,6 +140,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
         item,
         widget.itemWidth,
         layoutAspectRatio: layoutAspectRatio,
+        loadMedia: loadMedia,
         detail: detail,
       ),
     );
@@ -156,63 +160,76 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
         scrolling: widget.scrolling,
         onVisibilityChanged: _handleVisibility,
         builder: (context, hasBeenVisible, isScrolling) {
-          if (!hasBeenVisible && isScrolling && !_needsDetail) {
+          if (!_needsDetail) {
+            return _buildResourceCard(
+              context,
+              post,
+              layoutAspectRatio,
+              loadMedia: hasBeenVisible,
+            );
+          }
+          if (!hasBeenVisible) {
             return SizedBox(
               height: (widget.itemWidth / layoutAspectRatio).clamp(
                 80.0,
                 widget.itemWidth * 2.5,
               ),
-              child: const Card(child: SizedBox.shrink()),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: const OnlineGalleryImagePlaceholder(),
+              ),
             );
           }
-          if (!_needsDetail) {
-            return _buildResourceCard(context, post, layoutAspectRatio);
-          }
-          if (!hasBeenVisible || _detailFuture == null) {
+          if (_detailFuture == null) {
             return const AspectRatio(
               aspectRatio: 1,
-              child: Card(child: SizedBox.shrink()),
+              child: ClipRRect(
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+                child: OnlineGalleryImagePlaceholder(),
+              ),
             );
           }
-          return AnimatedSize(
-            duration: const Duration(milliseconds: 180),
-            curve: Curves.easeOutCubic,
-            child: FutureBuilder<GalleryDetail>(
-              key: ValueKey((post.detailStableKey, widget.detailRequestScope)),
-              future: _detailFuture,
-              builder: (context, snapshot) {
-                if (snapshot.hasError) {
-                  return AspectRatio(
-                    aspectRatio: 1,
-                    child: Card(
-                      child: Center(
-                        child: TextButton.icon(
-                          onPressed: _retryDetail,
-                          icon: const Icon(Icons.refresh),
-                          label: Text(context.l10n.common_retry),
-                        ),
+          return FutureBuilder<GalleryDetail>(
+            key: ValueKey((post.detailStableKey, widget.detailRequestScope)),
+            future: _detailFuture,
+            builder: (context, snapshot) {
+              if (snapshot.hasError) {
+                return AspectRatio(
+                  aspectRatio: 1,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.surfaceContainerLow,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Center(
+                      child: TextButton.icon(
+                        onPressed: _retryDetail,
+                        icon: const Icon(Icons.refresh),
+                        label: Text(context.l10n.common_retry),
                       ),
                     ),
-                  );
-                }
-                final detail = snapshot.data;
-                final resolved = detail?.item;
-                if (resolved == null) {
-                  return const AspectRatio(
-                    aspectRatio: 1,
-                    child: Card(
-                      child: Center(child: CircularProgressIndicator()),
-                    ),
-                  );
-                }
-                return _buildResourceCard(
-                  context,
-                  resolved,
-                  layoutAspectRatio,
-                  detail: detail,
+                  ),
                 );
-              },
-            ),
+              }
+              final detail = snapshot.data;
+              final resolved = detail?.item;
+              if (resolved == null) {
+                return const AspectRatio(
+                  aspectRatio: 1,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.all(Radius.circular(8)),
+                    child: OnlineGalleryImagePlaceholder(),
+                  ),
+                );
+              }
+              return _buildResourceCard(
+                context,
+                resolved,
+                layoutAspectRatio,
+                loadMedia: true,
+                detail: detail,
+              );
+            },
           );
         },
       ),

--- a/lib/presentation/screens/online_gallery/online_gallery_content.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_content.dart
@@ -316,12 +316,20 @@ class _OnlineGalleryContentPresenter {
             priority: priority,
             forceRefresh: forceRefresh,
           ),
-      buildCard: (context, item, width, {required layoutAspectRatio, detail}) =>
-          _buildResolvedPostCard(
+      buildCard:
+          (
+            context,
+            item,
+            width, {
+            required layoutAspectRatio,
+            required loadMedia,
+            detail,
+          }) => _buildResolvedPostCard(
             state,
             item,
             width,
             layoutAspectRatio: layoutAspectRatio,
+            loadMedia: loadMedia,
             detail: detail,
           ),
     );
@@ -332,6 +340,7 @@ class _OnlineGalleryContentPresenter {
     GalleryItem post,
     double itemWidth, {
     required double layoutAspectRatio,
+    required bool loadMedia,
     GalleryDetail? detail,
   }) {
     final capabilities = gallerySourceCapabilities[post.sourceId]!;
@@ -408,6 +417,7 @@ class _OnlineGalleryContentPresenter {
           post: post,
           itemWidth: itemWidth,
           layoutAspectRatio: layoutAspectRatio,
+          loadMedia: loadMedia,
           isFavorited: isFavorited,
           isFavoriteLoading: favoriteState.$3,
           showFavoriteAction: canWriteFavorite,
@@ -554,32 +564,49 @@ class _OnlineGalleryContentPresenter {
   /// 构建页面显示内容（加载中、错误、空状态、网格）
   Widget _buildPageContent(ThemeData theme, OnlineGalleryState state) {
     if (state.isLoading && state.posts.isEmpty) {
+      final grid = _buildImageGrid(theme, state);
       final cache = state.currentCache;
       final tagCount = GalleryTagQueryParser.parse(
         state.viewMode == GalleryViewMode.popular
             ? state.popularQuery
             : state.searchQuery,
       ).ordinaryTagCount;
-      return Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const CircularProgressIndicator(),
-            if (tagCount > 1 && cache.queryRequestCount > 0) ...[
-              const SizedBox(height: 12),
-              Text(
-                context.l10n.onlineGallery_multiTagScanning(
-                  cache.queryRequestCount,
-                  cache.queryCandidateCount,
+      if (tagCount <= 1 || cache.queryRequestCount <= 0) return grid;
+      return Stack(
+        children: [
+          Positioned.fill(child: grid),
+          Positioned(
+            top: 12,
+            left: 12,
+            right: 12,
+            child: IgnorePointer(
+              child: Center(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.surfaceContainerLow,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    child: Text(
+                      context.l10n.onlineGallery_multiTagScanning(
+                        cache.queryRequestCount,
+                        cache.queryCandidateCount,
+                      ),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
                 ),
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-                textAlign: TextAlign.center,
               ),
-            ],
-          ],
-        ),
+            ),
+          ),
+        ],
       );
     }
     if (state.hasError && state.posts.isEmpty) {

--- a/lib/presentation/screens/online_gallery/online_gallery_grid.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_grid.dart
@@ -5,6 +5,7 @@ import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../../core/cache/online_gallery_preload_policy.dart';
 import '../../providers/online_gallery_provider.dart';
+import '../../widgets/online_gallery/online_gallery_image_placeholder.dart';
 import 'online_gallery_screen_controller.dart';
 
 typedef OnlineGalleryGridItemBuilder =
@@ -36,6 +37,16 @@ class OnlineGalleryGrid extends StatelessWidget {
   final OnlineGalleryScreenController controller;
   final OnlineGalleryGridItemBuilder itemBuilder;
 
+  int _placeholderCount() {
+    if (!(state.isLoadingMore || (state.isLoading && state.posts.isEmpty))) {
+      return 0;
+    }
+    if (state.randomEnabled) return 1;
+    final total = state.currentCache.total;
+    if (total == null) return onlineGalleryPageSize;
+    return (total - state.posts.length).clamp(0, onlineGalleryPageSize);
+  }
+
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
@@ -58,6 +69,7 @@ class OnlineGalleryGrid extends StatelessWidget {
         final storageScope = state.randomEnabled
             ? 'random:${state.randomSession.scopeKey}'
             : 'normal';
+        final placeholderCount = _placeholderCount();
         return MasonryGridView.count(
           key: PageStorageKey<String>(
             'online_gallery_$storageScope:${state.currentCacheKey}',
@@ -68,11 +80,43 @@ class OnlineGalleryGrid extends StatelessWidget {
           crossAxisCount: columnCount,
           mainAxisSpacing: spacing,
           crossAxisSpacing: spacing,
-          itemCount: state.posts.length + 1,
-          itemBuilder: (context, index) =>
-              itemBuilder(context, index, itemWidth, columnCount),
+          itemCount: state.posts.length + placeholderCount + 1,
+          itemBuilder: (context, index) {
+            if (index >= state.posts.length &&
+                index < state.posts.length + placeholderCount) {
+              return OnlineGalleryPendingCard(
+                key: ValueKey(
+                  'online-gallery-pending:${state.currentCacheKey}:$index',
+                ),
+                itemWidth: itemWidth,
+              );
+            }
+            return itemBuilder(
+              context,
+              index < state.posts.length ? index : state.posts.length,
+              itemWidth,
+              columnCount,
+            );
+          },
         );
       },
+    );
+  }
+}
+
+class OnlineGalleryPendingCard extends StatelessWidget {
+  const OnlineGalleryPendingCard({super.key, required this.itemWidth});
+
+  final double itemWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: itemWidth,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: const OnlineGalleryImagePlaceholder(),
+      ),
     );
   }
 }
@@ -137,11 +181,23 @@ class OnlineGalleryVisibilityDrivenItemState
   void _handleScrollingChanged() {
     final value = widget.scrolling.value;
     if (_isScrolling == value) return;
-    if (!_hasBeenVisible && value && mounted) {
-      setState(() => _isScrolling = value);
-    } else {
+    if (_hasBeenVisible || !mounted) {
       _isScrolling = value;
+      return;
     }
+    if (!value && _isVisible) {
+      _stopListeningForScrolling();
+      setState(() {
+        _isScrolling = false;
+        _hasBeenVisible = true;
+      });
+      return;
+    }
+    if (!value) {
+      _isScrolling = false;
+      return;
+    }
+    setState(() => _isScrolling = value);
   }
 
   @override
@@ -164,7 +220,7 @@ class OnlineGalleryVisibilityDrivenItemState
         }
         if (_isVisible == visible) return;
         _isVisible = visible;
-        if (visible && !_hasBeenVisible && mounted) {
+        if (visible && !_hasBeenVisible && !_isScrolling && mounted) {
           _stopListeningForScrolling();
           setState(() => _hasBeenVisible = true);
         }

--- a/lib/presentation/widgets/danbooru_post_card.dart
+++ b/lib/presentation/widgets/danbooru_post_card.dart
@@ -28,6 +28,7 @@ import 'common/card_action_buttons.dart';
 import 'common/image_card_hover_motion.dart';
 import 'online_gallery/online_gallery_hover_controller.dart';
 import 'online_gallery/online_gallery_card_status_overlays.dart';
+import 'online_gallery/online_gallery_image_placeholder.dart';
 import 'online_gallery/progressive_gallery_image.dart';
 
 import 'common/app_toast.dart';
@@ -72,6 +73,7 @@ class DanbooruPostCard extends StatefulWidget {
   final OnlineGalleryHoverController? hoverController;
   final VoidCallback? onHoverIntent;
   final OnlineGalleryPrefetchCoordinator? imageCoordinator;
+  final bool loadMedia;
 
   const DanbooruPostCard({
     super.key,
@@ -103,6 +105,7 @@ class DanbooruPostCard extends StatefulWidget {
     this.hoverController,
     this.onHoverIntent,
     this.imageCoordinator,
+    this.loadMedia = true,
   });
 
   @override
@@ -149,7 +152,8 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
     }
     if (oldWidget.post.previewUrl != widget.post.previewUrl ||
         oldWidget.post.width != widget.post.width ||
-        oldWidget.post.height != widget.post.height) {
+        oldWidget.post.height != widget.post.height ||
+        oldWidget.loadMedia != widget.loadMedia) {
       _resolvedAspectRatio = null;
       _resolveUnknownDimensions();
     }
@@ -157,7 +161,8 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
 
   void _resolveUnknownDimensions() {
     final post = widget.post;
-    if ((post.width > 0 && post.height > 0) ||
+    if (!widget.loadMedia ||
+        (post.width > 0 && post.height > 0) ||
         _resolvedAspectRatio != null ||
         post.previewUrl.isEmpty) {
       _detachDimensionListener();
@@ -507,7 +512,9 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
                       child: Stack(
                         fit: StackFit.expand,
                         children: [
-                          if (gridImageRequest.url.isEmpty)
+                          if (!widget.loadMedia)
+                            const OnlineGalleryImagePlaceholder()
+                          else if (gridImageRequest.url.isEmpty)
                             _buildNoImageContent(theme)
                           else
                             CachedNetworkImage(
@@ -521,23 +528,12 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
                               errorListener: (error) {
                                 // 静默处理图片加载错误，避免控制台警告
                               },
-                              placeholder: (context, url) => Container(
-                                color:
-                                    theme.colorScheme.surfaceContainerHighest,
-                                child: const Center(
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
+                              placeholder: (context, url) =>
+                                  const OnlineGalleryImagePlaceholder(),
+                              errorWidget: (context, url, error) =>
+                                  const OnlineGalleryImagePlaceholder(
+                                    failed: true,
                                   ),
-                                ),
-                              ),
-                              errorWidget: (context, url, error) => Container(
-                                color:
-                                    theme.colorScheme.surfaceContainerHighest,
-                                child: Icon(
-                                  Icons.broken_image,
-                                  color: theme.colorScheme.onSurfaceVariant,
-                                ),
-                              ),
                             ),
                           if (widget.selectionMode) ...[
                             // Selection Overlay

--- a/lib/presentation/widgets/online_gallery/online_gallery_image_placeholder.dart
+++ b/lib/presentation/widgets/online_gallery/online_gallery_image_placeholder.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+/// Stable, low-contrast surface used while gallery media is unavailable.
+class OnlineGalleryImagePlaceholder extends StatelessWidget {
+  const OnlineGalleryImagePlaceholder({super.key, this.failed = false});
+
+  final bool failed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return ColoredBox(
+      color: colors.surfaceContainerLow,
+      child: failed
+          ? Center(
+              child: Icon(
+                Icons.image_not_supported_outlined,
+                color: colors.onSurfaceVariant.withValues(alpha: 0.38),
+              ),
+            )
+          : const SizedBox.expand(),
+    );
+  }
+}

--- a/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
+++ b/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
@@ -152,6 +152,7 @@ void main() {
 
     firstAttempt.completeError(StateError('network failed'));
     await tester.pump();
+    await tester.pump();
 
     expect(find.text('Retry'), findsOneWidget);
     expect(find.byIcon(Icons.refresh), findsOneWidget);
@@ -165,6 +166,49 @@ void main() {
     expect(find.byKey(const ValueKey('resolved-card')), findsOneWidget);
     expect(find.text('Retry'), findsNothing);
   });
+
+  testWidgets(
+    'missing dimensions remain an empty stable card until first visibility',
+    (tester) async {
+      const item = GalleryItem(
+        id: 2,
+        workId: 'work-2',
+        sourceId: GallerySourceId.danbooru,
+        previewFileUrl: 'https://example.test/pending.jpg',
+      );
+      final loadMediaValues = <bool>[];
+
+      await tester.pumpWidget(
+        _app(
+          post: item,
+          detailRequestScope: 1,
+          loadDetail: (_, {required priority, forceRefresh = false}) =>
+              throw StateError('detail should not load'),
+          onBuildCard: loadMediaValues.add,
+        ),
+      );
+
+      expect(loadMediaValues, [isFalse]);
+      expect(find.byKey(const ValueKey('resolved-card')), findsOneWidget);
+      expect(tester.getSize(find.byType(GalleryGridItem)).height, 200);
+
+      final detector = tester.widget<VisibilityDetector>(
+        find.byType(VisibilityDetector),
+      );
+      detector.onVisibilityChanged?.call(
+        VisibilityInfo(
+          key: detector.key!,
+          size: const Size(200, 200),
+          visibleBounds: const Rect.fromLTWH(0, 0, 200, 200),
+        ),
+      );
+      await tester.pump();
+
+      expect(loadMediaValues.last, isTrue);
+      expect(find.byKey(const ValueKey('resolved-card')), findsOneWidget);
+      expect(tester.getSize(find.byType(GalleryGridItem)).height, 200);
+    },
+  );
 }
 
 const _item = GalleryItem(
@@ -174,6 +218,7 @@ const _item = GalleryItem(
 );
 
 Widget _app({
+  GalleryItem post = _item,
   required Object detailRequestScope,
   required Future<GalleryDetail> Function(
     GalleryItem item, {
@@ -181,6 +226,7 @@ Widget _app({
     bool forceRefresh,
   })
   loadDetail,
+  ValueChanged<bool>? onBuildCard,
 }) {
   return MaterialApp(
     locale: const Locale('en'),
@@ -191,7 +237,7 @@ Widget _app({
         width: 200,
         height: 200,
         child: GalleryGridItem(
-          post: _item,
+          post: post,
           index: 0,
           itemWidth: 200,
           columnCount: 1,
@@ -206,8 +252,15 @@ Widget _app({
                 item,
                 itemWidth, {
                 required layoutAspectRatio,
+                required loadMedia,
                 detail,
-              }) => const SizedBox(key: ValueKey('resolved-card')),
+              }) {
+                onBuildCard?.call(loadMedia);
+                return SizedBox(
+                  key: const ValueKey('resolved-card'),
+                  height: itemWidth / layoutAspectRatio,
+                );
+              },
         ),
       ),
     ),

--- a/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
@@ -68,10 +68,6 @@ void main() {
     await tester.pump();
     expect((builds, lastHasBeenVisible, lastIsScrolling), (2, false, true));
 
-    scrolling.value = false;
-    await tester.pump();
-    expect(builds, 2);
-
     final detector = tester.widget<VisibilityDetector>(
       find.byType(VisibilityDetector, skipOffstage: false),
     );
@@ -82,6 +78,10 @@ void main() {
         visibleBounds: const Rect.fromLTWH(0, 0, 100, 100),
       ),
     );
+    await tester.pump();
+    expect((builds, lastHasBeenVisible, lastIsScrolling), (2, false, true));
+
+    scrolling.value = false;
     await tester.pump();
     expect((builds, lastHasBeenVisible, lastIsScrolling), (3, true, false));
 
@@ -175,6 +175,94 @@ void main() {
       greaterThan(initialLastIndex),
     );
     expect(builtIndices.length, lessThan(400));
+  });
+
+  testWidgets('initial loading creates a scrollable batch of empty cards', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(360, 640);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    final controller = OnlineGalleryScreenController(
+      prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
+        preloader: (_) async {},
+      ),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: OnlineGalleryGrid(
+            state: const OnlineGalleryState(isLoading: true),
+            controller: controller,
+            itemBuilder: (context, index, itemWidth, columnCount) =>
+                const SizedBox(height: 24),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(OnlineGalleryPendingCard), findsWidgets);
+    expect(
+      controller.scrollController.position.maxScrollExtent,
+      greaterThan(0),
+    );
+    final before = controller.scrollController.offset;
+    await tester.drag(find.byType(OnlineGalleryGrid), const Offset(0, -400));
+    await tester.pump();
+    expect(controller.scrollController.offset, greaterThan(before));
+  });
+
+  testWidgets('append placeholders reserve slots after existing posts', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(360, 640);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    final controller = OnlineGalleryScreenController(
+      prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
+        preloader: (_) async {},
+      ),
+    );
+    addTearDown(controller.dispose);
+    final items = List.generate(
+      4,
+      (index) => GalleryItem(
+        id: index,
+        workId: 'post-$index',
+        sourceId: GallerySourceId.danbooru,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: OnlineGalleryGrid(
+            state: OnlineGalleryState(
+              isLoadingMore: true,
+              searchCache: ModeCache(posts: items),
+            ),
+            controller: controller,
+            itemBuilder: (context, index, itemWidth, columnCount) =>
+                SizedBox(key: ValueKey('loaded-$index'), height: itemWidth),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('loaded-0')), findsOneWidget);
+    expect(find.byType(OnlineGalleryPendingCard), findsWidgets);
+    final pending = tester.widgetList<OnlineGalleryPendingCard>(
+      find.byType(OnlineGalleryPendingCard),
+    );
+    expect(pending.every((card) => card.itemWidth > 0), isTrue);
+    expect(
+      controller.scrollController.position.maxScrollExtent,
+      greaterThan(0),
+    );
   });
 
   testWidgets(

--- a/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
@@ -919,6 +919,18 @@ void main() {
     await tester.tap(find.byIcon(Icons.chevron_right));
     await tester.pump();
 
+    final detector = tester.widget<VisibilityDetector>(
+      find.byKey(const ValueKey('gallery-visibility:danbooru:402')),
+    );
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      ),
+    );
+    await tester.pump();
+
     expect(find.byKey(const ValueKey('danbooru:401')), findsNothing);
     expect(find.byKey(const ValueKey('danbooru:402')), findsOneWidget);
     expect(

--- a/test/presentation/widgets/danbooru_post_card_test.dart
+++ b/test/presentation/widgets/danbooru_post_card_test.dart
@@ -113,6 +113,58 @@ void main() {
     );
   });
 
+  testWidgets(
+    'offscreen cards defer image creation without changing geometry',
+    (tester) async {
+      const post = DanbooruPost(
+        id: 124,
+        previewFileUrl: 'https://example.com/pending.jpg',
+        tagString: 'test_tag',
+      );
+
+      Widget app(bool loadMedia) => ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: DanbooruPostCard(
+                post: post,
+                itemWidth: 200,
+                layoutAspectRatio: 1,
+                loadMedia: loadMedia,
+                isFavorited: false,
+                onTap: () {},
+                onTagTap: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(app(false));
+
+      expect(find.byType(CachedNetworkImage), findsNothing);
+      expect(
+        tester
+            .getSize(find.byKey(const ValueKey('online-gallery-card-layout')))
+            .height,
+        200,
+      );
+
+      await tester.pumpWidget(app(true));
+
+      expect(find.byType(CachedNetworkImage), findsOneWidget);
+      expect(
+        tester
+            .getSize(find.byKey(const ValueKey('online-gallery-card-layout')))
+            .height,
+        200,
+      );
+    },
+  );
+
   testWidgets('online gallery cards use the shared hover scale', (
     tester,
   ) async {

--- a/test/presentation/widgets/online_gallery/online_gallery_image_placeholder_test.dart
+++ b/test/presentation/widgets/online_gallery/online_gallery_image_placeholder_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/presentation/widgets/online_gallery/online_gallery_image_placeholder.dart';
+
+void main() {
+  testWidgets('loading placeholder stays empty and fills its reserved space', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 180,
+            height: 120,
+            child: OnlineGalleryImagePlaceholder(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.byIcon(Icons.image_not_supported_outlined), findsNothing);
+    expect(
+      tester.getSize(find.byType(OnlineGalleryImagePlaceholder)),
+      const Size(180, 120),
+    );
+  });
+
+  testWidgets('failed image keeps the same low-contrast placeholder geometry', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 180,
+            height: 120,
+            child: OnlineGalleryImagePlaceholder(failed: true),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+    expect(
+      tester.getSize(find.byType(OnlineGalleryImagePlaceholder)),
+      const Size(180, 120),
+    );
+  });
+}


### PR DESCRIPTION
## 用户可见变化
- 首次进入在线画廊和加载下一页时，立即预留一批稳定、可滚动的低对比空状态卡片，不再由数据请求或图片处理阻塞滚动。
- 条目到达后直接填充对应卡片；图片未加载、缺少尺寸或加载失败时保持固定布局，避免卡片跳变和反复重排。
- 快速滚动期间继续保留空状态，停止滚动且卡片可见后才创建图片请求；离屏图片和 AI TAG 缺失详情不会提前加载。
- 保留多标签扫描进度提示，但不再用居中加载界面阻断画廊。

## 验证
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run_flutter_tests.ps1 -TimeoutSeconds 120 -Concurrency 2 -Path \"test/presentation/screens/online_gallery/gallery_grid_item_test.dart,test/presentation/screens/online_gallery/online_gallery_grid_test.dart,test/presentation/widgets/online_gallery/online_gallery_image_placeholder_test.dart,test/presentation/widgets/danbooru_post_card_test.dart,test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart\"`
- `dart analyze lib/presentation/providers/online_gallery_provider.dart lib/presentation/screens/online_gallery/gallery_grid_item.dart lib/presentation/screens/online_gallery/online_gallery_content.dart lib/presentation/screens/online_gallery/online_gallery_grid.dart lib/presentation/widgets/danbooru_post_card.dart lib/presentation/widgets/online_gallery/online_gallery_image_placeholder.dart`
- `git diff --check`

未执行会抢占键鼠的运行时自动化，未发起任何消耗 Anlas 的请求。