### PR TITLE
fix(gallery): 隔离后台网络活动与图像生成

### DIFF
--- a/lib/core/cache/cancellable_gallery_image_loader.dart
+++ b/lib/core/cache/cancellable_gallery_image_loader.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+import 'gallery_image_request.dart';
+import 'online_gallery_image_cache_manager.dart';
+import 'online_gallery_prefetch_coordinator.dart';
+
+/// Downloads gallery images with request-scoped transport cancellation.
+///
+/// flutter_cache_manager keeps downloads alive after its last stream listener
+/// detaches. This loader aborts the underlying HttpClientRequest instead, then
+/// publishes only complete responses into the existing shared disk cache.
+class CancellableGalleryImageLoader {
+  CancellableGalleryImageLoader({
+    BaseCacheManager? cacheManager,
+    HttpClient? httpClient,
+  }) : _cacheManager = cacheManager ?? OnlineGalleryImageCacheManager.instance,
+       _httpClient = httpClient ?? HttpClient() {
+    _httpClient.connectionTimeout = const Duration(seconds: 15);
+    _httpClient.maxConnectionsPerHost = 4;
+  }
+
+  final BaseCacheManager _cacheManager;
+  final HttpClient _httpClient;
+  bool _disposed = false;
+
+  GalleryImagePreloadOperation start(GalleryImageRequest request) {
+    if (_disposed) {
+      return GalleryImagePreloadOperation.fromFuture(
+        Future<void>.error(StateError('Gallery image loader is disposed')),
+      );
+    }
+
+    final completer = Completer<void>();
+    HttpClientRequest? httpRequest;
+    var cancelled = false;
+
+    Future<void> run() async {
+      try {
+        final cacheKey = request.canonicalCacheKey;
+        final cached = await _cacheManager.getFileFromCache(cacheKey);
+        if (cached != null && cached.validTill.isAfter(DateTime.now())) return;
+        if (cancelled) throw const _GalleryDownloadCancelled();
+
+        final outgoing = await _httpClient.getUrl(Uri.parse(request.url));
+        httpRequest = outgoing;
+        request.headers.forEach(outgoing.headers.set);
+        if (cancelled) {
+          outgoing.abort();
+          throw const _GalleryDownloadCancelled();
+        }
+
+        final response = await outgoing.close();
+        if (response.statusCode < HttpStatus.ok ||
+            response.statusCode >= HttpStatus.multipleChoices) {
+          throw HttpException(
+            'Gallery image HTTP status ${response.statusCode}',
+          );
+        }
+        final contentType = response.headers.contentType;
+        if (contentType != null && contentType.primaryType != 'image') {
+          throw const HttpException('Gallery response is not an image');
+        }
+
+        final bytes = BytesBuilder(copy: false);
+        await for (final chunk in response) {
+          if (cancelled) throw const _GalleryDownloadCancelled();
+          bytes.add(chunk);
+        }
+        if (cancelled) throw const _GalleryDownloadCancelled();
+
+        await _cacheManager.putFile(
+          request.url,
+          bytes.takeBytes(),
+          key: cacheKey,
+          eTag: response.headers.value(HttpHeaders.etagHeader),
+          maxAge: const Duration(days: 7),
+          fileExtension: _fileExtension(response, request.url),
+        );
+      } catch (error, stackTrace) {
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+        return;
+      }
+      if (!completer.isCompleted) completer.complete();
+    }
+
+    unawaited(run());
+    return GalleryImagePreloadOperation(
+      future: completer.future,
+      cancel: () {
+        if (cancelled) return;
+        cancelled = true;
+        httpRequest?.abort(const _GalleryDownloadCancelled());
+        if (!completer.isCompleted) {
+          completer.completeError(const _GalleryDownloadCancelled());
+        }
+      },
+    );
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _httpClient.close(force: true);
+  }
+
+  static String _fileExtension(HttpClientResponse response, String url) {
+    final mime = response.headers.contentType?.mimeType.toLowerCase();
+    final mimeExtension = switch (mime) {
+      'image/jpeg' => 'jpg',
+      'image/png' => 'png',
+      'image/gif' => 'gif',
+      'image/webp' => 'webp',
+      'image/avif' => 'avif',
+      _ => null,
+    };
+    if (mimeExtension != null) return mimeExtension;
+    final path = Uri.tryParse(url)?.path ?? '';
+    final separator = path.lastIndexOf('.');
+    if (separator < 0 || separator == path.length - 1) return 'file';
+    return path.substring(separator + 1).toLowerCase();
+  }
+}
+
+class _GalleryDownloadCancelled implements Exception {
+  const _GalleryDownloadCancelled();
+
+  @override
+  String toString() => 'Gallery image download cancelled';
+}

--- a/lib/core/cache/gallery_image_request.dart
+++ b/lib/core/cache/gallery_image_request.dart
@@ -2,12 +2,13 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
+import '../../data/models/online_gallery/gallery_media_capability.dart';
 import '../../data/models/online_gallery/gallery_source.dart';
 import 'online_gallery_image_cache_manager.dart';
 
 enum GalleryImageTier { thumbnail, sample, original }
 
