### PR TITLE
fix(navigation): 更正画廊与统计导航文案

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -98,7 +98,9 @@
   },
 
   "nav_canvas": "Canvas",
+  "nav_localGallery": "Local Library",
   "nav_onlineGallery": "Online Gallery",
+  "nav_statistics": "Statistics",
   "nav_randomConfig": "Random Config",
   "nav_dictionary": "Dictionary",
   "nav_discordCommunity": "Discord Community",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -94,7 +94,9 @@
     }
   },
   "nav_canvas": "キャンバス",
-  "nav_onlineGallery": "オンライン ギャラリー",
+  "nav_localGallery": "ローカルライブラリ",
+  "nav_onlineGallery": "オンラインギャラリー",
+  "nav_statistics": "統計",
   "nav_randomConfig": "ランダム構成",
   "nav_dictionary": "辞書",
   "nav_discordCommunity": "Discord コミュニティ",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -545,11 +545,23 @@ abstract class AppLocalizations {
   /// **'Canvas'**
   String get nav_canvas;
 
+  /// No description provided for @nav_localGallery.
+  ///
+  /// In en, this message translates to:
+  /// **'Local Library'**
+  String get nav_localGallery;
+
   /// No description provided for @nav_onlineGallery.
   ///
   /// In en, this message translates to:
   /// **'Online Gallery'**
   String get nav_onlineGallery;
+
+  /// No description provided for @nav_statistics.
+  ///
+  /// In en, this message translates to:
+  /// **'Statistics'**
+  String get nav_statistics;
 
   /// No description provided for @nav_randomConfig.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -245,7 +245,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get nav_canvas => 'Canvas';
 
   @override
+  String get nav_localGallery => 'Local Library';
+
+  @override
   String get nav_onlineGallery => 'Online Gallery';
+
+  @override
+  String get nav_statistics => 'Statistics';
 
   @override
   String get nav_randomConfig => 'Random Config';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -241,7 +241,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get nav_canvas => 'キャンバス';
 
   @override
-  String get nav_onlineGallery => 'オンライン ギャラリー';
+  String get nav_localGallery => 'ローカルライブラリ';
+
+  @override
+  String get nav_onlineGallery => 'オンラインギャラリー';
+
+  @override
+  String get nav_statistics => '統計';
 
   @override
   String get nav_randomConfig => 'ランダム構成';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -239,7 +239,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get nav_canvas => '画布';
 
   @override
-  String get nav_onlineGallery => '画廊';
+  String get nav_localGallery => '本地图库';
+
+  @override
+  String get nav_onlineGallery => '在线画廊';
+
+  @override
+  String get nav_statistics => '统计';
 
   @override
   String get nav_randomConfig => '随机配置';
@@ -13332,7 +13338,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get nav_canvas => '畫布';
 
   @override
-  String get nav_onlineGallery => '畫廊';
+  String get nav_localGallery => '本地圖庫';
+
+  @override
+  String get nav_onlineGallery => '線上畫廊';
+
+  @override
+  String get nav_statistics => '統計';
 
   @override
   String get nav_randomConfig => '隨機配置';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -98,7 +98,9 @@
   },
 
   "nav_canvas": "画布",
-  "nav_onlineGallery": "画廊",
+  "nav_localGallery": "本地图库",
+  "nav_onlineGallery": "在线画廊",
+  "nav_statistics": "统计",
   "nav_randomConfig": "随机配置",
   "nav_dictionary": "词库",
   "nav_discordCommunity": "Discord 社群",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -97,7 +97,9 @@
     }
   },
   "nav_canvas": "畫布",
-  "nav_onlineGallery": "畫廊",
+  "nav_localGallery": "本地圖庫",
+  "nav_onlineGallery": "線上畫廊",
+  "nav_statistics": "統計",
   "nav_randomConfig": "隨機配置",
   "nav_dictionary": "詞庫",
   "nav_discordCommunity": "Discord 社群",

--- a/lib/presentation/router/mobile_more_panel.dart
+++ b/lib/presentation/router/mobile_more_panel.dart
@@ -72,7 +72,7 @@ Future<void> showMobileMorePanel({
         ),
         _MobileMoreDestination(
           icon: Icons.insights_outlined,
-          label: panelContext.l10n.statistics_title,
+          label: panelContext.l10n.nav_statistics,
           onTap: () => _selectBranch(
             panelContext,
             navigationShell,

--- a/lib/presentation/widgets/navigation/main_nav_rail.dart
+++ b/lib/presentation/widgets/navigation/main_nav_rail.dart
@@ -124,10 +124,10 @@ class MainNavRail extends ConsumerWidget {
                           navigationShell.goBranch(AppBranch.generation.index),
                     ),
 
-                    // 本地画廊（App生成的图片）
+                    // 本地图库（App生成的图片）
                     _NavIcon(
                       icon: Icons.folder, // Local Generated Images
-                      label: context.l10n.localGallery_title,
+                      label: context.l10n.nav_localGallery,
                       isSelected: selectedIndex == 1,
                       onTap: () => navigationShell.goBranch(
                         AppBranch.localGallery.index,
@@ -182,10 +182,10 @@ class MainNavRail extends ConsumerWidget {
                           navigationShell.goBranch(AppBranch.tagLibrary.index),
                     ),
 
-                    // 画廊统计
+                    // 统计
                     _NavIcon(
                       icon: Icons.bar_chart, // Gallery Statistics
-                      label: context.l10n.statistics_title,
+                      label: context.l10n.nav_statistics,
                       isSelected: selectedIndex == 7,
                       onTap: () =>
                           navigationShell.goBranch(AppBranch.statistics.index),

--- a/test/presentation/widgets/main_nav_rail_test.dart
+++ b/test/presentation/widgets/main_nav_rail_test.dart
@@ -130,7 +130,9 @@ void main() {
       MainNavRail.expandedWidth,
     );
     expect(find.text('画布'), findsOneWidget);
-    expect(find.text('本地画廊'), findsOneWidget);
+    expect(find.text('本地图库'), findsOneWidget);
+    expect(find.text('在线画廊'), findsOneWidget);
+    expect(find.text('统计'), findsOneWidget);
     expect(find.text('Discord 社群'), findsOneWidget);
     expect(find.text('GitHub 仓库'), findsOneWidget);
     expect(find.text('队列管理'), findsOneWidget);


### PR DESCRIPTION
## 变更
- 将桌面侧边栏“本地画廊”更名为“本地图库”，使用独立导航 l10n key，保留本地图库页面内部原有标题语义
- 将在线来源导航“画廊”更名为“在线画廊”
- 将桌面及移动端更多面板“统计仪表盘”更名为“统计”，保留统计页面标题语义
- 同步简体中文、繁体中文、英文、日文 ARB，并重新生成本地化代码
- 更新侧边栏 widget 测试，覆盖三项中文导航文案

## 验证
- `flutter gen-l10n`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run_flutter_tests.ps1 -Path test/presentation/widgets/main_nav_rail_test.dart -TimeoutSeconds 120 -Concurrency 1`（3 tests passed）
- `git diff --check`
