### PR TITLE
perf(gallery): 优化在线画廊滚动与分页加载

### DIFF
--- a/lib/core/cache/online_gallery_prefetch_coordinator.dart
+++ b/lib/core/cache/online_gallery_prefetch_coordinator.dart
@@ -10,12 +10,14 @@ class OnlineGalleryPrefetchCoordinator {
   OnlineGalleryPrefetchCoordinator({
     required GalleryImagePreloader preloader,
     this.maxConcurrent = 4,
+    this.maxQueued = 64,
     DateTime Function()? now,
   }) : _preloader = preloader,
        _now = now ?? DateTime.now;
 
   final GalleryImagePreloader _preloader;
   final int maxConcurrent;
+  final int maxQueued;
   final DateTime Function() _now;
 
   final ListQueue<_PrefetchTask> _interactive = ListQueue<_PrefetchTask>();
@@ -55,7 +57,7 @@ class OnlineGalleryPrefetchCoordinator {
   void rotateGeneration() {
     _generation++;
     for (final task in _pending.values) {
-      if (!task.completer.isCompleted) task.completer.complete(false);
+      _completeCancelled(task);
     }
     _pending.clear();
     _interactive.clear();
@@ -67,6 +69,34 @@ class OnlineGalleryPrefetchCoordinator {
   void setScrolling(bool scrolling) {
     _lowPriorityPaused = scrolling;
     if (!scrolling) _pump();
+  }
+
+  /// Cancels queued work for a card that left the active viewport window.
+  /// Downloads already handed to the image pipeline are allowed to finish so
+  /// the shared disk cache is not left with a partially consumed response.
+  void cancelPending(GalleryImageRequest request) {
+    final task = _pending.remove(request.stableRequestKey);
+    if (task == null) return;
+    _removeFromQueue(task);
+    _completeCancelled(task);
+  }
+
+  /// Keeps the moving thumbnail window bounded while a user scrolls through
+  /// many rows faster than the network can consume them.
+  void retainThumbnailWindow(Set<String> stableRequestKeys) {
+    final stale = _pending.values
+        .where(
+          (task) =>
+              (task.priority == GalleryImagePriority.visible ||
+                  task.priority == GalleryImagePriority.lookahead) &&
+              !stableRequestKeys.contains(task.request.stableRequestKey),
+        )
+        .toList(growable: false);
+    for (final task in stale) {
+      _pending.remove(task.request.stableRequestKey);
+      _removeFromQueue(task);
+      _completeCancelled(task);
+    }
   }
 
   Future<bool> submit(
@@ -106,6 +136,10 @@ class OnlineGalleryPrefetchCoordinator {
       });
     }
 
+    if (_pending.length >= maxQueued && !_makeRoomFor(priority)) {
+      return Future<bool>.value(false);
+    }
+
     final task = _PrefetchTask(
       request: request,
       priority: priority,
@@ -136,11 +170,31 @@ class OnlineGalleryPrefetchCoordinator {
     _queueFor(task.priority).remove(task);
   }
 
+  bool _makeRoomFor(GalleryImagePriority incoming) {
+    for (final priority in GalleryImagePriority.values.reversed) {
+      if (priority.index < incoming.index) continue;
+      final queue = _queueFor(priority);
+      if (queue.isEmpty) continue;
+      final evicted = queue.removeLast();
+      _pending.remove(evicted.request.stableRequestKey);
+      _completeCancelled(evicted);
+      return true;
+    }
+    return false;
+  }
+
+  void _completeCancelled(_PrefetchTask task) {
+    if (!task.downloadCompleter.isCompleted) {
+      task.downloadCompleter.complete(false);
+    }
+    if (!task.completer.isCompleted) task.completer.complete(false);
+  }
+
   _PrefetchTask? _takeNext() {
     if (_interactive.isNotEmpty) return _interactive.removeFirst();
     if (_hover.isNotEmpty) return _hover.removeFirst();
-    if (_lowPriorityPaused) return null;
     if (_visible.isNotEmpty) return _visible.removeFirst();
+    if (_lowPriorityPaused) return null;
     if (_lookahead.isNotEmpty) return _lookahead.removeFirst();
     return null;
   }

--- a/lib/core/network/system_proxy_http_overrides.dart
+++ b/lib/core/network/system_proxy_http_overrides.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:io';
 
 import '../utils/app_logger.dart';
@@ -10,6 +11,7 @@ import '../utils/app_logger.dart';
 class SystemProxyHttpOverrides extends HttpOverrides {
   /// 代理配置字符串
   final String _proxyString;
+  final LinkedHashSet<String> _loggedRoutes = LinkedHashSet<String>();
 
   /// 构造函数
   ///
@@ -24,10 +26,13 @@ class SystemProxyHttpOverrides extends HttpOverrides {
     // 设置代理配置
     // findProxy 回调接收请求 URI，返回代理字符串
     client.findProxy = (uri) {
-      AppLogger.d(
-        'Proxy request for: ${uri.host}:${uri.port} -> $_proxyString',
-        'PROXY',
-      );
+      final route = '${uri.host}:${uri.port}';
+      if (_loggedRoutes.add(route)) {
+        AppLogger.d('Proxy route: $route -> $_proxyString', 'PROXY');
+        if (_loggedRoutes.length > 64) {
+          _loggedRoutes.remove(_loggedRoutes.first);
+        }
+      }
       return _proxyString;
     };
 

--- a/lib/presentation/providers/online_gallery_pagination_service.dart
+++ b/lib/presentation/providers/online_gallery_pagination_service.dart
@@ -93,18 +93,13 @@ class OnlineGalleryPaginationService {
         : state.sourceId;
     final generation = _beginRequest();
     final requestCancelToken = generation.cancelToken;
-    await Future.wait([_ensureQuickFilter(), _ensureAuth(sourceId)]);
-    if (!_isActive(generation) ||
-        state.randomEnabled ||
-        state.activeSourceId != sourceId) {
-      return;
-    }
-    final cache = state.currentCache;
-    final cursor = initialCursor ?? (refresh ? '1' : cache.nextCursor);
-    if (cursor == null) return;
-    final adapter = _repository().adapter(sourceId);
-    final cacheKey = state.currentCacheKey;
-    final isAppend = !refresh && cache.posts.isNotEmpty;
+    var cache = state.currentCache;
+    var cacheKey = state.currentCacheKey;
+    var isAppend = !refresh && cache.posts.isNotEmpty;
+
+    // Claim the append synchronously. Scroll and underfill callbacks can fire
+    // in the same frame; publishing this state before authentication/setup
+    // makes them converge on one request and exposes the runway immediately.
     state = state.copyWith(
       isLoading: !isAppend,
       isLoadingMore: isAppend,
@@ -115,6 +110,22 @@ class OnlineGalleryPaginationService {
     }
 
     try {
+      await Future.wait([_ensureQuickFilter(), _ensureAuth(sourceId)]);
+      if (!_isActive(generation) ||
+          state.randomEnabled ||
+          state.activeSourceId != sourceId) {
+        return;
+      }
+      cache = state.currentCache;
+      cacheKey = state.currentCacheKey;
+      isAppend = !refresh && cache.posts.isNotEmpty;
+      final cursor = initialCursor ?? (refresh ? '1' : cache.nextCursor);
+      if (cursor == null) {
+        state = state.copyWith(isLoading: false, isLoadingMore: false);
+        return;
+      }
+      state = state.copyWith(isLoading: !isAppend, isLoadingMore: isAppend);
+      final adapter = _repository().adapter(sourceId);
       await _ref
           .read(onlineGalleryBlacklistNotifierProvider.notifier)
           .ensureInitialized();

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -109,6 +109,8 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   final Set<String> _remoteFavoriteKeys = <String>{};
   final OnlineGallerySearchService _search = OnlineGallerySearchService();
   int _detailRequestScopeRevision = 0;
+  bool _loadMoreClaimed = false;
+  int _loadMoreClaimRevision = 0;
 
   int get detailRequestScopeRevision => _detailRequestScopeRevision;
 
@@ -229,6 +231,8 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
 
   void _cancelCurrentRequest() {
     _loadCoordinator.cancel('Superseded by a gallery state change');
+    _loadMoreClaimRevision++;
+    _loadMoreClaimed = false;
     _detailRequestScopeRevision++;
     _detailCoordinator?.cancelQueuedVisible();
     if (state.isLoading || state.isLoadingMore) {
@@ -331,23 +335,24 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     final sourceId = state.activeSourceId;
     final requestHandle = _beginRequest();
     final requestCancelToken = requestHandle.cancelToken;
-    await Future.wait([
-      _ensureQuickTagCloudFilterInitialized(),
-      _ensureAuthenticationReady(sourceId),
-    ]);
-    if (!_loadCoordinator.isCurrent(requestHandle) ||
-        !state.randomEnabled ||
-        !state.supportsRandom ||
-        state.activeSourceId != sourceId) {
-      return;
-    }
-    final cacheKey = state.currentCacheKey;
+    var cacheKey = state.currentCacheKey;
     state = state.copyWith(
       isLoading: replace,
       isLoadingMore: !replace,
       clearError: true,
     );
     try {
+      await Future.wait([
+        _ensureQuickTagCloudFilterInitialized(),
+        _ensureAuthenticationReady(sourceId),
+      ]);
+      if (!_loadCoordinator.isCurrent(requestHandle) ||
+          !state.randomEnabled ||
+          !state.supportsRandom ||
+          state.activeSourceId != sourceId) {
+        return;
+      }
+      cacheKey = state.currentCacheKey;
       await ref
           .read(onlineGalleryBlacklistNotifierProvider.notifier)
           .ensureInitialized();
@@ -800,10 +805,19 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
         state.isLoadingMore ||
         state.hasError ||
         activeCache.appendErrorCode != null ||
-        !state.hasMore) {
+        !state.hasMore ||
+        _loadMoreClaimed) {
       return;
     }
-    await loadPosts();
+    _loadMoreClaimed = true;
+    final claimRevision = ++_loadMoreClaimRevision;
+    try {
+      await loadPosts();
+    } finally {
+      if (claimRevision == _loadMoreClaimRevision) {
+        _loadMoreClaimed = false;
+      }
+    }
   }
 
   Future<void> refresh() {
@@ -852,12 +866,6 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
 
   Future<void> _loadFavorites({required bool refresh, int? targetPage}) async {
     final sourceId = state.favoritesSourceId;
-    await _ensureAuthenticationReady(sourceId);
-    if (_lifecycle.disposed ||
-        state.viewMode != GalleryViewMode.favorites ||
-        state.favoritesSourceId != sourceId) {
-      return;
-    }
     final previousCache = state.currentCache;
     final pageNumber = targetPage ?? (refresh ? 1 : previousCache.page + 1);
     final generation = _beginRequest();
@@ -888,6 +896,13 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     Object? remoteError;
     var blacklistDetailFailures = 0;
     try {
+      await _ensureAuthenticationReady(sourceId);
+      if (_lifecycle.disposed ||
+          !_isCurrentRequest(generation, cacheKey) ||
+          state.viewMode != GalleryViewMode.favorites ||
+          state.favoritesSourceId != sourceId) {
+        return;
+      }
       await ref
           .read(onlineGalleryBlacklistNotifierProvider.notifier)
           .ensureInitialized();

--- a/lib/presentation/screens/online_gallery/gallery_grid_item.dart
+++ b/lib/presentation/screens/online_gallery/gallery_grid_item.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -25,6 +27,7 @@ class GalleryGridItem extends StatefulWidget {
     required this.anchorKey,
     required this.onVisibilityChanged,
     required this.detailRequestScope,
+    required this.prepareMedia,
     required this.loadDetail,
     required this.buildCard,
   });
@@ -45,6 +48,7 @@ class GalleryGridItem extends StatefulWidget {
   )
   onVisibilityChanged;
   final Object detailRequestScope;
+  final Future<bool> Function(GalleryItem item, double itemWidth) prepareMedia;
   final Future<GalleryDetail> Function(
     GalleryItem item, {
     required GalleryDetailPriority priority,
@@ -89,6 +93,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
   }
 
   void _handleVisibility(bool visible, double visibleTop) {
+    final visibilityChanged = _isVisible != visible;
     _isVisible = visible;
     widget.onVisibilityChanged(
       widget.index,
@@ -98,10 +103,13 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
       visible,
       visibleTop,
     );
+    if (!mounted) return;
     if (visible && _needsDetail && _detailFuture == null) {
       setState(() {
         _detailFuture = _loadDetail();
       });
+    } else if (visibilityChanged) {
+      setState(() {});
     }
   }
 
@@ -161,11 +169,25 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
         onVisibilityChanged: _handleVisibility,
         builder: (context, hasBeenVisible, isScrolling) {
           if (!_needsDetail) {
-            return _buildResourceCard(
-              context,
-              post,
-              layoutAspectRatio,
-              loadMedia: hasBeenVisible,
+            if (!hasBeenVisible) {
+              return _buildResourceCard(
+                context,
+                post,
+                layoutAspectRatio,
+                loadMedia: false,
+              );
+            }
+            return _PreparedGalleryMediaCard(
+              item: post,
+              itemWidth: widget.itemWidth,
+              visible: _isVisible,
+              prepareMedia: widget.prepareMedia,
+              builder: (loadMedia) => _buildResourceCard(
+                context,
+                post,
+                layoutAspectRatio,
+                loadMedia: loadMedia,
+              ),
             );
           }
           if (!hasBeenVisible) {
@@ -222,12 +244,22 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
                   ),
                 );
               }
-              return _buildResourceCard(
-                context,
-                resolved,
-                layoutAspectRatio,
-                loadMedia: true,
-                detail: detail,
+              final resolvedAspectRatio =
+                  resolved.width > 0 && resolved.height > 0
+                  ? resolved.width / resolved.height
+                  : layoutAspectRatio;
+              return _PreparedGalleryMediaCard(
+                item: resolved,
+                itemWidth: widget.itemWidth,
+                visible: _isVisible,
+                prepareMedia: widget.prepareMedia,
+                builder: (loadMedia) => _buildResourceCard(
+                  context,
+                  resolved,
+                  resolvedAspectRatio,
+                  loadMedia: loadMedia,
+                  detail: detail,
+                ),
               );
             },
           );
@@ -235,4 +267,100 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
       ),
     );
   }
+}
+
+class _PreparedGalleryMediaCard extends StatefulWidget {
+  const _PreparedGalleryMediaCard({
+    required this.item,
+    required this.itemWidth,
+    required this.visible,
+    required this.prepareMedia,
+    required this.builder,
+  });
+
+  final GalleryItem item;
+  final double itemWidth;
+  final bool visible;
+  final Future<bool> Function(GalleryItem item, double itemWidth) prepareMedia;
+  final Widget Function(bool loadMedia) builder;
+
+  @override
+  State<_PreparedGalleryMediaCard> createState() =>
+      _PreparedGalleryMediaCardState();
+}
+
+class _PreparedGalleryMediaCardState extends State<_PreparedGalleryMediaCard> {
+  static const _retryDelays = <Duration>[
+    Duration(seconds: 1),
+    Duration(seconds: 3),
+    Duration(seconds: 15),
+  ];
+
+  Timer? _retryTimer;
+  bool _ready = false;
+  bool _preparing = false;
+  int _revision = 0;
+  int _retryCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.visible) _prepare();
+  }
+
+  @override
+  void didUpdateWidget(covariant _PreparedGalleryMediaCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final requestChanged =
+        oldWidget.item.stableKey != widget.item.stableKey ||
+        oldWidget.item.previewUrl != widget.item.previewUrl ||
+        oldWidget.itemWidth != widget.itemWidth;
+    if (requestChanged) {
+      _retryTimer?.cancel();
+      _revision++;
+      _ready = false;
+      _preparing = false;
+      _retryCount = 0;
+    }
+    if (!widget.visible) {
+      _retryTimer?.cancel();
+      return;
+    }
+    if (requestChanged || !oldWidget.visible) _prepare();
+  }
+
+  void _prepare() {
+    if (_ready || _preparing || !widget.visible) return;
+    _retryTimer?.cancel();
+    _preparing = true;
+    final revision = ++_revision;
+    widget.prepareMedia(widget.item, widget.itemWidth).then((ready) {
+      if (!mounted || revision != _revision) return;
+      _preparing = false;
+      if (ready) {
+        _retryCount = 0;
+        setState(() => _ready = true);
+        return;
+      }
+      if (!widget.visible) return;
+      if (_retryCount >= _retryDelays.length) {
+        // Preparation only warms the shared cache. After bounded retries,
+        // reveal the real image widget so its normal error UI remains the
+        // source of truth instead of polling a broken URL forever.
+        setState(() => _ready = true);
+        return;
+      }
+      _retryTimer = Timer(_retryDelays[_retryCount++], _prepare);
+    });
+  }
+
+  @override
+  void dispose() {
+    _retryTimer?.cancel();
+    _revision++;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.builder(_ready);
 }

--- a/lib/presentation/screens/online_gallery/online_gallery_content.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_content.dart
@@ -310,6 +310,7 @@ class _OnlineGalleryContentPresenter {
         state.currentCacheKey,
         _galleryNotifier.detailRequestScopeRevision,
       ),
+      prepareMedia: _scrollCoordinator.prepareVisibleMedia,
       loadDetail: (item, {required priority, forceRefresh = false}) =>
           _galleryNotifier.loadDetail(
             item,

--- a/lib/presentation/screens/online_gallery/online_gallery_grid.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_grid.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
@@ -41,10 +42,12 @@ class OnlineGalleryGrid extends StatelessWidget {
     if (!(state.isLoadingMore || (state.isLoading && state.posts.isEmpty))) {
       return 0;
     }
+    if (!state.hasMore) return 0;
     if (state.randomEnabled) return 1;
-    final total = state.currentCache.total;
-    if (total == null) return onlineGalleryPageSize;
-    return (total - state.posts.length).clamp(0, onlineGalleryPageSize);
+    // Keep one immutable runway for the whole request. Deriving this from a
+    // total that may arrive mid-request shrinks the sliver while it is being
+    // scrolled and defeats the placeholder's purpose.
+    return onlineGalleryPageSize;
   }
 
   @override
@@ -70,34 +73,72 @@ class OnlineGalleryGrid extends StatelessWidget {
             ? 'random:${state.randomSession.scopeKey}'
             : 'normal';
         final placeholderCount = _placeholderCount();
-        return MasonryGridView.count(
+        return CustomScrollView(
           key: PageStorageKey<String>(
             'online_gallery_$storageScope:${state.currentCacheKey}',
           ),
           controller: controller.scrollController,
-          cacheExtent: OnlineGalleryPreloadPolicy.cacheExtent(viewportHeight),
-          padding: const EdgeInsets.all(12),
-          crossAxisCount: columnCount,
-          mainAxisSpacing: spacing,
-          crossAxisSpacing: spacing,
-          itemCount: state.posts.length + placeholderCount + 1,
-          itemBuilder: (context, index) {
-            if (index >= state.posts.length &&
-                index < state.posts.length + placeholderCount) {
-              return OnlineGalleryPendingCard(
-                key: ValueKey(
-                  'online-gallery-pending:${state.currentCacheKey}:$index',
+          scrollCacheExtent: ScrollCacheExtent.pixels(
+            OnlineGalleryPreloadPolicy.cacheExtent(viewportHeight),
+          ),
+          slivers: [
+            SliverPadding(
+              padding: EdgeInsets.fromLTRB(
+                12,
+                12,
+                12,
+                state.posts.isEmpty ? 0 : 6,
+              ),
+              sliver: SliverMasonryGrid.count(
+                crossAxisCount: columnCount,
+                mainAxisSpacing: spacing,
+                crossAxisSpacing: spacing,
+                childCount: state.posts.length,
+                itemBuilder: (context, index) =>
+                    itemBuilder(context, index, itemWidth, columnCount),
+              ),
+            ),
+            if (placeholderCount > 0)
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(
+                  12,
+                  state.posts.isEmpty ? 12 : 0,
+                  12,
+                  0,
                 ),
-                itemWidth: itemWidth,
-              );
-            }
-            return itemBuilder(
-              context,
-              index < state.posts.length ? index : state.posts.length,
-              itemWidth,
-              columnCount,
-            );
-          },
+                sliver: SliverGrid(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: columnCount,
+                    mainAxisSpacing: spacing,
+                    crossAxisSpacing: spacing,
+                  ),
+                  delegate: SliverChildBuilderDelegate(
+                    (context, placeholderIndex) => OnlineGalleryPendingCard(
+                      key: ValueKey(
+                        'online-gallery-pending:'
+                        '${state.currentCacheKey}:$placeholderIndex',
+                      ),
+                      itemWidth: itemWidth,
+                    ),
+                    childCount: placeholderCount,
+                  ),
+                ),
+              ),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(12, 6, 12, 12),
+              sliver: SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (context, _) => itemBuilder(
+                    context,
+                    state.posts.length,
+                    itemWidth,
+                    columnCount,
+                  ),
+                  childCount: 1,
+                ),
+              ),
+            ),
+          ],
         );
       },
     );

--- a/lib/presentation/screens/online_gallery/online_gallery_screen_controller.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../../core/cache/gallery_image_request.dart';
 import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
 import '../../../data/models/online_gallery/danbooru_post.dart';
 import '../../providers/online_gallery_provider.dart';
@@ -33,7 +34,15 @@ class OnlineGalleryScreenController extends ChangeNotifier {
   final primarySearchRevealKey = GlobalKey();
   final scrolling = ValueNotifier<bool>(false);
 
-  final Map<int, ({GalleryItem item, double itemWidth, double visibleTop})>
+  final Map<
+    int,
+    ({
+      GalleryItem item,
+      double itemWidth,
+      double visibleTop,
+      GalleryImageRequest? thumbnailRequest,
+    })
+  >
   visibleItems = {};
   final Set<String> pendingGalleryDetails = <String>{};
 
@@ -80,12 +89,14 @@ class OnlineGalleryScreenController extends ChangeNotifier {
     required GalleryItem item,
     required double itemWidth,
     required double visibleTop,
+    GalleryImageRequest? thumbnailRequest,
   }) {
     final previous = visibleItems[index];
     visibleItems[index] = (
       item: item,
       itemWidth: itemWidth,
       visibleTop: visibleTop,
+      thumbnailRequest: thumbnailRequest,
     );
     return previous?.item.stableKey != item.stableKey;
   }

--- a/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
@@ -46,17 +46,32 @@ class OnlineGalleryScrollPrefetchCoordinator {
       metrics.extentAfter <=
       OnlineGalleryPreloadPolicy.loadAheadDistance(metrics.viewportDimension);
 
+  Future<bool> prepareVisibleMedia(GalleryItem item, double itemWidth) {
+    if (item.previewUrl.isEmpty) return Future<bool>.value(true);
+    return controller.prefetchCoordinator.submit(
+      imageRequest(
+        item,
+        item.previewUrl,
+        GalleryImageTier.thumbnail,
+        itemWidth,
+      ),
+      priority: GalleryImagePriority.visible,
+    );
+  }
+
   void onScroll() {
     controller.hoverController.dismiss();
     if (!controller.branchVisible) return;
     final offset = controller.scrollController.offset;
     if (offset != controller.lastScrollOffset) {
+      final startedScrolling = !controller.isScrolling;
       controller.scrollDirection = offset >= controller.lastScrollOffset
           ? 1
           : -1;
       controller.lastScrollOffset = offset;
       controller.setScrolling(true);
       controller.prefetchCoordinator.setScrolling(true);
+      if (startedScrolling) _retainVisibleThumbnailWindow();
       controller.scrollStopTimer?.cancel();
       controller.scrollStopTimer = Timer(const Duration(milliseconds: 150), () {
         if (!isMounted() || !controller.branchVisible) return;
@@ -171,14 +186,27 @@ class OnlineGalleryScrollPrefetchCoordinator {
       final current = controller.visibleItems[index];
       if (current?.item.stableKey == item.stableKey) {
         controller.visibleItems.remove(index);
+        final request = current!.thumbnailRequest;
+        if (request != null) {
+          controller.prefetchCoordinator.cancelPending(request);
+        }
       }
       return;
     }
+    final thumbnailRequest = item.previewUrl.isEmpty
+        ? null
+        : imageRequest(
+            item,
+            item.previewUrl,
+            GalleryImageTier.thumbnail,
+            itemWidth,
+          );
     final enteredViewport = controller.recordVisibleItem(
       index: index,
       item: item,
       itemWidth: itemWidth,
       visibleTop: visibleTop,
+      thumbnailRequest: thumbnailRequest,
     );
     if (controller.scrollController.hasClients) {
       final position = controller.scrollController.position;
@@ -193,19 +221,6 @@ class OnlineGalleryScrollPrefetchCoordinator {
     // visible. Keep the anchor and viewport sizing current, but do not repeat
     // image queue and idle-prefetch work until a card actually enters.
     if (!enteredViewport) return;
-    if (item.previewUrl.isNotEmpty) {
-      unawaited(
-        controller.prefetchCoordinator.submit(
-          imageRequest(
-            item,
-            item.previewUrl,
-            GalleryImageTier.thumbnail,
-            itemWidth,
-          ),
-          priority: GalleryImagePriority.visible,
-        ),
-      );
-    }
     if (!controller.isScrolling) {
       controller.idlePrefetchTimer?.cancel();
       controller.idlePrefetchTimer = Timer(
@@ -230,20 +245,27 @@ class OnlineGalleryScrollPrefetchCoordinator {
     final edge = controller.scrollDirection >= 0
         ? visible.last.key
         : visible.first.key;
+    final thumbnailWindow = <String>{};
+    for (final entry in visible) {
+      final request = entry.value.thumbnailRequest;
+      if (request != null) thumbnailWindow.add(request.stableRequestKey);
+    }
     var detailCount = 0;
     for (var step = 1; step <= controller.lookaheadItemCount; step++) {
       final index = edge + step * controller.scrollDirection;
       if (index < 0 || index >= state.posts.length) continue;
       final item = state.posts[index];
       if (item.previewUrl.isNotEmpty) {
+        final request = imageRequest(
+          item,
+          item.previewUrl,
+          GalleryImageTier.thumbnail,
+          itemWidth,
+        );
+        thumbnailWindow.add(request.stableRequestKey);
         unawaited(
           controller.prefetchCoordinator.submit(
-            imageRequest(
-              item,
-              item.previewUrl,
-              GalleryImageTier.thumbnail,
-              itemWidth,
-            ),
+            request,
             priority: GalleryImagePriority.lookahead,
           ),
         );
@@ -257,30 +279,15 @@ class OnlineGalleryScrollPrefetchCoordinator {
         );
       }
     }
-    for (final entry in visible.take(12)) {
-      final item = entry.value.item;
-      if (item.isVideo ||
-          item.isAnimated ||
-          item.sourceId == GallerySourceId.aiTag) {
-        continue;
-      }
-      final sampleUrl = item.sampleUrl ?? item.largeFileUrl;
-      if (sampleUrl == null ||
-          sampleUrl.isEmpty ||
-          sampleUrl == item.previewUrl) {
-        continue;
-      }
-      unawaited(
-        controller.prefetchCoordinator.submit(
-          imageRequest(
-            item,
-            sampleUrl,
-            GalleryImageTier.sample,
-            entry.value.itemWidth,
-          ),
-          priority: GalleryImagePriority.lookahead,
-        ),
-      );
+    controller.prefetchCoordinator.retainThumbnailWindow(thumbnailWindow);
+  }
+
+  void _retainVisibleThumbnailWindow() {
+    final keys = <String>{};
+    for (final entry in controller.visibleItems.values) {
+      final request = entry.thumbnailRequest;
+      if (request != null) keys.add(request.stableRequestKey);
     }
+    controller.prefetchCoordinator.retainThumbnailWindow(keys);
   }
 }

--- a/test/core/cache/online_gallery_prefetch_coordinator_test.dart
+++ b/test/core/cache/online_gallery_prefetch_coordinator_test.dart
@@ -145,30 +145,103 @@ void main() {
   );
 
   test(
-    'scrolling pauses low priority work but still starts hover work',
+    'scrolling keeps visible work moving but pauses lookahead work',
     () async {
       final started = <String>[];
       final coordinator = OnlineGalleryPrefetchCoordinator(
+        maxConcurrent: 1,
         preloader: (request) async => started.add(request.url),
       );
       coordinator.setScrolling(true);
 
-      final low = coordinator.submit(
+      final lookahead = coordinator.submit(
         _request(1),
         priority: GalleryImagePriority.lookahead,
       );
-      final hover = coordinator.submit(
-        _request(2, tier: GalleryImageTier.sample),
-        priority: GalleryImagePriority.hover,
+      final visible = coordinator.submit(
+        _request(2),
+        priority: GalleryImagePriority.visible,
       );
       await Future<void>.delayed(Duration.zero);
 
       expect(started, ['https://example.com/2.jpg']);
-      expect(await hover, isTrue);
+      expect(await visible, isTrue);
       coordinator.setScrolling(false);
-      expect(await low, isTrue);
+      expect(await lookahead, isTrue);
     },
   );
+
+  test('moving thumbnail window cancels stale queued requests', () async {
+    final gate = Completer<void>();
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      maxConcurrent: 1,
+      preloader: (request) =>
+          request.url.endsWith('/0.jpg') ? gate.future : Future<void>.value(),
+    );
+    final active = coordinator.submit(
+      _request(0),
+      priority: GalleryImagePriority.visible,
+    );
+    final stale = coordinator.submit(
+      _request(1),
+      priority: GalleryImagePriority.lookahead,
+    );
+    final retained = coordinator.submit(
+      _request(2),
+      priority: GalleryImagePriority.lookahead,
+    );
+
+    coordinator.retainThumbnailWindow({_request(2).stableRequestKey});
+    expect(await stale, isFalse);
+    expect(coordinator.queueDepth, 1);
+
+    gate.complete();
+    expect(await active, isTrue);
+    expect(await retained, isTrue);
+  });
+
+  test('queue stays bounded and visible work displaces lookahead', () async {
+    final gate = Completer<void>();
+    final started = <String>[];
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      maxConcurrent: 1,
+      maxQueued: 2,
+      preloader: (request) {
+        started.add(request.url);
+        return request.url.endsWith('/0.jpg')
+            ? gate.future
+            : Future<void>.value();
+      },
+    );
+    final active = coordinator.submit(
+      _request(0),
+      priority: GalleryImagePriority.visible,
+    );
+    final oldestLookahead = coordinator.submit(
+      _request(1),
+      priority: GalleryImagePriority.lookahead,
+    );
+    final newestLookahead = coordinator.submit(
+      _request(2),
+      priority: GalleryImagePriority.lookahead,
+    );
+    final visible = coordinator.submit(
+      _request(3),
+      priority: GalleryImagePriority.visible,
+    );
+
+    expect(coordinator.queueDepth, 2);
+    expect(await newestLookahead, isFalse);
+    gate.complete();
+    expect(await active, isTrue);
+    expect(await visible, isTrue);
+    expect(await oldestLookahead, isTrue);
+    expect(started, [
+      'https://example.com/0.jpg',
+      'https://example.com/3.jpg',
+      'https://example.com/1.jpg',
+    ]);
+  });
 
   test(
     'completed sample LRU retains only the latest sixteen requests',

--- a/test/presentation/providers/online_gallery_pagination_test.dart
+++ b/test/presentation/providers/online_gallery_pagination_test.dart
@@ -48,6 +48,44 @@ void main() {
   );
 
   test(
+    'concurrent load-more triggers claim one append synchronously',
+    () async {
+      final secondPage = Completer<GalleryPage>();
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) => request.cursor == '1'
+            ? Future.value(_page('1', [_item(1)], nextCursor: '2'))
+            : secondPage.future,
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+      await notifier.loadPosts();
+
+      final first = notifier.loadMore();
+      final duplicate = notifier.loadMore();
+      final underfillDuplicate = notifier.loadMore();
+
+      expect(
+        container.read(onlineGalleryNotifierProvider).isLoadingMore,
+        isTrue,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(adapter.searchCursors, ['1', '2']);
+
+      secondPage.complete(_page('2', [_item(2)], nextCursor: null));
+      await Future.wait([first, duplicate, underfillDuplicate]);
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(state.posts.map((item) => item.id), [1, 2]);
+      expect(state.isLoadingMore, isFalse);
+      expect(state.hasMore, isFalse);
+      await notifier.loadMore();
+      expect(adapter.searchCursors, ['1', '2']);
+    },
+  );
+
+  test(
     'popular ranking advances from page 1 to page 2 without rendering page 1 again',
     () async {
       final adapter = _FakeGalleryAdapter(

--- a/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
+++ b/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
@@ -177,6 +177,7 @@ void main() {
         previewFileUrl: 'https://example.test/pending.jpg',
       );
       final loadMediaValues = <bool>[];
+      final mediaGate = Completer<bool>();
 
       await tester.pumpWidget(
         _app(
@@ -184,6 +185,7 @@ void main() {
           detailRequestScope: 1,
           loadDetail: (_, {required priority, forceRefresh = false}) =>
               throw StateError('detail should not load'),
+          prepareMedia: (_, __) => mediaGate.future,
           onBuildCard: loadMediaValues.add,
         ),
       );
@@ -204,11 +206,148 @@ void main() {
       );
       await tester.pump();
 
+      expect(loadMediaValues.last, isFalse);
+      mediaGate.complete(true);
+      await tester.pump();
+      await tester.pump();
+
       expect(loadMediaValues.last, isTrue);
       expect(find.byKey(const ValueKey('resolved-card')), findsOneWidget);
       expect(tester.getSize(find.byType(GalleryGridItem)).height, 200);
     },
   );
+
+  testWidgets('AI TAG resolved media is prepared using its real URL', (
+    tester,
+  ) async {
+    final resolved = _item.copyWith(
+      imageWidth: 1200,
+      imageHeight: 800,
+      previewFileUrl: 'https://example.test/ai-tag-resolved.jpg',
+    );
+    final prepared = <GalleryItem>[];
+    final mediaGate = Completer<bool>();
+    final loadMediaValues = <bool>[];
+    final layoutAspectRatios = <double>[];
+    await tester.pumpWidget(
+      _app(
+        detailRequestScope: 1,
+        loadDetail: (_, {required priority, forceRefresh = false}) =>
+            Future.value(GalleryDetail(item: resolved, media: const [])),
+        prepareMedia: (item, _) {
+          prepared.add(item);
+          return mediaGate.future;
+        },
+        onBuildCard: loadMediaValues.add,
+        onLayoutAspectRatio: layoutAspectRatios.add,
+      ),
+    );
+
+    final detector = tester.widget<VisibilityDetector>(
+      find.byType(VisibilityDetector),
+    );
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(prepared, [resolved]);
+    expect(loadMediaValues.last, isFalse);
+    expect(layoutAspectRatios.last, 1.5);
+
+    mediaGate.complete(true);
+    await tester.pump();
+    await tester.pump();
+    expect(loadMediaValues.last, isTrue);
+  });
+
+  testWidgets('visible thumbnail retries after a transient prepare failure', (
+    tester,
+  ) async {
+    const item = GalleryItem(
+      id: 3,
+      workId: 'work-3',
+      sourceId: GallerySourceId.danbooru,
+      previewFileUrl: 'https://example.test/retry.jpg',
+    );
+    var attempts = 0;
+    final loadMediaValues = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        post: item,
+        detailRequestScope: 1,
+        loadDetail: (_, {required priority, forceRefresh = false}) =>
+            throw StateError('detail should not load'),
+        prepareMedia: (_, __) async => ++attempts > 1,
+        onBuildCard: loadMediaValues.add,
+      ),
+    );
+
+    final detector = tester.widget<VisibilityDetector>(
+      find.byType(VisibilityDetector),
+    );
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      ),
+    );
+    await tester.pump();
+    expect(attempts, 1);
+    expect(loadMediaValues.last, isFalse);
+
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+    expect(attempts, 2);
+    expect(loadMediaValues.last, isTrue);
+  });
+
+  testWidgets('persistent prepare failures fall back without polling forever', (
+    tester,
+  ) async {
+    var attempts = 0;
+    final loadMediaValues = <bool>[];
+    await tester.pumpWidget(
+      _app(
+        post: _item.copyWith(previewFileUrl: 'https://example.test/broken.jpg'),
+        detailRequestScope: 1,
+        loadDetail: (_, {required priority, forceRefresh = false}) =>
+            throw StateError('detail should not load'),
+        prepareMedia: (_, __) async {
+          attempts++;
+          return false;
+        },
+        onBuildCard: loadMediaValues.add,
+      ),
+    );
+
+    final detector = tester.widget<VisibilityDetector>(
+      find.byType(VisibilityDetector),
+    );
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(seconds: 15));
+    await tester.pump();
+
+    expect(attempts, 4);
+    expect(loadMediaValues.last, isTrue);
+    await tester.pump(const Duration(minutes: 1));
+    expect(attempts, 4);
+  });
 }
 
 const _item = GalleryItem(
@@ -226,7 +365,9 @@ Widget _app({
     bool forceRefresh,
   })
   loadDetail,
+  Future<bool> Function(GalleryItem item, double itemWidth)? prepareMedia,
   ValueChanged<bool>? onBuildCard,
+  ValueChanged<double>? onLayoutAspectRatio,
 }) {
   return MaterialApp(
     locale: const Locale('en'),
@@ -245,6 +386,7 @@ Widget _app({
           anchorKey: null,
           onVisibilityChanged: (_, __, ___, ____, _____, ______) {},
           detailRequestScope: detailRequestScope,
+          prepareMedia: prepareMedia ?? (_, __) => Future<bool>.value(true),
           loadDetail: loadDetail,
           buildCard:
               (
@@ -256,6 +398,7 @@ Widget _app({
                 detail,
               }) {
                 onBuildCard?.call(loadMedia);
+                onLayoutAspectRatio?.call(layoutAspectRatio);
                 return SizedBox(
                   key: const ValueKey('resolved-card'),
                   height: itemWidth / layoutAspectRatio,

--- a/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/cache/online_gallery_prefetch_coordinator.dart';
 import 'package:nai_launcher/data/models/online_gallery/gallery_item.dart';
@@ -154,7 +155,7 @@ void main() {
             state: OnlineGalleryState(searchCache: ModeCache(posts: items)),
             controller: controller,
             itemBuilder: (context, index, itemWidth, columnCount) {
-              builtIndices.add(index);
+              if (index < items.length) builtIndices.add(index);
               return const SizedBox(height: 120);
             },
           ),
@@ -255,6 +256,20 @@ void main() {
 
     expect(find.byKey(const ValueKey('loaded-0')), findsOneWidget);
     expect(find.byType(OnlineGalleryPendingCard), findsWidgets);
+    expect(
+      find.descendant(
+        of: find.byType(SliverGrid),
+        matching: find.byType(OnlineGalleryPendingCard),
+      ),
+      findsWidgets,
+    );
+    expect(
+      find.descendant(
+        of: find.byType(SliverMasonryGrid),
+        matching: find.byKey(const ValueKey('loaded-0')),
+      ),
+      findsOneWidget,
+    );
     final pending = tester.widgetList<OnlineGalleryPendingCard>(
       find.byType(OnlineGalleryPendingCard),
     );
@@ -263,6 +278,33 @@ void main() {
       controller.scrollController.position.maxScrollExtent,
       greaterThan(0),
     );
+
+    final completedItems = List.generate(
+      8,
+      (index) => GalleryItem(
+        id: index,
+        workId: 'post-$index',
+        sourceId: GallerySourceId.danbooru,
+      ),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: OnlineGalleryGrid(
+            state: OnlineGalleryState(
+              searchCache: ModeCache(posts: completedItems, hasMore: false),
+            ),
+            controller: controller,
+            itemBuilder: (context, index, itemWidth, columnCount) =>
+                SizedBox(key: ValueKey('completed-$index'), height: itemWidth),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(OnlineGalleryPendingCard), findsNothing);
+    expect(find.byKey(const ValueKey('completed-0')), findsOneWidget);
   });
 
   testWidgets(

--- a/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
@@ -911,8 +911,9 @@ void main() {
     expect(find.byKey(const ValueKey('danbooru:401')), findsOneWidget);
     expect(
       tester
-          .widget<CachedNetworkImage>(find.byType(CachedNetworkImage).first)
-          .imageUrl,
+          .widget<DanbooruPostCard>(find.byType(DanbooruPostCard))
+          .post
+          .previewUrl,
       contains('page-1'),
     );
 
@@ -935,8 +936,9 @@ void main() {
     expect(find.byKey(const ValueKey('danbooru:402')), findsOneWidget);
     expect(
       tester
-          .widget<CachedNetworkImage>(find.byType(CachedNetworkImage).first)
-          .imageUrl,
+          .widget<DanbooruPostCard>(find.byType(DanbooruPostCard))
+          .post
+          .previewUrl,
       contains('page-2'),
     );
     expect(


### PR DESCRIPTION
## 变更说明

- 将已加载内容、分页占位与分页控制拆为独立 sliver，加载期间预留完整一页稳定占位，最终页自动移除
- 分页请求在鉴权和初始化前同步声明 loading，并增加 revision-aware single-flight，避免滚动与内容不足回调同帧重复请求
- 可见缩略图优先于 lookahead，请求队列保持有界并在滚动窗口变化、来源或查询切换时取消过期任务
- 图片缓存准备采用有界重试，失败后交回真实图片组件展示正常错误状态，避免持续轮询坏 URL
- 移除滚动空闲阶段的 sample 扇出预取，并对代理路由日志去重，降低快速滚动时的网络和日志压力
- 修复卡片销毁时通过失效 BuildContext 读取 MediaQuery 的生命周期异常

## 验证

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1 ...`：253 tests passed
- 相关源码与测试 `dart analyze`：No issues found
- `git diff --check`
- 两轮独立只读审查覆盖滚动渲染、生命周期、分页竞态和预取队列
