### PR TITLE
feat(agent): 统一响应式聊天界面

### DIFF
--- a/lib/core/agent/agent_tool_presentation.dart
+++ b/lib/core/agent/agent_tool_presentation.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+
+/// Presentation-safe projection of tool protocol text.
+///
+/// Tool results intentionally retain their structured JSON for auditability,
+/// but the transcript should lead with a human-readable outcome instead of
+/// exposing that wire format by default.
+abstract final class AgentToolPresentation {
+  static String summary(String raw, {required String fallback}) {
+    final text = raw.trim();
+    if (text.isEmpty) return fallback;
+    final decoded = _tryDecode(text);
+    if (decoded is Map) {
+      for (final key in const [
+        'summary',
+        'message',
+        'error',
+        'status_message',
+        'statusMessage',
+        'title',
+      ]) {
+        final value = decoded[key];
+        if (value is String && value.trim().isNotEmpty) {
+          return _bounded(value.trim(), fallback: fallback);
+        }
+      }
+      return fallback;
+    }
+    if (decoded is List) return fallback;
+    return _bounded(text.replaceAll(RegExp(r'\s+'), ' '), fallback: fallback);
+  }
+
+  static String formattedDetails(String raw) {
+    final text = raw.trim();
+    if (text.isEmpty) return '';
+    final decoded = _tryDecode(text);
+    if (decoded == null) return text;
+    return const JsonEncoder.withIndent('  ').convert(decoded);
+  }
+
+  static String formattedValue(Object? value) {
+    if (value == null) return '';
+    try {
+      return const JsonEncoder.withIndent('  ').convert(value);
+    } on JsonUnsupportedObjectError {
+      return value.toString();
+    }
+  }
+
+  static Object? _tryDecode(String text) {
+    if (!(text.startsWith('{') && text.endsWith('}')) &&
+        !(text.startsWith('[') && text.endsWith(']'))) {
+      return null;
+    }
+    try {
+      return jsonDecode(text);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  static String _bounded(String value, {required String fallback}) {
+    if (value.isEmpty) return fallback;
+    return value.length <= 96 ? value : '${value.substring(0, 96)}…';
+  }
+}

--- a/lib/core/windowing/agent_chat_layout_contract.dart
+++ b/lib/core/windowing/agent_chat_layout_contract.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+/// Shared responsive contract used by the embedded and detached Agent clients.
+///
+/// The secondary window remains an IPC-only client; sharing these presentation
+/// rules prevents it from drifting into a separate chat experience.
+enum AgentChatWidthClass { compact, regular, wide }
+
+@immutable
+class AgentChatLayoutContract {
+  const AgentChatLayoutContract._();
+
+  static AgentChatWidthClass widthClassFor(double width) {
+    if (width < 420) return AgentChatWidthClass.compact;
+    if (width < 760) return AgentChatWidthClass.regular;
+    return AgentChatWidthClass.wide;
+  }
+
+  static double transcriptHorizontalPadding(double width) =>
+      switch (widthClassFor(width)) {
+        AgentChatWidthClass.compact => 12,
+        AgentChatWidthClass.regular => 16,
+        AgentChatWidthClass.wide => 24,
+      };
+
+  static double transcriptMaxWidth(double width) =>
+      switch (widthClassFor(width)) {
+        AgentChatWidthClass.compact => width,
+        AgentChatWidthClass.regular => 680,
+        AgentChatWidthClass.wide => 820,
+      };
+
+  static double userBubbleMaxWidth(double width) {
+    final available = width - transcriptHorizontalPadding(width) * 2;
+    final fraction = switch (widthClassFor(width)) {
+      AgentChatWidthClass.compact => 0.82,
+      AgentChatWidthClass.regular => 0.72,
+      AgentChatWidthClass.wide => 0.64,
+    };
+    return (available * fraction).clamp(180.0, 560.0);
+  }
+
+  static double assistantMaxWidth(double width) =>
+      switch (widthClassFor(width)) {
+        AgentChatWidthClass.compact => width,
+        AgentChatWidthClass.regular => 660,
+        AgentChatWidthClass.wide => 760,
+      };
+
+  static bool stackComposerControls(double width, {required bool running}) =>
+      width < (running ? 520 : 400);
+
+  static EdgeInsets composerOuterPadding(double width) =>
+      EdgeInsets.fromLTRB(width < 420 ? 10 : 14, 6, width < 420 ? 10 : 14, 10);
+}

--- a/lib/core/windowing/agent_chat_shared_widgets.dart
+++ b/lib/core/windowing/agent_chat_shared_widgets.dart
@@ -1,0 +1,227 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart' as md;
+
+/// Markdown presentation shared by the authoritative panel and IPC client.
+class AgentChatMarkdownContent extends StatelessWidget {
+  const AgentChatMarkdownContent({
+    super.key,
+    required this.text,
+    required this.touchOptimized,
+    this.imageBuilder,
+  });
+
+  final String text;
+  final bool touchOptimized;
+  final Widget Function(Uri uri, String? title, String? alt)? imageBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final bodyStyle = touchOptimized
+        ? theme.textTheme.bodyMedium
+        : theme.textTheme.bodySmall;
+    return md.MarkdownBody(
+      data: text,
+      selectable: true,
+      imageBuilder: imageBuilder,
+      styleSheet: md.MarkdownStyleSheet.fromTheme(theme).copyWith(
+        p: bodyStyle?.copyWith(height: 1.55),
+        code: bodyStyle?.copyWith(
+          fontFamily: 'monospace',
+          backgroundColor: theme.colorScheme.surfaceContainerHighest.withValues(
+            alpha: 0.6,
+          ),
+        ),
+        codeblockDecoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHighest.withValues(
+            alpha: 0.6,
+          ),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        blockquoteDecoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHigh.withValues(alpha: 0.5),
+          borderRadius: BorderRadius.circular(8),
+        ),
+      ),
+    );
+  }
+}
+
+/// Resolves the same Markdown image schemes in every Agent chat surface.
+class AgentChatMarkdownImage extends StatelessWidget {
+  const AgentChatMarkdownImage({
+    super.key,
+    required this.uri,
+    required this.alt,
+    this.dataBytes,
+  });
+
+  final Uri uri;
+  final String? alt;
+  final Uint8List? dataBytes;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = uri.scheme.toLowerCase();
+    final image = switch (scheme) {
+      'http' || 'https' => Image.network(
+        uri.toString(),
+        fit: BoxFit.contain,
+        gaplessPlayback: true,
+        filterQuality: FilterQuality.medium,
+        errorBuilder: (_, _, _) => _brokenImage(context),
+      ),
+      'resource' => Image.asset(
+        uri.path,
+        fit: BoxFit.contain,
+        gaplessPlayback: true,
+        filterQuality: FilterQuality.medium,
+        errorBuilder: (_, _, _) => _brokenImage(context),
+      ),
+      'data' => _dataImage(context),
+      _ => _fileImage(context, scheme),
+    };
+    return Semantics(
+      label: alt,
+      image: true,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 320, maxHeight: 220),
+        child: AspectRatio(
+          aspectRatio: 320 / 220,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: image,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _dataImage(BuildContext context) {
+    try {
+      return Image.memory(
+        dataBytes ?? uri.data!.contentAsBytes(),
+        fit: BoxFit.contain,
+        gaplessPlayback: true,
+        filterQuality: FilterQuality.medium,
+        errorBuilder: (_, _, _) => _brokenImage(context),
+      );
+    } catch (_) {
+      return _brokenImage(context);
+    }
+  }
+
+  Widget _fileImage(BuildContext context, String scheme) {
+    try {
+      final file = scheme == 'file'
+          ? File.fromUri(uri)
+          : File(uri.toFilePath(windows: Platform.isWindows));
+      return Image.file(
+        file,
+        fit: BoxFit.contain,
+        gaplessPlayback: true,
+        filterQuality: FilterQuality.medium,
+        errorBuilder: (_, _, _) => _brokenImage(context),
+      );
+    } catch (_) {
+      return _brokenImage(context);
+    }
+  }
+
+  Widget _brokenImage(BuildContext context) => ColoredBox(
+    color: Theme.of(
+      context,
+    ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.35),
+    child: const Center(child: Icon(Icons.broken_image_outlined)),
+  );
+}
+
+/// Bounded, selectable and copyable detail surface for tool protocol data.
+class AgentToolDetailSurface extends StatefulWidget {
+  const AgentToolDetailSurface({
+    super.key,
+    required this.text,
+    required this.copyTooltip,
+    required this.onCopy,
+    this.maxHeight = 240,
+    this.margin = const EdgeInsets.fromLTRB(24, 2, 4, 6),
+  });
+
+  final String text;
+  final String copyTooltip;
+  final VoidCallback onCopy;
+  final double maxHeight;
+  final EdgeInsets margin;
+
+  @override
+  State<AgentToolDetailSurface> createState() => _AgentToolDetailSurfaceState();
+}
+
+class _AgentToolDetailSurfaceState extends State<AgentToolDetailSurface> {
+  final ScrollController _scrollController = ScrollController(
+    keepScrollOffset: false,
+  );
+  final PageStorageBucket _detailPageStorage = PageStorageBucket();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: widget.margin,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Stack(
+        children: [
+          ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: widget.maxHeight),
+            child: Scrollbar(
+              controller: _scrollController,
+              child: SingleChildScrollView(
+                controller: _scrollController,
+                primary: false,
+                padding: const EdgeInsets.fromLTRB(10, 9, 42, 10),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: PageStorage(
+                    bucket: _detailPageStorage,
+                    child: SelectableText(
+                      widget.text,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                        fontFamily: 'monospace',
+                        height: 1.45,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            top: 2,
+            right: 2,
+            child: IconButton(
+              key: const ValueKey('agent-tool-detail-copy'),
+              tooltip: widget.copyTooltip,
+              visualDensity: VisualDensity.compact,
+              iconSize: 16,
+              onPressed: widget.onCopy,
+              icon: const Icon(Icons.copy_all_outlined),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/windowing/agent_window_shell.dart
+++ b/lib/core/windowing/agent_window_shell.dart
@@ -10,6 +10,7 @@ import '../agent/resources/agent_chat_resource_drag_format.dart';
 import '../agent/resources/agent_chat_resource_reference_codec.dart';
 import 'agent_window_protocol.dart';
 import 'agent_window_shell_widgets.dart';
+import 'agent_window_transcript_widgets.dart';
 
 abstract interface class AgentWindowShellBridge {
   AgentWindowSnapshot get snapshot;
@@ -81,6 +82,20 @@ class _AgentWindowBridgeShellState extends State<_AgentWindowBridgeShell> {
       }
       if (mounted) setState(() => _localError = error.toString());
     }
+  }
+
+  Future<void> _copyText(String text) async {
+    await Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(AppLocalizations.of(context)!.common_copied),
+          duration: const Duration(seconds: 2),
+        ),
+      );
   }
 
   void _composerChanged(String value) {
@@ -163,8 +178,9 @@ class _AgentWindowBridgeShellState extends State<_AgentWindowBridgeShell> {
               child: AgentWindowMessageList(
                 messages: messages,
                 controller: _scrollController,
-                copyText: (text) =>
-                    Clipboard.setData(ClipboardData(text: text)),
+                copyText: _copyText,
+                retryLastMessage: () => bridge.sendCommand('retryLastMessage'),
+                running: running,
               ),
             ),
             ..._buildStatusPanels(
@@ -252,6 +268,7 @@ class _AgentWindowBridgeShellState extends State<_AgentWindowBridgeShell> {
     String activeSessionId,
     bool running,
   ) => Padding(
+    key: const ValueKey('agent-window-session-picker'),
     padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
     child: DropdownButtonFormField<String>(
       initialValue:
@@ -294,7 +311,8 @@ class _AgentWindowBridgeShellState extends State<_AgentWindowBridgeShell> {
   ) => [
     if (payload['activities'] case final List activities)
       for (final activity in activities)
-        if (activity is Map) AgentWindowToolActivityTile(activity: activity),
+        if (activity is Map && activity['status'] == 'running')
+          AgentWindowToolActivityTile(activity: activity, copyText: _copyText),
     if (compacting)
       Padding(
         padding: const EdgeInsets.fromLTRB(14, 4, 14, 4),
@@ -398,170 +416,203 @@ class _AgentWindowBridgeShellState extends State<_AgentWindowBridgeShell> {
     bool routeReady,
     bool running,
     bool hasUnavailableResources,
-  ) => SafeArea(
-    top: false,
-    child: Padding(
-      padding: const EdgeInsets.all(10),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Focus(
-            onKeyEvent: (_, event) {
-              if (event is! KeyDownEvent) return KeyEventResult.ignored;
-              if (event.logicalKey == LogicalKeyboardKey.escape && running) {
-                bridge.sendCommand('stop');
-                return KeyEventResult.handled;
-              }
-              if (event.logicalKey != LogicalKeyboardKey.enter &&
-                  event.logicalKey != LogicalKeyboardKey.numpadEnter) {
-                return KeyEventResult.ignored;
-              }
-              if (_composer.value.composing.isValid &&
-                  !_composer.value.composing.isCollapsed) {
-                return KeyEventResult.ignored;
-              }
-              if (HardwareKeyboard.instance.isShiftPressed ||
-                  HardwareKeyboard.instance.isControlPressed ||
-                  HardwareKeyboard.instance.isMetaPressed) {
-                final value = _composer.value;
-                final selection = value.selection;
-                final start = selection.isValid
-                    ? selection.start
-                    : value.text.length;
-                final end = selection.isValid
-                    ? selection.end
-                    : value.text.length;
-                _composer.value = value.copyWith(
-                  text: value.text.replaceRange(start, end, '\n'),
-                  selection: TextSelection.collapsed(offset: start + 1),
-                  composing: TextRange.empty,
-                );
-                return KeyEventResult.handled;
-              }
-              if (!hasUnavailableResources) unawaited(_send());
-              return KeyEventResult.handled;
-            },
-            child: TextField(
-              controller: _composer,
-              focusNode: _composerFocus,
-              enabled: initialized,
-              minLines: 2,
-              maxLines: 7,
-              onChanged: _composerChanged,
-              textInputAction: TextInputAction.newline,
-              decoration: InputDecoration(
-                hintText: l10n.agentChat_inputHint,
-                filled: true,
-                fillColor: Theme.of(context).colorScheme.surfaceContainerLow,
-                border: OutlineInputBorder(
-                  borderSide: BorderSide.none,
-                  borderRadius: BorderRadius.circular(14),
-                ),
-                isDense: true,
+  ) {
+    final permission = AgentWindowPermissionModeButton(
+      sendCommand: (name, payload) => bridge.sendCommand(name, payload),
+      payload: payload,
+    );
+    final webAccess = FilterChip(
+      selected: payload['webAccessEnabled'] == true,
+      avatar: const Icon(Icons.public, size: 16),
+      label: Text(l10n.agentChat_webAccess),
+      onSelected: running
+          ? null
+          : (value) => bridge.sendCommand('setWebAccess', {'value': value}),
+    );
+    final model = AgentWindowModelButton(
+      payload: payload,
+      sendCommand: (name, payload) => bridge.sendCommand(name, payload),
+    );
+    final actions = <Widget>[
+      if (running)
+        PopupMenuButton<bool>(
+          tooltip: l10n.agentChat_queueFollowUp,
+          onSelected: (_) => _send(followUp: true),
+          itemBuilder: (_) => [
+            PopupMenuItem<bool>(
+              value: true,
+              child: ListTile(
+                dense: true,
+                contentPadding: EdgeInsets.zero,
+                leading: const Icon(Icons.playlist_add_rounded),
+                title: Text(l10n.agentChat_queueFollowUp),
               ),
             ),
-          ),
-          const SizedBox(height: 6),
-          SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              children: [
-                AgentWindowPermissionModeButton(
-                  sendCommand: (name, payload) =>
-                      bridge.sendCommand(name, payload),
-                  payload: payload,
-                ),
-                const SizedBox(width: 4),
-                FilterChip(
-                  selected: payload['webAccessEnabled'] == true,
-                  avatar: const Icon(Icons.public, size: 16),
-                  label: Text(l10n.agentChat_webAccess),
-                  onSelected: running
-                      ? null
-                      : (value) => bridge.sendCommand('setWebAccess', {
-                          'value': value,
-                        }),
-                ),
-                const SizedBox(width: 4),
-                AgentWindowModelButton(
-                  payload: payload,
-                  sendCommand: (name, payload) =>
-                      bridge.sendCommand(name, payload),
-                ),
-                const SizedBox(width: 8),
-                ConstrainedBox(
-                  constraints: const BoxConstraints(
-                    minWidth: 96,
-                    maxWidth: 180,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        '$routeLabel${_workPhaseLabel(l10n, payload['workPhase'])}',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.labelSmall,
-                      ),
-                      Text(
-                        _contextLabel(l10n, payload['contextUsage']),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                          fontFeatures: const [FontFeature.tabularFigures()],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                if (running)
-                  PopupMenuButton<bool>(
-                    tooltip: l10n.agentChat_queueFollowUp,
-                    onSelected: (_) => _send(followUp: true),
-                    itemBuilder: (_) => [
-                      PopupMenuItem<bool>(
-                        value: true,
-                        child: ListTile(
-                          dense: true,
-                          contentPadding: EdgeInsets.zero,
-                          leading: const Icon(Icons.playlist_add_rounded),
-                          title: Text(l10n.agentChat_queueFollowUp),
-                        ),
-                      ),
-                    ],
-                    icon: const Icon(Icons.playlist_add_rounded),
-                  ),
-                if (running)
-                  IconButton(
-                    tooltip: l10n.agentChat_stop,
-                    onPressed: () => bridge.sendCommand('stop'),
-                    color: Theme.of(context).colorScheme.error,
-                    icon: const Icon(Icons.stop_rounded),
-                  ),
-                IconButton.filled(
-                  tooltip: hasUnavailableResources
-                      ? l10n.agentChat_resourceUnavailable
-                      : running
-                      ? l10n.agentChat_queued
-                      : l10n.agentChat_send,
-                  onPressed: initialized && routeReady
-                      ? hasUnavailableResources
-                            ? null
-                            : _send
-                      : null,
-                  icon: Icon(
-                    running ? Icons.queue_rounded : Icons.send_rounded,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
+          ],
+          icon: const Icon(Icons.playlist_add_rounded),
+        ),
+      if (running)
+        IconButton(
+          tooltip: l10n.agentChat_stop,
+          onPressed: () => bridge.sendCommand('stop'),
+          color: Theme.of(context).colorScheme.error,
+          icon: const Icon(Icons.stop_rounded),
+        ),
+      IconButton.filled(
+        key: const ValueKey('agent-window-send'),
+        tooltip: hasUnavailableResources
+            ? l10n.agentChat_resourceUnavailable
+            : running
+            ? l10n.agentChat_queued
+            : l10n.agentChat_send,
+        onPressed: initialized && routeReady && !hasUnavailableResources
+            ? _send
+            : null,
+        icon: Icon(running ? Icons.queue_rounded : Icons.send_rounded),
       ),
-    ),
-  );
+    ];
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 6, 12, 10),
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(8, 8, 8, 6),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerLow,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Focus(
+                onKeyEvent: (_, event) {
+                  if (event is! KeyDownEvent) return KeyEventResult.ignored;
+                  if (event.logicalKey == LogicalKeyboardKey.escape &&
+                      running) {
+                    bridge.sendCommand('stop');
+                    return KeyEventResult.handled;
+                  }
+                  if (event.logicalKey != LogicalKeyboardKey.enter &&
+                      event.logicalKey != LogicalKeyboardKey.numpadEnter) {
+                    return KeyEventResult.ignored;
+                  }
+                  if (_composer.value.composing.isValid &&
+                      !_composer.value.composing.isCollapsed) {
+                    return KeyEventResult.ignored;
+                  }
+                  if (HardwareKeyboard.instance.isShiftPressed ||
+                      HardwareKeyboard.instance.isControlPressed ||
+                      HardwareKeyboard.instance.isMetaPressed) {
+                    final value = _composer.value;
+                    final selection = value.selection;
+                    final start = selection.isValid
+                        ? selection.start
+                        : value.text.length;
+                    final end = selection.isValid
+                        ? selection.end
+                        : value.text.length;
+                    _composer.value = value.copyWith(
+                      text: value.text.replaceRange(start, end, '\n'),
+                      selection: TextSelection.collapsed(offset: start + 1),
+                      composing: TextRange.empty,
+                    );
+                    return KeyEventResult.handled;
+                  }
+                  if (!hasUnavailableResources) unawaited(_send());
+                  return KeyEventResult.handled;
+                },
+                child: TextField(
+                  controller: _composer,
+                  focusNode: _composerFocus,
+                  enabled: initialized,
+                  minLines: 1,
+                  maxLines: 7,
+                  onChanged: _composerChanged,
+                  textInputAction: TextInputAction.newline,
+                  decoration: InputDecoration(
+                    hintText: l10n.agentChat_inputHint,
+                    border: InputBorder.none,
+                    isDense: true,
+                    contentPadding: const EdgeInsets.fromLTRB(8, 8, 8, 6),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 6),
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  final status = Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          '$routeLabel${_workPhaseLabel(l10n, payload['workPhase'])}',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.labelSmall,
+                        ),
+                        Text(
+                          _contextLabel(l10n, payload['contextUsage']),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                                fontFeatures: const [
+                                  FontFeature.tabularFigures(),
+                                ],
+                              ),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (constraints.maxWidth < 560) {
+                    return Column(
+                      children: [
+                        Align(
+                          alignment: Alignment.centerLeft,
+                          child: Wrap(
+                            spacing: 4,
+                            runSpacing: 4,
+                            crossAxisAlignment: WrapCrossAlignment.center,
+                            children: [
+                              permission,
+                              webAccess,
+                              ConstrainedBox(
+                                constraints: BoxConstraints(
+                                  maxWidth: constraints.maxWidth,
+                                ),
+                                child: model,
+                              ),
+                            ],
+                          ),
+                        ),
+                        Row(children: [status, ...actions]),
+                      ],
+                    );
+                  }
+                  return Row(
+                    children: [
+                      permission,
+                      const SizedBox(width: 4),
+                      webAccess,
+                      const SizedBox(width: 4),
+                      Flexible(child: model),
+                      const SizedBox(width: 10),
+                      status,
+                      ...actions,
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 
   String _workPhaseLabel(AppLocalizations l10n, Object? value) {
     final label = switch (value) {

--- a/lib/core/windowing/agent_window_shell_widgets.dart
+++ b/lib/core/windowing/agent_window_shell_widgets.dart
@@ -1,9 +1,7 @@
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown_plus/flutter_markdown_plus.dart' as md;
 
+import '../agent/agent_tool_presentation.dart';
+import 'agent_chat_shared_widgets.dart';
 import '../../l10n/app_localizations.dart';
 
 class AgentWindowPermissionModeButton extends StatelessWidget {
@@ -48,50 +46,100 @@ class AgentWindowPermissionModeButton extends StatelessWidget {
 }
 
 class AgentWindowToolActivityTile extends StatelessWidget {
-  const AgentWindowToolActivityTile({required this.activity, super.key});
-
-  final Map activity;
-
-  @override
-  Widget build(BuildContext context) => ListTile(
-    dense: true,
-    leading: activity['status'] == 'running'
-        ? const SizedBox(
-            width: 16,
-            height: 16,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          )
-        : Icon(
-            activity['status'] == 'failed'
-                ? Icons.error_outline
-                : Icons.check_circle_outline,
-            size: 18,
-          ),
-    title: Text(activity['toolName']?.toString() ?? ''),
-    subtitle: activity['content']?.toString().isNotEmpty == true
-        ? Text(
-            activity['content'].toString(),
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-          )
-        : null,
-  );
-}
-
-class AgentWindowMessageList extends StatefulWidget {
-  const AgentWindowMessageList({
-    required this.messages,
-    required this.controller,
+  const AgentWindowToolActivityTile({
+    required this.activity,
     required this.copyText,
     super.key,
   });
 
-  final List messages;
-  final ScrollController controller;
+  final Map activity;
   final ValueChanged<String> copyText;
 
   @override
-  State<AgentWindowMessageList> createState() => _AgentWindowMessageListState();
+  Widget build(BuildContext context) {
+    final toolName = activity['toolName']?.toString() ?? '';
+    final running = activity['status'] == 'running';
+    final failed = activity['status'] == 'failed';
+    final content = activity['content']?.toString() ?? '';
+    final summary = AgentToolPresentation.summary(content, fallback: toolName);
+    final args = activity['args'];
+    final detailSections = <String>[
+      if (!(args is Map && args.isEmpty))
+        AgentToolPresentation.formattedValue(args),
+      if (content.trim().isNotEmpty)
+        AgentToolPresentation.formattedDetails(content),
+    ].where((value) => value.isNotEmpty).toSet();
+    final detailText = detailSections.join('\n\n');
+    final statusRow = Row(
+      children: [
+        if (running)
+          const SizedBox.square(
+            dimension: 14,
+            child: CircularProgressIndicator(strokeWidth: 1.8),
+          )
+        else
+          Icon(
+            failed ? Icons.error_outline : Icons.check_circle_outline,
+            size: 16,
+            color: failed ? Theme.of(context).colorScheme.error : null,
+          ),
+        const SizedBox(width: 8),
+        Flexible(
+          child: Text(
+            summary,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.labelMedium,
+          ),
+        ),
+      ],
+    );
+    return Semantics(
+      liveRegion: running,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(14, 2, 14, 4),
+        child: Material(
+          color: Theme.of(
+            context,
+          ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.42),
+          borderRadius: BorderRadius.circular(9),
+          clipBehavior: Clip.antiAlias,
+          child: detailText.isEmpty
+              ? Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 7,
+                  ),
+                  child: statusRow,
+                )
+              : Theme(
+                  data: Theme.of(
+                    context,
+                  ).copyWith(dividerColor: Colors.transparent),
+                  child: ExpansionTile(
+                    key: ValueKey(
+                      'agent-window-tool-activity-${activity['toolCallId']}',
+                    ),
+                    initiallyExpanded: false,
+                    minTileHeight: 38,
+                    tilePadding: const EdgeInsets.symmetric(horizontal: 10),
+                    childrenPadding: const EdgeInsets.fromLTRB(10, 0, 10, 8),
+                    title: statusRow,
+                    children: [
+                      AgentToolDetailSurface(
+                        text: detailText,
+                        copyTooltip: AppLocalizations.of(context)!.common_copy,
+                        onCopy: () => copyText(detailText),
+                        maxHeight: 180,
+                        margin: EdgeInsets.zero,
+                      ),
+                    ],
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
 }
 
 class AgentWindowModelButton extends StatelessWidget {
@@ -203,518 +251,6 @@ class AgentWindowModelButton extends StatelessWidget {
     _ => l10n.agentChat_reasoningOff,
   };
 }
-
-class _AgentWindowMessageListState extends State<AgentWindowMessageList> {
-  bool _followLatest = true;
-  String _lastSignature = '';
-
-  @override
-  void initState() {
-    super.initState();
-    widget.controller.addListener(_scrollChanged);
-  }
-
-  @override
-  void didUpdateWidget(covariant AgentWindowMessageList oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.controller != widget.controller) {
-      oldWidget.controller.removeListener(_scrollChanged);
-      widget.controller.addListener(_scrollChanged);
-    }
-    final signature = widget.messages.isEmpty
-        ? ''
-        : '${widget.messages.length}:${widget.messages.last.hashCode}';
-    if (signature != _lastSignature) {
-      _lastSignature = signature;
-      if (_followLatest) {
-        WidgetsBinding.instance.addPostFrameCallback(
-          (_) => _scrollToLatest(animate: false),
-        );
-      }
-    }
-  }
-
-  @override
-  void dispose() {
-    widget.controller.removeListener(_scrollChanged);
-    super.dispose();
-  }
-
-  void _scrollChanged() {
-    if (!widget.controller.hasClients) return;
-    final next =
-        widget.controller.position.maxScrollExtent - widget.controller.offset <
-        96;
-    if (next != _followLatest && mounted) setState(() => _followLatest = next);
-  }
-
-  void _scrollToLatest({bool animate = true}) {
-    if (!widget.controller.hasClients) return;
-    final target = widget.controller.position.maxScrollExtent;
-    if (animate && !MediaQuery.disableAnimationsOf(context)) {
-      widget.controller.animateTo(
-        target,
-        duration: const Duration(milliseconds: 180),
-        curve: Curves.easeOutCubic,
-      );
-    } else {
-      widget.controller.jumpTo(target);
-    }
-    if (!_followLatest) setState(() => _followLatest = true);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    if (widget.messages.isEmpty) {
-      return Center(child: Text(l10n.agentChat_heroSubtitle));
-    }
-    final items = _groupMessages(widget.messages);
-    return Stack(
-      children: [
-        ListView.builder(
-          controller: widget.controller,
-          padding: const EdgeInsets.fromLTRB(18, 14, 18, 20),
-          itemCount: items.length,
-          itemBuilder: (context, index) => _buildItem(context, items[index]),
-        ),
-        if (!_followLatest)
-          Positioned(
-            right: 16,
-            bottom: 12,
-            child: FilledButton.tonalIcon(
-              onPressed: _scrollToLatest,
-              icon: const Icon(Icons.arrow_downward_rounded, size: 16),
-              label: Text(l10n.agentChat_jumpToLatest),
-            ),
-          ),
-      ],
-    );
-  }
-
-  List<Object> _groupMessages(List messages) {
-    final items = <Object>[];
-    var index = 0;
-    while (index < messages.length) {
-      final message = Map<Object?, Object?>.from(messages[index] as Map);
-      if (_isInvisibleToolAssistant(message) &&
-          index + 1 < messages.length &&
-          (messages[index + 1] as Map)['role'] == 'tool') {
-        index++;
-        continue;
-      }
-      if (message['role'] == 'tool') {
-        final group = <Map<Object?, Object?>>[];
-        while (index < messages.length) {
-          final current = Map<Object?, Object?>.from(messages[index] as Map);
-          if (current['role'] == 'tool') {
-            group.add(current);
-            index++;
-            continue;
-          }
-          if (_isInvisibleToolAssistant(current) &&
-              index + 1 < messages.length &&
-              (messages[index + 1] as Map)['role'] == 'tool') {
-            index++;
-            continue;
-          }
-          break;
-        }
-        items.add(group);
-      } else {
-        items.add(message);
-        index++;
-      }
-    }
-    return items;
-  }
-
-  bool _isInvisibleToolAssistant(Map<Object?, Object?> message) =>
-      message['role'] == 'assistant' &&
-      (message['text']?.toString().trim().isEmpty ?? true) &&
-      (message['thinking']?.toString().trim().isEmpty ?? true) &&
-      message['stopReason'] == 'toolUse';
-
-  Widget _buildItem(BuildContext context, Object item) {
-    if (item is List<Map<Object?, Object?>>) {
-      return _AgentWindowToolGroup(results: item);
-    }
-    final message = item as Map<Object?, Object?>;
-    final role = message['role'];
-    final text = message['text'] as String? ?? '';
-    if (role == 'user') {
-      final images = message['images'] is List
-          ? message['images'] as List
-          : const [];
-      return Align(
-        alignment: Alignment.centerRight,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            Container(
-              constraints: const BoxConstraints(maxWidth: 620),
-              margin: const EdgeInsets.only(left: 48),
-              padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 10),
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primaryContainer,
-                borderRadius: BorderRadius.circular(14),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  if (text.isNotEmpty) SelectableText(text),
-                  for (final image in images)
-                    if (image is Map) _AgentWindowImageCard(image: image),
-                ],
-              ),
-            ),
-            _copyButton(context, text),
-            const SizedBox(height: 6),
-          ],
-        ),
-      );
-    }
-    final thinking = message['thinking'] as String? ?? '';
-    return Padding(
-      padding: const EdgeInsets.only(right: 24, bottom: 14),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          if (thinking.trim().isNotEmpty)
-            _AgentWindowReasoning(thinking: thinking),
-          if (text.trim().isNotEmpty)
-            md.MarkdownBody(
-              data: text,
-              selectable: true,
-              styleSheet: md.MarkdownStyleSheet.fromTheme(Theme.of(context))
-                  .copyWith(
-                    p: Theme.of(
-                      context,
-                    ).textTheme.bodyMedium?.copyWith(height: 1.55),
-                  ),
-            ),
-          if (text.trim().isNotEmpty)
-            Align(
-              alignment: Alignment.centerLeft,
-              child: _copyButton(context, text),
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _copyButton(BuildContext context, String text) => IconButton(
-    tooltip: AppLocalizations.of(context)!.common_copy,
-    visualDensity: VisualDensity.compact,
-    onPressed: () => widget.copyText(text),
-    icon: const Icon(Icons.copy_all_outlined, size: 15),
-  );
-}
-
-class _AgentWindowReasoning extends StatelessWidget {
-  const _AgentWindowReasoning({required this.thinking});
-
-  final String thinking;
-
-  @override
-  Widget build(BuildContext context) => Theme(
-    data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
-    child: ExpansionTile(
-      minTileHeight: 34,
-      tilePadding: EdgeInsets.zero,
-      childrenPadding: const EdgeInsets.only(bottom: 8),
-      leading: Icon(
-        Icons.psychology_alt_outlined,
-        size: 17,
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
-      title: Text(
-        AppLocalizations.of(context)!.agentChat_reasoning,
-        style: Theme.of(context).textTheme.labelMedium,
-      ),
-      children: [
-        Align(
-          alignment: Alignment.centerLeft,
-          child: SelectableText(
-            thinking,
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              height: 1.5,
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ),
-      ],
-    ),
-  );
-}
-
-class _AgentWindowToolGroup extends StatelessWidget {
-  const _AgentWindowToolGroup({required this.results});
-
-  final List<Map<Object?, Object?>> results;
-
-  @override
-  Widget build(BuildContext context) {
-    final hasError = results.any((result) => result['isError'] == true);
-    final hasImages = results.any(
-      (result) =>
-          (result['images'] is List && (result['images'] as List).isNotEmpty) ||
-          (result['files'] is List && (result['files'] as List).isNotEmpty),
-    );
-    return Theme(
-      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
-      child: ExpansionTile(
-        initiallyExpanded: hasError || hasImages,
-        minTileHeight: 38,
-        tilePadding: EdgeInsets.zero,
-        childrenPadding: const EdgeInsets.only(bottom: 10),
-        leading: Icon(
-          hasError ? Icons.error_outline : Icons.terminal_rounded,
-          size: 17,
-          color: hasError
-              ? Theme.of(context).colorScheme.error
-              : Theme.of(context).colorScheme.onSurfaceVariant,
-        ),
-        title: Text(
-          AppLocalizations.of(
-            context,
-          )!.agentChat_toolGroupCount(results.length),
-          style: Theme.of(context).textTheme.labelMedium,
-        ),
-        children: [
-          for (final result in results) _AgentWindowToolResult(result: result),
-        ],
-      ),
-    );
-  }
-}
-
-class _AgentWindowToolResult extends StatelessWidget {
-  const _AgentWindowToolResult({required this.result});
-
-  final Map<Object?, Object?> result;
-
-  @override
-  Widget build(BuildContext context) {
-    final images = result['images'] is List
-        ? result['images'] as List
-        : const [];
-    final files = result['files'] is List ? result['files'] as List : const [];
-    return Padding(
-      padding: const EdgeInsets.only(left: 25, top: 5),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Row(
-            children: [
-              Icon(
-                result['isError'] == true
-                    ? Icons.close_rounded
-                    : Icons.check_rounded,
-                size: 14,
-                color: result['isError'] == true
-                    ? Theme.of(context).colorScheme.error
-                    : Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-              const SizedBox(width: 6),
-              Expanded(
-                child: Text(
-                  result['toolName']?.toString() ?? '',
-                  style: Theme.of(context).textTheme.labelSmall,
-                ),
-              ),
-            ],
-          ),
-          if ((result['text'] as String? ?? '').trim().isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(top: 3),
-              child: SelectableText(
-                result['text'] as String,
-                maxLines: 8,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
-              ),
-            ),
-          for (final image in images)
-            if (image is Map) _AgentWindowImageCard(image: image),
-          for (final path in files)
-            if (path is String) _AgentWindowFileImageCard(path: path),
-        ],
-      ),
-    );
-  }
-}
-
-class _AgentWindowFileImageCard extends StatelessWidget {
-  const _AgentWindowFileImageCard({required this.path});
-
-  final String path;
-
-  @override
-  Widget build(BuildContext context) {
-    final file = File(path);
-    if (!file.existsSync()) {
-      return _AgentWindowBrokenImage(label: path);
-    }
-    return Padding(
-      padding: const EdgeInsets.only(top: 6),
-      child: Semantics(
-        button: true,
-        label: AppLocalizations.of(context)!.agentChat_toolGenerateImage,
-        child: InkWell(
-          borderRadius: BorderRadius.circular(9),
-          onTap: () => _showAgentWindowImagePreview(
-            context,
-            imageBuilder: () => Image.file(file, fit: BoxFit.contain),
-            path: path,
-          ),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(9),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: 280),
-              child: Image.file(
-                file,
-                alignment: Alignment.centerLeft,
-                fit: BoxFit.contain,
-                gaplessPlayback: true,
-                errorBuilder: (_, _, _) => _AgentWindowBrokenImage(label: path),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _AgentWindowImageCard extends StatelessWidget {
-  const _AgentWindowImageCard({required this.image});
-
-  final Map image;
-
-  @override
-  Widget build(BuildContext context) {
-    Widget Function() imageBuilder;
-    if (image['base64'] case final String data) {
-      try {
-        final bytes = base64Decode(data);
-        imageBuilder = () => Image.memory(bytes, fit: BoxFit.contain);
-      } on FormatException {
-        return const _AgentWindowBrokenImage();
-      }
-    } else if (image['url'] case final String url) {
-      imageBuilder = () => Image.network(
-        url,
-        fit: BoxFit.contain,
-        errorBuilder: (_, _, _) => const _AgentWindowBrokenImage(),
-      );
-    } else {
-      return const _AgentWindowBrokenImage();
-    }
-    return Semantics(
-      button: true,
-      label: AppLocalizations.of(context)!.agentChat_toolGenerateImage,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(10),
-        onTap: () =>
-            _showAgentWindowImagePreview(context, imageBuilder: imageBuilder),
-        child: Container(
-          margin: const EdgeInsets.only(top: 8),
-          constraints: const BoxConstraints(minHeight: 120, maxHeight: 420),
-          alignment: Alignment.centerLeft,
-          clipBehavior: Clip.antiAlias,
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surfaceContainerHighest,
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: imageBuilder(),
-        ),
-      ),
-    );
-  }
-}
-
-class _AgentWindowBrokenImage extends StatelessWidget {
-  const _AgentWindowBrokenImage({this.label});
-
-  final String? label;
-
-  @override
-  Widget build(BuildContext context) => Padding(
-    padding: const EdgeInsets.symmetric(vertical: 12),
-    child: Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        const Icon(Icons.broken_image_outlined, size: 18),
-        const SizedBox(width: 6),
-        Flexible(
-          child: Text(
-            label ??
-                AppLocalizations.of(context)!.agentChat_resourceUnavailable,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ),
-      ],
-    ),
-  );
-}
-
-Future<void> _showAgentWindowImagePreview(
-  BuildContext context, {
-  required Widget Function() imageBuilder,
-  String? path,
-}) => showDialog<void>(
-  context: context,
-  builder: (dialogContext) => Dialog(
-    clipBehavior: Clip.antiAlias,
-    child: ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: 1100, maxHeight: 800),
-      child: Stack(
-        children: [
-          Positioned.fill(
-            child: ColoredBox(
-              color: Theme.of(dialogContext).colorScheme.surfaceContainerLowest,
-              child: InteractiveViewer(
-                minScale: 0.5,
-                maxScale: 8,
-                child: Center(child: imageBuilder()),
-              ),
-            ),
-          ),
-          Positioned(
-            top: 8,
-            right: 8,
-            child: Row(
-              children: [
-                if (path != null)
-                  IconButton.filledTonal(
-                    tooltip: AppLocalizations.of(
-                      dialogContext,
-                    )!.localGallery_showInFolder,
-                    onPressed: () => Process.start('explorer.exe', [
-                      '/select,',
-                      path,
-                    ], mode: ProcessStartMode.detached),
-                    icon: const Icon(Icons.folder_open_outlined),
-                  ),
-                const SizedBox(width: 6),
-                IconButton.filledTonal(
-                  tooltip: MaterialLocalizations.of(
-                    dialogContext,
-                  ).closeButtonTooltip,
-                  onPressed: () => Navigator.of(dialogContext).pop(),
-                  icon: const Icon(Icons.close_rounded),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    ),
-  ),
-);
 
 class AgentWindowApprovalBar extends StatelessWidget {
   const AgentWindowApprovalBar({

--- a/lib/core/windowing/agent_window_transcript_widgets.dart
+++ b/lib/core/windowing/agent_window_transcript_widgets.dart
@@ -1,0 +1,660 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../agent/agent_tool_presentation.dart';
+import 'agent_chat_layout_contract.dart';
+import 'agent_chat_shared_widgets.dart';
+
+class AgentWindowMessageList extends StatefulWidget {
+  const AgentWindowMessageList({
+    required this.messages,
+    required this.controller,
+    required this.copyText,
+    required this.retryLastMessage,
+    required this.running,
+    super.key,
+  });
+
+  final List messages;
+  final ScrollController controller;
+  final ValueChanged<String> copyText;
+  final VoidCallback retryLastMessage;
+  final bool running;
+
+  @override
+  State<AgentWindowMessageList> createState() => _AgentWindowMessageListState();
+}
+
+class _AgentWindowMessageListState extends State<AgentWindowMessageList> {
+  bool _followLatest = true;
+  String _lastSignature = '';
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_scrollChanged);
+    _lastSignature = widget.messages.isEmpty
+        ? ''
+        : '${widget.messages.length}:${widget.messages.last.hashCode}';
+    if (widget.messages.isNotEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _scrollToLatest(animate: false);
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AgentWindowMessageList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_scrollChanged);
+      widget.controller.addListener(_scrollChanged);
+    }
+    final signature = widget.messages.isEmpty
+        ? ''
+        : '${widget.messages.length}:${widget.messages.last.hashCode}';
+    if (signature != _lastSignature) {
+      _lastSignature = signature;
+      if (_followLatest) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _scrollToLatest(animate: false);
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_scrollChanged);
+    super.dispose();
+  }
+
+  void _scrollChanged() {
+    if (!widget.controller.hasClients) return;
+    final next =
+        widget.controller.position.maxScrollExtent - widget.controller.offset <
+        96;
+    if (next != _followLatest && mounted) setState(() => _followLatest = next);
+  }
+
+  void _scrollToLatest({bool animate = true}) {
+    if (!mounted || !widget.controller.hasClients) return;
+    final target = widget.controller.position.maxScrollExtent;
+    if (animate && !MediaQuery.disableAnimationsOf(context)) {
+      widget.controller.animateTo(
+        target,
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOutCubic,
+      );
+    } else {
+      widget.controller.jumpTo(target);
+    }
+    if (!_followLatest) setState(() => _followLatest = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    if (widget.messages.isEmpty) {
+      return Center(child: Text(l10n.agentChat_heroSubtitle));
+    }
+    final items = _groupMessages(widget.messages);
+    final lastAssistantItemIndex = items.lastIndexWhere(
+      (item) =>
+          item is Map<Object?, Object?> &&
+          item['role'] == 'assistant' &&
+          (item['text']?.toString().trim().isNotEmpty ?? false),
+    );
+    return Stack(
+      children: [
+        LayoutBuilder(
+          builder: (context, constraints) => ListView.builder(
+            controller: widget.controller,
+            padding: EdgeInsets.fromLTRB(
+              AgentChatLayoutContract.transcriptHorizontalPadding(
+                constraints.maxWidth,
+              ),
+              16,
+              AgentChatLayoutContract.transcriptHorizontalPadding(
+                constraints.maxWidth,
+              ),
+              24,
+            ),
+            itemCount: items.length,
+            itemBuilder: (context, index) => Align(
+              alignment: Alignment.center,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxWidth: AgentChatLayoutContract.transcriptMaxWidth(
+                    constraints.maxWidth,
+                  ),
+                ),
+                child: _buildItem(
+                  context,
+                  items[index],
+                  isLastAssistant: index == lastAssistantItemIndex,
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (!_followLatest)
+          Positioned(
+            right: 16,
+            bottom: 12,
+            child: FilledButton.tonalIcon(
+              onPressed: _scrollToLatest,
+              icon: const Icon(Icons.arrow_downward_rounded, size: 16),
+              label: Text(l10n.agentChat_jumpToLatest),
+            ),
+          ),
+      ],
+    );
+  }
+
+  List<Object> _groupMessages(List messages) {
+    final items = <Object>[];
+    var index = 0;
+    while (index < messages.length) {
+      final message = Map<Object?, Object?>.from(messages[index] as Map);
+      if (_isInvisibleToolAssistant(message) &&
+          index + 1 < messages.length &&
+          (messages[index + 1] as Map)['role'] == 'tool') {
+        index++;
+        continue;
+      }
+      if (message['role'] == 'tool') {
+        final group = <Map<Object?, Object?>>[];
+        while (index < messages.length) {
+          final current = Map<Object?, Object?>.from(messages[index] as Map);
+          if (current['role'] == 'tool') {
+            group.add(current);
+            index++;
+            continue;
+          }
+          if (_isInvisibleToolAssistant(current) &&
+              index + 1 < messages.length &&
+              (messages[index + 1] as Map)['role'] == 'tool') {
+            index++;
+            continue;
+          }
+          break;
+        }
+        items.add(group);
+      } else {
+        items.add(message);
+        index++;
+      }
+    }
+    return items;
+  }
+
+  bool _isInvisibleToolAssistant(Map<Object?, Object?> message) =>
+      message['role'] == 'assistant' &&
+      (message['text']?.toString().trim().isEmpty ?? true) &&
+      (message['thinking']?.toString().trim().isEmpty ?? true) &&
+      message['stopReason'] == 'toolUse';
+
+  Widget _buildItem(
+    BuildContext context,
+    Object item, {
+    required bool isLastAssistant,
+  }) {
+    if (item is List<Map<Object?, Object?>>) {
+      if (item.length == 1) {
+        return _AgentWindowToolResult(
+          result: item.single,
+          copyText: widget.copyText,
+        );
+      }
+      return _AgentWindowToolGroup(results: item, copyText: widget.copyText);
+    }
+    final message = item as Map<Object?, Object?>;
+    final role = message['role'];
+    final text = message['text'] as String? ?? '';
+    if (role == 'user') {
+      final images = message['images'] is List
+          ? message['images'] as List
+          : const [];
+      return LayoutBuilder(
+        builder: (context, constraints) => Align(
+          alignment: Alignment.centerRight,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Container(
+                key: ValueKey('agent-window-user-bubble-${text.hashCode}'),
+                constraints: BoxConstraints(
+                  minWidth: text.isEmpty ? 0 : 44,
+                  maxWidth: AgentChatLayoutContract.userBubbleMaxWidth(
+                    constraints.maxWidth,
+                  ),
+                ),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 13,
+                  vertical: 10,
+                ),
+                decoration: BoxDecoration(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.primaryContainer.withValues(alpha: 0.58),
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(14),
+                    topRight: Radius.circular(14),
+                    bottomLeft: Radius.circular(14),
+                    bottomRight: Radius.circular(4),
+                  ),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (text.isNotEmpty) SelectableText(text),
+                    for (final image in images)
+                      if (image is Map) _AgentWindowImageCard(image: image),
+                  ],
+                ),
+              ),
+              _copyButton(context, text),
+              const SizedBox(height: 8),
+            ],
+          ),
+        ),
+      );
+    }
+    final thinking = message['thinking'] as String? ?? '';
+    return LayoutBuilder(
+      builder: (context, constraints) => Align(
+        alignment: Alignment.centerLeft,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: AgentChatLayoutContract.assistantMaxWidth(
+              constraints.maxWidth,
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.only(right: 8, bottom: 14),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (thinking.trim().isNotEmpty)
+                  _AgentWindowReasoning(thinking: thinking),
+                if (text.trim().isNotEmpty)
+                  AgentChatMarkdownContent(
+                    text: text,
+                    touchOptimized: false,
+                    imageBuilder: (uri, _, alt) =>
+                        AgentChatMarkdownImage(uri: uri, alt: alt),
+                  ),
+                if (text.trim().isNotEmpty)
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _copyButton(context, text),
+                      if (isLastAssistant && !widget.running)
+                        IconButton(
+                          key: const ValueKey(
+                            'agent-window-retry-last-message',
+                          ),
+                          tooltip: AppLocalizations.of(context)!.common_retry,
+                          visualDensity: VisualDensity.compact,
+                          onPressed: widget.retryLastMessage,
+                          icon: const Icon(Icons.refresh_rounded, size: 16),
+                        ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _copyButton(BuildContext context, String text) => IconButton(
+    tooltip: AppLocalizations.of(context)!.common_copy,
+    visualDensity: VisualDensity.compact,
+    onPressed: () => widget.copyText(text),
+    icon: const Icon(Icons.copy_all_outlined, size: 15),
+  );
+}
+
+class _AgentWindowReasoning extends StatelessWidget {
+  const _AgentWindowReasoning({required this.thinking});
+
+  final String thinking;
+
+  @override
+  Widget build(BuildContext context) => Theme(
+    data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+    child: ExpansionTile(
+      minTileHeight: 34,
+      tilePadding: EdgeInsets.zero,
+      childrenPadding: const EdgeInsets.only(bottom: 8),
+      leading: Icon(
+        Icons.psychology_alt_outlined,
+        size: 17,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+      title: Text(
+        AppLocalizations.of(context)!.agentChat_reasoning,
+        style: Theme.of(context).textTheme.labelMedium,
+      ),
+      children: [
+        Align(
+          alignment: Alignment.centerLeft,
+          child: SelectableText(
+            thinking,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              height: 1.5,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+class _AgentWindowToolGroup extends StatelessWidget {
+  const _AgentWindowToolGroup({required this.results, required this.copyText});
+
+  final List<Map<Object?, Object?>> results;
+  final ValueChanged<String> copyText;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasError = results.any((result) => result['isError'] == true);
+    String? failureSummary;
+    for (final result in results) {
+      if (result['isError'] == true) {
+        failureSummary = AgentToolPresentation.summary(
+          result['text']?.toString() ?? '',
+          fallback: AppLocalizations.of(context)!.common_error,
+        );
+        break;
+      }
+    }
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        initiallyExpanded: false,
+        minTileHeight: 38,
+        tilePadding: EdgeInsets.zero,
+        childrenPadding: const EdgeInsets.only(bottom: 10),
+        leading: Icon(
+          hasError ? Icons.error_outline : Icons.terminal_rounded,
+          size: 17,
+          color: hasError
+              ? Theme.of(context).colorScheme.error
+              : Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+        title: Text(
+          AppLocalizations.of(
+            context,
+          )!.agentChat_toolGroupCount(results.length),
+          style: Theme.of(context).textTheme.labelMedium,
+        ),
+        subtitle: failureSummary == null
+            ? null
+            : Text(
+                '${AppLocalizations.of(context)!.common_error} · $failureSummary',
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+              ),
+        children: [
+          for (final result in results)
+            _AgentWindowToolResult(result: result, copyText: copyText),
+        ],
+      ),
+    );
+  }
+}
+
+class _AgentWindowToolResult extends StatelessWidget {
+  const _AgentWindowToolResult({required this.result, required this.copyText});
+
+  final Map<Object?, Object?> result;
+  final ValueChanged<String> copyText;
+
+  @override
+  Widget build(BuildContext context) {
+    final images = result['images'] is List
+        ? result['images'] as List
+        : const [];
+    final files = result['files'] is List ? result['files'] as List : const [];
+    final text = result['text'] as String? ?? '';
+    final toolName = result['toolName']?.toString() ?? '';
+    final failed = result['isError'] == true;
+    final summary = AgentToolPresentation.summary(text, fallback: toolName);
+    final detailSections = <String>[
+      AgentToolPresentation.formattedDetails(text),
+      if (result['details'] != null)
+        AgentToolPresentation.formattedValue(result['details']),
+    ].where((value) => value.isNotEmpty).toSet();
+    final details = detailSections.join('\n\n');
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        key: ValueKey('agent-window-tool-${result['toolCallId'] ?? toolName}'),
+        initiallyExpanded: false,
+        minTileHeight: 38,
+        tilePadding: const EdgeInsets.symmetric(horizontal: 4),
+        childrenPadding: const EdgeInsets.fromLTRB(28, 0, 4, 8),
+        leading: Icon(
+          failed ? Icons.error_outline : Icons.check_circle_outline,
+          size: 17,
+          color: failed
+              ? Theme.of(context).colorScheme.error
+              : Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+        title: Text(
+          toolName,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.labelMedium,
+        ),
+        subtitle: Text(
+          summary,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+            color: failed
+                ? Theme.of(context).colorScheme.error
+                : Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+        children: [
+          if (details.isNotEmpty)
+            AgentToolDetailSurface(
+              text: details,
+              copyTooltip: AppLocalizations.of(context)!.common_copy,
+              onCopy: () => copyText(details),
+              maxHeight: 220,
+              margin: EdgeInsets.zero,
+            ),
+          for (final image in images)
+            if (image is Map) _AgentWindowImageCard(image: image),
+          for (final path in files)
+            if (path is String) _AgentWindowFileImageCard(path: path),
+        ],
+      ),
+    );
+  }
+}
+
+class _AgentWindowFileImageCard extends StatelessWidget {
+  const _AgentWindowFileImageCard({required this.path});
+
+  final String path;
+
+  @override
+  Widget build(BuildContext context) {
+    final file = File(path);
+    if (!file.existsSync()) {
+      return _AgentWindowBrokenImage(label: path);
+    }
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Semantics(
+        button: true,
+        label: AppLocalizations.of(context)!.agentChat_toolGenerateImage,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(9),
+          onTap: () => _showAgentWindowImagePreview(
+            context,
+            imageBuilder: () => Image.file(file, fit: BoxFit.contain),
+            path: path,
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(9),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 280),
+              child: Image.file(
+                file,
+                alignment: Alignment.centerLeft,
+                fit: BoxFit.contain,
+                gaplessPlayback: true,
+                errorBuilder: (_, _, _) => _AgentWindowBrokenImage(label: path),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AgentWindowImageCard extends StatelessWidget {
+  const _AgentWindowImageCard({required this.image});
+
+  final Map image;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget Function() imageBuilder;
+    if (image['base64'] case final String data) {
+      try {
+        final bytes = base64Decode(data);
+        imageBuilder = () => Image.memory(bytes, fit: BoxFit.contain);
+      } on FormatException {
+        return const _AgentWindowBrokenImage();
+      }
+    } else if (image['url'] case final String url) {
+      imageBuilder = () => Image.network(
+        url,
+        fit: BoxFit.contain,
+        errorBuilder: (_, _, _) => const _AgentWindowBrokenImage(),
+      );
+    } else {
+      return const _AgentWindowBrokenImage();
+    }
+    return Semantics(
+      button: true,
+      label: AppLocalizations.of(context)!.agentChat_toolGenerateImage,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(10),
+        onTap: () =>
+            _showAgentWindowImagePreview(context, imageBuilder: imageBuilder),
+        child: Container(
+          margin: const EdgeInsets.only(top: 8),
+          constraints: const BoxConstraints(minHeight: 120, maxHeight: 420),
+          alignment: Alignment.centerLeft,
+          clipBehavior: Clip.antiAlias,
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: imageBuilder(),
+        ),
+      ),
+    );
+  }
+}
+
+class _AgentWindowBrokenImage extends StatelessWidget {
+  const _AgentWindowBrokenImage({this.label});
+
+  final String? label;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(vertical: 12),
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Icon(Icons.broken_image_outlined, size: 18),
+        const SizedBox(width: 6),
+        Flexible(
+          child: Text(
+            label ??
+                AppLocalizations.of(context)!.agentChat_resourceUnavailable,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+Future<void> _showAgentWindowImagePreview(
+  BuildContext context, {
+  required Widget Function() imageBuilder,
+  String? path,
+}) => showDialog<void>(
+  context: context,
+  builder: (dialogContext) => Dialog(
+    clipBehavior: Clip.antiAlias,
+    child: ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 1100, maxHeight: 800),
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: ColoredBox(
+              color: Theme.of(dialogContext).colorScheme.surfaceContainerLowest,
+              child: InteractiveViewer(
+                minScale: 0.5,
+                maxScale: 8,
+                child: Center(child: imageBuilder()),
+              ),
+            ),
+          ),
+          Positioned(
+            top: 8,
+            right: 8,
+            child: Row(
+              children: [
+                if (path != null)
+                  IconButton.filledTonal(
+                    tooltip: AppLocalizations.of(
+                      dialogContext,
+                    )!.localGallery_showInFolder,
+                    onPressed: () => Process.start('explorer.exe', [
+                      '/select,',
+                      path,
+                    ], mode: ProcessStartMode.detached),
+                    icon: const Icon(Icons.folder_open_outlined),
+                  ),
+                const SizedBox(width: 6),
+                IconButton.filledTonal(
+                  tooltip: MaterialLocalizations.of(
+                    dialogContext,
+                  ).closeButtonTooltip,
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  icon: const Icon(Icons.close_rounded),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  ),
+);

--- a/lib/presentation/agent_chat/services/agent_window_bridge_adapter.dart
+++ b/lib/presentation/agent_chat/services/agent_window_bridge_adapter.dart
@@ -140,6 +140,10 @@ final class AgentWindowBridgeAdapter {
       case 'stop':
         notifier.abort();
       case 'retryLastMessage':
+        if (_container.read(agentChatNotifierProvider).status ==
+            AgentChatRunStatus.running) {
+          return const {'ok': false, 'error': 'agent_running'};
+        }
         final message = await notifier.rewindLastUserMessage();
         if (message == null) return const {'ok': false};
         await notifier.sendContent(message.content);
@@ -341,6 +345,7 @@ final class AgentWindowBridgeAdapter {
                 'toolName': activity.toolName,
                 'status': activity.status.name,
                 'content': activity.content,
+                'args': _ipcValue(activity.args),
               },
           ],
           if (state.approvalRequest case final approval?)
@@ -449,6 +454,7 @@ final class AgentWindowBridgeAdapter {
       'toolName': message.toolName,
       'text': message.text,
       'isError': message.isError,
+      if (message.details != null) 'details': _ipcValue(message.details),
       'images': [
         if (!preferFileImages)
           for (final content in message.content)
@@ -458,6 +464,22 @@ final class AgentWindowBridgeAdapter {
       ],
       'files': files,
     };
+  }
+
+  Object? _ipcValue(Object? value) {
+    if (value == null || value is String || value is bool || value is num) {
+      return value;
+    }
+    if (value is Map) {
+      return {
+        for (final entry in value.entries)
+          entry.key.toString(): _ipcValue(entry.value),
+      };
+    }
+    if (value is Iterable) {
+      return [for (final item in value) _ipcValue(item)];
+    }
+    return value.toString();
   }
 
   List<ImageContent> _messageImages(AgentMessage message) => switch (message) {

--- a/lib/presentation/agent_chat/widgets/agent_chat_composer.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_composer.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../../../core/agent/agent_types.dart';
 import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
 import '../../../core/utils/localization_extension.dart';
+import '../../../core/windowing/agent_chat_layout_contract.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../prompt_assistant/models/prompt_assistant_models.dart';
 import '../providers/agent_chat_state.dart';
@@ -29,18 +30,11 @@ class AgentChatComposer extends StatelessWidget {
     final l10n = context.l10n;
     return Padding(
       key: const ValueKey('agent-chat-input-container'),
-      padding: EdgeInsets.fromLTRB(
-        viewData.mobile ? 12 : 8,
-        6,
-        viewData.mobile ? 12 : 8,
-        viewData.mobile ? 10 : 8,
-      ),
+      padding: AgentChatLayoutContract.composerOuterPadding(viewData.width),
       child: Container(
         decoration: BoxDecoration(
-          color: viewData.mobile
-              ? theme.colorScheme.surfaceContainerHigh
-              : theme.colorScheme.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(viewData.mobile ? 16 : 12),
+          color: theme.colorScheme.surfaceContainerLow,
+          borderRadius: BorderRadius.circular(16),
         ),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -93,12 +87,12 @@ class AgentChatComposer extends StatelessWidget {
                 controller: controller.inputController,
                 focusNode: controller.inputFocus,
                 enabled: viewData.state.initialized,
-                minLines: viewData.compactMobile
+                minLines: viewData.compactMobile || viewData.compactWidth
                     ? 1
-                    : (viewData.mobile ? 2 : 3),
+                    : 2,
                 maxLines: viewData.compactMobile
                     ? 3
-                    : (viewData.mobile ? 5 : 8),
+                    : (viewData.mobile ? 5 : 7),
                 style:
                     (viewData.mobile
                             ? theme.textTheme.bodyMedium
@@ -151,28 +145,23 @@ class AgentChatComposer extends StatelessWidget {
       touchOptimized: viewData.mobile,
       onSend: commands.send,
     );
-    final leading = <Widget>[
-      _attachButton(theme, l10n),
-      _moreMenu(theme, l10n),
-      SizedBox(width: viewData.mobile ? 0 : 2),
-      _permissionModeButton(theme, l10n),
-      const SizedBox(width: 2),
-      _webAccessToggle(theme, l10n),
-      const SizedBox(width: 2),
-    ];
-    if (viewData.mobile && viewData.running) {
+    if (viewData.stackComposerControls) {
       return Column(
         key: const ValueKey('agent-chat-composer-controls'),
         mainAxisSize: MainAxisSize.min,
         children: [
           SizedBox(
-            height: 48,
+            key: const ValueKey('agent-chat-session-controls'),
+            height: viewData.mobile ? 48 : 34,
             child: Row(
               children: [
-                ...leading,
+                _permissionModeButton(theme, l10n),
+                const SizedBox(width: 2),
+                _webAccessToggle(theme, l10n),
+                const SizedBox(width: 4),
                 Expanded(
                   child: SizedBox(
-                    height: 48,
+                    height: viewData.mobile ? 48 : 34,
                     child: _modelSelector(theme, l10n),
                   ),
                 ),
@@ -180,12 +169,20 @@ class AgentChatComposer extends StatelessWidget {
             ),
           ),
           SizedBox(
-            height: 44,
+            key: const ValueKey('agent-chat-message-actions'),
+            height: viewData.mobile ? 48 : 34,
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
               children: [
-                _followUpButton(l10n),
-                _StopButton(touchOptimized: true, onStop: commands.stop),
+                _attachButton(theme, l10n),
+                _moreMenu(theme, l10n),
+                const Spacer(),
+                if (viewData.running) ...[
+                  _followUpButton(l10n),
+                  _StopButton(
+                    touchOptimized: viewData.mobile,
+                    onStop: commands.stop,
+                  ),
+                ],
                 const SizedBox(width: 4),
                 sendButton,
               ],
@@ -200,7 +197,13 @@ class AgentChatComposer extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          ...leading,
+          _attachButton(theme, l10n),
+          _moreMenu(theme, l10n),
+          const SizedBox(width: 2),
+          _permissionModeButton(theme, l10n),
+          const SizedBox(width: 2),
+          _webAccessToggle(theme, l10n),
+          const SizedBox(width: 2),
           if (viewData.mobile)
             Expanded(
               child: SizedBox(height: 48, child: _modelSelector(theme, l10n)),

--- a/lib/presentation/agent_chat/widgets/agent_chat_header.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_header.dart
@@ -28,6 +28,7 @@ class AgentChatHeader extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = context.l10n;
     if (viewData.mobile) return _mobile(context, theme, l10n);
+    if (viewData.compactWidth) return _compact(context, theme, l10n);
     Widget iconButton({
       Key? key,
       required IconData icon,
@@ -47,33 +48,19 @@ class AgentChatHeader extends StatelessWidget {
       ),
     );
     return Padding(
-      padding: const EdgeInsets.only(left: 8, right: 4, top: 12, bottom: 12),
+      key: const ValueKey('agent-chat-desktop-header'),
+      padding: const EdgeInsets.fromLTRB(10, 8, 6, 8),
       child: Row(
         children: [
-          Material(
-            color: Colors.transparent,
-            child: InkWell(
-              onTap: commands.collapse,
-              borderRadius: BorderRadius.circular(4),
-              child: Container(
-                padding: const EdgeInsets.all(4),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.surfaceContainerHighest.withValues(
-                    alpha: 0.5,
-                  ),
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: Icon(
-                  Icons.chevron_right,
-                  size: 16,
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
-                ),
-              ),
-            ),
+          iconButton(
+            key: const ValueKey('agent-chat-collapse'),
+            icon: Icons.chevron_right_rounded,
+            tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+            onTap: commands.collapse,
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: 4),
           ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 96),
+            constraints: const BoxConstraints(maxWidth: 120),
             child: Text(
               l10n.agentChat_tab,
               style: theme.textTheme.titleSmall?.copyWith(
@@ -82,7 +69,7 @@ class AgentChatHeader extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: 6),
           iconButton(
             icon: Icons.add_comment_outlined,
             tooltip: l10n.agentChat_newChat,
@@ -93,7 +80,9 @@ class AgentChatHeader extends StatelessWidget {
             child: Align(
               alignment: Alignment.centerLeft,
               child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 180),
+                constraints: BoxConstraints(
+                  maxWidth: viewData.width >= 760 ? 260 : 180,
+                ),
                 child: SizedBox(
                   height: 30,
                   child: _sessionSelector(context, theme, l10n),
@@ -130,6 +119,88 @@ class AgentChatHeader extends StatelessWidget {
             icon: Icons.settings_outlined,
             tooltip: l10n.settings_agent,
             onTap: () => _openAgentSettings(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _compact(
+    BuildContext context,
+    ThemeData theme,
+    AppLocalizations l10n,
+  ) {
+    Widget action({
+      required Key key,
+      required IconData icon,
+      required String tooltip,
+      required VoidCallback? onPressed,
+    }) => IconButton(
+      key: key,
+      icon: Icon(icon, size: 18),
+      tooltip: tooltip,
+      onPressed: onPressed,
+      constraints: const BoxConstraints.tightFor(width: 40, height: 40),
+      padding: EdgeInsets.zero,
+    );
+    return Padding(
+      key: const ValueKey('agent-chat-compact-header'),
+      padding: const EdgeInsets.fromLTRB(4, 4, 4, 4),
+      child: Row(
+        children: [
+          action(
+            key: const ValueKey('agent-chat-collapse'),
+            icon: Icons.chevron_right_rounded,
+            tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+            onPressed: commands.collapse,
+          ),
+          Expanded(
+            child: SizedBox(
+              height: 40,
+              child: _sessionSelector(context, theme, l10n),
+            ),
+          ),
+          action(
+            key: const ValueKey('agent-chat-compact-new-session'),
+            icon: Icons.add_comment_outlined,
+            tooltip: l10n.agentChat_newChat,
+            onPressed: viewData.sessionActionsEnabled
+                ? commands.newSession
+                : null,
+          ),
+          PopupMenuButton<String>(
+            key: const ValueKey('agent-chat-compact-more'),
+            tooltip: l10n.agentChat_moreActions,
+            constraints: const BoxConstraints.tightFor(width: 40, height: 40),
+            onSelected: (value) {
+              if (value == 'detach') commands.detach();
+              if (value == 'settings') _openAgentSettings(context);
+            },
+            itemBuilder: (_) => [
+              if (AgentWindowRuntime.isDesktop)
+                PopupMenuItem(
+                  value: 'detach',
+                  child: ListTile(
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.open_in_new_rounded),
+                    title: Text(l10n.agentChat_detachWindow),
+                  ),
+                ),
+              PopupMenuItem(
+                value: 'settings',
+                child: ListTile(
+                  dense: true,
+                  contentPadding: EdgeInsets.zero,
+                  leading: const Icon(Icons.settings_outlined),
+                  title: Text(l10n.settings_agent),
+                ),
+              ),
+            ],
+            child: const SizedBox.square(
+              dimension: 40,
+              child: Icon(Icons.more_horiz_rounded, size: 19),
+            ),
           ),
         ],
       ),

--- a/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
@@ -1,11 +1,12 @@
-import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown_plus/flutter_markdown_plus.dart' as md;
 
 import '../../../core/agent/agent_types.dart';
 import '../../../core/agent/harness/harness_messages.dart';
 import '../../../core/utils/localization_extension.dart';
+import '../../../core/windowing/agent_chat_layout_contract.dart';
+import '../../../core/windowing/agent_chat_shared_widgets.dart';
 import '../../widgets/common/draggable_memory_image.dart';
 import '../providers/agent_chat_notifier.dart';
 import 'agent_chat_panel_controller.dart';
@@ -58,6 +59,9 @@ class AgentChatMessages extends StatelessWidget {
         break;
       }
     }
+    final lastAssistantMessageIndex = state.messages.lastIndexWhere(
+      (message) => message is AssistantMessage,
+    );
     final items = _transcriptItems(state.messages);
     return Stack(
       children: [
@@ -67,24 +71,59 @@ class AgentChatMessages extends StatelessWidget {
             controller: controller.scrollController,
             reverse: true,
             padding: EdgeInsets.symmetric(
-              horizontal: viewData.mobile ? 16 : 10,
-              vertical: viewData.mobile ? 12 : 8,
+              horizontal: AgentChatLayoutContract.transcriptHorizontalPadding(
+                viewData.width,
+              ),
+              vertical: 12,
             ),
             itemCount: items.length + 1,
             itemBuilder: (context, itemIndex) {
               if (itemIndex == 0) {
-                return _liveTile(context, theme, state);
+                return Align(
+                  alignment: Alignment.center,
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: AgentChatLayoutContract.transcriptMaxWidth(
+                        viewData.width,
+                      ),
+                    ),
+                    child: _liveTile(context, theme, state),
+                  ),
+                );
               }
               final item = items[items.length - itemIndex];
               if (item.toolResults != null) {
-                return AgentChatToolResultGroup(results: item.toolResults!);
+                return Align(
+                  alignment: Alignment.center,
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: AgentChatLayoutContract.transcriptMaxWidth(
+                        viewData.width,
+                      ),
+                    ),
+                    child: AgentChatToolResultGroup(results: item.toolResults!),
+                  ),
+                );
               }
-              return _messageTile(
-                context,
-                theme,
-                item.message!,
-                messageIndex: item.messageIndex,
-                isLastUserMessage: item.messageIndex == lastUserMessageIndex,
+              return Align(
+                alignment: Alignment.center,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: AgentChatLayoutContract.transcriptMaxWidth(
+                      viewData.width,
+                    ),
+                  ),
+                  child: _messageTile(
+                    context,
+                    theme,
+                    item.message!,
+                    messageIndex: item.messageIndex,
+                    isLastUserMessage:
+                        item.messageIndex == lastUserMessageIndex,
+                    isLastAssistantMessage:
+                        item.messageIndex == lastAssistantMessageIndex,
+                  ),
+                ),
               );
             },
           ),
@@ -322,6 +361,7 @@ class AgentChatMessages extends StatelessWidget {
     Message message, {
     required int messageIndex,
     required bool isLastUserMessage,
+    required bool isLastAssistantMessage,
   }) {
     if (message is HarnessCustomMessage &&
         message.customType == 'agentResourcePrompt') {
@@ -334,6 +374,7 @@ class AgentChatMessages extends StatelessWidget {
         ),
         messageIndex: messageIndex,
         isLastUserMessage: isLastUserMessage,
+        isLastAssistantMessage: isLastAssistantMessage,
       );
     }
     if (message is UserMessage) {
@@ -363,6 +404,11 @@ class AgentChatMessages extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
                 Container(
+                  key: ValueKey('agent-user-message-bubble-$messageIndex'),
+                  constraints: BoxConstraints(
+                    minWidth: hasText ? 44 : 0,
+                    maxWidth: viewData.userBubbleMaxWidth,
+                  ),
                   padding: const EdgeInsets.symmetric(
                     horizontal: 12,
                     vertical: 8,
@@ -391,7 +437,11 @@ class AgentChatMessages extends StatelessWidget {
                             alignment: WrapAlignment.end,
                             children: [
                               for (final image in message.images)
-                                _userImage(theme, image),
+                                _userImage(
+                                  theme,
+                                  image,
+                                  maxWidth: viewData.userBubbleMaxWidth - 24,
+                                ),
                             ],
                           ),
                         ),
@@ -476,64 +526,48 @@ class AgentChatMessages extends StatelessWidget {
       if (message.text.trim().isEmpty && thinking.trim().isEmpty) {
         return const SizedBox.shrink();
       }
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          if (thinking.trim().isNotEmpty)
-            AgentChatReasoningTile(thinking: thinking),
-          if (message.text.trim().isNotEmpty)
-            Container(
-              width: double.infinity,
-              margin: const EdgeInsets.only(bottom: 10, right: 12),
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-              child: md.MarkdownBody(
-                data: message.text,
-                selectable: true,
-                imageBuilder: (uri, _, alt) => _markdownImage(theme, uri, alt),
-                styleSheet: md.MarkdownStyleSheet.fromTheme(theme).copyWith(
-                  p:
-                      (viewData.mobile
-                              ? theme.textTheme.bodyMedium
-                              : theme.textTheme.bodySmall)
-                          ?.copyWith(height: 1.55),
-                  code:
-                      (viewData.mobile
-                              ? theme.textTheme.bodyMedium
-                              : theme.textTheme.bodySmall)
-                          ?.copyWith(
-                            fontFamily: 'monospace',
-                            backgroundColor: theme
-                                .colorScheme
-                                .surfaceContainerHighest
-                                .withValues(alpha: 0.6),
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: viewData.assistantMaxWidth),
+          child: Padding(
+            padding: const EdgeInsets.only(right: 8, bottom: 10),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (thinking.trim().isNotEmpty)
+                  AgentChatReasoningTile(thinking: thinking),
+                if (message.text.trim().isNotEmpty)
+                  _assistantMarkdown(message.text),
+                if (message.text.trim().isNotEmpty)
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _MessageActionButton(
+                        key: ValueKey(
+                          'agent-assistant-message-copy-$messageIndex',
+                        ),
+                        tooltip: context.l10n.common_copy,
+                        icon: Icons.copy_all_outlined,
+                        largeHitArea: viewData.mobile,
+                        onPressed: () => commands.copyAssistantMessage(message),
+                      ),
+                      if (isLastAssistantMessage && !viewData.running)
+                        _MessageActionButton(
+                          key: ValueKey(
+                            'agent-assistant-message-retry-$messageIndex',
                           ),
-                  codeblockDecoration: BoxDecoration(
-                    color: theme.colorScheme.surfaceContainerHighest.withValues(
-                      alpha: 0.6,
-                    ),
-                    borderRadius: BorderRadius.circular(8),
+                          tooltip: context.l10n.common_retry,
+                          icon: Icons.refresh_rounded,
+                          largeHitArea: viewData.mobile,
+                          onPressed: commands.retryLastMessage,
+                        ),
+                    ],
                   ),
-                  blockquoteDecoration: BoxDecoration(
-                    color: theme.colorScheme.surfaceContainerHigh.withValues(
-                      alpha: 0.5,
-                    ),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-              ),
+              ],
             ),
-          if (message.text.trim().isNotEmpty)
-            Align(
-              alignment: Alignment.centerLeft,
-              child: _MessageActionButton(
-                key: ValueKey('agent-assistant-message-copy-$messageIndex'),
-                tooltip: context.l10n.common_copy,
-                icon: Icons.copy_all_outlined,
-                largeHitArea: viewData.mobile,
-                onPressed: () => commands.copyAssistantMessage(message),
-              ),
-            ),
-        ],
+          ),
+        ),
       );
     }
     if (message is ToolResultMessage) {
@@ -542,7 +576,11 @@ class AgentChatMessages extends StatelessWidget {
     return const SizedBox.shrink();
   }
 
-  Widget _userImage(ThemeData theme, ImageContent image) {
+  Widget _userImage(
+    ThemeData theme,
+    ImageContent image, {
+    required double maxWidth,
+  }) {
     final source = image.source;
     final bytes = controller.bytesForMessageImage(source);
     final Size size;
@@ -573,9 +611,11 @@ class AgentChatMessages extends StatelessWidget {
       size = const Size(160, 120);
       imageWidget = _brokenImage(theme);
     }
+    final scale = size.width > maxWidth ? maxWidth / size.width : 1.0;
+    final displaySize = Size(size.width * scale, size.height * scale);
     final content = SizedBox(
-      width: size.width,
-      height: size.height,
+      width: displaySize.width,
+      height: displaySize.height,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(8),
         child: imageWidget,
@@ -591,73 +631,26 @@ class AgentChatMessages extends StatelessWidget {
     );
   }
 
-  Widget _markdownImage(ThemeData theme, Uri uri, String? alt) {
-    Widget image;
-    final scheme = uri.scheme.toLowerCase();
-    if (scheme == 'http' || scheme == 'https') {
-      image = Image.network(
-        uri.toString(),
-        fit: BoxFit.contain,
-        gaplessPlayback: true,
-        filterQuality: FilterQuality.medium,
-        errorBuilder: (_, __, ___) => _brokenImage(theme),
-      );
-    } else if (scheme == 'data') {
+  Widget _markdownImage(Uri uri, String? alt) {
+    Uint8List? dataBytes;
+    if (uri.scheme.toLowerCase() == 'data') {
       try {
         final key = uri.toString();
-        final bytes = controller.markdownDataImageBytes.putIfAbsent(
+        dataBytes = controller.markdownDataImageBytes.putIfAbsent(
           key,
           () => uri.data!.contentAsBytes(),
         );
-        image = Image.memory(
-          bytes,
-          fit: BoxFit.contain,
-          gaplessPlayback: true,
-          filterQuality: FilterQuality.medium,
-          errorBuilder: (_, __, ___) => _brokenImage(theme),
-        );
-      } catch (_) {
-        image = _brokenImage(theme);
-      }
-    } else if (scheme == 'resource') {
-      image = Image.asset(
-        uri.path,
-        fit: BoxFit.contain,
-        gaplessPlayback: true,
-        filterQuality: FilterQuality.medium,
-        errorBuilder: (_, __, ___) => _brokenImage(theme),
-      );
-    } else {
-      try {
-        final file = scheme == 'file'
-            ? File.fromUri(uri)
-            : File(uri.toFilePath(windows: Platform.isWindows));
-        image = Image.file(
-          file,
-          fit: BoxFit.contain,
-          gaplessPlayback: true,
-          filterQuality: FilterQuality.medium,
-          errorBuilder: (_, __, ___) => _brokenImage(theme),
-        );
-      } catch (_) {
-        image = _brokenImage(theme);
-      }
+      } catch (_) {}
     }
-    return Semantics(
-      label: alt,
-      image: true,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 320, maxHeight: 220),
-        child: AspectRatio(
-          aspectRatio: 320 / 220,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(8),
-            child: image,
-          ),
-        ),
-      ),
-    );
+    return AgentChatMarkdownImage(uri: uri, alt: alt, dataBytes: dataBytes);
   }
+
+  Widget _assistantMarkdown(String text) => AgentChatMarkdownContent(
+    key: ValueKey('agent-assistant-markdown-${text.hashCode}'),
+    text: text,
+    touchOptimized: viewData.mobile,
+    imageBuilder: (uri, _, alt) => _markdownImage(uri, alt),
+  );
 
   Widget _brokenImage(ThemeData theme) => ColoredBox(
     color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.35),
@@ -705,17 +698,11 @@ class AgentChatMessages extends StatelessWidget {
               live: streaming.text.isEmpty,
             ),
           if (streaming.text.isNotEmpty)
-            Container(
-              width: double.infinity,
-              margin: const EdgeInsets.only(bottom: 10, right: 12),
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-              child: Text(
-                streaming.text,
-                style:
-                    (viewData.mobile
-                            ? theme.textTheme.bodyMedium
-                            : theme.textTheme.bodySmall)
-                        ?.copyWith(height: 1.55),
+            ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: viewData.assistantMaxWidth),
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 10, right: 8),
+                child: _assistantMarkdown(streaming.text),
               ),
             ),
         ],

--- a/lib/presentation/agent_chat/widgets/agent_chat_panel.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_panel.dart
@@ -96,31 +96,36 @@ class _AgentChatPanelState extends ConsumerState<AgentChatPanel> {
           mobile: widget.mobile,
           fullScreen: widget.fullScreen,
           compactMobile: widget.mobile && constraints.maxHeight < 480,
+          width: constraints.maxWidth,
+          height: constraints.maxHeight,
           onClose: widget.onClose,
           onOpenSettings: widget.onOpenSettings,
           mobileHeaderWrapper: widget.mobileHeaderWrapper,
         );
-        return AgentResourceDropRegion(
-          onDrop: commands.addPendingResource,
-          child: Column(
-            children: [
-              AgentChatHeader(viewData: viewData, commands: commands),
-              const Divider(height: 1),
-              Expanded(
-                child: AgentChatMessages(
-                  viewData: viewData,
-                  commands: commands,
-                  controller: _controller,
+        return SafeArea(
+          top: widget.mobile,
+          bottom: widget.mobile,
+          child: AgentResourceDropRegion(
+            onDrop: commands.addPendingResource,
+            child: Column(
+              children: [
+                AgentChatHeader(viewData: viewData, commands: commands),
+                Expanded(
+                  child: AgentChatMessages(
+                    viewData: viewData,
+                    commands: commands,
+                    controller: _controller,
+                  ),
                 ),
-              ),
-              AgentChatStatus(viewData: viewData, commands: commands),
-              if (state.routeReady)
-                AgentChatComposer(
-                  viewData: viewData,
-                  commands: commands,
-                  controller: _controller,
-                ),
-            ],
+                AgentChatStatus(viewData: viewData, commands: commands),
+                if (state.routeReady)
+                  AgentChatComposer(
+                    viewData: viewData,
+                    commands: commands,
+                    controller: _controller,
+                  ),
+              ],
+            ),
           ),
         );
       },

--- a/lib/presentation/agent_chat/widgets/agent_chat_panel_view_data.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_panel_view_data.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/agent/agent_types.dart';
 import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/windowing/agent_chat_layout_contract.dart';
 import '../../prompt_assistant/models/prompt_assistant_models.dart';
 import '../../prompt_assistant/providers/web_access_provider.dart';
 import '../../agent_settings/providers/agent_settings_provider.dart';
@@ -17,6 +18,8 @@ class AgentChatPanelViewData {
     required this.mobile,
     required this.fullScreen,
     required this.compactMobile,
+    required this.width,
+    required this.height,
     required this.onClose,
     required this.onOpenSettings,
     required this.mobileHeaderWrapper,
@@ -29,11 +32,22 @@ class AgentChatPanelViewData {
   final bool mobile;
   final bool fullScreen;
   final bool compactMobile;
+  final double width;
+  final double height;
   final VoidCallback? onClose;
   final VoidCallback? onOpenSettings;
   final Widget Function(Widget child)? mobileHeaderWrapper;
 
   bool get running => state.status == AgentChatRunStatus.running;
+  AgentChatWidthClass get widthClass =>
+      AgentChatLayoutContract.widthClassFor(width);
+  bool get compactWidth => widthClass == AgentChatWidthClass.compact;
+  bool get stackComposerControls =>
+      AgentChatLayoutContract.stackComposerControls(width, running: running);
+  double get userBubbleMaxWidth =>
+      AgentChatLayoutContract.userBubbleMaxWidth(width);
+  double get assistantMaxWidth =>
+      AgentChatLayoutContract.assistantMaxWidth(width);
   bool get sessionActionsEnabled => canManageAgentChatSessions(state);
   bool get controlsLocked => running || state.sessionTransitioning;
   bool get canSend =>

--- a/lib/presentation/agent_chat/widgets/agent_chat_tool_widgets.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_tool_widgets.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/agent/agent_types.dart';
+import '../../../core/agent/agent_tool_presentation.dart';
+import '../../../core/windowing/agent_chat_shared_widgets.dart';
 import '../../../core/agent/resources/agent_chat_resource_reference.dart';
 import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
 import '../../../core/utils/localization_extension.dart';
@@ -15,6 +17,7 @@ import '../../../data/models/gallery/local_image_record.dart';
 import '../../utils/image_detail_opener.dart';
 import '../../providers/krita/krita_bridge_notifier.dart';
 import '../../services/image_send_action_dispatcher.dart';
+import '../../widgets/common/app_toast.dart';
 import '../../widgets/common/image_card_hover_motion.dart';
 import '../../widgets/common/image_detail/file_image_detail_data.dart';
 import '../../widgets/gallery/draggable_image_card.dart';
@@ -141,6 +144,7 @@ class AgentChatToolActivityTile extends StatefulWidget {
 class _AgentChatToolActivityTileState extends State<AgentChatToolActivityTile>
     with SingleTickerProviderStateMixin {
   late final AnimationController _gradientController;
+  bool _expanded = false;
 
   @override
   void initState() {
@@ -191,87 +195,121 @@ class _AgentChatToolActivityTileState extends State<AgentChatToolActivityTile>
     final animation = MediaQuery.disableAnimationsOf(context)
         ? const AlwaysStoppedAnimation<double>(0.5)
         : _gradientController;
+    final details = _activityDetails(activity);
     return RepaintBoundary(
-      child: AnimatedBuilder(
-        animation: animation,
-        builder: (context, _) {
-          final progress = Curves.easeInOut.transform(animation.value);
-          final changingColor = Color.lerp(
-            visual.color,
-            Color.lerp(
-              theme.colorScheme.onSurfaceVariant,
-              theme.colorScheme.onSurface,
-              0.18,
-            )!,
-            0.16 + progress * 0.24,
-          )!;
-          return Container(
-            key: ValueKey('agent-tool-activity-${activity.toolCallId}'),
-            constraints: const BoxConstraints(minHeight: 28),
-            margin: const EdgeInsets.only(bottom: 6),
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-            decoration: BoxDecoration(
-              gradient: activity.status == AgentToolActivityStatus.running
-                  ? LinearGradient(
-                      begin: Alignment(-1.15 + progress * 0.45, -0.35),
-                      end: Alignment(0.45 + progress * 0.45, 0.35),
-                      colors: [
-                        theme.colorScheme.surfaceContainerHighest.withValues(
-                          alpha: 0.42,
-                        ),
-                        changingColor.withValues(alpha: 0.13),
-                        theme.colorScheme.surfaceContainerHighest.withValues(
-                          alpha: 0.38,
-                        ),
-                      ],
-                      stops: const [0, 0.52, 1],
-                    )
-                  : null,
-              color: activity.status == AgentToolActivityStatus.running
-                  ? null
-                  : theme.colorScheme.surfaceContainerHighest.withValues(
-                      alpha: 0.42,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          AnimatedBuilder(
+            animation: animation,
+            builder: (context, _) {
+              final progress = Curves.easeInOut.transform(animation.value);
+              final changingColor = Color.lerp(
+                visual.color,
+                Color.lerp(
+                  theme.colorScheme.onSurfaceVariant,
+                  theme.colorScheme.onSurface,
+                  0.18,
+                )!,
+                0.16 + progress * 0.24,
+              )!;
+              return Material(
+                type: MaterialType.transparency,
+                child: InkWell(
+                  key: ValueKey('agent-tool-activity-${activity.toolCallId}'),
+                  borderRadius: BorderRadius.circular(8),
+                  onTap: details.isEmpty
+                      ? null
+                      : () => setState(() => _expanded = !_expanded),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 28),
+                    child: Ink(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 5,
+                      ),
+                      decoration: BoxDecoration(
+                        gradient:
+                            activity.status == AgentToolActivityStatus.running
+                            ? LinearGradient(
+                                begin: Alignment(
+                                  -1.15 + progress * 0.45,
+                                  -0.35,
+                                ),
+                                end: Alignment(0.45 + progress * 0.45, 0.35),
+                                colors: [
+                                  theme.colorScheme.surfaceContainerHighest
+                                      .withValues(alpha: 0.42),
+                                  changingColor.withValues(alpha: 0.13),
+                                  theme.colorScheme.surfaceContainerHighest
+                                      .withValues(alpha: 0.38),
+                                ],
+                                stops: const [0, 0.52, 1],
+                              )
+                            : null,
+                        color:
+                            activity.status == AgentToolActivityStatus.running
+                            ? null
+                            : theme.colorScheme.surfaceContainerHighest
+                                  .withValues(alpha: 0.42),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        children: [
+                          SizedBox.square(
+                            key: ValueKey(
+                              'agent-tool-activity-icon-${activity.toolCallId}',
+                            ),
+                            dimension: 18,
+                            child: Center(
+                              child: Icon(icon, size: 15, color: statusColor),
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                          Text(statusLabel, style: theme.textTheme.labelSmall),
+                          const SizedBox(width: 6),
+                          Container(
+                            width: 3,
+                            height: 3,
+                            decoration: BoxDecoration(
+                              color: statusColor.withValues(alpha: 0.7),
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                          Expanded(
+                            child: Text(
+                              _summarize(activity, toolLabel),
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                color: statusColor.withValues(alpha: 0.9),
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          if (details.isNotEmpty)
+                            Icon(
+                              _expanded ? Icons.expand_less : Icons.expand_more,
+                              size: 16,
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                        ],
+                      ),
                     ),
-              borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              );
+            },
+          ),
+          if (_expanded)
+            _ToolDetailPanel(
+              key: ValueKey(
+                'agent-tool-activity-details-${activity.toolCallId}',
+              ),
+              text: details,
             ),
-            child: Row(
-              children: [
-                SizedBox.square(
-                  key: ValueKey(
-                    'agent-tool-activity-icon-${activity.toolCallId}',
-                  ),
-                  dimension: 18,
-                  child: Center(
-                    child: Icon(icon, size: 15, color: statusColor),
-                  ),
-                ),
-                const SizedBox(width: 6),
-                Text(statusLabel, style: theme.textTheme.labelSmall),
-                const SizedBox(width: 6),
-                Container(
-                  width: 3,
-                  height: 3,
-                  decoration: BoxDecoration(
-                    color: statusColor.withValues(alpha: 0.7),
-                    shape: BoxShape.circle,
-                  ),
-                ),
-                const SizedBox(width: 6),
-                Expanded(
-                  child: Text(
-                    _summarize(activity, toolLabel),
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: statusColor.withValues(alpha: 0.9),
-                      fontFamily: 'monospace',
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
-            ),
-          );
-        },
+          const SizedBox(height: 6),
+        ],
       ),
     );
   }
@@ -280,22 +318,37 @@ class _AgentChatToolActivityTileState extends State<AgentChatToolActivityTile>
     if (activity.status == AgentToolActivityStatus.running) {
       return toolLabel;
     }
-    final text = activity.content.trim();
-    if (text.isEmpty) return toolLabel;
-    final normalized = text.replaceAll(RegExp(r'\s+'), ' ');
-    return normalized.length <= 60
-        ? normalized
-        : '${normalized.substring(0, 60)}…';
+    return _humanReadableTextSummary(activity.content, fallback: toolLabel);
+  }
+
+  String _activityDetails(AgentToolActivity activity) {
+    final sections = <String>[];
+    if (activity.args.isNotEmpty) {
+      sections.add(_formatDetailValue(activity.args));
+    }
+    if (activity.content.trim().isNotEmpty) {
+      sections.add(_formatDetailText(activity.content));
+    }
+    return sections.join('\n\n');
   }
 }
 
-class AgentChatToolResultTile extends StatelessWidget {
+class AgentChatToolResultTile extends StatefulWidget {
   const AgentChatToolResultTile({super.key, required this.result});
 
   final ToolResultMessage result;
 
   @override
+  State<AgentChatToolResultTile> createState() =>
+      _AgentChatToolResultTileState();
+}
+
+class _AgentChatToolResultTileState extends State<AgentChatToolResultTile> {
+  bool _expanded = false;
+
+  @override
   Widget build(BuildContext context) {
+    final result = widget.result;
     final theme = Theme.of(context);
     final toolLabel = agentToolLabel(context, result.toolName);
     final visual = _agentToolVisual(theme, result.toolName);
@@ -323,42 +376,78 @@ class AgentChatToolResultTile extends StatelessWidget {
         files.isEmpty && inlineImages.isEmpty && remoteImages.isEmpty
         ? _extractResourceReferences(result)
         : const <AgentChatResourceReference>[];
+    final detailText = _resultDetailText(result);
+    final summary = _resultSummary(context, result);
+    final hasExpandedContent =
+        detailText.isNotEmpty ||
+        files.isNotEmpty ||
+        inlineImages.isNotEmpty ||
+        remoteImages.isNotEmpty ||
+        resourceReferences.isNotEmpty;
     return Padding(
       padding: const EdgeInsets.only(bottom: 6, left: 4),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              SizedBox.square(
-                key: ValueKey('agent-tool-result-icon-${result.toolCallId}'),
-                dimension: 18,
-                child: Center(
-                  child: Icon(
-                    result.isError ? Icons.error_outline : visual.icon,
-                    size: 15,
-                    color: color.withValues(alpha: 0.82),
-                  ),
+          Material(
+            type: MaterialType.transparency,
+            child: InkWell(
+              key: ValueKey('agent-tool-result-${result.toolCallId}'),
+              borderRadius: BorderRadius.circular(8),
+              onTap: !hasExpandedContent
+                  ? null
+                  : () => setState(() => _expanded = !_expanded),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 5),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    SizedBox.square(
+                      key: ValueKey(
+                        'agent-tool-result-icon-${result.toolCallId}',
+                      ),
+                      dimension: 18,
+                      child: Center(
+                        child: Icon(
+                          result.isError ? Icons.error_outline : visual.icon,
+                          size: 15,
+                          color: color.withValues(alpha: 0.82),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        '$toolLabel · ${result.isError ? context.l10n.common_error : context.l10n.common_success} · $summary',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: color.withValues(alpha: 0.9),
+                          height: 1,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (hasExpandedContent)
+                      Icon(
+                        _expanded ? Icons.expand_less : Icons.expand_more,
+                        size: 17,
+                        color: color.withValues(alpha: 0.78),
+                      ),
+                  ],
                 ),
               ),
-              const SizedBox(width: 6),
-              Flexible(
-                child: Text(
-                  toolLabel,
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: color.withValues(alpha: 0.78),
-                    height: 1,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            ],
+            ),
           ),
-          if (files.isNotEmpty ||
-              inlineImages.isNotEmpty ||
-              remoteImages.isNotEmpty ||
-              resourceReferences.isNotEmpty)
+          if (_expanded && detailText.isNotEmpty)
+            _ToolDetailPanel(
+              key: ValueKey('agent-tool-result-details-${result.toolCallId}'),
+              text: detailText,
+            ),
+          if (_expanded &&
+              (files.isNotEmpty ||
+                  inlineImages.isNotEmpty ||
+                  remoteImages.isNotEmpty ||
+                  resourceReferences.isNotEmpty))
             Padding(
               padding: const EdgeInsets.only(top: 4),
               child: Column(
@@ -384,9 +473,76 @@ class AgentChatToolResultTile extends StatelessWidget {
   }
 }
 
+class _ToolDetailPanel extends StatelessWidget {
+  const _ToolDetailPanel({super.key, required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return AgentToolDetailSurface(
+      text: text,
+      copyTooltip: context.l10n.common_copy,
+      onCopy: () async {
+        await Clipboard.setData(ClipboardData(text: text));
+        if (context.mounted) {
+          AppToast.info(context, context.l10n.common_copied);
+        }
+      },
+    );
+  }
+}
+
+String _resultSummary(BuildContext context, ToolResultMessage result) {
+  final text = result.text.trim();
+  if (text.isEmpty) {
+    return result.isError
+        ? context.l10n.common_error
+        : context.l10n.common_success;
+  }
+  return _humanReadableTextSummary(
+    text,
+    fallback: result.isError
+        ? context.l10n.common_error
+        : context.l10n.common_success,
+  );
+}
+
+String _humanReadableTextSummary(String text, {required String fallback}) {
+  return AgentToolPresentation.summary(text, fallback: fallback);
+}
+
+String _resultDetailText(ToolResultMessage result) {
+  final sections = <String>[];
+  for (final content in result.content.whereType<ToolResultTextContent>()) {
+    if (content.text.trim().isNotEmpty) {
+      sections.add(_formatDetailText(content.text));
+    }
+  }
+  if (result.details != null) {
+    final formatted = _formatDetailValue(result.details);
+    if (formatted.isNotEmpty && !sections.contains(formatted)) {
+      sections.add(formatted);
+    }
+  }
+  return sections.join('\n\n');
+}
+
+String _formatDetailText(String text) {
+  return AgentToolPresentation.formattedDetails(text);
+}
+
+String _formatDetailValue(Object? value) {
+  if (value == null) return '';
+  try {
+    return const JsonEncoder.withIndent('  ').convert(value);
+  } on JsonUnsupportedObjectError {
+    return value.toString();
+  }
+}
+
 /// Keeps consecutive tool results in one quiet, auditable turn activity unit.
-/// Image/error results expand by default because hiding them would obscure the
-/// outcome the user is waiting for.
+/// Groups stay compact by default while their title keeps failures visible.
 class AgentChatToolResultGroup extends StatelessWidget {
   const AgentChatToolResultGroup({super.key, required this.results});
 
@@ -399,12 +555,14 @@ class AgentChatToolResultGroup extends StatelessWidget {
     }
     final theme = Theme.of(context);
     final failed = results.where((result) => result.isError).length;
-    final containsImages = results.any(
-      (result) =>
-          result.content.any((item) => item is ToolResultImageContent) ||
-          _extractImageFiles(result).isNotEmpty ||
-          _extractResourceReferences(result).isNotEmpty,
-    );
+    String? failureSummary;
+    for (final result in results) {
+      if (result.isError) {
+        failureSummary = _resultSummary(context, result);
+        break;
+      }
+    }
+    final disableAnimations = MediaQuery.disableAnimationsOf(context);
     return Theme(
       data: theme.copyWith(dividerColor: Colors.transparent),
       child: Material(
@@ -413,7 +571,13 @@ class AgentChatToolResultGroup extends StatelessWidget {
           key: PageStorageKey(
             'agent-tool-group-${results.first.toolCallId}-${results.length}',
           ),
-          initiallyExpanded: containsImages || failed > 0,
+          initiallyExpanded: false,
+          expansionAnimationStyle: disableAnimations
+              ? const AnimationStyle(
+                  duration: Duration.zero,
+                  reverseDuration: Duration.zero,
+                )
+              : null,
           tilePadding: const EdgeInsets.symmetric(horizontal: 4),
           childrenPadding: const EdgeInsets.only(left: 12),
           minTileHeight: 34,
@@ -429,10 +593,13 @@ class AgentChatToolResultGroup extends StatelessWidget {
             style: theme.textTheme.labelMedium,
           ),
           subtitle: Text(
-            results
-                .map((result) => agentToolLabel(context, result.toolName))
-                .toSet()
-                .join(' · '),
+            [
+              if (failed > 0) context.l10n.common_error,
+              if (failureSummary != null) failureSummary,
+              ...results
+                  .map((result) => agentToolLabel(context, result.toolName))
+                  .toSet(),
+            ].join(' · '),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: theme.textTheme.labelSmall?.copyWith(
@@ -621,7 +788,7 @@ class _ToolResultInlineImage extends StatelessWidget {
           child: Image.memory(
             bytes,
             fit: BoxFit.contain,
-            alignment: Alignment.centerLeft,
+            alignment: Alignment.center,
             gaplessPlayback: true,
             errorBuilder: (_, _, _) => const SizedBox.shrink(),
           ),
@@ -646,7 +813,7 @@ class _ToolResultNetworkImage extends StatelessWidget {
         child: Image.network(
           url,
           fit: BoxFit.contain,
-          alignment: Alignment.centerLeft,
+          alignment: Alignment.center,
           gaplessPlayback: true,
           errorBuilder: (_, _, _) => const SizedBox.shrink(),
         ),

--- a/test/core/windowing/agent_window_shell_test.dart
+++ b/test/core/windowing/agent_window_shell_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/windowing/agent_chat_shared_widgets.dart';
 import 'package:nai_launcher/core/windowing/agent_window_protocol.dart';
 import 'package:nai_launcher/core/windowing/agent_window_shell.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
@@ -136,6 +138,203 @@ void main() {
     );
   });
 
+  testWidgets(
+    'secondary shell reserves session header and folds structured tool details',
+    (tester) async {
+      tester.view.physicalSize = const Size(360, 700);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(SystemChannels.platform, (_) async {
+        return null;
+      });
+      addTearDown(
+        () => messenger.setMockMethodCallHandler(SystemChannels.platform, null),
+      );
+      final bridge = _FakeBridge()
+        ..snapshot = const AgentWindowSnapshot(
+          revision: 4,
+          payload: {
+            'ready': true,
+            'initialized': true,
+            'routeReady': true,
+            'sessions': [
+              {'id': 'session-a', 'name': 'Session A'},
+            ],
+            'activeSessionId': 'session-a',
+            'messages': [
+              {'role': 'user', 'text': 'first visible message'},
+              {
+                'role': 'tool',
+                'toolCallId': 'tool-a',
+                'toolName': 'web_search',
+                'text':
+                    '{"ok":true,"message":"Found two useful pages","items":[1,2]}',
+                'details': {'query': 'cats', 'page': 1},
+              },
+              {'role': 'assistant', 'text': 'final answer'},
+            ],
+            'activities': [],
+            'resources': [],
+            'composerText': '',
+            'routeLabel': 'Default',
+            'activeProviderId': 'openai',
+            'activeModel': 'gpt-5',
+            'modelOptions': [],
+            'permissionMode': 'safe',
+            'webAccessEnabled': false,
+          },
+        );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) => buildAgentWindowBridgeShell(context, bridge),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final selector = find.byKey(
+        const ValueKey('agent-window-session-picker'),
+      );
+      final firstMessage = find.text('first visible message');
+      expect(selector, findsOneWidget);
+      expect(firstMessage, findsOneWidget);
+      expect(
+        tester.getTopLeft(firstMessage).dy,
+        greaterThan(tester.getBottomLeft(selector).dy),
+      );
+      expect(find.text('Found two useful pages'), findsOneWidget);
+      expect(find.textContaining('"items"'), findsNothing);
+      expect(find.byKey(const ValueKey('agent-window-send')), findsOneWidget);
+      final retry = find.byKey(
+        const ValueKey('agent-window-retry-last-message'),
+      );
+      expect(retry, findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(retry);
+      expect(
+        bridge.commands.any((entry) => entry.$1 == 'retryLastMessage'),
+        isTrue,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('agent-window-tool-tool-a')));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('"items"'), findsOneWidget);
+      expect(find.textContaining('"query"'), findsOneWidget);
+      final detailCopy = find.descendant(
+        of: find.byKey(const ValueKey('agent-window-tool-tool-a')),
+        matching: find.byKey(const ValueKey('agent-tool-detail-copy')),
+      );
+      await tester.ensureVisible(detailCopy);
+      await tester.pump();
+      await tester.tap(detailCopy);
+      await tester.pump();
+      expect(find.text('Copied'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 3));
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'secondary follows initial history and hides retry while running at narrow width',
+    (tester) async {
+      tester.view.physicalSize = const Size(300, 700);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final bridge = _FakeBridge()
+        ..snapshot = AgentWindowSnapshot(
+          revision: 8,
+          payload: {
+            'ready': true,
+            'initialized': true,
+            'routeReady': true,
+            'running': true,
+            'sessions': const [
+              {'id': 'session-a', 'name': 'Session A'},
+            ],
+            'activeSessionId': 'session-a',
+            'messages': [
+              for (var index = 0; index < 30; index++) ...[
+                {'role': 'user', 'text': 'question $index'},
+                {'role': 'assistant', 'text': 'answer $index'},
+              ],
+            ],
+            'activities': const [
+              {
+                'toolCallId': 'running-search',
+                'toolName': 'web_search',
+                'status': 'running',
+                'content': '{"message":"Searching now"}',
+                'args': {'query': 'cats', 'limit': 20},
+              },
+              {
+                'toolCallId': 'completed-search',
+                'toolName': 'web_search',
+                'status': 'completed',
+                'content': '{"message":"Done"}',
+                'args': <String, Object?>{},
+              },
+            ],
+            'resources': const [],
+            'composerText': '',
+            'routeLabel': 'Default',
+            'activeProviderId': 'openai',
+            'activeModel': 'provider/model-with-a-very-long-name',
+            'modelOptions': const [],
+            'permissionMode': 'safe',
+            'webAccessEnabled': false,
+          },
+        );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MediaQuery(
+            data: const MediaQueryData(
+              size: Size(300, 700),
+              textScaler: TextScaler.linear(1.5),
+            ),
+            child: Builder(
+              builder: (context) =>
+                  buildAgentWindowBridgeShell(context, bridge),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('answer 29'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('agent-window-retry-last-message')),
+        findsNothing,
+      );
+      final activity = find.byKey(
+        const ValueKey('agent-window-tool-activity-running-search'),
+      );
+      expect(activity, findsOneWidget);
+      expect(
+        find.byKey(
+          const ValueKey('agent-window-tool-activity-completed-search'),
+        ),
+        findsNothing,
+      );
+      await tester.tap(activity);
+      await tester.pump();
+      expect(find.textContaining('"query"'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets('secondary shell renders user images and survives corrupt data', (
     tester,
   ) async {
@@ -161,6 +360,11 @@ void main() {
               'images': [
                 {'assetId': 'image-1'},
               ],
+            },
+            {
+              'role': 'assistant',
+              'text':
+                  'preview ![dot](data:image/png;base64,$_oneByOnePngBase64)',
             },
             {
               'role': 'tool',
@@ -192,6 +396,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('look'), findsOneWidget);
+    expect(find.byType(AgentChatMarkdownImage), findsOneWidget);
     expect(tester.takeException(), isNull);
     await tester.drag(find.byType(ListView).first, const Offset(0, -120));
     await tester.pumpAndSettle();
@@ -199,6 +404,8 @@ void main() {
       of: find.byType(Image).first,
       matching: find.byType(InkWell),
     );
+    await tester.ensureVisible(imageCard.first);
+    await tester.pumpAndSettle();
     await tester.tap(imageCard.first);
     await tester.pumpAndSettle();
     expect(find.byType(Dialog), findsOneWidget);
@@ -207,6 +414,10 @@ void main() {
     await tester.pumpAndSettle();
     await tester.drag(find.byType(ListView).first, const Offset(0, -500));
     await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('agent-window-tool-generate_image')),
+    );
+    await tester.pump();
     expect(find.byIcon(Icons.broken_image_outlined), findsOneWidget);
   });
 }

--- a/test/presentation/agent_chat/widgets/agent_chat_panel_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_panel_test.dart
@@ -82,11 +82,16 @@ void main() {
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
-            body: SizedBox(width: 420, height: 720, child: AgentChatPanel()),
+            body: SizedBox(width: 240, height: 720, child: AgentChatPanel()),
           ),
         ),
       ),
     );
+    expect(
+      find.byKey(const ValueKey('agent-chat-compact-header')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
 
     PopupMenuButton<String> selector() => tester.widget(
       find.byKey(const ValueKey('agent-chat-session-selector')),
@@ -108,6 +113,26 @@ void main() {
     notifier.setSessionTransitioning(false);
     await tester.pump();
     expect(selector().enabled, isTrue);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(width: 960, height: 720, child: AgentChatPanel()),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey('agent-chat-desktop-header')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('web access button reads the shared agent configuration', (
@@ -187,14 +212,18 @@ void main() {
       Colors.transparent,
     );
     expect(
-      tester
-          .getSize(find.byKey(const ValueKey('agent-chat-composer-controls')))
-          .height,
-      30,
+      find.byKey(const ValueKey('agent-chat-session-controls')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('agent-chat-message-actions')),
+      findsOneWidget,
     );
     expect(
       tester.getCenter(find.byKey(key)).dy,
-      tester.getCenter(find.byIcon(Icons.image_outlined)).dy,
+      tester
+          .getCenter(find.byKey(const ValueKey('agent-chat-permission-mode')))
+          .dy,
     );
     expect(container.read(webAccessConfigProvider).config.enabled, isTrue);
     expect(tester.takeException(), isNull);
@@ -304,6 +333,8 @@ void main() {
       expect(find.byType(md.MarkdownBody), findsNothing);
       expect(find.byType(ExpansionTile), findsOneWidget);
       expect(find.text('Ran 2 actions'), findsOneWidget);
+      await tester.tap(find.byType(ExpansionTile));
+      await tester.pump();
       final resultIcon = tester.widget<Icon>(
         find.descendant(
           of: find.byKey(const ValueKey('agent-tool-result-icon-read-image')),
@@ -311,7 +342,15 @@ void main() {
         ),
       );
       expect(resultIcon.icon, Icons.description_outlined);
-      expect(find.text('Read file'), findsOneWidget);
+      expect(find.textContaining('Image read successfully'), findsOneWidget);
+      expect(find.byKey(ValueKey(imageFile.path)), findsNothing);
+      final resultTile = find.byKey(
+        const ValueKey('agent-tool-result-read-image'),
+      );
+      await tester.ensureVisible(resultTile);
+      await tester.pumpAndSettle();
+      await tester.tap(resultTile);
+      await tester.pumpAndSettle();
 
       notifier.setRunningActivity(
         const AgentToolActivity(
@@ -335,13 +374,17 @@ void main() {
       expect(activityIcon.color, isNot(resultIcon.color));
       expect(find.text('Generate image'), findsOneWidget);
 
-      final firstDecoration = tester.widget<Container>(activity).decoration;
+      final activityInk = find.descendant(
+        of: activity,
+        matching: find.byType(Ink),
+      );
+      final firstDecoration = tester.widget<Ink>(activityInk).decoration;
       expect(firstDecoration, isA<BoxDecoration>());
       final firstGradient = (firstDecoration! as BoxDecoration).gradient;
       expect(firstGradient, isA<LinearGradient>());
       await tester.pump(const Duration(milliseconds: 600));
       final secondGradient =
-          (tester.widget<Container>(activity).decoration! as BoxDecoration)
+          (tester.widget<Ink>(activityInk).decoration! as BoxDecoration)
                   .gradient!
               as LinearGradient;
       expect(
@@ -512,6 +555,16 @@ void main() {
       find.byType(DraggableMemoryImage),
     );
     expect(memoryDrag.localData, {'source': 'agent_chat_internal'});
+    expect(
+      find.byKey(const ValueKey('agent-assistant-message-retry-3')),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('agent-user-message-bubble-0')))
+          .width,
+      lessThan(100),
+    );
 
     final latestMessage = find.byKey(const ValueKey('agent-user-message-2'));
     final actions = find.byKey(const ValueKey('agent-user-message-actions-2'));
@@ -660,21 +713,28 @@ void main() {
 
     var closed = false;
     var settingsOpened = false;
-    Widget buildPanel(double height) {
+    Widget buildPanel({
+      required double width,
+      required double height,
+      EdgeInsets padding = EdgeInsets.zero,
+    }) {
       return UncontrolledProviderScope(
         container: container,
         child: MaterialApp(
           locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: SizedBox(
-              width: 320,
-              height: height,
-              child: AgentChatPanel(
-                mobile: true,
-                onClose: () => closed = true,
-                onOpenSettings: () => settingsOpened = true,
+          home: MediaQuery(
+            data: MediaQueryData(size: Size(width, height), padding: padding),
+            child: Scaffold(
+              body: SizedBox(
+                width: width,
+                height: height,
+                child: AgentChatPanel(
+                  mobile: true,
+                  onClose: () => closed = true,
+                  onOpenSettings: () => settingsOpened = true,
+                ),
               ),
             ),
           ),
@@ -682,8 +742,20 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(buildPanel(640));
+    await tester.pumpWidget(
+      buildPanel(
+        width: 320,
+        height: 640,
+        padding: const EdgeInsets.only(top: 24, bottom: 28),
+      ),
+    );
     await tester.pump();
+    expect(
+      tester
+          .getTopLeft(find.byKey(const ValueKey('agent-chat-mobile-header')))
+          .dy,
+      greaterThanOrEqualTo(24),
+    );
 
     for (final key in [
       'agent-chat-mobile-close',
@@ -719,6 +791,15 @@ void main() {
       expect(size.width, greaterThanOrEqualTo(48), reason: '$key width');
       expect(size.height, greaterThanOrEqualTo(48), reason: '$key height');
     }
+    await tester.enterText(
+      find.byKey(const ValueKey('agent-chat-input')),
+      List.filled(20, 'line').join('\n'),
+    );
+    await tester.pump();
+    expect(
+      tester.getSize(find.byKey(const ValueKey('agent-chat-input'))).height,
+      lessThanOrEqualTo(176),
+    );
 
     notifier.setError('Request failed');
     await tester.pump();
@@ -738,7 +819,7 @@ void main() {
       ),
     );
     notifier.setQueuedMessages(20);
-    await tester.pumpWidget(buildPanel(420));
+    await tester.pumpWidget(buildPanel(width: 320, height: 420));
     await tester.pump();
     expect(find.byKey(const ValueKey('agent-chat-stop')), findsOneWidget);
     expect(
@@ -755,6 +836,19 @@ void main() {
           'header=${tester.getSize(find.byKey(const ValueKey('agent-chat-mobile-header')))}, '
           'input=${tester.getSize(find.byKey(const ValueKey('agent-chat-input-container')))}',
     );
+
+    for (final size in const [Size(640, 360), Size(800, 640)]) {
+      await tester.pumpWidget(
+        buildPanel(width: size.width, height: size.height),
+      );
+      await tester.pump();
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'mobile Agent overflow at ${size.width}x${size.height}',
+      );
+      expect(find.byKey(const ValueKey('agent-chat-send')), findsOneWidget);
+    }
 
     await tester.tap(find.byKey(const ValueKey('agent-chat-mobile-close')));
     await tester.pump();

--- a/test/presentation/agent_chat/widgets/agent_chat_tool_widgets_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_tool_widgets_test.dart
@@ -1,12 +1,131 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/agent/agent_types.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/agent_chat/widgets/agent_chat_tool_widgets.dart';
 
 void main() {
+  Future<void> pumpResult(WidgetTester tester, ToolResultMessage result) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: AgentChatToolResultTile(result: result)),
+      ),
+    );
+  }
+
+  testWidgets('successful result is a collapsed human readable summary', (
+    tester,
+  ) async {
+    final result = ToolResultMessage(
+      toolCallId: 'success-1',
+      toolName: 'search_tags',
+      content: const [
+        ToolResultTextContent(
+          '{"ok":true,"message":"Found 3 matching tags","items":[1,2,3]}',
+        ),
+      ],
+    );
+
+    await pumpResult(tester, result);
+
+    expect(find.textContaining('Found 3 matching tags'), findsOneWidget);
+    expect(find.textContaining('Success'), findsOneWidget);
+    expect(find.textContaining('{"ok":true,"message"'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('agent-tool-result-details-success-1')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('error summary stays visible and details can be expanded', (
+    tester,
+  ) async {
+    final result = ToolResultMessage(
+      toolCallId: 'error-1',
+      toolName: 'web_search',
+      isError: true,
+      content: const [
+        ToolResultTextContent(
+          '{"error":"Network request failed","status":503}',
+        ),
+      ],
+    );
+
+    await pumpResult(tester, result);
+
+    expect(find.textContaining('Network request failed'), findsOneWidget);
+    expect(find.textContaining('Error'), findsOneWidget);
+    expect(find.textContaining('"status": 503'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('agent-tool-result-error-1')));
+    await tester.pump();
+
+    expect(find.textContaining('"status": 503'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('agent-tool-result-details-error-1')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('expanded detail is bounded scrollable selectable and copyable', (
+    tester,
+  ) async {
+    String? copiedText;
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.setData') {
+        copiedText =
+            (call.arguments as Map<Object?, Object?>)['text'] as String?;
+      }
+      return null;
+    });
+    addTearDown(
+      () => messenger.setMockMethodCallHandler(SystemChannels.platform, null),
+    );
+    final values = List<String>.generate(80, (index) => 'value-$index');
+    final rawJson = jsonEncode({'values': values});
+    final result = ToolResultMessage(
+      toolCallId: 'detail-1',
+      toolName: 'read',
+      content: [ToolResultTextContent(rawJson)],
+    );
+
+    await pumpResult(tester, result);
+    await tester.tap(find.byKey(const ValueKey('agent-tool-result-detail-1')));
+    await tester.pump();
+
+    final panel = find.byKey(
+      const ValueKey('agent-tool-result-details-detail-1'),
+    );
+    expect(panel, findsOneWidget);
+    expect(
+      find.descendant(of: panel, matching: find.byType(SingleChildScrollView)),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.byType(SelectableText)),
+      findsOneWidget,
+    );
+    expect(tester.getSize(panel).height, lessThanOrEqualTo(252));
+
+    await tester.tap(
+      find.descendant(
+        of: panel,
+        matching: find.byKey(const ValueKey('agent-tool-detail-copy')),
+      ),
+    );
+    await tester.pump();
+    expect(copiedText, contains('"value-79"'));
+    expect(copiedText, contains('\n'));
+    await tester.pump(const Duration(seconds: 4));
+  });
+
   testWidgets('renders explicit ToolResultImageContent previews', (
     tester,
   ) async {
@@ -25,14 +144,11 @@ void main() {
       ],
     );
 
-    await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(body: AgentChatToolResultTile(result: result)),
-      ),
-    );
+    await pumpResult(tester, result);
 
+    expect(find.byType(Image), findsNothing);
+    await tester.tap(find.byKey(const ValueKey('agent-tool-result-preview-1')));
+    await tester.pump();
     expect(find.byType(Image), findsOneWidget);
   });
 
@@ -48,16 +164,50 @@ void main() {
       },
     );
 
+    await pumpResult(tester, result);
+    await tester.pump();
+
+    expect(find.textContaining('missing-generated-result.png'), findsNothing);
+    await tester.tap(
+      find.byKey(const ValueKey('agent-tool-result-generate-1')),
+    );
+    await tester.pump();
+    expect(find.textContaining('missing-generated-result.png'), findsWidgets);
+  });
+
+  testWidgets('tool group keeps a concrete failure summary visible', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(body: AgentChatToolResultTile(result: result)),
+        home: Scaffold(
+          body: AgentChatToolResultGroup(
+            results: [
+              ToolResultMessage(
+                toolCallId: 'ok',
+                toolName: 'read',
+                content: const [ToolResultTextContent('{"ok":true}')],
+              ),
+              ToolResultMessage(
+                toolCallId: 'failed',
+                toolName: 'web_search',
+                isError: true,
+                content: const [
+                  ToolResultTextContent(
+                    '{"error":"Upstream search timed out","status":504}',
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
       ),
     );
-    await tester.pump();
 
-    expect(find.textContaining('missing-generated-result.png'), findsOneWidget);
+    expect(find.textContaining('Upstream search timed out'), findsOneWidget);
+    expect(find.textContaining('"status"'), findsNothing);
   });
 }
 


### PR DESCRIPTION
## 用户可见变化

- 统一侧边栏、独立 Agent 窗口和 Android 聊天界面的消息布局、角色语义、Markdown、附件、图片与操作栏。
- 用户短消息保持紧凑右对齐，AI 正文使用响应式最大宽度；完善窄屏、横屏、平板、SafeArea 与文字缩放布局。
- 工具调用改为人类可读状态与摘要：运行中明确展示，成功默认折叠，错误摘要始终可见，详情可有界滚动和复制。
- 完善独立窗口的会话顶栏占位、初始滚动、跟随最新、未读提示、重试、模型设置和媒体预览。
- 保持独立窗口为 authoritative main Agent runtime 的 secondary-engine IPC client，不引入第二套 runtime 或状态源。

## 实现说明

- 新增共享聊天布局契约、Markdown/工具详情组件和工具结果呈现投影。
- 按职责拆分独立窗口 transcript/media 与控制组件。
- IPC snapshot 补充重试状态，并避免 secondary 重复显示已完成工具 activity。

## 验证

- `flutter test test/core/windowing/agent_window_shell_test.dart test/presentation/agent_chat/widgets/agent_chat_tool_widgets_test.dart test/presentation/agent_chat/widgets/agent_chat_panel_test.dart --reporter expanded`（21 tests passed）
- `flutter test test/core/windowing/agent_window_shell_test.dart --reporter expanded`（拆分后 7 tests passed）
- `flutter analyze`
- 拆分后相关文件 `dart analyze`
- `dart format --output=none --set-exit-if-changed ...`
- `git diff --check`

## 其他

- 未修改生成文件、LFS 资源或 `CHANGELOG.md`。