-enum GalleryImagePriority { interactiveDetail, hover, visible, lookahead }
+enum GalleryImagePriority { interactiveDetail, visible, hover, lookahead }
 
 class GalleryImageSizing {
   const GalleryImageSizing._();
@@ -110,11 +111,16 @@ class GalleryImageRequest {
     required GalleryImageTier tier,
     required int targetDecodeWidth,
   }) {
+    final imageUrl = GalleryMediaCapability.isKnownVideoUrl(url) ? '' : url;
     return GalleryImageRequest(
       sourceId: sourceId ?? _sourceIdForUrl(url),
-      url: url,
-      cacheKey: onlineGalleryImageCacheKeyForUrl(url),
-      headers: onlineGalleryImageHeadersForUrl(url),
+      url: imageUrl,
+      cacheKey: imageUrl.isEmpty
+          ? null
+          : onlineGalleryImageCacheKeyForUrl(imageUrl),
+      headers: imageUrl.isEmpty
+          ? const <String, String>{}
+          : onlineGalleryImageHeadersForUrl(imageUrl),
       tier: tier,
       targetDecodeWidth: targetDecodeWidth,
     );
@@ -125,12 +131,16 @@ class GalleryImageRequest {
     required GalleryImageTier tier,
     int? targetDecodeWidth,
   }) {
-    final isGelbooru = Uri.tryParse(url)?.host.contains('gelbooru') == true;
+    final imageUrl = GalleryMediaCapability.isKnownVideoUrl(url) ? '' : url;
+    final isGelbooru =
+        Uri.tryParse(imageUrl)?.host.contains('gelbooru') == true;
     return GalleryImageRequest(
       sourceId: GallerySourceId.gelbooru.key,
-      url: url,
-      cacheKey: isGelbooru ? onlineGalleryImageCacheKeyForUrl(url) : null,
-      headers: isGelbooru ? onlineGalleryImageHeadersForUrl(url) : const {},
+      url: imageUrl,
+      cacheKey: isGelbooru ? onlineGalleryImageCacheKeyForUrl(imageUrl) : null,
+      headers: isGelbooru
+          ? onlineGalleryImageHeadersForUrl(imageUrl)
+          : const {},
       tier: tier,
       targetDecodeWidth: targetDecodeWidth,
     );
@@ -183,5 +193,7 @@ class GalleryImageRequest {
   int get hashCode => stableRequestKey.hashCode;
 
   @override
-  String toString() => 'GalleryImageRequest($stableRequestKey)';
+  String toString() =>
+      'GalleryImageRequest(source=$sourceKey, tier=${tier.name}, '
+      'targetWidth=${targetDecodeWidth ?? 'auto'})';
 }

--- a/lib/core/cache/online_gallery_detail_coordinator.dart
+++ b/lib/core/cache/online_gallery_detail_coordinator.dart
@@ -5,7 +5,7 @@ import 'package:dio/dio.dart';
 
 import '../../data/models/online_gallery/gallery_item.dart';
 
-enum GalleryDetailPriority { interactive, visible }
+enum GalleryDetailPriority { interactive, visible, lookahead }
 
 typedef GalleryDetailLoader =
     Future<GalleryDetail> Function(GalleryItem item, CancelToken cancelToken);
@@ -31,11 +31,14 @@ class OnlineGalleryDetailCoordinator {
   final Map<String, _DetailTask> _tasks = <String, _DetailTask>{};
   final List<_DetailTask> _interactiveQueue = <_DetailTask>[];
   final List<_DetailTask> _visibleQueue = <_DetailTask>[];
+  final List<_DetailTask> _lookaheadQueue = <_DetailTask>[];
   final Map<String, int> _revisions = <String, int>{};
   int _active = 0;
+  bool _backgroundPaused = false;
 
   int get activeCount => _active;
-  int get queuedCount => _interactiveQueue.length + _visibleQueue.length;
+  int get queuedCount =>
+      _interactiveQueue.length + _visibleQueue.length + _lookaheadQueue.length;
   int get completedCount {
     _pruneExpired();
     return _completed.length;
@@ -46,6 +49,9 @@ class OnlineGalleryDetailCoordinator {
     GalleryDetailPriority priority = GalleryDetailPriority.interactive,
     bool forceRefresh = false,
   }) {
+    if (_backgroundPaused && priority != GalleryDetailPriority.interactive) {
+      return Future<GalleryDetail>.error(_cancelled(item, 'Gallery paused'));
+    }
     final key = item.detailStableKey;
     if (forceRefresh) {
       _completed.remove(key);
@@ -53,13 +59,11 @@ class OnlineGalleryDetailCoordinator {
       if (oldTask != null) {
         _interactiveQueue.remove(oldTask);
         _visibleQueue.remove(oldTask);
+        _lookaheadQueue.remove(oldTask);
         if (!oldTask.started && !oldTask.completer.isCompleted) {
           oldTask.cancelToken.cancel('Superseded by a forced detail refresh');
           oldTask.completer.completeError(
-            DioException.requestCancelled(
-              requestOptions: RequestOptions(path: item.postUrl),
-              reason: 'Superseded by a forced detail refresh',
-            ),
+            _cancelled(item, 'Superseded by a forced detail refresh'),
           );
         } else if (!oldTask.cancelToken.isCancelled) {
           oldTask.cancelToken.cancel('Superseded by a forced detail refresh');
@@ -70,12 +74,10 @@ class OnlineGalleryDetailCoordinator {
       if (cached != null) return Future<GalleryDetail>.value(cached);
       final existing = _tasks[key];
       if (existing != null) {
-        if (!existing.started &&
-            priority == GalleryDetailPriority.interactive &&
-            existing.priority == GalleryDetailPriority.visible) {
-          _visibleQueue.remove(existing);
-          existing.priority = GalleryDetailPriority.interactive;
-          _interactiveQueue.add(existing);
+        if (!existing.started && priority.index < existing.priority.index) {
+          _queueFor(existing.priority).remove(existing);
+          existing.priority = priority;
+          _queueFor(priority).add(existing);
         }
         return existing.completer.future;
       }
@@ -89,10 +91,7 @@ class OnlineGalleryDetailCoordinator {
       priority: priority,
     );
     _tasks[key] = task;
-    (priority == GalleryDetailPriority.interactive
-            ? _interactiveQueue
-            : _visibleQueue)
-        .add(task);
+    _queueFor(priority).add(task);
     _pump();
     return task.completer.future;
   }
@@ -105,17 +104,41 @@ class OnlineGalleryDetailCoordinator {
     _cancelVisibleTasks(includeActive: true);
   }
 
+  void cancelLookahead() {
+    _cancelTasks(
+      (task) => task.priority == GalleryDetailPriority.lookahead,
+      includeActive: true,
+    );
+  }
+
+  void setBackgroundPaused(bool paused) {
+    if (_backgroundPaused == paused) return;
+    _backgroundPaused = paused;
+    if (paused) {
+      _cancelVisibleTasks(includeActive: true);
+    } else {
+      _pump();
+    }
+  }
+
   void _cancelVisibleTasks({required bool includeActive}) {
+    _cancelTasks(
+      (task) => task.priority != GalleryDetailPriority.interactive,
+      includeActive: includeActive,
+    );
+  }
+
+  void _cancelTasks(
+    bool Function(_DetailTask task) predicate, {
+    required bool includeActive,
+  }) {
     final tasks = _tasks.values
-        .where(
-          (task) =>
-              task.priority == GalleryDetailPriority.visible &&
-              (includeActive || !task.started),
-        )
+        .where((task) => predicate(task) && (includeActive || !task.started))
         .toList(growable: false);
     for (final task in tasks) {
       _interactiveQueue.remove(task);
       _visibleQueue.remove(task);
+      _lookaheadQueue.remove(task);
       if (_tasks[task.item.detailStableKey] == task) {
         _tasks.remove(task.item.detailStableKey);
       }
@@ -123,12 +146,7 @@ class OnlineGalleryDetailCoordinator {
         task.cancelToken.cancel('Gallery scope changed');
       }
       if (!task.completer.isCompleted) {
-        task.completer.completeError(
-          DioException.requestCancelled(
-            requestOptions: RequestOptions(path: task.item.postUrl),
-            reason: 'Gallery scope changed',
-          ),
-        );
+        task.completer.completeError(_cancelled(task.item, 'Gallery paused'));
       }
     }
     _pump();
@@ -141,14 +159,10 @@ class OnlineGalleryDetailCoordinator {
     _revisions[key] = (_revisions[key] ?? task.revision) + 1;
     _interactiveQueue.remove(task);
     _visibleQueue.remove(task);
+    _lookaheadQueue.remove(task);
     if (!task.cancelToken.isCancelled) task.cancelToken.cancel(reason);
     if (!task.completer.isCompleted) {
-      task.completer.completeError(
-        DioException.requestCancelled(
-          requestOptions: RequestOptions(path: item.postUrl),
-          reason: reason,
-        ),
-      );
+      task.completer.completeError(_cancelled(item, reason));
     }
     _pump();
   }
@@ -157,17 +171,13 @@ class OnlineGalleryDetailCoordinator {
     for (final task in _tasks.values) {
       if (!task.cancelToken.isCancelled) task.cancelToken.cancel('Disposed');
       if (!task.completer.isCompleted) {
-        task.completer.completeError(
-          DioException.requestCancelled(
-            requestOptions: RequestOptions(path: task.item.postUrl),
-            reason: 'Disposed',
-          ),
-        );
+        task.completer.completeError(_cancelled(task.item, 'Disposed'));
       }
     }
     _tasks.clear();
     _interactiveQueue.clear();
     _visibleQueue.clear();
+    _lookaheadQueue.clear();
     _completed.clear();
   }
 
@@ -207,6 +217,8 @@ class OnlineGalleryDetailCoordinator {
           ? _interactiveQueue.removeAt(0)
           : _visibleQueue.isNotEmpty
           ? _visibleQueue.removeAt(0)
+          : !_backgroundPaused && _lookaheadQueue.isNotEmpty
+          ? _lookaheadQueue.removeAt(0)
           : null;
       if (task == null) return;
       if (_tasks[task.item.detailStableKey] != task ||
@@ -240,6 +252,21 @@ class OnlineGalleryDetailCoordinator {
       _pump();
     }
   }
+
+  List<_DetailTask> _queueFor(GalleryDetailPriority priority) =>
+      switch (priority) {
+        GalleryDetailPriority.interactive => _interactiveQueue,
+        GalleryDetailPriority.visible => _visibleQueue,
+        GalleryDetailPriority.lookahead => _lookaheadQueue,
+      };
+
+  DioException _cancelled(GalleryItem item, String reason) =>
+      DioException.requestCancelled(
+        requestOptions: RequestOptions(
+          path: '/gallery-detail/${item.sourceId.key}/${item.id}',
+        ),
+        reason: reason,
+      );
 }
 
 class _DetailTask {

--- a/lib/core/cache/online_gallery_prefetch_coordinator.dart
+++ b/lib/core/cache/online_gallery_prefetch_coordinator.dart
@@ -1,45 +1,83 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:flutter/foundation.dart';
+
+import '../utils/app_logger.dart';
 import 'gallery_image_request.dart';
 
 typedef GalleryImagePreloader =
-    Future<void> Function(GalleryImageRequest request);
+    GalleryImagePreloadOperation Function(GalleryImageRequest request);
 
-class OnlineGalleryPrefetchCoordinator {
+class GalleryImagePreloadOperation {
+  GalleryImagePreloadOperation({
+    required this.future,
+    required void Function() cancel,
+  }) : _cancel = cancel;
+
+  factory GalleryImagePreloadOperation.fromFuture(Future<void> future) =>
+      GalleryImagePreloadOperation(future: future, cancel: () {});
+
+  final Future<void> future;
+  final void Function() _cancel;
+  bool _cancelled = false;
+
+  bool get isCancelled => _cancelled;
+
+  void cancel() {
+    if (_cancelled) return;
+    _cancelled = true;
+    _cancel();
+  }
+}
+
+enum GalleryPrefetchPauseReason {
+  scrolling,
+  pageHidden,
+  appBackground,
+  criticalNetworkActivity,
+}
+
+class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
   OnlineGalleryPrefetchCoordinator({
     required GalleryImagePreloader preloader,
     this.maxConcurrent = 4,
     this.maxQueued = 64,
     DateTime Function()? now,
-  }) : _preloader = preloader,
+  }) : assert(maxConcurrent > 0),
+       _preloader = preloader,
        _now = now ?? DateTime.now;
 
   final GalleryImagePreloader _preloader;
   final int maxConcurrent;
   final int maxQueued;
   final DateTime Function() _now;
-
-  final ListQueue<_PrefetchTask> _interactive = ListQueue<_PrefetchTask>();
-  final ListQueue<_PrefetchTask> _hover = ListQueue<_PrefetchTask>();
-  final ListQueue<_PrefetchTask> _visible = ListQueue<_PrefetchTask>();
-  final ListQueue<_PrefetchTask> _lookahead = ListQueue<_PrefetchTask>();
-  final Map<String, _PrefetchTask> _pending = <String, _PrefetchTask>{};
-  final Map<String, _PrefetchTask> _inFlight = <String, _PrefetchTask>{};
-  final LinkedHashMap<String, DateTime> _completedSamples =
-      LinkedHashMap<String, DateTime>();
-  final LinkedHashMap<String, DateTime> _failures =
-      LinkedHashMap<String, DateTime>();
+  final Map<GalleryImagePriority, ListQueue<_PrefetchTask>> _queues = {
+    for (final priority in GalleryImagePriority.values)
+      priority: ListQueue<_PrefetchTask>(),
+  };
+  final Map<String, _PrefetchTask> _pending = {};
+  final Map<String, _PrefetchTask> _inFlight = {};
+  final LinkedHashMap<String, DateTime> _completedSamples = LinkedHashMap();
+  final LinkedHashMap<String, DateTime> _failures = LinkedHashMap();
+  final Set<GalleryPrefetchPauseReason> _pauseReasons = {};
 
   int _generation = 0;
   int _active = 0;
-  bool _lowPriorityPaused = false;
+  int _interactiveStreak = 0;
+  bool _disposed = false;
+  int debugRequestCount = 0;
+  int debugDeduplicatedCount = 0;
+  int debugCancelledCount = 0;
+  int debugNegativeCacheHitCount = 0;
 
   int get generation => _generation;
   int get activeCount => _active;
   int get queueDepth => _pending.length;
-  int debugRequestCount = 0;
-  int debugDeduplicatedCount = 0;
+  bool get isPaused => _pauseReasons.isNotEmpty;
+  bool get isDisposed => _disposed;
+  Set<GalleryPrefetchPauseReason> get pauseReasons =>
+      Set.unmodifiable(_pauseReasons);
 
   bool isSampleReady(GalleryImageRequest request) =>
       _completedSamples.containsKey(request.stableRequestKey);
@@ -55,21 +93,39 @@ class OnlineGalleryPrefetchCoordinator {
   }
 
   void rotateGeneration() {
+    if (_disposed) return;
     _generation++;
-    for (final task in _pending.values) {
-      _completeCancelled(task);
-    }
-    _pending.clear();
-    _interactive.clear();
-    _hover.clear();
-    _visible.clear();
-    _lookahead.clear();
+    _cancelWhere((_) => true, reason: 'generation-rotated');
+    notifyListeners();
   }
 
-  void setScrolling(bool scrolling) {
-    _lowPriorityPaused = scrolling;
-    if (!scrolling) _pump();
-  }
+  void setScrolling(bool scrolling) => _setPause(
+    GalleryPrefetchPauseReason.scrolling,
+    scrolling,
+    cancelPriorities: const {GalleryImagePriority.lookahead},
+  );
+
+  void setPageVisible(bool visible) => _setPause(
+    GalleryPrefetchPauseReason.pageHidden,
+    !visible,
+    cancelPriorities: GalleryImagePriority.values.toSet(),
+  );
+
+  void setAppForeground(bool foreground) => _setPause(
+    GalleryPrefetchPauseReason.appBackground,
+    !foreground,
+    cancelPriorities: GalleryImagePriority.values.toSet(),
+  );
+
+  void setCriticalNetworkActive(bool active) => _setPause(
+    GalleryPrefetchPauseReason.criticalNetworkActivity,
+    active,
+    cancelPriorities: const {
+      GalleryImagePriority.visible,
+      GalleryImagePriority.hover,
+      GalleryImagePriority.lookahead,
+    },
+  );
 
   /// Cancels queued work for a card that left the active viewport window.
   /// Downloads already handed to the image pipeline are allowed to finish so
@@ -104,36 +160,25 @@ class OnlineGalleryPrefetchCoordinator {
     required GalleryImagePriority priority,
     bool retry = false,
   }) {
+    if (_disposed || !_accepts(priority)) return Future.value(false);
     if (retry) _failures.remove(request.stableRequestKey);
     if (!retry && isNegativelyCached(request)) {
-      return Future<bool>.value(false);
+      debugNegativeCacheHitCount++;
+      return Future.value(false);
     }
     if (request.tier == GalleryImageTier.sample && isSampleReady(request)) {
-      return Future<bool>.value(true);
+      return Future.value(true);
     }
     final key = request.stableRequestKey;
-    final existing = _pending[key];
-    if (existing != null) {
+    final existing = _pending[key] ?? _inFlight[key];
+    if (existing != null && !existing.cancelled) {
       debugDeduplicatedCount++;
-      if (priority.index < existing.priority.index) {
-        _removeFromQueue(existing);
+      if (_pending[key] != null && priority.index < existing.priority.index) {
+        _queues[existing.priority]!.remove(existing);
         existing.priority = priority;
-        _queueFor(priority).add(existing);
+        _queues[priority]!.add(existing);
       }
       return existing.completer.future;
-    }
-    final active = _inFlight[key];
-    if (active != null) {
-      debugDeduplicatedCount++;
-      if (active.generation == _generation) return active.completer.future;
-      final submittedGeneration = _generation;
-      return active.downloadCompleter.future.then((downloaded) {
-        if (!downloaded || submittedGeneration != _generation) return false;
-        if (request.tier == GalleryImageTier.sample) {
-          _rememberCompletedSample(key);
-        }
-        return true;
-      });
     }
 
     if (_pending.length >= maxQueued && !_makeRoomFor(priority)) {
@@ -146,25 +191,83 @@ class OnlineGalleryPrefetchCoordinator {
       generation: _generation,
     );
     _pending[key] = task;
-    _queueFor(priority).add(task);
+    _queues[priority]!.add(task);
     _pump();
     return task.completer.future;
   }
 
-  void dispose() {
-    rotateGeneration();
-    _completedSamples.clear();
-    _failures.clear();
+  void cancel(
+    GalleryImageRequest request, {
+    GalleryImagePriority? priority,
+    String reason = 'request-cancelled',
+  }) {
+    if (_disposed) return;
+    final key = request.stableRequestKey;
+    _cancelWhere(
+      (task) =>
+          task.request.stableRequestKey == key &&
+          (priority == null || task.priority == priority),
+      reason: reason,
+    );
   }
 
-  ListQueue<_PrefetchTask> _queueFor(GalleryImagePriority priority) {
-    return switch (priority) {
-      GalleryImagePriority.interactiveDetail => _interactive,
-      GalleryImagePriority.hover => _hover,
-      GalleryImagePriority.visible => _visible,
-      GalleryImagePriority.lookahead => _lookahead,
-    };
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _cancelWhere((_) => true, reason: 'disposed');
+    _completedSamples.clear();
+    _failures.clear();
+    super.dispose();
   }
+
+  void _setPause(
+    GalleryPrefetchPauseReason reason,
+    bool paused, {
+    required Set<GalleryImagePriority> cancelPriorities,
+  }) {
+    if (_disposed) return;
+    final changed = paused
+        ? _pauseReasons.add(reason)
+        : _pauseReasons.remove(reason);
+    if (!changed) return;
+    if (paused) {
+      _cancelWhere(
+        (task) => cancelPriorities.contains(task.priority),
+        reason: reason.name,
+      );
+    } else {
+      _pump();
+    }
+    notifyListeners();
+    AppLogger.d(
+      'Gallery prefetch ${paused ? 'paused' : 'resumed'}: '
+          'reason=${reason.name}, queue=$queueDepth, active=$activeCount, '
+          'reasons=${_pauseReasons.map((value) => value.name).join(',')}',
+      'GalleryPrefetch',
+    );
+  }
+
+  bool _accepts(GalleryImagePriority priority) {
+    if (_pauseReasons.contains(GalleryPrefetchPauseReason.pageHidden) ||
+        _pauseReasons.contains(GalleryPrefetchPauseReason.appBackground)) {
+      return false;
+    }
+    if (_pauseReasons.contains(
+          GalleryPrefetchPauseReason.criticalNetworkActivity,
+        ) &&
+        priority != GalleryImagePriority.interactiveDetail) {
+      return false;
+    }
+    if (_pauseReasons.contains(GalleryPrefetchPauseReason.scrolling) &&
+        priority == GalleryImagePriority.lookahead) {
+      return false;
+    }
+    return true;
+  }
+
+  ListQueue<_PrefetchTask> _queueFor(GalleryImagePriority priority) =>
+      _queues[priority]!;
 
   void _removeFromQueue(_PrefetchTask task) {
     _queueFor(task.priority).remove(task);
@@ -184,28 +287,39 @@ class OnlineGalleryPrefetchCoordinator {
   }
 
   void _completeCancelled(_PrefetchTask task) {
-    if (!task.downloadCompleter.isCompleted) {
-      task.downloadCompleter.complete(false);
-    }
     if (!task.completer.isCompleted) task.completer.complete(false);
   }
 
   _PrefetchTask? _takeNext() {
-    if (_interactive.isNotEmpty) return _interactive.removeFirst();
-    if (_hover.isNotEmpty) return _hover.removeFirst();
-    if (_visible.isNotEmpty) return _visible.removeFirst();
-    if (_lowPriorityPaused) return null;
-    if (_lookahead.isNotEmpty) return _lookahead.removeFirst();
+    final interactive = _queues[GalleryImagePriority.interactiveDetail]!;
+    final visible = _queues[GalleryImagePriority.visible]!;
+    if (interactive.isNotEmpty && (_interactiveStreak < 3 || visible.isEmpty)) {
+      _interactiveStreak++;
+      return interactive.removeFirst();
+    }
+    if (visible.isNotEmpty) {
+      _interactiveStreak = 0;
+      return visible.removeFirst();
+    }
+    for (final priority in const [
+      GalleryImagePriority.hover,
+      GalleryImagePriority.lookahead,
+    ]) {
+      if (!_accepts(priority)) continue;
+      final queue = _queues[priority]!;
+      if (queue.isNotEmpty) return queue.removeFirst();
+    }
     return null;
   }
 
   void _pump() {
+    if (_disposed) return;
     while (_active < maxConcurrent) {
       final task = _takeNext();
       if (task == null) return;
       final key = task.request.stableRequestKey;
       if (_pending.remove(key) != task || task.generation != _generation) {
-        if (!task.completer.isCompleted) task.completer.complete(false);
+        _completeCancelled(task);
         continue;
       }
       _active++;
@@ -218,34 +332,69 @@ class OnlineGalleryPrefetchCoordinator {
   Future<void> _run(_PrefetchTask task) async {
     final key = task.request.stableRequestKey;
     try {
-      await _preloader(task.request);
-      if (!task.downloadCompleter.isCompleted) {
-        task.downloadCompleter.complete(true);
-      }
-      if (task.generation != _generation) {
-        if (!task.completer.isCompleted) task.completer.complete(false);
+      final operation = _preloader(task.request);
+      task.operation = operation;
+      if (task.cancelled) operation.cancel();
+      await operation.future;
+      if (task.cancelled ||
+          task.generation != _generation ||
+          operation.isCancelled) {
+        _completeCancelled(task);
         return;
       }
       if (task.request.tier == GalleryImageTier.sample) {
         _rememberCompletedSample(key);
       }
       if (!task.completer.isCompleted) task.completer.complete(true);
-    } catch (_) {
-      if (task.generation == _generation) {
+    } catch (error) {
+      if (!task.cancelled && task.generation == _generation) {
         _failures.remove(key);
         _failures[key] = _now();
         while (_failures.length > 500) {
           _failures.remove(_failures.keys.first);
         }
-      }
-      if (!task.downloadCompleter.isCompleted) {
-        task.downloadCompleter.complete(false);
+        AppLogger.d(
+          'Gallery prefetch failed: source=${task.request.sourceKey}, '
+              'tier=${task.request.tier.name}, '
+              'errorType=${error.runtimeType}',
+          'GalleryPrefetch',
+        );
       }
       if (!task.completer.isCompleted) task.completer.complete(false);
     } finally {
-      _inFlight.remove(key);
+      if (_inFlight[key] == task) _inFlight.remove(key);
       _active--;
       _pump();
+    }
+  }
+
+  void _cancelWhere(
+    bool Function(_PrefetchTask task) predicate, {
+    required String reason,
+  }) {
+    var cancelled = 0;
+    for (final task in _pending.values.toList()) {
+      if (!predicate(task)) continue;
+      _pending.remove(task.request.stableRequestKey);
+      _queues[task.priority]!.remove(task);
+      task.cancelled = true;
+      _completeCancelled(task);
+      cancelled++;
+    }
+    for (final task in _inFlight.values.toList()) {
+      if (!predicate(task) || task.cancelled) continue;
+      task.cancelled = true;
+      task.operation?.cancel();
+      _completeCancelled(task);
+      cancelled++;
+    }
+    if (cancelled > 0) {
+      debugCancelledCount += cancelled;
+      AppLogger.d(
+        'Gallery prefetch cancelled: reason=$reason, count=$cancelled, '
+            'queue=$queueDepth, active=$activeCount',
+        'GalleryPrefetch',
+      );
     }
   }
 
@@ -269,5 +418,6 @@ class _PrefetchTask {
   GalleryImagePriority priority;
   final int generation;
   final Completer<bool> completer = Completer<bool>();
-  final Completer<bool> downloadCompleter = Completer<bool>();
+  GalleryImagePreloadOperation? operation;
+  bool cancelled = false;
 }

--- a/lib/core/network/critical_network_activity.dart
+++ b/lib/core/network/critical_network_activity.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/foundation.dart';
+
+import '../utils/app_logger.dart';
+
+enum CriticalNetworkActivityType {
+  imageGeneration,
+  vibeEncoding,
+  directorTool,
+  cloudUpscale,
+}
+
+/// Process-local authority for latency-sensitive, potentially billed network
+/// work. Leases are acquired at the API boundary so early returns before a
+/// request do not create false activity and every transport exit releases it.
+class CriticalNetworkActivityCoordinator extends ChangeNotifier {
+  CriticalNetworkActivityCoordinator();
+
+  static final instance = CriticalNetworkActivityCoordinator();
+
+  final Map<CriticalNetworkActivityType, int> _counts = {};
+  int _activeLeaseCount = 0;
+
+  bool get isActive => _activeLeaseCount > 0;
+  int get activeLeaseCount => _activeLeaseCount;
+  Set<CriticalNetworkActivityType> get activeTypes => Set.unmodifiable(
+    _counts.entries.where((entry) => entry.value > 0).map((entry) => entry.key),
+  );
+
+  CriticalNetworkActivityLease acquire(CriticalNetworkActivityType type) {
+    final wasActive = isActive;
+    _activeLeaseCount++;
+    _counts[type] = (_counts[type] ?? 0) + 1;
+    if (!wasActive) notifyListeners();
+    AppLogger.d(
+      'Critical network activity begin: type=${type.name}, '
+          'active=$_activeLeaseCount',
+      'NetworkQoS',
+    );
+    return CriticalNetworkActivityLease._(this, type, DateTime.now());
+  }
+
+  void _release(CriticalNetworkActivityType type, DateTime startedAt) {
+    final count = _counts[type] ?? 0;
+    if (count <= 0 || _activeLeaseCount <= 0) {
+      throw StateError('Unbalanced critical network activity lease: $type');
+    }
+    if (count == 1) {
+      _counts.remove(type);
+    } else {
+      _counts[type] = count - 1;
+    }
+    _activeLeaseCount--;
+    AppLogger.d(
+      'Critical network activity end: type=${type.name}, '
+          'active=$_activeLeaseCount, elapsedMs='
+          '${DateTime.now().difference(startedAt).inMilliseconds}',
+      'NetworkQoS',
+    );
+    if (!isActive) notifyListeners();
+  }
+}
+
+class CriticalNetworkActivityLease {
+  CriticalNetworkActivityLease._(this._owner, this.type, this._startedAt);
+
+  final CriticalNetworkActivityCoordinator _owner;
+  final CriticalNetworkActivityType type;
+  final DateTime _startedAt;
+  bool _released = false;
+
+  void release() {
+    if (_released) return;
+    _released = true;
+    _owner._release(type, _startedAt);
+  }
+}

--- a/lib/data/datasources/remote/nai_image_enhancement_api_service.dart
+++ b/lib/data/datasources/remote/nai_image_enhancement_api_service.dart
@@ -8,6 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/constants/api_constants.dart';
 import '../../../core/network/dio_client.dart';
+import '../../../core/network/critical_network_activity.dart';
 import '../../../core/network/nai_api_endpoint_service.dart';
 import '../../../core/utils/app_logger.dart';
 import '../../../core/utils/zip_utils.dart';
@@ -18,11 +19,15 @@ part 'nai_image_enhancement_api_service.g.dart';
 class NAIImageEnhancementApiService {
   final Dio _dio;
   final NaiApiEndpointService _endpointService;
+  final CriticalNetworkActivityCoordinator _networkActivity;
 
   NAIImageEnhancementApiService(
     this._dio, [
     NaiApiEndpointService? endpointService,
-  ]) : _endpointService = endpointService ?? NaiApiEndpointService();
+    CriticalNetworkActivityCoordinator? networkActivity,
+  ]) : _endpointService = endpointService ?? NaiApiEndpointService(),
+       _networkActivity =
+           networkActivity ?? CriticalNetworkActivityCoordinator.instance;
 
   // ==================== 图像增强类型常量 ====================
   static const String _reqTypeEmotion = 'emotion';
@@ -54,6 +59,9 @@ class NAIImageEnhancementApiService {
     int scale = 2,
     void Function(int, int)? onProgress,
   }) async {
+    final activity = _networkActivity.acquire(
+      CriticalNetworkActivityType.cloudUpscale,
+    );
     try {
       final request = jsonEncode({
         'image': 'image',
@@ -96,6 +104,8 @@ class NAIImageEnhancementApiService {
         'NAIEnhancement',
       );
       return _upscaleImageLegacy(image, scale: scale, onProgress: onProgress);
+    } finally {
+      activity.release();
     }
   }
 
@@ -144,6 +154,9 @@ class NAIImageEnhancementApiService {
     required String model,
     double informationExtracted = 1.0,
   }) async {
+    final activity = _networkActivity.acquire(
+      CriticalNetworkActivityType.vibeEncoding,
+    );
     try {
       final response = await _dio.post(
         _endpointService.imageUrl(ApiConstants.encodeVibeEndpoint),
@@ -159,6 +172,8 @@ class NAIImageEnhancementApiService {
     } on DioException catch (e) {
       AppLogger.w('Encode vibe failed: ${e.message}', 'NAIEnhancement');
       throw Exception('Vibe编码失败: ${_mapDioError(e)}');
+    } finally {
+      activity.release();
     }
   }
 
@@ -169,6 +184,9 @@ class NAIImageEnhancementApiService {
     String? prompt,
     int defry = 0,
   }) async {
+    final activity = _networkActivity.acquire(
+      CriticalNetworkActivityType.directorTool,
+    );
     try {
       final decoded = img.decodeImage(image);
       if (decoded == null) {
@@ -202,6 +220,8 @@ class NAIImageEnhancementApiService {
     } on DioException catch (e) {
       AppLogger.w('Augment image failed: ${e.message}', 'NAIEnhancement');
       throw Exception('图像增强失败: ${_mapDioError(e)}');
+    } finally {
+      activity.release();
     }
   }
 

--- a/lib/data/datasources/remote/nai_image_generation_api_service.dart
+++ b/lib/data/datasources/remote/nai_image_generation_api_service.dart
@@ -10,6 +10,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/constants/api_constants.dart';
 import '../../../core/models/image_generation_artifact.dart';
 import '../../../core/network/dio_client.dart';
+import '../../../core/network/critical_network_activity.dart';
 import '../../../core/network/nai_api_endpoint_service.dart';
 import '../../../core/network/request_builders/nai_image_request_builder.dart';
 import '../../../core/utils/app_logger.dart';
@@ -29,15 +30,19 @@ class NAIImageGenerationApiService {
   NAIImageGenerationApiService(
     Dio dio,
     this._enhancementService,
-    NaiApiEndpointService endpointService,
-  ) : _transport = NaiGenerationTransport(dio, endpointService),
-      _responseProcessor = NaiGenerationResponseProcessor();
+    NaiApiEndpointService endpointService, [
+    CriticalNetworkActivityCoordinator? networkActivity,
+  ]) : _transport = NaiGenerationTransport(dio, endpointService),
+       _responseProcessor = NaiGenerationResponseProcessor(),
+       _networkActivity =
+           networkActivity ?? CriticalNetworkActivityCoordinator.instance;
 
   static final Object _cancellationLeaseZoneKey = Object();
 
   final NAIImageEnhancementApiService _enhancementService;
   final NaiGenerationTransport _transport;
   final NaiGenerationResponseProcessor _responseProcessor;
+  final CriticalNetworkActivityCoordinator _networkActivity;
   var _legacyCancellationEpoch = 0;
 
   static T withCancellationLease<T>(
@@ -170,6 +175,9 @@ class NAIImageGenerationApiService {
     Rect? focusedSelectionRect,
     NaiGenerationCancellationLease? cancellationLease,
   }) async {
+    final activity = _networkActivity.acquire(
+      CriticalNetworkActivityType.imageGeneration,
+    );
     final request = _transport.beginRequest(
       _effectiveCancellationLease(cancellationLease),
     );
@@ -193,6 +201,7 @@ class NAIImageGenerationApiService {
       return (artifacts, command.buildResult.vibeEncodingMap);
     } finally {
       _transport.completeRequest(request);
+      activity.release();
     }
   }
 
@@ -247,6 +256,9 @@ class NAIImageGenerationApiService {
   }) async* {
     // async* does not execute until listen, so an abandoned stream owns no
     // transport request. Leases and the legacy epoch retain pre-listen cancel.
+    final activity = _networkActivity.acquire(
+      CriticalNetworkActivityType.imageGeneration,
+    );
     final request = _transport.beginRequest(cancellationLease);
     try {
       if (legacyCancellationEpoch != null &&
@@ -287,6 +299,7 @@ class NAIImageGenerationApiService {
       yield ImageStreamChunk.error(error.toString());
     } finally {
       _transport.completeRequest(request);
+      activity.release();
     }
   }
 

--- a/lib/data/datasources/remote/nai_user_info_api_service.dart
+++ b/lib/data/datasources/remote/nai_user_info_api_service.dart
@@ -22,6 +22,7 @@ class NAIUserInfoApiService {
   Future<Map<String, dynamic>> getUserSubscription({
     Duration? receiveTimeout,
     Duration? sendTimeout,
+    CancelToken? cancelToken,
   }) async {
     try {
       final response = await _dio.get(
@@ -30,6 +31,7 @@ class NAIUserInfoApiService {
           receiveTimeout: receiveTimeout ?? _timeout,
           sendTimeout: sendTimeout ?? _timeout,
         ),
+        cancelToken: cancelToken,
       );
 
       return response.data as Map<String, dynamic>;

--- a/lib/data/datasources/remote/online_gallery/quick_tag_cloud_gallery_mapper.dart
+++ b/lib/data/datasources/remote/online_gallery/quick_tag_cloud_gallery_mapper.dart
@@ -174,6 +174,7 @@ class QuickTagCloudGalleryMapper {
       width: dimensions.width,
       height: dimensions.height,
       extension: extension.isEmpty ? null : extension,
+      mediaType: 'image',
       rawMetadata: image.rawTag.isEmpty ? record.entry.rawTag : image.rawTag,
       prompt: record.entry.tags,
       negativePrompt: record.entry.negative,

--- a/lib/data/models/online_gallery/gallery_item.dart
+++ b/lib/data/models/online_gallery/gallery_item.dart
@@ -1,4 +1,5 @@
 import 'artist_chain.dart';
+import 'gallery_media_capability.dart';
 import 'gallery_source.dart';
 
 class GalleryMedia {
@@ -12,7 +13,7 @@ class GalleryMedia {
     this.extension,
     this.mimeType,
     this.rawMetadata,
-    this.mediaType = 'image',
+    this.mediaType = 'unknown',
     this.prompt,
     this.negativePrompt,
     this.metadataFormat,
@@ -39,6 +40,15 @@ class GalleryMedia {
   bool get hasKnownDimensions => width > 0 && height > 0;
   double get aspectRatio => hasKnownDimensions ? width / height : 1;
 
+  GalleryMediaCapability get capability => GalleryMediaCapability.resolve(
+    declaredType: mediaType,
+    extension: extension,
+    mimeType: mimeType,
+    previewUrl: previewUrl,
+    displayUrl: displayUrl,
+    downloadUrl: downloadUrl,
+  );
+
   GalleryMedia copyWith({
     String? id,
     String? previewUrl,
@@ -49,6 +59,7 @@ class GalleryMedia {
     String? extension,
     String? mimeType,
     String? rawMetadata,
+    String? mediaType,
   }) {
     return GalleryMedia(
       id: id ?? this.id,
@@ -60,7 +71,7 @@ class GalleryMedia {
       extension: extension ?? this.extension,
       mimeType: mimeType ?? this.mimeType,
       rawMetadata: rawMetadata ?? this.rawMetadata,
-      mediaType: mediaType,
+      mediaType: mediaType ?? this.mediaType,
       prompt: prompt,
       negativePrompt: negativePrompt,
       metadataFormat: metadataFormat,
@@ -228,20 +239,16 @@ class GalleryItem {
   List<String> get metaTags => _splitTags(tagStringMeta);
   String get downloadUrl => cover.downloadUrl;
 
-  bool get isVideo {
-    final extension = fileExt?.toLowerCase();
-    return extension == 'webm' || extension == 'mp4';
-  }
-
-  bool get isAnimated => fileExt?.toLowerCase() == 'gif';
+  GalleryMediaCapability get mediaCapability => cover.capability;
+  bool get isVideo => mediaCapability.isVideo;
+  bool get isAnimated => mediaCapability.isAnimatedImage;
 
   bool get hasValidPreview => previewUrl.isNotEmpty;
   bool get hasFile => downloadUrl.isNotEmpty;
   bool get hasLarge => (largeFileUrl ?? '').isNotEmpty;
   String? get mediaTypeLabel {
-    final extension = fileExt?.toLowerCase();
-    if (extension == 'webm' || extension == 'mp4') return 'Video';
-    if (extension == 'gif') return 'GIF';
+    if (mediaCapability.isVideo) return 'Video';
+    if (mediaCapability.isAnimatedImage) return 'GIF';
     return null;
   }
 

--- a/lib/data/models/online_gallery/gallery_media_capability.dart
+++ b/lib/data/models/online_gallery/gallery_media_capability.dart
@@ -1,0 +1,166 @@
+enum GalleryMediaKind { staticImage, animatedImage, video, unknown }
+
+/// Canonical media decision used before anything is handed to Flutter's image
+/// codecs. A video signal always wins a conflicting image signal because the
+/// safe failure mode is a stable placeholder, not decoding video bytes.
+class GalleryMediaCapability {
+  const GalleryMediaCapability({
+    required this.kind,
+    required this.previewKind,
+    required this.previewUrl,
+    required this.displayUrl,
+    required this.downloadUrl,
+  });
+
+  final GalleryMediaKind kind;
+  final GalleryMediaKind previewKind;
+  final String previewUrl;
+  final String displayUrl;
+  final String downloadUrl;
+
+  bool get isVideo => kind == GalleryMediaKind.video;
+  bool get isAnimatedImage => kind == GalleryMediaKind.animatedImage;
+  bool get isFlutterImage =>
+      kind == GalleryMediaKind.staticImage ||
+      kind == GalleryMediaKind.animatedImage;
+  bool get hasStaticThumbnail =>
+      previewUrl.isNotEmpty && previewKind == GalleryMediaKind.staticImage;
+  bool get canPrefetchPreview =>
+      previewUrl.isNotEmpty &&
+      (previewKind == GalleryMediaKind.staticImage ||
+          previewKind == GalleryMediaKind.animatedImage);
+
+  static bool isKnownVideoUrl(String url) =>
+      _kindForUrl(url) == GalleryMediaKind.video;
+
+  String get imageDisplayUrl {
+    if (isFlutterImage && displayUrl.isNotEmpty) {
+      final displayKind = _kindForUrl(displayUrl);
+      if (displayKind != GalleryMediaKind.video) return displayUrl;
+    }
+    if (canPrefetchPreview) return previewUrl;
+    return '';
+  }
+
+  String get videoUrl {
+    if (!isVideo) return '';
+    final candidates = <String>[downloadUrl, displayUrl];
+    for (final candidate in candidates) {
+      if (_kindForUrl(candidate) == GalleryMediaKind.video) {
+        return candidate.trim();
+      }
+    }
+    for (final candidate in candidates) {
+      if (candidate.trim().isNotEmpty &&
+          _kindForUrl(candidate) == GalleryMediaKind.unknown) {
+        return candidate.trim();
+      }
+    }
+    return '';
+  }
+
+  static GalleryMediaCapability resolve({
+    String? declaredType,
+    String? extension,
+    String? mimeType,
+    String previewUrl = '',
+    String displayUrl = '',
+    String downloadUrl = '',
+  }) {
+    final declaredKind = _kindForDeclaredType(declaredType);
+    final extensionKind = _kindForExtension(extension);
+    final mimeKind = _kindForMime(mimeType);
+    final primaryUrl = _firstNonEmpty(<String>[downloadUrl, displayUrl]);
+    final urlKind = _kindForUrl(primaryUrl);
+    final kind = _strongest(<GalleryMediaKind>[
+      declaredKind,
+      extensionKind,
+      mimeKind,
+      urlKind,
+    ]);
+    final detectedPreviewKind = _kindForUrl(previewUrl);
+    final previewKind = detectedPreviewKind != GalleryMediaKind.unknown
+        ? detectedPreviewKind
+        : isImageKind(kind)
+        ? kind
+        : GalleryMediaKind.unknown;
+    return GalleryMediaCapability(
+      kind: kind,
+      previewKind: previewKind,
+      previewUrl: previewUrl.trim(),
+      displayUrl: displayUrl.trim(),
+      downloadUrl: downloadUrl.trim(),
+    );
+  }
+
+  static GalleryMediaKind _kindForDeclaredType(String? value) {
+    final normalized = value?.trim().toLowerCase();
+    return switch (normalized) {
+      'video' || 'movie' => GalleryMediaKind.video,
+      'animation' || 'animated' || 'gif' => GalleryMediaKind.animatedImage,
+      'image' || 'photo' || 'static' => GalleryMediaKind.staticImage,
+      _ => GalleryMediaKind.unknown,
+    };
+  }
+
+  static GalleryMediaKind _kindForMime(String? value) {
+    final mime = value?.split(';').first.trim().toLowerCase() ?? '';
+    if (mime.startsWith('video/')) return GalleryMediaKind.video;
+    if (mime == 'image/gif') return GalleryMediaKind.animatedImage;
+    if (mime.startsWith('image/')) return GalleryMediaKind.staticImage;
+    return GalleryMediaKind.unknown;
+  }
+
+  static GalleryMediaKind _kindForUrl(String value) {
+    if (value.trim().isEmpty) return GalleryMediaKind.unknown;
+    final uri = Uri.tryParse(value.trim());
+    return _kindForExtension(_pathExtension(uri?.path ?? value));
+  }
+
+  static GalleryMediaKind _kindForExtension(String? value) {
+    final extension = value?.trim().toLowerCase().replaceFirst(
+      RegExp(r'^\.'),
+      '',
+    );
+    return switch (extension) {
+      'webm' || 'mp4' || 'm4v' || 'mov' => GalleryMediaKind.video,
+      'gif' => GalleryMediaKind.animatedImage,
+      'jpg' ||
+      'jpeg' ||
+      'png' ||
+      'webp' ||
+      'bmp' ||
+      'avif' => GalleryMediaKind.staticImage,
+      _ => GalleryMediaKind.unknown,
+    };
+  }
+
+  static GalleryMediaKind _strongest(Iterable<GalleryMediaKind> kinds) {
+    if (kinds.contains(GalleryMediaKind.video)) return GalleryMediaKind.video;
+    if (kinds.contains(GalleryMediaKind.animatedImage)) {
+      return GalleryMediaKind.animatedImage;
+    }
+    if (kinds.contains(GalleryMediaKind.staticImage)) {
+      return GalleryMediaKind.staticImage;
+    }
+    return GalleryMediaKind.unknown;
+  }
+
+  static String _pathExtension(String path) {
+    final slash = path.lastIndexOf('/');
+    final dot = path.lastIndexOf('.');
+    if (dot <= slash || dot == path.length - 1) return '';
+    return path.substring(dot + 1);
+  }
+
+  static bool isImageKind(GalleryMediaKind kind) =>
+      kind == GalleryMediaKind.staticImage ||
+      kind == GalleryMediaKind.animatedImage;
+
+  static String _firstNonEmpty(Iterable<String> values) {
+    for (final value in values) {
+      if (value.trim().isNotEmpty) return value.trim();
+    }
+    return '';
+  }
+}

--- a/lib/data/repositories/online_gallery_local_favorites_repository.dart
+++ b/lib/data/repositories/online_gallery_local_favorites_repository.dart
@@ -550,6 +550,7 @@ OnlineGalleryFavoriteRecord _quickTagCloudRecord(
         width: dimensions.width,
         height: dimensions.height,
         extension: extension.isEmpty ? null : extension,
+        mediaType: 'image',
         rawMetadata: image.rawTag.isEmpty ? entry.rawTag : image.rawTag,
         prompt: entry.tags,
         negativePrompt: entry.negative,

--- a/lib/presentation/providers/auth_provider.dart
+++ b/lib/presentation/providers/auth_provider.dart
@@ -11,7 +11,6 @@ import '../../core/network/nai_api_endpoint_service.dart';
 import '../../core/storage/secure_storage_service.dart';
 import '../../core/utils/app_logger.dart';
 import '../../data/datasources/remote/nai_auth_api_service.dart';
-import '../../data/datasources/remote/nai_user_info_api_service.dart';
 import '../../data/models/auth/saved_account.dart';
 import 'account_manager_provider.dart';
 
@@ -1059,19 +1058,6 @@ class AuthNotifier extends _$AuthNotifier {
     } else {
       state = const AuthState(status: AuthStatus.unauthenticated);
       AppLogger.w('[AuthNotifier] state set to unauthenticated', 'AUTH');
-    }
-  }
-
-  /// 刷新订阅信息
-  Future<void> refreshSubscription() async {
-    if (!state.isAuthenticated) return;
-
-    try {
-      final apiService = ref.read(naiUserInfoApiServiceProvider);
-      final subscriptionInfo = await apiService.getUserSubscription();
-      state = state.copyWith(subscriptionInfo: subscriptionInfo);
-    } catch (e) {
-      AppLogger.e('Failed to refresh subscription: $e');
     }
   }
 

--- a/lib/presentation/providers/generation/vibe_reference_service.dart
+++ b/lib/presentation/providers/generation/vibe_reference_service.dart
@@ -253,7 +253,6 @@ final class VibeReferenceService {
         model: model,
         informationExtracted: informationExtracted,
       );
-      _schedulePostBillingRefresh();
       storeCached(
         imageData,
         encoding,
@@ -269,6 +268,8 @@ final class VibeReferenceService {
         'VibeCache',
       );
       return VibeEncodingResult.failed(error);
+    } finally {
+      _schedulePostBillingRefresh();
     }
   }
 

--- a/lib/presentation/providers/krita/krita_bridge_notifier.dart
+++ b/lib/presentation/providers/krita/krita_bridge_notifier.dart
@@ -14,6 +14,7 @@ import '../fixed_tags_provider.dart';
 import '../generation/image_workflow_controller.dart';
 import '../image_generation_provider.dart';
 import '../image_save_settings_provider.dart';
+import '../subscription_provider.dart';
 import 'krita_bridge_service.dart';
 
 typedef KritaBridgeServerFactory = KritaBridgeServer Function();
@@ -329,6 +330,9 @@ final kritaBridgeNotifierProvider =
               ),
           cancelGeneration: () =>
               ref.read(naiImageGenerationApiServiceProvider).cancelGeneration(),
+          schedulePostBillingRefresh: () => ref
+              .read(subscriptionNotifierProvider.notifier)
+              .schedulePostBillingRefresh(),
         ),
       );
       final enabled =

--- a/lib/presentation/providers/krita/krita_bridge_service.dart
+++ b/lib/presentation/providers/krita/krita_bridge_service.dart
@@ -34,6 +34,7 @@ typedef KritaBridgeExternalImageRegistrar =
       bool? addToDisplay,
     });
 typedef KritaBridgeCancelGeneration = void Function();
+typedef KritaBridgePostBillingRefresh = void Function();
 typedef KritaBridgeClock = DateTime Function();
 typedef KritaBridgeActiveRequestReporter = void Function(String? requestId);
 
@@ -71,6 +72,7 @@ class KritaBridgeService implements KritaBridgeMessageService {
     required KritaBridgeFallbackGenerator generateFallback,
     required KritaBridgeExternalImageRegistrar registerExternalImage,
     required KritaBridgeCancelGeneration cancelGeneration,
+    KritaBridgePostBillingRefresh? schedulePostBillingRefresh,
     KritaBridgePromptSnapshotReader? readPromptSnapshot,
     KritaBridgeMinimumContextReader? readMinimumContextPixels,
     KritaBridgeClock? clock,
@@ -87,6 +89,7 @@ class KritaBridgeService implements KritaBridgeMessageService {
        _generateFallback = generateFallback,
        _registerExternalImage = registerExternalImage,
        _cancelGeneration = cancelGeneration,
+       _schedulePostBillingRefresh = schedulePostBillingRefresh ?? _noop,
        _clock = clock ?? DateTime.now,
        _failureCooldown = failureCooldown,
        _readMinimumContextPixels = readMinimumContextPixels ?? (() => 88);
@@ -101,6 +104,7 @@ class KritaBridgeService implements KritaBridgeMessageService {
   final KritaBridgeFallbackGenerator _generateFallback;
   final KritaBridgeExternalImageRegistrar _registerExternalImage;
   final KritaBridgeCancelGeneration _cancelGeneration;
+  final KritaBridgePostBillingRefresh _schedulePostBillingRefresh;
   final KritaBridgeClock _clock;
   final Duration _failureCooldown;
 
@@ -296,12 +300,15 @@ class KritaBridgeService implements KritaBridgeMessageService {
         _sendError(id, code, _publicErrorMessage(code));
       }
     } finally {
+      _schedulePostBillingRefresh();
       _isBridgeGenerating = false;
       _activeRequestId = null;
       _activeRequestReporter?.call(null);
       _cancelled = false;
     }
   }
+
+  static void _noop() {}
 
   Rect? _resolveFocusedSelectionRect(KritaImageParamsMapping mapping) {
     final selection = _toRect(mapping.selectionRect);

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -111,6 +111,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   int _detailRequestScopeRevision = 0;
   bool _loadMoreClaimed = false;
   int _loadMoreClaimRevision = 0;
+  bool _backgroundNetworkPaused = false;
 
   int get detailRequestScopeRevision => _detailRequestScopeRevision;
 
@@ -118,7 +119,27 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       _detailCoordinator ??= OnlineGalleryDetailCoordinator(
         loader: (item, cancelToken) =>
             _repository.detail(item, cancelToken: cancelToken),
-      );
+      )..setBackgroundPaused(_backgroundNetworkPaused);
+
+  void setBackgroundNetworkPaused(bool paused) {
+    if (_backgroundNetworkPaused == paused) return;
+    _backgroundNetworkPaused = paused;
+    if (paused) {
+      _loadCoordinator.cancel('Gallery background network paused');
+      if (state.isLoading || state.isLoadingMore) {
+        state = state.copyWith(isLoading: false, isLoadingMore: false);
+      }
+    }
+    _details.setBackgroundPaused(paused);
+    if (!paused) {
+      _detailRequestScopeRevision++;
+      state = state.copyWith();
+    }
+  }
+
+  void cancelLookaheadDetailRequests() {
+    _detailCoordinator?.cancelLookahead();
+  }
 
   OnlineGalleryPaginationService get _pagination =>
       _paginationService ??= OnlineGalleryPaginationService(
@@ -235,6 +256,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     _loadMoreClaimed = false;
     _detailRequestScopeRevision++;
     _detailCoordinator?.cancelQueuedVisible();
+    _detailCoordinator?.cancelLookahead();
     if (state.isLoading || state.isLoadingMore) {
       state = state.copyWith(isLoading: false, isLoadingMore: false);
     }
@@ -323,7 +345,11 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     required bool replace,
     bool restart = false,
   }) async {
-    if (!state.randomEnabled || !state.supportsRandom) return;
+    if (_backgroundNetworkPaused ||
+        !state.randomEnabled ||
+        !state.supportsRandom) {
+      return;
+    }
     if (!replace &&
         (state.isLoading ||
             state.isLoadingMore ||
@@ -772,6 +798,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   }
 
   Future<void> loadPosts({bool refresh = false}) async {
+    if (_backgroundNetworkPaused) return;
     if (state.randomEnabled) {
       await _loadRandom(replace: refresh);
       return;
@@ -820,13 +847,15 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     }
   }
 
-  Future<void> refresh() {
+  Future<void> refresh() async {
+    if (_backgroundNetworkPaused) return;
     _cancelCurrentRequest();
-    return loadPosts(refresh: true);
+    await loadPosts(refresh: true);
   }
 
   Future<void> retryAppend() async {
-    if (state.randomEnabled ||
+    if (_backgroundNetworkPaused ||
+        state.randomEnabled ||
         state.isLoading ||
         state.isLoadingMore ||
         state.currentCache.appendErrorCode == null) {
@@ -836,7 +865,12 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   }
 
   Future<void> goToPage(int page) async {
-    if (page < 1 || state.isLoading || state.isLoadingMore) return;
+    if (_backgroundNetworkPaused ||
+        page < 1 ||
+        state.isLoading ||
+        state.isLoadingMore) {
+      return;
+    }
     if (state.viewMode == GalleryViewMode.favorites) {
       await _loadFavorites(refresh: true, targetPage: page);
       return;

--- a/lib/presentation/providers/subscription_provider.dart
+++ b/lib/presentation/providers/subscription_provider.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
-import 'dart:io';
 
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../core/constants/api_constants.dart';
+import '../../core/network/critical_network_activity.dart';
 import '../../core/utils/app_logger.dart';
 import '../../data/datasources/remote/nai_user_info_api_service.dart';
 import '../../data/models/user/user_subscription.dart';
@@ -12,6 +12,8 @@ import '../../data/services/anlas_statistics_service.dart';
 import 'auth_provider.dart';
 
 part 'subscription_provider.g.dart';
+
+enum SubscriptionRefreshPriority { background, postBilling, userInitiated }
 
 /// 订阅状态 Notifier
 ///
@@ -23,25 +25,39 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
   bool _hasInitiallyLoaded = false;
   Timer? _refreshTimer;
   Future<void>? _inflightFetch;
+  CancelToken? _inflightFetchCancelToken;
   Future<bool>? _inflightBalanceRefresh;
+  CancelToken? _inflightBalanceRefreshCancelToken;
   bool _balanceRefreshQueued = false;
+  SubscriptionRefreshPriority _activeBalanceRefreshPriority =
+      SubscriptionRefreshPriority.background;
+  SubscriptionRefreshPriority _queuedBalanceRefreshPriority =
+      SubscriptionRefreshPriority.background;
+  int _balanceRefreshGeneration = 0;
+  bool _lastBalanceRefreshWasPreempted = false;
   Timer? _postBillingRefreshTimer;
-  Timer? _networkRecoveryProbeTimer;
-  bool _isNetworkRecoveryProbing = false;
   int _networkFailureCount = 0;
   bool _isAppForeground = true;
+  bool _criticalActivityListenerAttached = false;
+  bool _refreshDeferredForCriticalActivity = false;
+  SubscriptionRefreshPriority _deferredRefreshPriority =
+      SubscriptionRefreshPriority.background;
 
   /// 自动刷新间隔
   static const Duration _refreshInterval = Duration(seconds: 30);
   static const Duration _initialFetchTimeout = Duration(seconds: 6);
   static const Duration _maxBackoffInterval = Duration(minutes: 2);
-  static const Duration _networkProbeInterval = Duration(seconds: 3);
-  static const Duration _networkProbeTimeout = Duration(seconds: 2);
   static const Duration postBillingRefreshDelay = Duration(milliseconds: 500);
 
   @override
   SubscriptionState build() {
     ref.keepAlive();
+    if (!_criticalActivityListenerAttached) {
+      _criticalActivityListenerAttached = true;
+      CriticalNetworkActivityCoordinator.instance.addListener(
+        _handleCriticalNetworkActivityChanged,
+      );
+    }
 
     // Watch authentication state changes
     final authState = ref.watch(authNotifierProvider);
@@ -59,14 +75,22 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
         previousAuthState?.isAuthenticated == true;
 
     if (switchedAccount || loggedOut) {
-      // 旧请求无法取消，但会被 session 校验丢弃。切换账号时解除去重，
-      // 让新账号无需等待旧请求结束即可立即拉取自己的余额。
-      if (switchedAccount) _inflightFetch = null;
+      _inflightFetchCancelToken?.cancel('Authentication session changed');
+      _inflightBalanceRefreshCancelToken?.cancel(
+        'Authentication session changed',
+      );
+      _inflightFetch = null;
+      _inflightFetchCancelToken = null;
+      _inflightBalanceRefresh = null;
+      _inflightBalanceRefreshCancelToken = null;
+      _balanceRefreshQueued = false;
+      _balanceRefreshGeneration += 1;
       _lastKnownState = null;
       _hasInitiallyLoaded = false;
       _networkFailureCount = 0;
+      _refreshDeferredForCriticalActivity = false;
+      _deferredRefreshPriority = SubscriptionRefreshPriority.background;
       _stopAutoRefresh();
-      _stopNetworkRecoveryProbe();
       _cancelPostBillingRefresh();
     }
 
@@ -95,8 +119,15 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
     // Cleanup on dispose
     ref.onDispose(() {
       _stopAutoRefresh();
-      _stopNetworkRecoveryProbe();
       _cancelPostBillingRefresh();
+      _inflightFetchCancelToken?.cancel('Subscription notifier disposed');
+      _inflightBalanceRefreshCancelToken?.cancel(
+        'Subscription notifier disposed',
+      );
+      CriticalNetworkActivityCoordinator.instance.removeListener(
+        _handleCriticalNetworkActivityChanged,
+      );
+      _criticalActivityListenerAttached = false;
     });
 
     if (hydratedState != null) {
@@ -175,11 +206,19 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
   }
 
   Future<void> _runRefreshCycle() async {
+    if (CriticalNetworkActivityCoordinator.instance.isActive) {
+      _deferRefresh(SubscriptionRefreshPriority.background);
+      _refreshTimer = null;
+      AppLogger.d(
+        'Subscription background refresh deferred for critical network activity',
+        'Subscription',
+      );
+      return;
+    }
     if (!state.isLoaded) {
       await fetchSubscription();
       if (state.isLoaded) {
         _networkFailureCount = 0;
-        _stopNetworkRecoveryProbe();
         _scheduleNextRefresh(_refreshInterval);
       }
       return;
@@ -188,10 +227,10 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
     final success = await refreshBalance();
     if (success) {
       _networkFailureCount = 0;
-      _stopNetworkRecoveryProbe();
       _scheduleNextRefresh(_refreshInterval);
       return;
     }
+    if (_lastBalanceRefreshWasPreempted) return;
 
     _networkFailureCount += 1;
     final backoff = _computeBackoffDuration();
@@ -200,48 +239,6 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
       'Subscription',
     );
     _scheduleNextRefresh(backoff);
-    _startNetworkRecoveryProbe();
-  }
-
-  void _startNetworkRecoveryProbe() {
-    if (!_isAppForeground || _networkRecoveryProbeTimer != null) {
-      return;
-    }
-
-    AppLogger.d('Starting network recovery probe', 'Subscription');
-    _networkRecoveryProbeTimer = Timer.periodic(_networkProbeInterval, (
-      _,
-    ) async {
-      if (_isNetworkRecoveryProbing) {
-        return;
-      }
-
-      _isNetworkRecoveryProbing = true;
-      try {
-        final reachable = await _isNovelApiReachable();
-        if (!reachable) {
-          return;
-        }
-
-        AppLogger.i(
-          'Network recovered, triggering immediate subscription refresh',
-          'Subscription',
-        );
-        _networkFailureCount = 0;
-        _stopNetworkRecoveryProbe();
-        _scheduleNextRefresh(Duration.zero);
-      } finally {
-        _isNetworkRecoveryProbing = false;
-      }
-    });
-  }
-
-  void _stopNetworkRecoveryProbe() {
-    if (_networkRecoveryProbeTimer != null) {
-      AppLogger.d('Stopping network recovery probe', 'Subscription');
-      _networkRecoveryProbeTimer?.cancel();
-      _networkRecoveryProbeTimer = null;
-    }
   }
 
   /// Stops periodic network work while the app is backgrounded and performs
@@ -252,45 +249,83 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
 
     if (!isForeground) {
       _stopAutoRefresh();
-      _stopNetworkRecoveryProbe();
       return;
     }
 
     if (_previousAuthState?.isAuthenticated == true) {
-      _networkFailureCount = 0;
       _scheduleNextRefresh(Duration.zero);
     }
   }
 
-  Future<bool> _isNovelApiReachable() async {
-    try {
-      final result = await InternetAddress.lookup(
-        Uri.parse(ApiConstants.imageBaseUrl).host,
-      ).timeout(_networkProbeTimeout);
-      return result.isNotEmpty;
-    } catch (_) {
-      return false;
+  void _handleCriticalNetworkActivityChanged() {
+    if (CriticalNetworkActivityCoordinator.instance.isActive) {
+      if (_inflightFetchCancelToken?.isCancelled == false) {
+        _deferRefresh(SubscriptionRefreshPriority.background);
+        _inflightFetchCancelToken?.cancel(
+          'Subscription fetch preempted by critical network activity',
+        );
+      }
+      if (_inflightBalanceRefreshCancelToken?.isCancelled == false) {
+        _deferRefresh(_activeBalanceRefreshPriority);
+        _inflightBalanceRefreshCancelToken?.cancel(
+          'Balance refresh preempted by critical network activity',
+        );
+      }
+      return;
     }
+    if (!_refreshDeferredForCriticalActivity || !_isAppForeground) {
+      return;
+    }
+    _refreshDeferredForCriticalActivity = false;
+    final priority = _deferredRefreshPriority;
+    _deferredRefreshPriority = SubscriptionRefreshPriority.background;
+    AppLogger.d(
+      'Critical network activity ended; resuming one deferred subscription refresh',
+      'Subscription',
+    );
+    if (priority == SubscriptionRefreshPriority.background) {
+      _scheduleNextRefresh(Duration.zero);
+    } else {
+      unawaited(refreshBalance(priority: priority));
+    }
+  }
+
+  void _deferRefresh(SubscriptionRefreshPriority priority) {
+    _refreshDeferredForCriticalActivity = true;
+    if (priority.index > _deferredRefreshPriority.index) {
+      _deferredRefreshPriority = priority;
+    }
+    AppLogger.d(
+      'Subscription refresh deferred: priority=${priority.name}',
+      'Subscription',
+    );
   }
 
   /// 获取订阅信息
   Future<void> fetchSubscription() async {
+    if (CriticalNetworkActivityCoordinator.instance.isActive) {
+      _deferRefresh(SubscriptionRefreshPriority.background);
+      return;
+    }
     if (_inflightFetch != null) {
       return _inflightFetch;
     }
 
-    final fetchFuture = _doFetchSubscription();
+    final cancelToken = CancelToken();
+    _inflightFetchCancelToken = cancelToken;
+    final fetchFuture = _doFetchSubscription(cancelToken);
     _inflightFetch = fetchFuture;
     try {
       await fetchFuture;
     } finally {
       if (identical(_inflightFetch, fetchFuture)) {
         _inflightFetch = null;
+        _inflightFetchCancelToken = null;
       }
     }
   }
 
-  Future<void> _doFetchSubscription() async {
+  Future<void> _doFetchSubscription(CancelToken cancelToken) async {
     final authSession = ref.read(authNotifierProvider);
     if (!authSession.isAuthenticated) return;
 
@@ -312,6 +347,7 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
       final apiService = ref.read(naiUserInfoApiServiceProvider);
       final data = await apiService.getUserSubscription(
         receiveTimeout: _initialFetchTimeout,
+        cancelToken: cancelToken,
       );
       if (!_isCurrentAuthSession(authSession)) return;
 
@@ -327,6 +363,13 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
       );
     } catch (e) {
       if (!_isCurrentAuthSession(authSession)) return;
+      if (e is DioException && CancelToken.isCancel(e)) {
+        AppLogger.d(
+          'Subscription fetch cancelled for critical network activity',
+          'Subscription',
+        );
+        return;
+      }
       AppLogger.e('Failed to fetch subscription: $e', 'Subscription');
 
       // 首次加载失败时不进入 error 态，避免 UI 因网络抖动出现卡顿感
@@ -353,7 +396,6 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
         AppLogger.w('Network error detected, allowing retry', 'Subscription');
         _networkFailureCount += 1;
         _scheduleNextRefresh(_computeBackoffDuration());
-        _startNetworkRecoveryProbe();
       }
     }
   }
@@ -375,7 +417,17 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
     _postBillingRefreshTimer?.cancel();
     _postBillingRefreshTimer = Timer(delay, () {
       _postBillingRefreshTimer = null;
-      unawaited(refreshBalance());
+      if (CriticalNetworkActivityCoordinator.instance.isActive) {
+        _deferRefresh(SubscriptionRefreshPriority.postBilling);
+        AppLogger.d(
+          'Post-billing balance refresh deferred for critical network activity',
+          'Subscription',
+        );
+        return;
+      }
+      unawaited(
+        refreshBalance(priority: SubscriptionRefreshPriority.postBilling),
+      );
     });
   }
 
@@ -388,32 +440,61 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
   ///
   /// 刷新进行中收到的新请求不会被丢弃：当前请求结束后再拉取一次，确保生成
   /// 完成时恰逢定时刷新也能拿到扣费后的余额。
-  Future<bool> refreshBalance() {
+  Future<bool> refreshBalance({
+    SubscriptionRefreshPriority priority =
+        SubscriptionRefreshPriority.background,
+  }) {
     if (!ref.read(authNotifierProvider).isAuthenticated) {
+      return Future.value(false);
+    }
+    if (CriticalNetworkActivityCoordinator.instance.isActive) {
+      _deferRefresh(priority);
       return Future.value(false);
     }
 
     final inflightRefresh = _inflightBalanceRefresh;
     if (inflightRefresh != null) {
       _balanceRefreshQueued = true;
+      if (priority.index > _queuedBalanceRefreshPriority.index) {
+        _queuedBalanceRefreshPriority = priority;
+      }
       return inflightRefresh;
     }
 
+    _activeBalanceRefreshPriority = priority;
+    _queuedBalanceRefreshPriority = SubscriptionRefreshPriority.background;
+    final refreshGeneration = _balanceRefreshGeneration;
     late final Future<bool> trackedRefresh;
-    trackedRefresh = _drainBalanceRefreshQueue().whenComplete(() {
-      if (identical(_inflightBalanceRefresh, trackedRefresh)) {
-        _inflightBalanceRefresh = null;
-      }
-    });
+    trackedRefresh = _drainBalanceRefreshQueue(priority, refreshGeneration)
+        .whenComplete(() {
+          if (identical(_inflightBalanceRefresh, trackedRefresh)) {
+            _inflightBalanceRefresh = null;
+            _inflightBalanceRefreshCancelToken = null;
+          }
+        });
     _inflightBalanceRefresh = trackedRefresh;
     return trackedRefresh;
   }
 
-  Future<bool> _drainBalanceRefreshQueue() async {
+  Future<bool> _drainBalanceRefreshQueue(
+    SubscriptionRefreshPriority initialPriority,
+    int refreshGeneration,
+  ) async {
     var latestRefreshSucceeded = false;
+    var currentPriority = initialPriority;
     do {
+      if (CriticalNetworkActivityCoordinator.instance.isActive) {
+        _deferRefresh(currentPriority);
+        _balanceRefreshQueued = false;
+        _lastBalanceRefreshWasPreempted = true;
+        return false;
+      }
       _balanceRefreshQueued = false;
+      _activeBalanceRefreshPriority = currentPriority;
       latestRefreshSucceeded = await _refreshBalanceOnce();
+      if (refreshGeneration != _balanceRefreshGeneration) return false;
+      currentPriority = _queuedBalanceRefreshPriority;
+      _queuedBalanceRefreshPriority = SubscriptionRefreshPriority.background;
     } while (_balanceRefreshQueued);
     return latestRefreshSucceeded;
   }
@@ -422,21 +503,38 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
     // 保持当前状态，静默刷新
     final authSession = ref.read(authNotifierProvider);
     if (!authSession.isAuthenticated) return false;
+    final cancelToken = CancelToken();
+    _inflightBalanceRefreshCancelToken = cancelToken;
+    _lastBalanceRefreshWasPreempted = false;
 
     try {
       final apiService = ref.read(naiUserInfoApiServiceProvider);
       final data = await apiService.getUserSubscription(
         receiveTimeout: _initialFetchTimeout,
+        cancelToken: cancelToken,
       );
       if (!_isCurrentAuthSession(authSession)) return false;
 
       final subscription = UserSubscription.fromJson(data);
       _updateState(SubscriptionState.loaded(subscription));
+      _networkFailureCount = 0;
       return true;
     } catch (e) {
+      if (e is DioException && CancelToken.isCancel(e)) {
+        _lastBalanceRefreshWasPreempted = true;
+        AppLogger.d(
+          'Balance refresh cancelled for critical network activity',
+          'Subscription',
+        );
+        return false;
+      }
       AppLogger.w('Failed to refresh balance: $e', 'Subscription');
       // 刷新失败不更新状态，保持上次数据
       return false;
+    } finally {
+      if (identical(_inflightBalanceRefreshCancelToken, cancelToken)) {
+        _inflightBalanceRefreshCancelToken = null;
+      }
     }
   }
 

--- a/lib/presentation/screens/online_gallery/gallery_grid_item.dart
+++ b/lib/presentation/screens/online_gallery/gallery_grid_item.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -211,57 +212,74 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
               ),
             );
           }
-          return FutureBuilder<GalleryDetail>(
-            key: ValueKey((post.detailStableKey, widget.detailRequestScope)),
-            future: _detailFuture,
-            builder: (context, snapshot) {
-              if (snapshot.hasError) {
-                return AspectRatio(
-                  aspectRatio: 1,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.surfaceContainerLow,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Center(
-                      child: TextButton.icon(
-                        onPressed: _retryDetail,
-                        icon: const Icon(Icons.refresh),
-                        label: Text(context.l10n.common_retry),
+          return AnimatedSize(
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOutCubic,
+            child: FutureBuilder<GalleryDetail>(
+              key: ValueKey((post.detailStableKey, widget.detailRequestScope)),
+              future: _detailFuture,
+              builder: (context, snapshot) {
+                if (snapshot.hasError) {
+                  final error = snapshot.error;
+                  if (error is DioException &&
+                      error.type == DioExceptionType.cancel) {
+                    return const AspectRatio(
+                      aspectRatio: 1,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.all(Radius.circular(8)),
+                        child: OnlineGalleryImagePlaceholder(),
+                      ),
+                    );
+                  }
+                  return AspectRatio(
+                    aspectRatio: 1,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerLow,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Center(
+                        child: TextButton.icon(
+                          onPressed: _retryDetail,
+                          icon: const Icon(Icons.refresh),
+                          label: Text(context.l10n.common_retry),
+                        ),
                       ),
                     ),
+                  );
+                }
+                final detail = snapshot.data;
+                final resolved = detail?.item;
+                if (resolved == null) {
+                  return const AspectRatio(
+                    aspectRatio: 1,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.all(Radius.circular(8)),
+                      child: OnlineGalleryImagePlaceholder(),
+                    ),
+                  );
+                }
+                final resolvedAspectRatio =
+                    resolved.width > 0 && resolved.height > 0
+                    ? resolved.width / resolved.height
+                    : layoutAspectRatio;
+                return _PreparedGalleryMediaCard(
+                  item: resolved,
+                  itemWidth: widget.itemWidth,
+                  visible: _isVisible,
+                  prepareMedia: widget.prepareMedia,
+                  builder: (loadMedia) => _buildResourceCard(
+                    context,
+                    resolved,
+                    resolvedAspectRatio,
+                    loadMedia: loadMedia,
+                    detail: detail,
                   ),
                 );
-              }
-              final detail = snapshot.data;
-              final resolved = detail?.item;
-              if (resolved == null) {
-                return const AspectRatio(
-                  aspectRatio: 1,
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.all(Radius.circular(8)),
-                    child: OnlineGalleryImagePlaceholder(),
-                  ),
-                );
-              }
-              final resolvedAspectRatio =
-                  resolved.width > 0 && resolved.height > 0
-                  ? resolved.width / resolved.height
-                  : layoutAspectRatio;
-              return _PreparedGalleryMediaCard(
-                item: resolved,
-                itemWidth: widget.itemWidth,
-                visible: _isVisible,
-                prepareMedia: widget.prepareMedia,
-                builder: (loadMedia) => _buildResourceCard(
-                  context,
-                  resolved,
-                  resolvedAspectRatio,
-                  loadMedia: loadMedia,
-                  detail: detail,
-                ),
-              );
-            },
+              },
+            ),
           );
         },
       ),

--- a/lib/presentation/screens/online_gallery/online_gallery_content.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_content.dart
@@ -466,7 +466,11 @@ class _OnlineGalleryContentPresenter {
           hoverController: _controller.hoverController,
           imageCoordinator: _controller.prefetchCoordinator,
           onHoverIntent: () {
-            if (post.isVideo || post.isAnimated) return;
+            if (post.isVideo ||
+                post.isAnimated ||
+                !post.mediaCapability.isFlutterImage) {
+              return;
+            }
             final sampleUrl =
                 post.sampleUrl ?? post.largeFileUrl ?? post.cover.displayUrl;
             if (sampleUrl.isEmpty) return;
@@ -480,6 +484,26 @@ class _OnlineGalleryContentPresenter {
                 ),
                 priority: GalleryImagePriority.hover,
               ),
+            );
+          },
+          onHoverDismiss: () {
+            if (post.isVideo ||
+                post.isAnimated ||
+                !post.mediaCapability.isFlutterImage) {
+              return;
+            }
+            final sampleUrl =
+                post.sampleUrl ?? post.largeFileUrl ?? post.cover.displayUrl;
+            if (sampleUrl.isEmpty) return;
+            _controller.prefetchCoordinator.cancel(
+              _imageRequest(
+                post,
+                sampleUrl,
+                GalleryImageTier.sample,
+                itemWidth,
+              ),
+              priority: GalleryImagePriority.hover,
+              reason: 'hover-dismissed',
             );
           },
           onTap: () => unawaited(_commands.showDetail(context, post)),

--- a/lib/presentation/screens/online_gallery/online_gallery_detail_launcher.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_detail_launcher.dart
@@ -86,6 +86,7 @@ class OnlineGalleryDetailLauncher {
           favoriteLoading: galleryState.favoriteLoadingPostKeys.contains(
             stableKey,
           ),
+          prefetchCoordinator: _controller.prefetchCoordinator,
           canToggleFavorite: true,
           labels: GalleryDetailDialogLabels(
             sourceName: item.sourceId == GallerySourceId.quickTagCloud
@@ -353,9 +354,8 @@ class OnlineGalleryDetailLauncher {
     GalleryItem item,
     GalleryMedia media,
   ) async {
-    final url = media.displayUrl.isNotEmpty
-        ? media.displayUrl
-        : (media.downloadUrl.isNotEmpty ? media.downloadUrl : media.previewUrl);
+    final capability = media.capability;
+    final url = capability.isFlutterImage ? capability.imageDisplayUrl : '';
     if (url.isEmpty) {
       AppToast.info(dialogContext, dialogContext.l10n.onlineGallery_noImageUrl);
       return;

--- a/lib/presentation/screens/online_gallery/online_gallery_screen.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../core/cache/online_gallery_image_cache_manager.dart';
+import '../../../core/cache/cancellable_gallery_image_loader.dart';
+import '../../../core/cache/gallery_image_request.dart';
 import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
+import '../../../core/network/critical_network_activity.dart';
 import '../../../core/utils/localization_extension.dart';
 import '../../../data/services/danbooru_auth_service.dart';
 import '../../../data/services/gelbooru_auth_service.dart';
@@ -31,13 +33,15 @@ class OnlineGalleryScreen extends ConsumerStatefulWidget {
 }
 
 class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
-    with AutomaticKeepAliveClientMixin {
+    with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
   late final OnlineGalleryScreenController _controller;
+  late final CancellableGalleryImageLoader _imageLoader;
   late final OnlineGalleryScrollPrefetchCoordinator _scrollCoordinator;
   late final OnlineGalleryDetailLauncher _detailLauncher;
   late final OnlineGallerySelectionActions _selectionActions;
   late final OnlineGalleryScreenCommands _commands;
   late final ProviderSubscription<OnlineGalleryState> _gallerySubscription;
+  bool _appForeground = true;
 
   @override
   bool get wantKeepAlive => true;
@@ -53,14 +57,21 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    final lifecycleState = WidgetsBinding.instance.lifecycleState;
+    _appForeground =
+        lifecycleState == null || lifecycleState == AppLifecycleState.resumed;
+    _imageLoader = CancellableGalleryImageLoader();
     _controller = OnlineGalleryScreenController(
       prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
-        preloader: (request) => precacheImage(
-          request.createImageProvider(OnlineGalleryImageCacheManager.instance),
-          context,
-        ),
+        preloader: _startImagePreload,
       ),
     );
+    CriticalNetworkActivityCoordinator.instance.addListener(
+      _handleCriticalNetworkActivity,
+    );
+    _controller.prefetchCoordinator.setAppForeground(_appForeground);
+    _handleCriticalNetworkActivity();
     _detailLauncher = OnlineGalleryDetailLauncher(
       context: context,
       ref: ref,
@@ -120,6 +131,8 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
     final visible = AppBranchVisibility.of(context);
     if (_controller.branchVisible == visible) return;
     _controller.branchVisible = visible;
+    _controller.prefetchCoordinator.setPageVisible(visible);
+    _syncBackgroundNetworkActivity();
     if (!visible) {
       _controller.hoverController.dismiss();
       _controller.scheduledAutoLoadCacheKey = null;
@@ -131,6 +144,32 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         );
       });
     }
+  }
+
+  GalleryImagePreloadOperation _startImagePreload(
+    GalleryImageRequest request,
+  ) => _imageLoader.start(request);
+
+  void _handleCriticalNetworkActivity() {
+    _controller.prefetchCoordinator.setCriticalNetworkActive(
+      CriticalNetworkActivityCoordinator.instance.isActive,
+    );
+    _syncBackgroundNetworkActivity();
+  }
+
+  void _syncBackgroundNetworkActivity() {
+    _galleryNotifier.setBackgroundNetworkPaused(
+      !_controller.branchVisible ||
+          !_appForeground ||
+          CriticalNetworkActivityCoordinator.instance.isActive,
+    );
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    _appForeground = state == AppLifecycleState.resumed;
+    _controller.prefetchCoordinator.setAppForeground(_appForeground);
+    _syncBackgroundNetworkActivity();
   }
 
   void _handleGalleryStateChanged(OnlineGalleryState state) {
@@ -173,6 +212,10 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    CriticalNetworkActivityCoordinator.instance.removeListener(
+      _handleCriticalNetworkActivity,
+    );
     _scrollCoordinator.saveScrollOffset();
     _gallerySubscription.close();
     _controller.scrollController.removeListener(_scrollCoordinator.onScroll);
@@ -180,6 +223,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
       _controller.cancelPageEditingWhenUnfocused,
     );
     _controller.dispose();
+    _imageLoader.dispose();
     super.dispose();
   }
 

--- a/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
@@ -47,7 +47,9 @@ class OnlineGalleryScrollPrefetchCoordinator {
       OnlineGalleryPreloadPolicy.loadAheadDistance(metrics.viewportDimension);
 
   Future<bool> prepareVisibleMedia(GalleryItem item, double itemWidth) {
-    if (item.previewUrl.isEmpty) return Future<bool>.value(true);
+    if (!item.mediaCapability.canPrefetchPreview) {
+      return Future<bool>.value(true);
+    }
     return controller.prefetchCoordinator.submit(
       imageRequest(
         item,
@@ -72,6 +74,7 @@ class OnlineGalleryScrollPrefetchCoordinator {
       controller.setScrolling(true);
       controller.prefetchCoordinator.setScrolling(true);
       if (startedScrolling) _retainVisibleThumbnailWindow();
+      notifier.cancelLookaheadDetailRequests();
       controller.scrollStopTimer?.cancel();
       controller.scrollStopTimer = Timer(const Duration(milliseconds: 150), () {
         if (!isMounted() || !controller.branchVisible) return;
@@ -193,7 +196,7 @@ class OnlineGalleryScrollPrefetchCoordinator {
       }
       return;
     }
-    final thumbnailRequest = item.previewUrl.isEmpty
+    final thumbnailRequest = !item.mediaCapability.canPrefetchPreview
         ? null
         : imageRequest(
             item,
@@ -255,7 +258,7 @@ class OnlineGalleryScrollPrefetchCoordinator {
       final index = edge + step * controller.scrollDirection;
       if (index < 0 || index >= state.posts.length) continue;
       final item = state.posts[index];
-      if (item.previewUrl.isNotEmpty) {
+      if (item.mediaCapability.canPrefetchPreview) {
         final request = imageRequest(
           item,
           item.previewUrl,
@@ -273,11 +276,37 @@ class OnlineGalleryScrollPrefetchCoordinator {
         detailCount++;
         unawaited(
           notifier
-              .loadDetail(item, priority: GalleryDetailPriority.visible)
+              .loadDetail(item, priority: GalleryDetailPriority.lookahead)
               .then<void>((_) {})
               .catchError((_) {}),
         );
       }
+    }
+    for (final entry in visible.take(12)) {
+      final item = entry.value.item;
+      if (item.isVideo ||
+          item.isAnimated ||
+          !item.mediaCapability.isFlutterImage ||
+          item.sourceId == GallerySourceId.aiTag) {
+        continue;
+      }
+      final sampleUrl = item.sampleUrl ?? item.largeFileUrl;
+      if (sampleUrl == null ||
+          sampleUrl.isEmpty ||
+          sampleUrl == item.previewUrl) {
+        continue;
+      }
+      unawaited(
+        controller.prefetchCoordinator.submit(
+          imageRequest(
+            item,
+            sampleUrl,
+            GalleryImageTier.sample,
+            entry.value.itemWidth,
+          ),
+          priority: GalleryImagePriority.lookahead,
+        ),
+      );
     }
     controller.prefetchCoordinator.retainThumbnailWindow(thumbnailWindow);
   }

--- a/lib/presentation/screens/online_gallery/online_gallery_selection_actions.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_selection_actions.dart
@@ -37,8 +37,10 @@ class OnlineGallerySelectionActions {
         GalleryViewMode.favorites => state.favoritesSourceId,
       };
 
-  Future<String?> _queueThumbnailPath(String previewUrl) async {
-    if (previewUrl.isEmpty) return null;
+  Future<String?> _queueThumbnailPath(GalleryMedia media) async {
+    final capability = media.capability;
+    if (!capability.canPrefetchPreview) return null;
+    final previewUrl = capability.previewUrl;
     try {
       final file = await OnlineGalleryImageCacheManager.instance.getSingleFile(
         previewUrl,
@@ -92,9 +94,7 @@ class OnlineGallerySelectionActions {
           !hasCharacterPrompt) {
         return (task: null, failed: true);
       }
-      final thumbnailPath = await _queueThumbnailPath(
-        media?.previewUrl ?? post.previewUrl,
-      );
+      final thumbnailPath = await _queueThumbnailPath(media ?? post.cover);
       return (
         task: ReplicationTask.create(
           prompt: projection.positivePrompt,

--- a/lib/presentation/widgets/anlas/anlas_balance_chip.dart
+++ b/lib/presentation/widgets/anlas/anlas_balance_chip.dart
@@ -102,7 +102,11 @@ class AnlasBalanceChip extends ConsumerWidget {
     return InkWell(
       onTap: () {
         HapticFeedback.lightImpact();
-        ref.read(subscriptionNotifierProvider.notifier).refreshBalance();
+        ref
+            .read(subscriptionNotifierProvider.notifier)
+            .refreshBalance(
+              priority: SubscriptionRefreshPriority.userInitiated,
+            );
       },
       borderRadius: BorderRadius.circular(8),
       child: _ChipContainer(

--- a/lib/presentation/widgets/common/gallery_hover_controller.dart
+++ b/lib/presentation/widgets/common/gallery_hover_controller.dart
@@ -15,6 +15,8 @@ class GalleryHoverController with WidgetsBindingObserver {
   String? _stableKey;
   bool _observingMetrics = false;
   bool _metricsRebuildScheduled = false;
+  VoidCallback? _onDismissIntent;
+  bool _intentStarted = false;
 
   String? get activeStableKey => _stableKey;
   bool get isShowing => _entry != null;
@@ -27,12 +29,13 @@ class GalleryHoverController with WidgetsBindingObserver {
     required Size previewSize,
     required WidgetBuilder builder,
     VoidCallback? onIntent,
+    VoidCallback? onDismissIntent,
     Duration delay = const Duration(milliseconds: 280),
   }) {
-    onIntent?.call();
     dismiss();
     final revision = ++_revision;
     _stableKey = stableKey;
+    _onDismissIntent = onDismissIntent;
     _startObservingMetrics();
     _showTimer = Timer(delay, () {
       if (_revision != revision ||
@@ -40,6 +43,8 @@ class GalleryHoverController with WidgetsBindingObserver {
           !context.mounted) {
         return;
       }
+      _intentStarted = true;
+      onIntent?.call();
       final overlay = Overlay.of(context, rootOverlay: true);
       _entry = OverlayEntry(
         builder: (overlayContext) {
@@ -112,6 +117,9 @@ class GalleryHoverController with WidgetsBindingObserver {
   }
 
   void dismiss() {
+    if (_intentStarted) _onDismissIntent?.call();
+    _intentStarted = false;
+    _onDismissIntent = null;
     _revision++;
     _showTimer?.cancel();
     _showTimer = null;

--- a/lib/presentation/widgets/danbooru_post_card.dart
+++ b/lib/presentation/widgets/danbooru_post_card.dart
@@ -28,6 +28,7 @@ import 'common/card_action_buttons.dart';
 import 'common/image_card_hover_motion.dart';
 import 'online_gallery/online_gallery_hover_controller.dart';
 import 'online_gallery/online_gallery_card_status_overlays.dart';
+import 'online_gallery/coordinated_gallery_image.dart';
 import 'online_gallery/online_gallery_image_placeholder.dart';
 import 'online_gallery/progressive_gallery_image.dart';
 
@@ -72,6 +73,7 @@ class DanbooruPostCard extends StatefulWidget {
   final VoidCallback? onLongPress;
   final OnlineGalleryHoverController? hoverController;
   final VoidCallback? onHoverIntent;
+  final VoidCallback? onHoverDismiss;
   final OnlineGalleryPrefetchCoordinator? imageCoordinator;
   final bool loadMedia;
 
@@ -104,6 +106,7 @@ class DanbooruPostCard extends StatefulWidget {
     this.onLongPress,
     this.hoverController,
     this.onHoverIntent,
+    this.onHoverDismiss,
     this.imageCoordinator,
     this.loadMedia = true,
   });
@@ -164,7 +167,7 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
     if (!widget.loadMedia ||
         (post.width > 0 && post.height > 0) ||
         _resolvedAspectRatio != null ||
-        post.previewUrl.isEmpty) {
+        !post.mediaCapability.canPrefetchPreview) {
       _detachDimensionListener();
       return;
     }
@@ -245,6 +248,7 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
       targetRect: targetRect,
       previewSize: previewSize,
       onIntent: widget.onHoverIntent,
+      onDismissIntent: widget.onHoverDismiss,
       builder: (_) => _HoverPreviewCardInner(
         post: widget.post,
         aspectRatio:
@@ -433,7 +437,9 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
     final pixelRatio = MediaQuery.devicePixelRatioOf(context);
     final gridImageRequest = GalleryImageRequest.forUrl(
       sourceId: widget.post.sourceId,
-      url: widget.post.previewUrl,
+      url: widget.post.mediaCapability.canPrefetchPreview
+          ? widget.post.previewUrl
+          : '',
       tier: GalleryImageTier.thumbnail,
       targetDecodeWidth: GalleryImageSizing.gridTargetWidth(
         layoutWidth: widget.itemWidth,
@@ -516,6 +522,16 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
                             const OnlineGalleryImagePlaceholder()
                           else if (gridImageRequest.url.isEmpty)
                             _buildNoImageContent(theme)
+                          else if (widget.imageCoordinator != null)
+                            CoordinatedGalleryImage(
+                              request: gridImageRequest,
+                              coordinator: widget.imageCoordinator!,
+                              placeholder:
+                                  const OnlineGalleryImagePlaceholder(),
+                              errorWidget: const OnlineGalleryImagePlaceholder(
+                                failed: true,
+                              ),
+                            )
                           else
                             CachedNetworkImage(
                               imageUrl: gridImageRequest.url,
@@ -917,17 +933,22 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
                                   );
                                 },
                               ),
-                              if (widget.post.hasValidPreview)
+                              if (widget.post.mediaCapability.isFlutterImage &&
+                                  widget
+                                      .post
+                                      .mediaCapability
+                                      .imageDisplayUrl
+                                      .isNotEmpty)
                                 CardActionButtonConfig(
                                   icon: Icons.manage_search_rounded,
                                   tooltip: context
                                       .l10n
                                       .onlineGallery_sendToReversePrompt,
                                   onPressed: () async {
-                                    final imageUrl =
-                                        widget.post.sampleUrl ??
-                                        widget.post.fileUrl ??
-                                        widget.post.previewUrl;
+                                    final imageUrl = widget
+                                        .post
+                                        .mediaCapability
+                                        .imageDisplayUrl;
                                     if (imageUrl.isEmpty) {
                                       AppToast.warning(
                                         context,
@@ -1141,7 +1162,10 @@ class _HoverPreviewCardInnerState
         ? Alignment.topCenter
         : Alignment.center;
 
-    final imageUrl = post.sampleUrl ?? post.largeFileUrl ?? post.previewUrl;
+    final capability = post.mediaCapability;
+    final imageUrl = capability.isVideo
+        ? (capability.hasStaticThumbnail ? capability.previewUrl : '')
+        : capability.imageDisplayUrl;
 
     return Material(
       color: Colors.transparent,
@@ -1176,7 +1200,17 @@ class _HoverPreviewCardInnerState
                   fit: StackFit.expand,
                   children: [
                     ColoredBox(color: theme.colorScheme.surfaceContainerLowest),
-                    if (imageCoordinator != null)
+                    if (imageUrl.isEmpty)
+                      Center(
+                        child: Icon(
+                          post.isVideo
+                              ? Icons.play_circle_outline
+                              : Icons.image_not_supported_outlined,
+                          color: Colors.white70,
+                          size: 48,
+                        ),
+                      )
+                    else if (imageCoordinator != null)
                       ProgressiveGalleryImage(
                         thumbnail: GalleryImageRequest.forUrl(
                           sourceId: post.sourceId,

--- a/lib/presentation/widgets/online_gallery/coordinated_gallery_image.dart
+++ b/lib/presentation/widgets/online_gallery/coordinated_gallery_image.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../../core/cache/gallery_image_request.dart';
+import '../../../core/cache/online_gallery_image_cache_manager.dart';
+import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
+import '../../../core/utils/app_logger.dart';
+
+/// Routes gallery image downloads through the shared network QoS coordinator.
+///
+/// Already decoded pixels remain visible while critical requests pause gallery
+/// traffic. Images that were still loading resume after the pause ends.
+class CoordinatedGalleryImage extends StatefulWidget {
+  const CoordinatedGalleryImage({
+    super.key,
+    required this.request,
+    required this.coordinator,
+    this.priority = GalleryImagePriority.visible,
+    this.fit = BoxFit.cover,
+    this.alignment = Alignment.center,
+    this.placeholder,
+    this.errorWidget,
+  });
+
+  final GalleryImageRequest request;
+  final OnlineGalleryPrefetchCoordinator coordinator;
+  final GalleryImagePriority priority;
+  final BoxFit fit;
+  final AlignmentGeometry alignment;
+  final Widget? placeholder;
+  final Widget? errorWidget;
+
+  @override
+  State<CoordinatedGalleryImage> createState() =>
+      _CoordinatedGalleryImageState();
+}
+
+class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
+  bool _ready = false;
+  bool _failed = false;
+  bool _requesting = false;
+  int _revision = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.coordinator.addListener(_handleCoordinatorChanged);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _requestImage();
+  }
+
+  @override
+  void didUpdateWidget(CoordinatedGalleryImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final coordinatorChanged = !identical(
+      oldWidget.coordinator,
+      widget.coordinator,
+    );
+    final requestChanged =
+        oldWidget.request.stableRequestKey != widget.request.stableRequestKey;
+    if (coordinatorChanged) {
+      oldWidget.coordinator.removeListener(_handleCoordinatorChanged);
+      widget.coordinator.addListener(_handleCoordinatorChanged);
+    }
+    if (coordinatorChanged || requestChanged) {
+      _revision += 1;
+      _requesting = false;
+      if (requestChanged) {
+        _ready = false;
+        _failed = false;
+      } else if (!_ready) {
+        _failed = false;
+      }
+      _requestImage();
+    }
+  }
+
+  @override
+  void dispose() {
+    _revision += 1;
+    widget.coordinator.removeListener(_handleCoordinatorChanged);
+    super.dispose();
+  }
+
+  void _handleCoordinatorChanged() {
+    if (_ready || widget.coordinator.isPaused) return;
+    if (_failed && !widget.coordinator.isNegativelyCached(widget.request)) {
+      setState(() => _failed = false);
+    }
+    if (!_failed) _requestImage();
+  }
+
+  void _requestImage() {
+    if (_ready || _failed || _requesting || widget.request.url.isEmpty) return;
+    _requesting = true;
+    final revision = ++_revision;
+    widget.coordinator.submit(widget.request, priority: widget.priority).then((
+      loaded,
+    ) {
+      if (!mounted || revision != _revision) return;
+      final negativelyCached = widget.coordinator.isNegativelyCached(
+        widget.request,
+      );
+      setState(() {
+        _requesting = false;
+        _ready = loaded;
+        _failed = negativelyCached;
+      });
+      if (!loaded &&
+          !widget.coordinator.isDisposed &&
+          !widget.coordinator.isPaused &&
+          !negativelyCached) {
+        scheduleMicrotask(_requestImage);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_failed) return widget.errorWidget ?? const SizedBox.shrink();
+    if (!_ready) return widget.placeholder ?? const SizedBox.shrink();
+    return Image(
+      image: widget.request.createImageProvider(
+        OnlineGalleryImageCacheManager.instance,
+      ),
+      fit: widget.fit,
+      alignment: widget.alignment,
+      gaplessPlayback: true,
+      errorBuilder: (_, error, __) {
+        if (!_failed) {
+          _failed = true;
+          AppLogger.w(
+            'Gallery image decode failed after coordinated preload: '
+                'source=${widget.request.sourceKey}, errorType=${error.runtimeType}',
+            'GalleryImage',
+          );
+        }
+        return widget.errorWidget ?? const SizedBox.shrink();
+      },
+    );
+  }
+}

--- a/lib/presentation/widgets/online_gallery/gallery_detail_action_panel.dart
+++ b/lib/presentation/widgets/online_gallery/gallery_detail_action_panel.dart
@@ -20,7 +20,11 @@ class GalleryDetailActionPanel extends StatelessWidget {
         media != null &&
         galleryMediaHasOriginal(media) &&
         galleryMediaDownloadUrl(media).isNotEmpty;
-    final canReverse = media != null && actions.sendToReverse != null;
+    final canReverse =
+        media != null &&
+        media.capability.isFlutterImage &&
+        media.capability.imageDisplayUrl.isNotEmpty &&
+        actions.sendToReverse != null;
     final canDownloadAll =
         actions.downloadAll != null && viewModel.media.length > 1;
     const actionStyle = ButtonStyle(

--- a/lib/presentation/widgets/online_gallery/gallery_detail_controller.dart
+++ b/lib/presentation/widgets/online_gallery/gallery_detail_controller.dart
@@ -3,17 +3,19 @@ import 'package:flutter/material.dart';
 
 import '../../../core/cache/gallery_image_request.dart';
 import '../../../core/cache/online_gallery_image_cache_manager.dart';
+import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
 import '../../../data/models/online_gallery/gallery_item.dart';
-import 'gallery_detail_models.dart';
 
 class GalleryDetailController extends ChangeNotifier {
   GalleryDetailController({
     required GalleryItem item,
     required GalleryDetail detail,
     required bool isFavorited,
+    OnlineGalleryPrefetchCoordinator? prefetchCoordinator,
   }) : _item = item,
        _detail = detail,
        _isFavorited = isFavorited,
+       _prefetchCoordinator = prefetchCoordinator,
        mediaIndex = _resolveInitialMediaIndex(item, detail) {
     pageController = PageController(initialPage: mediaIndex);
   }
@@ -30,6 +32,7 @@ class GalleryDetailController extends ChangeNotifier {
   bool queueActionPending = false;
   bool downloadActionPending = false;
   bool _disposed = false;
+  final OnlineGalleryPrefetchCoordinator? _prefetchCoordinator;
 
   bool get isFavorited => _isFavorited;
   List<GalleryMedia> get media => _detail.media;
@@ -85,7 +88,11 @@ class GalleryDetailController extends ChangeNotifier {
   void prefetchAdjacent(BuildContext context, int index) {
     for (final targetIndex in [index - 1, index + 1]) {
       if (targetIndex < 0 || targetIndex >= media.length) continue;
-      final url = galleryMediaDisplayUrl(media[targetIndex]);
+      final target = media[targetIndex];
+      final capability = target.capability;
+      final url = capability.isVideo
+          ? (capability.hasStaticThumbnail ? capability.previewUrl : '')
+          : capability.imageDisplayUrl;
       if (url.isEmpty) continue;
       final request = GalleryImageRequest.forUrl(
         sourceId: _item.sourceId,
@@ -96,9 +103,9 @@ class GalleryDetailController extends ChangeNotifier {
           MediaQuery.sizeOf(context).width,
         ),
       );
-      precacheImage(
-        request.createImageProvider(OnlineGalleryImageCacheManager.instance),
-        context,
+      _prefetchCoordinator?.submit(
+        request,
+        priority: GalleryImagePriority.interactiveDetail,
       );
     }
   }

--- a/lib/presentation/widgets/online_gallery/gallery_detail_dialog.dart
+++ b/lib/presentation/widgets/online_gallery/gallery_detail_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
 import '../../../data/models/online_gallery/gallery_item.dart';
 import '../../providers/online_gallery_output_filter_provider.dart';
 import 'gallery_detail_controller.dart';
@@ -42,6 +43,7 @@ class GalleryDetailDialog extends ConsumerStatefulWidget {
     this.onCopyRawArtistFragments,
     this.hasArtistChain,
     this.isOutputFiltered,
+    this.prefetchCoordinator,
   });
 
   final GalleryItem item;
@@ -69,6 +71,7 @@ class GalleryDetailDialog extends ConsumerStatefulWidget {
   final void Function(GalleryMedia media)? onCopyRawArtistFragments;
   final bool Function(GalleryMedia media)? hasArtistChain;
   final bool Function(String tag)? isOutputFiltered;
+  final OnlineGalleryPrefetchCoordinator? prefetchCoordinator;
 
   @override
   ConsumerState<GalleryDetailDialog> createState() =>
@@ -85,6 +88,7 @@ class _GalleryDetailDialogState extends ConsumerState<GalleryDetailDialog> {
       item: widget.item,
       detail: widget.detail,
       isFavorited: widget.isFavorited,
+      prefetchCoordinator: widget.prefetchCoordinator,
     )..addListener(_rebuild);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {

--- a/lib/presentation/widgets/online_gallery/gallery_detail_media_viewer.dart
+++ b/lib/presentation/widgets/online_gallery/gallery_detail_media_viewer.dart
@@ -123,14 +123,15 @@ class GalleryDetailMediaViewer extends StatelessWidget {
     GalleryMedia media,
     int index,
   ) {
-    final imageUrl = galleryMediaDisplayUrl(media);
-    if (imageUrl.isEmpty) return _noImageState(theme, dark: true);
-    final extension = media.extension?.toLowerCase();
-    if (media.mediaType == 'video' ||
-        extension == 'webm' ||
-        extension == 'mp4') {
-      return VideoPlayerWidget(videoUrl: imageUrl);
+    final capability = media.capability;
+    if (capability.isVideo) {
+      final videoUrl = capability.videoUrl;
+      return videoUrl.isEmpty
+          ? _videoPlaceholder(theme)
+          : VideoPlayerWidget(videoUrl: videoUrl);
     }
+    final imageUrl = capability.imageDisplayUrl;
+    if (imageUrl.isEmpty) return _noImageState(theme, dark: true);
 
     return InteractiveViewer(
       minScale: 0.75,
@@ -161,6 +162,20 @@ class GalleryDetailMediaViewer extends StatelessWidget {
       ),
     );
   }
+
+  Widget _videoPlaceholder(ThemeData theme) => Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Icon(Icons.play_circle_outline, color: Colors.white70, size: 54),
+        const SizedBox(height: 10),
+        Text(
+          viewModel.labels.noImageDescription,
+          style: theme.textTheme.bodySmall?.copyWith(color: Colors.white70),
+        ),
+      ],
+    ),
+  );
 
   Widget _imageError(ThemeData theme, GalleryMedia media) {
     return Column(
@@ -259,8 +274,11 @@ class GalleryDetailMediaViewer extends StatelessWidget {
           separatorBuilder: (_, __) => const SizedBox(width: 8),
           itemBuilder: (context, index) {
             final media = viewModel.media[index];
+            final capability = media.capability;
             final selected = index == viewModel.mediaIndex;
-            final previewUrl = galleryMediaPreviewUrl(media);
+            final previewUrl = capability.canPrefetchPreview
+                ? capability.previewUrl
+                : '';
             return Semantics(
               button: true,
               selected: selected,
@@ -288,7 +306,11 @@ class GalleryDetailMediaViewer extends StatelessWidget {
                     ),
                   ),
                   child: previewUrl.isEmpty
-                      ? const Icon(Icons.image_not_supported_outlined)
+                      ? Icon(
+                          capability.isVideo
+                              ? Icons.play_circle_outline
+                              : Icons.image_not_supported_outlined,
+                        )
                       : CachedNetworkImage(
                           imageUrl: previewUrl,
                           cacheManager: OnlineGalleryImageCacheManager.instance,

--- a/lib/presentation/widgets/online_gallery/gallery_detail_models.dart
+++ b/lib/presentation/widgets/online_gallery/gallery_detail_models.dart
@@ -233,16 +233,14 @@ bool galleryMediaHasOriginal(GalleryMedia media) {
 }
 
 String galleryMediaDisplayUrl(GalleryMedia media) {
-  if (media.displayUrl.isNotEmpty) return media.displayUrl;
-  if (media.previewUrl.isNotEmpty) return media.previewUrl;
-  return media.downloadUrl;
+  final capability = media.capability;
+  return capability.isVideo ? capability.videoUrl : capability.imageDisplayUrl;
 }
 
-String galleryMediaPreviewUrl(GalleryMedia media) => media.previewUrl.isNotEmpty
-    ? media.previewUrl
-    : galleryMediaDisplayUrl(media);
+String galleryMediaPreviewUrl(GalleryMedia media) =>
+    media.capability.canPrefetchPreview ? media.capability.previewUrl : '';
 
 String galleryMediaDownloadUrl(GalleryMedia media) =>
-    media.downloadUrl.isNotEmpty
-    ? media.downloadUrl
-    : galleryMediaDisplayUrl(media);
+    media.capability.downloadUrl.isNotEmpty
+    ? media.capability.downloadUrl
+    : media.capability.displayUrl;

--- a/lib/presentation/widgets/online_gallery/progressive_gallery_image.dart
+++ b/lib/presentation/widgets/online_gallery/progressive_gallery_image.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../core/cache/gallery_image_request.dart';
 import '../../../core/cache/online_gallery_image_cache_manager.dart';
 import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
+import 'coordinated_gallery_image.dart';
 
 class ProgressiveGalleryImage extends StatefulWidget {
   const ProgressiveGalleryImage({
@@ -33,8 +34,15 @@ class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
   @override
   void initState() {
     super.initState();
+    widget.coordinator.addListener(_handleCoordinatorChanged);
     _sampleReady = widget.coordinator.isSampleReady(widget.sample);
     _showSampleImmediately = _sampleReady;
+  }
+
+  @override
+  void dispose() {
+    widget.coordinator.removeListener(_handleCoordinatorChanged);
+    super.dispose();
   }
 
   @override
@@ -46,12 +54,26 @@ class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
   @override
   void didUpdateWidget(ProgressiveGalleryImage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.sample.stableRequestKey != widget.sample.stableRequestKey) {
+    final coordinatorChanged = !identical(
+      oldWidget.coordinator,
+      widget.coordinator,
+    );
+    final sampleChanged =
+        oldWidget.sample.stableRequestKey != widget.sample.stableRequestKey;
+    if (coordinatorChanged) {
+      oldWidget.coordinator.removeListener(_handleCoordinatorChanged);
+      widget.coordinator.addListener(_handleCoordinatorChanged);
+    }
+    if (coordinatorChanged || sampleChanged) {
       _revision++;
       _sampleReady = widget.coordinator.isSampleReady(widget.sample);
       _showSampleImmediately = _sampleReady;
       _requestSample();
     }
+  }
+
+  void _handleCoordinatorChanged() {
+    if (!_sampleReady && !widget.coordinator.isPaused) _requestSample();
   }
 
   void _requestSample() {
@@ -71,12 +93,13 @@ class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
   @override
   Widget build(BuildContext context) {
     final manager = OnlineGalleryImageCacheManager.instance;
-    final thumbnail = Image(
-      image: widget.thumbnail.createImageProvider(manager),
+    final thumbnail = CoordinatedGalleryImage(
+      request: widget.thumbnail,
+      coordinator: widget.coordinator,
+      priority: GalleryImagePriority.visible,
       fit: widget.fit,
       alignment: widget.alignment,
-      gaplessPlayback: true,
-      errorBuilder: (_, __, ___) => const ColoredBox(
+      errorWidget: const ColoredBox(
         color: Colors.black12,
         child: Center(child: Icon(Icons.broken_image_outlined)),
       ),

--- a/test/core/cache/cancellable_gallery_image_loader_test.dart
+++ b/test/core/cache/cancellable_gallery_image_loader_test.dart
@@ -1,0 +1,186 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/cache/cancellable_gallery_image_loader.dart';
+import 'package:nai_launcher/core/cache/gallery_image_request.dart';
+import 'package:nai_launcher/core/cache/online_gallery_prefetch_coordinator.dart';
+import 'package:nai_launcher/core/network/critical_network_activity.dart';
+
+void main() {
+  test(
+    'cancel aborts an unfinished transfer without publishing cache',
+    () async {
+      final requestArrived = Completer<void>();
+      final finishResponse = Completer<void>();
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        request.response.headers.contentType = ContentType('image', 'png');
+        request.response.add(List<int>.filled(1024, 1));
+        await request.response.flush();
+        requestArrived.complete();
+        await finishResponse.future;
+        try {
+          request.response.add(List<int>.filled(1024, 2));
+          await request.response.close();
+        } on Object {
+          // The expected peer abort closes the response while the server waits.
+        }
+      });
+
+      final url = 'http://${server.address.host}:${server.port}/slow.png';
+      final request = GalleryImageRequest(
+        sourceId: 'test',
+        url: url,
+        cacheKey: 'cancel-test-${DateTime.now().microsecondsSinceEpoch}',
+        tier: GalleryImageTier.thumbnail,
+      );
+      final cache = _RecordingCacheManager();
+      final loader = CancellableGalleryImageLoader(cacheManager: cache);
+      addTearDown(loader.dispose);
+
+      final operation = loader.start(request);
+      await requestArrived.future.timeout(const Duration(seconds: 2));
+      operation.cancel();
+
+      await expectLater(operation.future, throwsA(isA<Exception>()));
+      finishResponse.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(cache.putCalled, isFalse);
+    },
+  );
+
+  test(
+    'cancel aborts a gallery transfer routed through a slow proxy',
+    () async {
+      final requestArrived = Completer<Uri>();
+      final finishResponse = Completer<void>();
+      final proxy = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => proxy.close(force: true));
+      proxy.listen((request) async {
+        requestArrived.complete(request.uri);
+        request.response.headers.contentType = ContentType('image', 'jpeg');
+        request.response.add(List<int>.filled(1024, 1));
+        await request.response.flush();
+        await finishResponse.future;
+        try {
+          request.response.add(List<int>.filled(1024, 2));
+          await request.response.close();
+        } on Object {
+          // The expected peer abort closes the proxied response while it waits.
+        }
+      });
+
+      final httpClient = HttpClient()
+        ..findProxy = (_) => 'PROXY ${proxy.address.host}:${proxy.port}';
+      final cache = _RecordingCacheManager();
+      final loader = CancellableGalleryImageLoader(
+        cacheManager: cache,
+        httpClient: httpClient,
+      );
+      addTearDown(loader.dispose);
+      const request = GalleryImageRequest(
+        sourceId: 'test',
+        url: 'http://gallery.invalid/slow.jpg',
+        cacheKey: 'slow-proxy-cancel-test',
+        tier: GalleryImageTier.thumbnail,
+      );
+
+      final operation = loader.start(request);
+      final proxyUri = await requestArrived.future.timeout(
+        const Duration(seconds: 2),
+      );
+      expect(proxyUri.host, 'gallery.invalid');
+      operation.cancel();
+
+      await expectLater(operation.future, throwsA(isA<Exception>()));
+      finishResponse.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(cache.putCalled, isFalse);
+    },
+  );
+
+  test('generation activity aborts an in-flight slow-proxy image', () async {
+    final requestArrived = Completer<void>();
+    final finishResponse = Completer<void>();
+    final proxy = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => proxy.close(force: true));
+    proxy.listen((request) async {
+      request.response.headers.contentType = ContentType('image', 'jpeg');
+      request.response.add(List<int>.filled(1024, 1));
+      await request.response.flush();
+      requestArrived.complete();
+      await finishResponse.future;
+      try {
+        request.response.add(List<int>.filled(1024, 2));
+        await request.response.close();
+      } on Object {
+        // The generation lease is expected to abort the gallery peer.
+      }
+    });
+
+    final httpClient = HttpClient()
+      ..findProxy = (_) => 'PROXY ${proxy.address.host}:${proxy.port}';
+    final cache = _RecordingCacheManager();
+    final loader = CancellableGalleryImageLoader(
+      cacheManager: cache,
+      httpClient: httpClient,
+    );
+    addTearDown(loader.dispose);
+    final prefetch = OnlineGalleryPrefetchCoordinator(preloader: loader.start);
+    addTearDown(prefetch.dispose);
+    final critical = CriticalNetworkActivityCoordinator();
+    void syncCriticalState() {
+      prefetch.setCriticalNetworkActive(critical.isActive);
+    }
+
+    critical.addListener(syncCriticalState);
+    addTearDown(() => critical.removeListener(syncCriticalState));
+    const request = GalleryImageRequest(
+      sourceId: 'test',
+      url: 'http://gallery.invalid/competing.jpg',
+      cacheKey: 'generation-qos-slow-proxy-test',
+      tier: GalleryImageTier.thumbnail,
+    );
+
+    final galleryTransfer = prefetch.submit(
+      request,
+      priority: GalleryImagePriority.visible,
+    );
+    await requestArrived.future.timeout(const Duration(seconds: 2));
+    final generation = critical.acquire(
+      CriticalNetworkActivityType.imageGeneration,
+    );
+
+    expect(await galleryTransfer, isFalse);
+    expect(cache.putCalled, isFalse);
+
+    generation.release();
+    finishResponse.complete();
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(cache.putCalled, isFalse);
+  });
+}
+
+class _RecordingCacheManager implements BaseCacheManager {
+  bool putCalled = false;
+
+  @override
+  Future<FileInfo?> getFileFromCache(
+    String key, {
+    bool ignoreMemCache = false,
+  }) async => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #putFile) {
+      putCalled = true;
+      return Future<Object>.error(
+        StateError('Cancelled responses must not be cached'),
+      );
+    }
+    return super.noSuchMethod(invocation);
+  }
+}

--- a/test/core/cache/gallery_image_request_test.dart
+++ b/test/core/cache/gallery_image_request_test.dart
@@ -242,6 +242,25 @@ void main() {
       },
     );
 
+    test('known video URLs are rejected before image provider creation', () {
+      final generic = GalleryImageRequest.forUrl(
+        url: 'https://example.com/clip.WEBM?token=secret',
+        tier: GalleryImageTier.thumbnail,
+        targetDecodeWidth: 320,
+      );
+      final gelbooru = GalleryImageRequest.gelbooru(
+        url: 'https://img4.gelbooru.com/video/clip.mp4',
+        tier: GalleryImageTier.sample,
+      );
+
+      expect(generic.url, isEmpty);
+      expect(generic.cacheKey, isNull);
+      expect(generic.headers, isEmpty);
+      expect(gelbooru.url, isEmpty);
+      expect(gelbooru.cacheKey, isNull);
+      expect(gelbooru.headers, isEmpty);
+    });
+
     test('toString returns readable representation', () {
       final request = GalleryImageRequest(
         sourceId: 'test',
@@ -252,7 +271,7 @@ void main() {
 
       expect(
         request.toString(),
-        'GalleryImageRequest(test:https://example.com/image.jpg:thumbnail:320)',
+        'GalleryImageRequest(source=test, tier=thumbnail, targetWidth=320)',
       );
     });
   });

--- a/test/core/cache/online_gallery_detail_coordinator_test.dart
+++ b/test/core/cache/online_gallery_detail_coordinator_test.dart
@@ -257,4 +257,75 @@ void main() {
       expect(calls, 2);
     },
   );
+
+  test('background pause cancels low-priority details and resumes', () async {
+    final item = _item(6);
+    var calls = 0;
+    final coordinator = OnlineGalleryDetailCoordinator(
+      loader: (requested, cancelToken) async {
+        calls++;
+        if (calls == 1) throw await cancelToken.whenCancel;
+        return _detail(requested, 'resumed');
+      },
+    );
+
+    final active = coordinator.request(
+      item,
+      priority: GalleryDetailPriority.lookahead,
+    );
+    coordinator.setBackgroundPaused(true);
+
+    await expectLater(
+      active,
+      throwsA(
+        isA<DioException>().having(
+          (error) => error.type,
+          'type',
+          DioExceptionType.cancel,
+        ),
+      ),
+    );
+    await expectLater(
+      coordinator.request(item, priority: GalleryDetailPriority.visible),
+      throwsA(isA<DioException>()),
+    );
+
+    coordinator.setBackgroundPaused(false);
+    expect(
+      (await coordinator.request(
+        item,
+        priority: GalleryDetailPriority.visible,
+      )).description,
+      'resumed',
+    );
+    expect(calls, 2);
+  });
+
+  test(
+    'scroll cancellation stops lookahead but keeps visible detail',
+    () async {
+      final visibleGate = Completer<GalleryDetail>();
+      final coordinator = OnlineGalleryDetailCoordinator(
+        maxConcurrent: 2,
+        loader: (item, cancelToken) async {
+          if (item.id == 1) return visibleGate.future;
+          throw await cancelToken.whenCancel;
+        },
+      );
+      final visible = coordinator.request(
+        _item(1),
+        priority: GalleryDetailPriority.visible,
+      );
+      final lookahead = coordinator.request(
+        _item(2),
+        priority: GalleryDetailPriority.lookahead,
+      );
+
+      coordinator.cancelLookahead();
+      await expectLater(lookahead, throwsA(isA<DioException>()));
+
+      visibleGate.complete(_detail(_item(1), 'visible'));
+      expect((await visible).description, 'visible');
+    },
+  );
 }

--- a/test/core/cache/online_gallery_prefetch_coordinator_test.dart
+++ b/test/core/cache/online_gallery_prefetch_coordinator_test.dart
@@ -14,6 +14,9 @@ GalleryImageRequest _request(
   targetDecodeWidth: 320,
 );
 
+GalleryImagePreloadOperation _operation(Future<void> future) =>
+    GalleryImagePreloadOperation.fromFuture(future);
+
 Future<void> _waitUntil(bool Function() condition) async {
   for (var attempt = 0; attempt < 100; attempt++) {
     if (condition()) return;
@@ -33,7 +36,7 @@ void main() {
         if (active > maxActive) maxActive = active;
         final gate = Completer<void>();
         gates.add(gate);
-        return gate.future.whenComplete(() => active--);
+        return _operation(gate.future.whenComplete(() => active--));
       },
     );
 
@@ -64,7 +67,7 @@ void main() {
         started.add(request.url);
         final gate = Completer<void>();
         gates.add(gate);
-        return gate.future;
+        return _operation(gate.future);
       },
     );
 
@@ -99,7 +102,7 @@ void main() {
       final gate = Completer<void>();
       final coordinator = OnlineGalleryPrefetchCoordinator(
         maxConcurrent: 1,
-        preloader: (_) => gate.future,
+        preloader: (_) => _operation(gate.future),
       );
       final request = _request(1, tier: GalleryImageTier.sample);
 
@@ -126,7 +129,7 @@ void main() {
       final gate = Completer<void>();
       final coordinator = OnlineGalleryPrefetchCoordinator(
         maxConcurrent: 1,
-        preloader: (_) => gate.future,
+        preloader: (_) => _operation(gate.future),
       );
       final running = coordinator.submit(
         _request(1),
@@ -144,39 +147,37 @@ void main() {
     },
   );
 
-  test(
-    'scrolling keeps visible work moving but pauses lookahead work',
-    () async {
-      final started = <String>[];
-      final coordinator = OnlineGalleryPrefetchCoordinator(
-        maxConcurrent: 1,
-        preloader: (request) async => started.add(request.url),
-      );
-      coordinator.setScrolling(true);
+  test('scrolling rejects lookahead but still starts hover work', () async {
+    final started = <String>[];
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (request) =>
+          _operation(Future<void>.sync(() => started.add(request.url))),
+    );
+    coordinator.setScrolling(true);
 
-      final lookahead = coordinator.submit(
-        _request(1),
-        priority: GalleryImagePriority.lookahead,
-      );
-      final visible = coordinator.submit(
-        _request(2),
-        priority: GalleryImagePriority.visible,
-      );
-      await Future<void>.delayed(Duration.zero);
+    final low = coordinator.submit(
+      _request(1),
+      priority: GalleryImagePriority.lookahead,
+    );
+    final hover = coordinator.submit(
+      _request(2, tier: GalleryImageTier.sample),
+      priority: GalleryImagePriority.hover,
+    );
+    await Future<void>.delayed(Duration.zero);
 
-      expect(started, ['https://example.com/2.jpg']);
-      expect(await visible, isTrue);
-      coordinator.setScrolling(false);
-      expect(await lookahead, isTrue);
-    },
-  );
+    expect(started, ['https://example.com/2.jpg']);
+    expect(await hover, isTrue);
+    coordinator.setScrolling(false);
+    expect(await low, isFalse);
+  });
 
   test('moving thumbnail window cancels stale queued requests', () async {
     final gate = Completer<void>();
     final coordinator = OnlineGalleryPrefetchCoordinator(
       maxConcurrent: 1,
-      preloader: (request) =>
-          request.url.endsWith('/0.jpg') ? gate.future : Future<void>.value(),
+      preloader: (request) => _operation(
+        request.url.endsWith('/0.jpg') ? gate.future : Future<void>.value(),
+      ),
     );
     final active = coordinator.submit(
       _request(0),
@@ -208,9 +209,9 @@ void main() {
       maxQueued: 2,
       preloader: (request) {
         started.add(request.url);
-        return request.url.endsWith('/0.jpg')
-            ? gate.future
-            : Future<void>.value();
+        return _operation(
+          request.url.endsWith('/0.jpg') ? gate.future : Future<void>.value(),
+        );
       },
     );
     final active = coordinator.submit(
@@ -247,7 +248,7 @@ void main() {
     'completed sample LRU retains only the latest sixteen requests',
     () async {
       final coordinator = OnlineGalleryPrefetchCoordinator(
-        preloader: (_) async {},
+        preloader: (_) => _operation(Future<void>.value()),
       );
 
       for (var index = 0; index < 17; index++) {
@@ -268,8 +269,9 @@ void main() {
     },
   );
 
-  test('new generation can reuse an old in-flight disk download', () async {
+  test('new generation cancels stale in-flight work on the wire', () async {
     final gates = <Completer<void>>[];
+    var cancels = 0;
     var starts = 0;
     final request = _request(1);
     final coordinator = OnlineGalleryPrefetchCoordinator(
@@ -278,7 +280,15 @@ void main() {
         starts++;
         final gate = Completer<void>();
         gates.add(gate);
-        return gate.future;
+        return GalleryImagePreloadOperation(
+          future: gate.future,
+          cancel: () {
+            cancels++;
+            if (!gate.isCompleted) {
+              gate.completeError(StateError('cancelled'));
+            }
+          },
+        );
       },
     );
 
@@ -291,10 +301,203 @@ void main() {
       request,
       priority: GalleryImagePriority.visible,
     );
-    gates.first.complete();
     expect(await old, isFalse);
+    await _waitUntil(() => gates.length == 2);
+    gates[1].complete();
     expect(await current, isTrue);
-    expect(starts, 1);
+    expect(starts, 2);
+    expect(cancels, 1);
+  });
+
+  test(
+    'stale completion cannot remove the replacement in-flight task',
+    () async {
+      final gates = <Completer<void>>[];
+      final coordinator = OnlineGalleryPrefetchCoordinator(
+        maxConcurrent: 2,
+        preloader: (_) {
+          final gate = Completer<void>();
+          gates.add(gate);
+          return GalleryImagePreloadOperation(
+            future: gate.future,
+            cancel: () {},
+          );
+        },
+      );
+      addTearDown(coordinator.dispose);
+      final request = _request(1);
+
+      final stale = coordinator.submit(
+        request,
+        priority: GalleryImagePriority.visible,
+      );
+      coordinator.rotateGeneration();
+      final replacement = coordinator.submit(
+        request,
+        priority: GalleryImagePriority.visible,
+      );
+      await _waitUntil(() => gates.length == 2);
+
+      gates.first.complete();
+      expect(await stale, isFalse);
+      expect(coordinator.activeCount, 1);
+
+      gates.last.complete();
+      expect(await replacement, isTrue);
+      expect(coordinator.activeCount, 0);
+    },
+  );
+
+  test(
+    'critical activity cancels low-priority work but keeps detail',
+    () async {
+      final cancelled = <String>[];
+      final gates = <String, Completer<void>>{};
+      final coordinator = OnlineGalleryPrefetchCoordinator(
+        preloader: (request) {
+          final gate = Completer<void>();
+          gates[request.url] = gate;
+          return GalleryImagePreloadOperation(
+            future: gate.future,
+            cancel: () {
+              cancelled.add(request.url);
+              if (!gate.isCompleted) {
+                gate.completeError(StateError('cancelled'));
+              }
+            },
+          );
+        },
+      );
+
+      final visible = coordinator.submit(
+        _request(1),
+        priority: GalleryImagePriority.visible,
+      );
+      coordinator.setCriticalNetworkActive(true);
+      expect(await visible, isFalse);
+      expect(cancelled, ['https://example.com/1.jpg']);
+
+      final rejected = coordinator.submit(
+        _request(2),
+        priority: GalleryImagePriority.hover,
+      );
+      final detail = coordinator.submit(
+        _request(3),
+        priority: GalleryImagePriority.interactiveDetail,
+      );
+      expect(await rejected, isFalse);
+      await _waitUntil(() => gates.containsKey('https://example.com/3.jpg'));
+      gates['https://example.com/3.jpg']!.complete();
+      expect(await detail, isTrue);
+    },
+  );
+
+  test('nested pause reasons resume only after every reason clears', () async {
+    final started = <String>[];
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (request) =>
+          _operation(Future<void>.sync(() => started.add(request.url))),
+    );
+
+    coordinator.setPageVisible(false);
+    coordinator.setAppForeground(false);
+    expect(coordinator.pauseReasons, {
+      GalleryPrefetchPauseReason.pageHidden,
+      GalleryPrefetchPauseReason.appBackground,
+    });
+
+    coordinator.setPageVisible(true);
+    expect(coordinator.isPaused, isTrue);
+    expect(
+      await coordinator.submit(
+        _request(1),
+        priority: GalleryImagePriority.interactiveDetail,
+      ),
+      isFalse,
+    );
+
+    coordinator.setAppForeground(true);
+    expect(coordinator.isPaused, isFalse);
+    expect(
+      await coordinator.submit(
+        _request(2),
+        priority: GalleryImagePriority.visible,
+      ),
+      isTrue,
+    );
+    expect(started, ['https://example.com/2.jpg']);
+  });
+
+  test('visible work is not starved by continuous detail work', () async {
+    final started = <String>[];
+    final gates = <Completer<void>>[];
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      maxConcurrent: 1,
+      preloader: (request) {
+        started.add(request.url);
+        final gate = Completer<void>();
+        gates.add(gate);
+        return _operation(gate.future);
+      },
+    );
+
+    final first = coordinator.submit(
+      _request(0),
+      priority: GalleryImagePriority.interactiveDetail,
+    );
+    final visible = coordinator.submit(
+      _request(9),
+      priority: GalleryImagePriority.visible,
+    );
+    final details = [
+      for (var index = 1; index <= 4; index++)
+        coordinator.submit(
+          _request(index),
+          priority: GalleryImagePriority.interactiveDetail,
+        ),
+    ];
+
+    for (var index = 0; index < 3; index++) {
+      gates[index].complete();
+      await _waitUntil(() => gates.length > index + 1);
+    }
+    expect(started[3], 'https://example.com/9.jpg');
+
+    for (var index = 3; index < 6; index++) {
+      gates[index].complete();
+      if (index < 5) await _waitUntil(() => gates.length > index + 1);
+    }
+    expect(await first, isTrue);
+    expect(await visible, isTrue);
+    expect(await Future.wait(details), everyElement(isTrue));
+  });
+
+  test('dispose cancels active work and rejects future submissions', () async {
+    final gate = Completer<void>();
+    var cancelled = false;
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (_) => GalleryImagePreloadOperation(
+        future: gate.future,
+        cancel: () {
+          cancelled = true;
+          if (!gate.isCompleted) gate.completeError(StateError('cancelled'));
+        },
+      ),
+    );
+    final active = coordinator.submit(
+      _request(1),
+      priority: GalleryImagePriority.visible,
+    );
+    coordinator.dispose();
+    expect(await active, isFalse);
+    expect(cancelled, isTrue);
+    expect(
+      await coordinator.submit(
+        _request(2),
+        priority: GalleryImagePriority.visible,
+      ),
+      isFalse,
+    );
   });
 
   test(
@@ -305,10 +508,12 @@ void main() {
       final request = _request(1, tier: GalleryImageTier.sample);
       final coordinator = OnlineGalleryPrefetchCoordinator(
         now: () => now,
-        preloader: (_) async {
-          attempts++;
-          throw StateError('failed');
-        },
+        preloader: (_) => _operation(
+          Future<void>.sync(() {
+            attempts++;
+            throw StateError('failed');
+          }),
+        ),
       );
 
       expect(
@@ -335,4 +540,45 @@ void main() {
       expect(coordinator.isNegativelyCached(request), isFalse);
     },
   );
+
+  test('cancels one hover request without cancelling visible work', () async {
+    final gates = <String, Completer<void>>{};
+    final cancelled = <String>[];
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      maxConcurrent: 2,
+      preloader: (request) {
+        final gate = Completer<void>();
+        gates[request.url] = gate;
+        return GalleryImagePreloadOperation(
+          future: gate.future,
+          cancel: () {
+            cancelled.add(request.url);
+            gate.completeError(StateError('cancelled'));
+          },
+        );
+      },
+    );
+    addTearDown(coordinator.dispose);
+    final hoverRequest = _request(1, tier: GalleryImageTier.sample);
+    final visibleRequest = _request(2);
+    final hover = coordinator.submit(
+      hoverRequest,
+      priority: GalleryImagePriority.hover,
+    );
+    final visible = coordinator.submit(
+      visibleRequest,
+      priority: GalleryImagePriority.visible,
+    );
+
+    coordinator.cancel(
+      hoverRequest,
+      priority: GalleryImagePriority.hover,
+      reason: 'hover-dismissed',
+    );
+    expect(await hover, isFalse);
+    expect(cancelled, [hoverRequest.url]);
+
+    gates[visibleRequest.url]!.complete();
+    expect(await visible, isTrue);
+  });
 }

--- a/test/core/network/critical_network_activity_test.dart
+++ b/test/core/network/critical_network_activity_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/network/critical_network_activity.dart';
+
+void main() {
+  test('nested leases notify only on inactive-active boundaries', () {
+    final coordinator = CriticalNetworkActivityCoordinator();
+    expect(coordinator.isActive, isFalse);
+    var notifications = 0;
+    void listener() => notifications++;
+    coordinator.addListener(listener);
+    addTearDown(() => coordinator.removeListener(listener));
+
+    final generation = coordinator.acquire(
+      CriticalNetworkActivityType.imageGeneration,
+    );
+    final vibe = coordinator.acquire(CriticalNetworkActivityType.vibeEncoding);
+    expect(coordinator.activeLeaseCount, 2);
+    expect(notifications, 1);
+
+    vibe.release();
+    vibe.release();
+    expect(coordinator.isActive, isTrue);
+    expect(notifications, 1);
+
+    generation.release();
+    expect(coordinator.isActive, isFalse);
+    expect(notifications, 2);
+  });
+}

--- a/test/data/datasources/remote/nai_image_enhancement_api_service_test.dart
+++ b/test/data/datasources/remote/nai_image_enhancement_api_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -7,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 import 'package:mocktail/mocktail.dart';
 import 'package:nai_launcher/data/datasources/remote/nai_image_enhancement_api_service.dart';
+import 'package:nai_launcher/core/network/critical_network_activity.dart';
+import 'package:nai_launcher/core/network/nai_api_endpoint_service.dart';
 
 class _MockDio extends Mock implements Dio {}
 
@@ -215,6 +218,94 @@ void main() {
       expect(capturedData?['model'], equals('nai-diffusion-4-5-full'));
       expect(capturedData?['information_extracted'], equals(0.35));
       expect(capturedData?.containsKey('informationExtracted'), isFalse);
+    });
+
+    test(
+      'critical network lease covers transport and releases on error',
+      () async {
+        final dio = _MockDio();
+        final activity = CriticalNetworkActivityCoordinator();
+        final response = Completer<Response<dynamic>>();
+        when(
+          () => dio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          ),
+        ).thenAnswer((_) => response.future);
+        final service = NAIImageEnhancementApiService(
+          dio,
+          NaiApiEndpointService(),
+          activity,
+        );
+
+        final request = service.encodeVibe(
+          _buildPng(width: 8, height: 8),
+          model: 'nai-diffusion-4-5-full',
+          informationExtracted: 1,
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(activity.isActive, isTrue);
+        expect(activity.activeTypes, {
+          CriticalNetworkActivityType.vibeEncoding,
+        });
+
+        response.completeError(
+          DioException(requestOptions: RequestOptions(path: '/encode-vibe')),
+        );
+        await expectLater(request, throwsA(isA<Exception>()));
+        expect(activity.isActive, isFalse);
+      },
+    );
+
+    test('cloud upscale uses its own critical network activity type', () async {
+      final dio = _MockDio();
+      final activity = CriticalNetworkActivityCoordinator();
+      final response = Completer<Response<dynamic>>();
+      when(
+        () => dio.post<dynamic>(
+          any(),
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+          onReceiveProgress: any(named: 'onReceiveProgress'),
+        ),
+      ).thenAnswer((_) => response.future);
+      final service = NAIImageEnhancementApiService(
+        dio,
+        NaiApiEndpointService(),
+        activity,
+      );
+
+      final request = service.upscaleImage(_buildPng(width: 8, height: 8));
+      await Future<void>.delayed(Duration.zero);
+      expect(activity.activeTypes, {CriticalNetworkActivityType.cloudUpscale});
+
+      response.completeError(
+        DioException(
+          requestOptions: RequestOptions(path: '/upscale'),
+          response: Response<dynamic>(
+            requestOptions: RequestOptions(path: '/upscale'),
+            statusCode: 500,
+          ),
+        ),
+      );
+      await expectLater(request, throwsA(isA<Exception>()));
+      expect(activity.isActive, isFalse);
+    });
+
+    test('director lease releases when local validation fails', () async {
+      final activity = CriticalNetworkActivityCoordinator();
+      final service = NAIImageEnhancementApiService(
+        _MockDio(),
+        NaiApiEndpointService(),
+        activity,
+      );
+
+      await expectLater(
+        service.augmentImage(Uint8List(0), reqType: 'bg-removal'),
+        throwsA(isA<RangeError>()),
+      );
+      expect(activity.isActive, isFalse);
     });
   });
 }

--- a/test/data/datasources/remote/nai_image_generation_api_service_test.dart
+++ b/test/data/datasources/remote/nai_image_generation_api_service_test.dart
@@ -12,9 +12,11 @@ import 'package:msgpack_dart/msgpack_dart.dart' as msgpack;
 import 'package:nai_launcher/core/constants/api_constants.dart';
 import 'package:nai_launcher/core/network/nai_api_endpoint.dart';
 import 'package:nai_launcher/core/network/nai_api_endpoint_service.dart';
+import 'package:nai_launcher/core/network/critical_network_activity.dart';
 import 'package:nai_launcher/data/datasources/remote/nai_image_enhancement_api_service.dart';
 import 'package:nai_launcher/data/datasources/remote/nai_image_generation_api_service.dart';
 import 'package:nai_launcher/data/models/image/image_params.dart';
+import 'package:nai_launcher/data/models/vibe/vibe_reference.dart';
 import 'package:nai_launcher/presentation/providers/generation/image_generation_service.dart';
 
 void main() {
@@ -163,6 +165,97 @@ void main() {
 
     adapter.requests.single.completeWithEmptyZip();
     await expectLater(generation, throwsA(isA<Exception>()));
+  });
+
+  test(
+    'proxy multipart read timeout remains a failed generation and releases QoS',
+    () async {
+      final adapter = _PendingDioAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      final endpointService = NaiApiEndpointService();
+      final networkActivity = CriticalNetworkActivityCoordinator();
+      final service = NAIImageGenerationApiService(
+        dio,
+        NAIImageEnhancementApiService(dio, endpointService),
+        endpointService,
+        networkActivity,
+      );
+
+      final generation = service.generateImage(
+        const ImageParams(prompt: 'slow multipart contract'),
+      );
+      await _waitForRequestCount(adapter, 1);
+      expect(networkActivity.isActive, isTrue);
+      adapter.requests.single.completeWithStatus(
+        400,
+        'failed to read multipart part: multipart: NextPart: '
+        'read tcp 10.5.218.109:3000->10.4.100.238:50298: i/o timeout',
+      );
+
+      await expectLater(
+        generation,
+        throwsA(
+          isA<DioException>().having(
+            (error) {
+              final data = error.response?.data;
+              return data is List<int> ? utf8.decode(data) : data.toString();
+            },
+            'response body',
+            contains('multipart: NextPart'),
+          ),
+        ),
+      );
+      expect(networkActivity.isActive, isFalse);
+    },
+  );
+
+  test('generation retains its lease across nested vibe encoding', () async {
+    final adapter = _PendingDioAdapter();
+    final dio = Dio()..httpClientAdapter = adapter;
+    final endpointService = NaiApiEndpointService();
+    final networkActivity = CriticalNetworkActivityCoordinator();
+    final enhancementService = NAIImageEnhancementApiService(
+      dio,
+      endpointService,
+      networkActivity,
+    );
+    final service = NAIImageGenerationApiService(
+      dio,
+      enhancementService,
+      endpointService,
+      networkActivity,
+    );
+
+    final generation = service.generateImage(
+      ImageParams(
+        prompt: 'nested vibe lease',
+        model: ImageModels.animeDiffusionV4Full,
+        vibeReferencesV4: [
+          VibeReference(
+            displayName: 'raw',
+            vibeEncoding: '',
+            rawImageData: Uint8List.fromList(const [1, 2, 3]),
+          ),
+        ],
+      ),
+    );
+    await _waitForRequestCount(adapter, 1);
+    expect(networkActivity.activeTypes, {
+      CriticalNetworkActivityType.imageGeneration,
+      CriticalNetworkActivityType.vibeEncoding,
+    });
+
+    adapter.requests.single.response.complete(
+      ResponseBody.fromBytes(const [4, 5, 6], 200),
+    );
+    await _waitForRequestCount(adapter, 2);
+    expect(networkActivity.activeTypes, {
+      CriticalNetworkActivityType.imageGeneration,
+    });
+
+    adapter.requests[1].completeWithEmptyZip();
+    await expectLater(generation, throwsA(isA<Exception>()));
+    expect(networkActivity.isActive, isFalse);
   });
 
   test('completed older request must not clear newer cancel token', () async {
@@ -1174,6 +1267,18 @@ class _PendingRequest {
 
   void completeWithError(Object error) {
     response.completeError(error);
+  }
+
+  void completeWithStatus(int statusCode, String body) {
+    response.complete(
+      ResponseBody.fromString(
+        body,
+        statusCode,
+        headers: {
+          Headers.contentTypeHeader: ['text/plain; charset=utf-8'],
+        },
+      ),
+    );
   }
 }
 

--- a/test/data/models/online_gallery/gallery_media_capability_test.dart
+++ b/test/data/models/online_gallery/gallery_media_capability_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_item.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_media_capability.dart';
+
+void main() {
+  group('GalleryMediaCapability', () {
+    test('video metadata wins a misleading image URL', () {
+      final capability = GalleryMediaCapability.resolve(
+        declaredType: 'video',
+        mimeType: 'video/webm',
+        extension: 'jpg',
+        previewUrl: 'https://cdn.example/thumb.jpg?size=small',
+        displayUrl: 'https://cdn.example/not-a-frame.jpg',
+        downloadUrl: 'https://cdn.example/movie.WEBM?token=secret',
+      );
+
+      expect(capability.kind, GalleryMediaKind.video);
+      expect(capability.hasStaticThumbnail, isTrue);
+      expect(capability.imageDisplayUrl, capability.previewUrl);
+      expect(capability.videoUrl, contains('movie.WEBM'));
+    });
+
+    test('mixed-case URL path and query classify without using query text', () {
+      expect(
+        GalleryMediaCapability.resolve(
+          displayUrl: 'https://cdn.example/a/b/IMAGE.JpG?format=mp4',
+        ).kind,
+        GalleryMediaKind.staticImage,
+      );
+      expect(
+        GalleryMediaCapability.resolve(
+          displayUrl: 'https://cdn.example/a/b/CLIP.MP4?format=jpg',
+        ).kind,
+        GalleryMediaKind.video,
+      );
+    });
+
+    test('video preview is never exposed to Flutter image decoding', () {
+      final capability = GalleryMediaCapability.resolve(
+        declaredType: 'video',
+        previewUrl: 'https://cdn.example/preview.webm',
+        downloadUrl: 'https://cdn.example/original.webm',
+      );
+
+      expect(capability.canPrefetchPreview, isFalse);
+      expect(capability.hasStaticThumbnail, isFalse);
+      expect(capability.imageDisplayUrl, isEmpty);
+    });
+
+    test('unknown extension remains unknown instead of guessing image', () {
+      final capability = GalleryMediaCapability.resolve(
+        displayUrl: 'https://cdn.example/blob?id=1',
+      );
+      expect(capability.kind, GalleryMediaKind.unknown);
+      expect(capability.isFlutterImage, isFalse);
+    });
+
+    test('media without source declarations defaults to unknown', () {
+      const media = GalleryMedia(
+        id: 'unknown',
+        displayUrl: 'https://cdn.example/blob?id=1',
+      );
+
+      expect(media.capability.kind, GalleryMediaKind.unknown);
+      expect(media.capability.isFlutterImage, isFalse);
+    });
+
+    test('declared images may use extensionless CDN URLs', () {
+      final capability = GalleryMediaCapability.resolve(
+        declaredType: 'image',
+        previewUrl: 'https://cdn.example/preview?id=1',
+        displayUrl: 'https://cdn.example/display?id=1',
+      );
+
+      expect(capability.canPrefetchPreview, isTrue);
+      expect(capability.imageDisplayUrl, capability.displayUrl);
+    });
+
+    test('extensionless video previews remain placeholders', () {
+      final capability = GalleryMediaCapability.resolve(
+        declaredType: 'video',
+        previewUrl: 'https://cdn.example/preview?id=1',
+        downloadUrl: 'https://cdn.example/video?id=1',
+      );
+
+      expect(capability.canPrefetchPreview, isFalse);
+      expect(capability.imageDisplayUrl, isEmpty);
+      expect(capability.videoUrl, capability.downloadUrl);
+    });
+
+    test('video metadata never sends a known static URL to the player', () {
+      final capability = GalleryMediaCapability.resolve(
+        declaredType: 'video',
+        displayUrl: 'https://cdn.example/fallback.jpg',
+      );
+
+      expect(capability.kind, GalleryMediaKind.video);
+      expect(capability.videoUrl, isEmpty);
+      expect(capability.imageDisplayUrl, isEmpty);
+    });
+  });
+}

--- a/test/presentation/providers/generation/generation_params_notifier_test.dart
+++ b/test/presentation/providers/generation/generation_params_notifier_test.dart
@@ -140,7 +140,7 @@ void main() {
     expect(subscriptionNotifier.refreshScheduleCount, 3);
   });
 
-  test('Vibe 编码失败不调度计费刷新', () async {
+  test('Vibe 编码失败也调度计费刷新以核对服务端余额', () async {
     final apiService = _FakeEnhancementApiService(shouldFail: true);
     final subscriptionNotifier = _TestSubscriptionNotifier();
     final container = ProviderContainer(
@@ -163,7 +163,7 @@ void main() {
 
     expect(encoding, isNull);
     expect(apiService.callCount, 1);
-    expect(subscriptionNotifier.refreshScheduleCount, 0);
+    expect(subscriptionNotifier.refreshScheduleCount, 1);
   });
 
   for (final status in [AuthStatus.unauthenticated, AuthStatus.loading]) {

--- a/test/presentation/providers/generation/image_generation_cancel_test.dart
+++ b/test/presentation/providers/generation/image_generation_cancel_test.dart
@@ -58,7 +58,10 @@ class TestSubscriptionNotifier extends SubscriptionNotifier {
   }
 
   @override
-  Future<bool> refreshBalance() async => true;
+  Future<bool> refreshBalance({
+    SubscriptionRefreshPriority priority =
+        SubscriptionRefreshPriority.userInitiated,
+  }) async => true;
 }
 
 /// 记录请求与取消状态的假 HTTP 适配器。

--- a/test/presentation/providers/krita/krita_bridge_service_test.dart
+++ b/test/presentation/providers/krita/krita_bridge_service_test.dart
@@ -138,6 +138,7 @@ void main() {
         var streamCalls = 0;
         var fallbackCalls = 0;
         var registerCalls = 0;
+        var refreshCalls = 0;
         final service = KritaBridgeService(
           readBaseParams: () => const ImageParams(),
           send: sent.add,
@@ -156,6 +157,7 @@ void main() {
             return null;
           },
           cancelGeneration: () {},
+          schedulePostBillingRefresh: () => refreshCalls++,
         )..setActiveRequestReporter(activeRequests.add);
 
         await service.handle(
@@ -172,6 +174,7 @@ void main() {
         expect(streamCalls, 0);
         expect(fallbackCalls, 0);
         expect(registerCalls, 0);
+        expect(refreshCalls, 0);
         expect(service.isBridgeGenerating, isFalse);
         expect(activeRequests, isEmpty);
         expect(sent, hasLength(1));
@@ -224,6 +227,7 @@ void main() {
     test('rate limits immediate retry after failed Krita request', () async {
       final sent = <Map<String, dynamic>>[];
       var streamCalls = 0;
+      var refreshCalls = 0;
       var now = DateTime.utc(2026, 5, 10, 12);
       final service = KritaBridgeService(
         readBaseParams: () => const ImageParams(),
@@ -238,6 +242,7 @@ void main() {
         registerExternalImage: (_, {required params, addToDisplay}) async =>
             null,
         cancelGeneration: () {},
+        schedulePostBillingRefresh: () => refreshCalls++,
         clock: () => now,
         failureCooldown: const Duration(seconds: 5),
       );
@@ -259,6 +264,7 @@ void main() {
       await sendRequest('img-fail-2');
 
       expect(streamCalls, 1);
+      expect(refreshCalls, 1);
       expect(sent, hasLength(2));
       expect(sent.first['code'], KritaBridgeErrorCode.serverError.value);
       expect(sent.last['id'], 'img-fail-2');
@@ -268,6 +274,7 @@ void main() {
       await sendRequest('img-fail-3');
 
       expect(streamCalls, 2);
+      expect(refreshCalls, 2);
       expect(sent.last['id'], 'img-fail-3');
       expect(sent.last['code'], KritaBridgeErrorCode.serverError.value);
     });
@@ -511,6 +518,7 @@ void main() {
       () async {
         final sent = <Map<String, dynamic>>[];
         final registered = <({Uint8List image, ImageParams params})>[];
+        var refreshCalls = 0;
         late KritaBridgeGenerateRequest capturedRequest;
         final finalImage = Uint8List.fromList([7, 8, 9]);
 
@@ -542,6 +550,7 @@ void main() {
                 return 'G:/AIdarw/generated/krita-result.png';
               },
           cancelGeneration: () {},
+          schedulePostBillingRefresh: () => refreshCalls++,
         );
 
         await service.handle(
@@ -587,6 +596,7 @@ void main() {
         expect(registered, hasLength(1));
         expect(registered.single.image, finalImage);
         expect(registered.single.params.prompt, 'dog');
+        expect(refreshCalls, 1);
       },
     );
 
@@ -893,6 +903,7 @@ void main() {
       () async {
         final sent = <Map<String, dynamic>>[];
         var cancelCalled = false;
+        var refreshCalls = 0;
         final streamController = StreamController<ImageStreamChunk>();
         final service = KritaBridgeService(
           readBaseParams: () => const ImageParams(),
@@ -906,6 +917,7 @@ void main() {
           cancelGeneration: () {
             cancelCalled = true;
           },
+          schedulePostBillingRefresh: () => refreshCalls++,
         );
 
         final generation = service.handle(
@@ -941,6 +953,7 @@ void main() {
 
         await streamController.close();
         await generation;
+        expect(refreshCalls, 1);
       },
     );
 

--- a/test/presentation/providers/online_gallery_pagination_test.dart
+++ b/test/presentation/providers/online_gallery_pagination_test.dart
@@ -47,6 +47,39 @@ void main() {
     },
   );
 
+  test('background pause cancels gallery page traffic until resume', () async {
+    final started = Completer<void>();
+    var calls = 0;
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, cancelToken) async {
+        calls++;
+        if (calls == 1) {
+          started.complete();
+          throw await cancelToken!.whenCancel;
+        }
+        return _page(request.cursor, [_item(1)], nextCursor: null);
+      },
+    );
+    final container = _container(danbooru: adapter);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    final active = notifier.loadPosts();
+    await started.future;
+    notifier.setBackgroundNetworkPaused(true);
+    await active;
+    expect(container.read(onlineGalleryNotifierProvider).isLoading, isFalse);
+
+    await notifier.loadPosts();
+    expect(calls, 1);
+
+    notifier.setBackgroundNetworkPaused(false);
+    await notifier.loadPosts();
+    expect(calls, 2);
+    expect(container.read(onlineGalleryNotifierProvider).posts, hasLength(1));
+  });
+
   test(
     'concurrent load-more triggers claim one append synchronously',
     () async {

--- a/test/presentation/providers/subscription_provider_test.dart
+++ b/test/presentation/providers/subscription_provider_test.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nai_launcher/core/network/critical_network_activity.dart';
 import 'package:nai_launcher/data/datasources/remote/nai_user_info_api_service.dart';
 import 'package:nai_launcher/data/models/user/user_subscription.dart';
 import 'package:nai_launcher/presentation/providers/auth_provider.dart';
@@ -36,6 +38,24 @@ class _AuthenticatedAuthNotifier extends AuthNotifier {
   }
 }
 
+class _HydratedAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() {
+    return const AuthState(
+      status: AuthStatus.authenticated,
+      accountId: 'test-account',
+      subscriptionInfo: {
+        'tier': 3,
+        'active': true,
+        'trainingStepsLeft': {
+          'fixedTrainingStepsLeft': 100,
+          'purchasedTrainingSteps': 0,
+        },
+      },
+    );
+  }
+}
+
 class _TestableSubscriptionNotifier extends SubscriptionNotifier {
   @override
   SubscriptionState build() {
@@ -51,6 +71,48 @@ class _TestableSubscriptionNotifier extends SubscriptionNotifier {
 }
 
 void main() {
+  test('initial subscription HTTP fetch waits for critical activity', () async {
+    final apiService = _MockNAIUserInfoApiService();
+    when(
+      () => apiService.getUserSubscription(
+        receiveTimeout: any(named: 'receiveTimeout'),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async => _subscriptionJson(balance: 73));
+    final activity = CriticalNetworkActivityCoordinator.instance;
+    final lease = activity.acquire(CriticalNetworkActivityType.imageGeneration);
+    addTearDown(lease.release);
+
+    final container = ProviderContainer(
+      overrides: [
+        authNotifierProvider.overrideWith(_AuthenticatedAuthNotifier.new),
+        naiUserInfoApiServiceProvider.overrideWithValue(apiService),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(subscriptionNotifierProvider);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    verifyNever(
+      () => apiService.getUserSubscription(
+        receiveTimeout: any(named: 'receiveTimeout'),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    );
+
+    lease.release();
+    for (var i = 0; i < 20; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      if (container.read(subscriptionNotifierProvider).balance == 73) break;
+    }
+    expect(container.read(subscriptionNotifierProvider).balance, 73);
+    verify(
+      () => apiService.getUserSubscription(
+        receiveTimeout: any(named: 'receiveTimeout'),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).called(1);
+  });
+
   test(
     'refresh queued during an in-flight refresh fetches the latest balance',
     () async {
@@ -61,6 +123,7 @@ void main() {
       when(
         () => apiService.getUserSubscription(
           receiveTimeout: any(named: 'receiveTimeout'),
+          cancelToken: any(named: 'cancelToken'),
         ),
       ).thenAnswer((_) {
         requestCount += 1;
@@ -95,12 +158,73 @@ void main() {
     },
   );
 
+  test(
+    'critical activity cancels an in-flight balance request and resumes once',
+    () async {
+      final apiService = _MockNAIUserInfoApiService();
+      final firstResponse = Completer<Map<String, dynamic>>();
+      CancelToken? firstCancelToken;
+      var requestCount = 0;
+      when(
+        () => apiService.getUserSubscription(
+          receiveTimeout: any(named: 'receiveTimeout'),
+          cancelToken: any(named: 'cancelToken'),
+        ),
+      ).thenAnswer((invocation) {
+        requestCount += 1;
+        final cancelToken =
+            invocation.namedArguments[#cancelToken] as CancelToken;
+        if (requestCount == 1) {
+          firstCancelToken = cancelToken;
+          cancelToken.whenCancel.then((error) {
+            if (!firstResponse.isCompleted) firstResponse.completeError(error);
+          });
+          return firstResponse.future;
+        }
+        return Future.value(_subscriptionJson(balance: 77));
+      });
+
+      final container = ProviderContainer(
+        overrides: [
+          authNotifierProvider.overrideWith(_HydratedAuthNotifier.new),
+          naiUserInfoApiServiceProvider.overrideWithValue(apiService),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(container.read(subscriptionNotifierProvider).balance, 100);
+      for (var i = 0; i < 20 && firstCancelToken == null; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      expect(firstCancelToken, isNotNull);
+
+      final activity = CriticalNetworkActivityCoordinator.instance;
+      final lease = activity.acquire(
+        CriticalNetworkActivityType.imageGeneration,
+      );
+      addTearDown(lease.release);
+      expect(firstCancelToken?.isCancelled, isTrue);
+      expect(requestCount, 1);
+
+      lease.release();
+      for (
+        var i = 0;
+        i < 20 && container.read(subscriptionNotifierProvider).balance != 77;
+        i++
+      ) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      expect(requestCount, 2);
+      expect(container.read(subscriptionNotifierProvider).balance, 77);
+    },
+  );
+
   test('does not restore a stale balance after sign-out', () async {
     final apiService = _MockNAIUserInfoApiService();
     final response = Completer<Map<String, dynamic>>();
     when(
       () => apiService.getUserSubscription(
         receiveTimeout: any(named: 'receiveTimeout'),
+        cancelToken: any(named: 'cancelToken'),
       ),
     ).thenAnswer((_) => response.future);
 
@@ -135,6 +259,7 @@ void main() {
     when(
       () => apiService.getUserSubscription(
         receiveTimeout: any(named: 'receiveTimeout'),
+        cancelToken: any(named: 'cancelToken'),
       ),
     ).thenAnswer((_) => response.future);
 
@@ -173,6 +298,7 @@ void main() {
       when(
         () => apiService.getUserSubscription(
           receiveTimeout: any(named: 'receiveTimeout'),
+          cancelToken: any(named: 'cancelToken'),
         ),
       ).thenAnswer((_) {
         requestCount += 1;
@@ -215,6 +341,7 @@ void main() {
       when(
         () => apiService.getUserSubscription(
           receiveTimeout: any(named: 'receiveTimeout'),
+          cancelToken: any(named: 'cancelToken'),
         ),
       ).thenAnswer((_) async => _subscriptionJson(balance: 80));
 
@@ -239,12 +366,88 @@ void main() {
     },
   );
 
+  testWidgets('periodic failures use exponential backoff over the HTTP path', (
+    tester,
+  ) async {
+    final apiService = _MockNAIUserInfoApiService();
+    var requestCount = 0;
+    when(
+      () => apiService.getUserSubscription(
+        receiveTimeout: any(named: 'receiveTimeout'),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async {
+      requestCount += 1;
+      throw DioException(
+        requestOptions: RequestOptions(path: '/user/subscription'),
+        type: DioExceptionType.receiveTimeout,
+      );
+    });
+    final container = ProviderContainer(
+      overrides: [
+        authNotifierProvider.overrideWith(_HydratedAuthNotifier.new),
+        naiUserInfoApiServiceProvider.overrideWithValue(apiService),
+      ],
+    );
+
+    container.read(subscriptionNotifierProvider);
+    await tester.pump();
+    expect(requestCount, 1);
+
+    await tester.pump(const Duration(seconds: 30));
+    await tester.pump();
+    expect(requestCount, 2);
+    await tester.pump(const Duration(seconds: 59));
+    expect(requestCount, 2);
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+    expect(requestCount, 3);
+    expect(container.read(subscriptionNotifierProvider).balance, 100);
+    container.dispose();
+  });
+
+  testWidgets('backgrounding stops periodic refresh until foreground', (
+    tester,
+  ) async {
+    final apiService = _MockNAIUserInfoApiService();
+    var requestCount = 0;
+    when(
+      () => apiService.getUserSubscription(
+        receiveTimeout: any(named: 'receiveTimeout'),
+        cancelToken: any(named: 'cancelToken'),
+      ),
+    ).thenAnswer((_) async {
+      requestCount += 1;
+      return _subscriptionJson(balance: 90 - requestCount);
+    });
+    final container = ProviderContainer(
+      overrides: [
+        authNotifierProvider.overrideWith(_HydratedAuthNotifier.new),
+        naiUserInfoApiServiceProvider.overrideWithValue(apiService),
+      ],
+    );
+    final notifier = container.read(subscriptionNotifierProvider.notifier);
+    await tester.pump();
+    expect(requestCount, 1);
+
+    notifier.setAppForeground(false);
+    await tester.pump(const Duration(minutes: 5));
+    expect(requestCount, 1);
+
+    notifier.setAppForeground(true);
+    await tester.pump(const Duration(milliseconds: 1));
+    await tester.pump();
+    expect(requestCount, 2);
+    container.dispose();
+  });
+
   test('post-billing refresh waits briefly and debounces bursts', () async {
     final apiService = _MockNAIUserInfoApiService();
     var requestCount = 0;
     when(
       () => apiService.getUserSubscription(
         receiveTimeout: any(named: 'receiveTimeout'),
+        cancelToken: any(named: 'cancelToken'),
       ),
     ).thenAnswer((_) async {
       requestCount += 1;

--- a/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
+++ b/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/cache/online_gallery_detail_coordinator.dart';
@@ -347,6 +348,58 @@ void main() {
     expect(loadMediaValues.last, isTrue);
     await tester.pump(const Duration(minutes: 1));
     expect(attempts, 4);
+  });
+
+  testWidgets('cancelled background detail stays quiet and scope resumes it', (
+    tester,
+  ) async {
+    final firstAttempt = Completer<GalleryDetail>();
+    final resolvedItem = _item.copyWith(
+      previewFileUrl: 'https://example.test/resolved.jpg',
+    );
+    var calls = 0;
+
+    Future<GalleryDetail> loadDetail(
+      GalleryItem item, {
+      required GalleryDetailPriority priority,
+      bool forceRefresh = false,
+    }) {
+      calls++;
+      return calls == 1
+          ? firstAttempt.future
+          : Future.value(GalleryDetail(item: resolvedItem, media: const []));
+    }
+
+    await tester.pumpWidget(
+      _app(detailRequestScope: 1, loadDetail: loadDetail),
+    );
+    final detector = tester.widget<VisibilityDetector>(
+      find.byType(VisibilityDetector),
+    );
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      ),
+    );
+    await tester.pump();
+
+    firstAttempt.completeError(
+      DioException.requestCancelled(
+        requestOptions: RequestOptions(path: '/detail'),
+        reason: 'Gallery paused',
+      ),
+    );
+    await tester.pump();
+    expect(find.text('Retry'), findsNothing);
+
+    await tester.pumpWidget(
+      _app(detailRequestScope: 2, loadDetail: loadDetail),
+    );
+    await tester.pump();
+    expect(calls, 2);
+    expect(find.byKey(const ValueKey('resolved-card')), findsOneWidget);
   });
 }
 

--- a/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
@@ -13,7 +13,8 @@ void main() {
   test('scroll state changes do not notify grid listeners', () {
     final controller = OnlineGalleryScreenController(
       prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
-        preloader: (_) async {},
+        preloader: (_) =>
+            GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
       ),
     );
     addTearDown(controller.dispose);
@@ -94,7 +95,8 @@ void main() {
   test('repeated visibility updates only enter the viewport once', () {
     final controller = OnlineGalleryScreenController(
       prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
-        preloader: (_) async {},
+        preloader: (_) =>
+            GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
       ),
     );
     addTearDown(controller.dispose);
@@ -134,7 +136,8 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     final controller = OnlineGalleryScreenController(
       prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
-        preloader: (_) async {},
+        preloader: (_) =>
+            GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
       ),
     );
     addTearDown(controller.dispose);
@@ -187,7 +190,8 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     final controller = OnlineGalleryScreenController(
       prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
-        preloader: (_) async {},
+        preloader: (_) =>
+            GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
       ),
     );
     addTearDown(controller.dispose);
@@ -225,7 +229,8 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     final controller = OnlineGalleryScreenController(
       prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
-        preloader: (_) async {},
+        preloader: (_) =>
+            GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
       ),
     );
     addTearDown(controller.dispose);
@@ -317,7 +322,8 @@ void main() {
 
       final controller = OnlineGalleryScreenController(
         prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
-          preloader: (_) async {},
+          preloader: (_) =>
+              GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
         ),
       );
       addTearDown(controller.dispose);

--- a/test/presentation/widgets/common/gallery_hover_controller_test.dart
+++ b/test/presentation/widgets/common/gallery_hover_controller_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/presentation/widgets/common/gallery_hover_controller.dart';
+
+void main() {
+  testWidgets('hover intent starts after delay and is cancelled on dismiss', (
+    tester,
+  ) async {
+    final controller = GalleryHoverController();
+    addTearDown(controller.dispose);
+    late BuildContext context;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (buildContext) {
+            context = buildContext;
+            return const SizedBox.expand();
+          },
+        ),
+      ),
+    );
+
+    var intents = 0;
+    var dismissals = 0;
+    controller.schedule(
+      context: context,
+      stableKey: 'post:1',
+      layerLink: LayerLink(),
+      targetRect: const Rect.fromLTWH(0, 0, 100, 100),
+      previewSize: const Size(200, 200),
+      builder: (_) => const Text('preview'),
+      onIntent: () => intents++,
+      onDismissIntent: () => dismissals++,
+    );
+
+    await tester.pump(const Duration(milliseconds: 279));
+    expect(intents, 0);
+    controller.dismiss();
+    expect(dismissals, 0);
+
+    controller.schedule(
+      context: context,
+      stableKey: 'post:1',
+      layerLink: LayerLink(),
+      targetRect: const Rect.fromLTWH(0, 0, 100, 100),
+      previewSize: const Size(200, 200),
+      builder: (_) => const Text('preview'),
+      onIntent: () => intents++,
+      onDismissIntent: () => dismissals++,
+    );
+    await tester.pump(const Duration(milliseconds: 280));
+    expect(intents, 1);
+
+    controller.dismiss();
+    expect(dismissals, 1);
+  });
+}

--- a/test/presentation/widgets/online_gallery/gallery_detail_dialog_test.dart
+++ b/test/presentation/widgets/online_gallery/gallery_detail_dialog_test.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,6 +8,7 @@ import 'package:nai_launcher/data/models/online_gallery/gallery_source.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/widgets/online_gallery/gallery_detail_dialog.dart';
 import 'package:nai_launcher/presentation/widgets/online_gallery/gallery_detail_overview_card.dart';
+import 'package:nai_launcher/presentation/widgets/online_gallery/video_player_widget.dart';
 import 'package:nai_launcher/presentation/widgets/tag_chip.dart';
 
 void main() {
@@ -180,6 +182,64 @@ void main() {
       );
     },
   );
+
+  testWidgets('conflicting video metadata renders a stable placeholder', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    const item = GalleryItem(
+      id: 7,
+      workId: '7',
+      sourceId: GallerySourceId.danbooru,
+    );
+    const detail = GalleryDetail(
+      item: item,
+      media: [
+        GalleryMedia(
+          id: 'video-conflict',
+          mediaType: 'video',
+          displayUrl: 'https://example.test/not-a-video.jpg',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: GalleryDetailDialog(
+              item: item,
+              detail: detail,
+              isFavorited: false,
+              favoriteLoading: false,
+              labels: _labels(),
+              onCopyPrompt: () {},
+              onCopyNegativePrompt: () {},
+              onCopyCharacter: (_) {},
+              onCopyAll: () {},
+              onToggleFavorite: () async => true,
+              onOpenSource: () {},
+              onSendToGenerate: () {},
+              onAddToQueue: () async {},
+              onSendToReverse: (_) async {},
+              onDownloadCurrentOriginal: (_) async {},
+              onTagSearch: (_) {},
+              onBlacklistChanged: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(VideoPlayerWidget), findsNothing);
+    expect(find.byType(CachedNetworkImage), findsNothing);
+    expect(find.byIcon(Icons.play_circle_outline), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, 'Reverse'), findsNothing);
+  });
 
   testWidgets('tag context menu searches one normalized tag', (tester) async {
     tester.view.physicalSize = const Size(1280, 900);

--- a/test/presentation/widgets/online_gallery/progressive_gallery_image_test.dart
+++ b/test/presentation/widgets/online_gallery/progressive_gallery_image_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/cache/gallery_image_request.dart';
 import 'package:nai_launcher/core/cache/online_gallery_prefetch_coordinator.dart';
+import 'package:nai_launcher/presentation/widgets/online_gallery/coordinated_gallery_image.dart';
 import 'package:nai_launcher/presentation/widgets/online_gallery/progressive_gallery_image.dart';
 
 const _thumbnail = GalleryImageRequest(
@@ -22,7 +23,8 @@ const _sample = GalleryImageRequest(
 void main() {
   testWidgets('preloaded sample is shown without a transition', (tester) async {
     final coordinator = OnlineGalleryPrefetchCoordinator(
-      preloader: (_) async {},
+      preloader: (_) =>
+          GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
     );
     addTearDown(coordinator.dispose);
     expect(
@@ -41,7 +43,7 @@ void main() {
   testWidgets('sample promotion fades for 140ms after loading', (tester) async {
     final gate = Completer<void>();
     final coordinator = OnlineGalleryPrefetchCoordinator(
-      preloader: (_) => gate.future,
+      preloader: (_) => GalleryImagePreloadOperation.fromFuture(gate.future),
     );
     addTearDown(coordinator.dispose);
 
@@ -60,7 +62,7 @@ void main() {
   testWidgets('reduced motion promotes the sample immediately', (tester) async {
     final gate = Completer<void>();
     final coordinator = OnlineGalleryPrefetchCoordinator(
-      preloader: (_) => gate.future,
+      preloader: (_) => GalleryImagePreloadOperation.fromFuture(gate.future),
     );
     addTearDown(coordinator.dispose);
 
@@ -72,6 +74,106 @@ void main() {
       find.byType(TweenAnimationBuilder<double>),
     );
     expect(transition.duration, Duration.zero);
+  });
+
+  testWidgets(
+    'visible image download is cancelled for critical activity and resumes',
+    (tester) async {
+      var starts = 0;
+      var cancellations = 0;
+      final coordinator = OnlineGalleryPrefetchCoordinator(
+        preloader: (_) {
+          starts += 1;
+          final gate = Completer<void>();
+          return GalleryImagePreloadOperation(
+            future: gate.future,
+            cancel: () {
+              cancellations += 1;
+              gate.completeError(StateError('cancelled'));
+            },
+          );
+        },
+      );
+      addTearDown(coordinator.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: CoordinatedGalleryImage(
+            request: _thumbnail,
+            coordinator: coordinator,
+            placeholder: const Text('waiting'),
+          ),
+        ),
+      );
+      expect(starts, 1);
+
+      coordinator.setCriticalNetworkActive(true);
+      await tester.pump();
+      expect(cancellations, 1);
+      expect(find.text('waiting'), findsOneWidget);
+
+      coordinator.setCriticalNetworkActive(false);
+      await tester.pump();
+      expect(starts, 2);
+    },
+  );
+
+  testWidgets('cancelled sample preload resumes with the coordinator', (
+    tester,
+  ) async {
+    var sampleStarts = 0;
+    final gates = <Completer<void>>[];
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (request) {
+        if (request.tier == GalleryImageTier.thumbnail) {
+          return GalleryImagePreloadOperation.fromFuture(Future<void>.value());
+        }
+        sampleStarts += 1;
+        final gate = Completer<void>();
+        gates.add(gate);
+        return GalleryImagePreloadOperation(
+          future: gate.future,
+          cancel: () => gate.completeError(StateError('cancelled')),
+        );
+      },
+    );
+    addTearDown(coordinator.dispose);
+
+    await tester.pumpWidget(_app(coordinator));
+    expect(sampleStarts, 1);
+
+    coordinator.setCriticalNetworkActive(true);
+    await tester.pump();
+    coordinator.setCriticalNetworkActive(false);
+    await tester.pump();
+
+    expect(sampleStarts, 2);
+  });
+
+  testWidgets('failed coordinated download renders a stable error state', (
+    tester,
+  ) async {
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (_) => GalleryImagePreloadOperation.fromFuture(
+        Future<void>.error(StateError('bad image')),
+      ),
+    );
+    addTearDown(coordinator.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CoordinatedGalleryImage(
+          request: _thumbnail,
+          coordinator: coordinator,
+          placeholder: const Text('waiting'),
+          errorWidget: const Text('failed'),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('failed'), findsOneWidget);
+    expect(find.text('waiting'), findsNothing);
   });
 }
 


### PR DESCRIPTION
## 概要

- 建立统一画廊媒体能力契约，阻止 WebM/MP4/未知媒体进入 Flutter 图片解码、缓存与预取链路，同时保留稳定占位及视频兼容操作。
- 重构画廊图片、详情和分页网络调度：按优先级、可见性、滚动状态、页面/App 生命周期和 generation 隔离调度，并支持真实传输取消、去重、负缓存及有界并发。
- 为生成、Vibe 编码、Director Tools、云端超分和 Krita 请求接入可嵌套关键网络租约；付费请求期间取消并暂停低优先级画廊流量。
- 将订阅余额刷新统一到真实 `/user/subscription` HTTP 路径，加入退避、账号隔离、请求合并和付费后延迟刷新。
- 保持服务端/代理 `multipart ... i/o timeout` 为真实失败；本 PR 消除客户端画廊流量竞争，但不把独立上游超时伪装为成功。

## 验证

- `scripts/run_flutter_tests.ps1`：23 个相关测试文件，289 tests passed
- `flutter analyze`：No issues found
- `git diff --check`
- 未发起真实消耗 Anlas 的请求
- 未修改 `CHANGELOG.md`