### PR TITLE
fix(gallery): 修复本地图片标签搜索缺失

### DIFF
--- a/lib/core/database/datasources/gallery_image_repository.dart
+++ b/lib/core/database/datasources/gallery_image_repository.dart
@@ -769,7 +769,7 @@ class SqliteGalleryImageRepository implements GalleryImageRepository {
           stack,
           'GalleryDS',
         );
-        return {'success': 0, 'failed': 0, 'none': 0};
+        rethrow;
       }
     });
   }

--- a/lib/data/services/gallery/gallery_scan_coordinator.dart
+++ b/lib/data/services/gallery/gallery_scan_coordinator.dart
@@ -13,8 +13,11 @@ enum GalleryStartupIndexAction { none, fullScan }
 GalleryStartupIndexAction chooseStartupIndexAction({
   required int databaseImageCount,
   required int fileSystemImageCount,
+  int? unparsedImageCount = 0,
 }) {
-  if (databaseImageCount > 0 && databaseImageCount == fileSystemImageCount) {
+  if (databaseImageCount > 0 &&
+      databaseImageCount == fileSystemImageCount &&
+      unparsedImageCount == 0) {
     return GalleryStartupIndexAction.none;
   }
   return GalleryStartupIndexAction.fullScan;
@@ -145,9 +148,20 @@ class GalleryScanCoordinator {
         'Database has $existingCount images, file system has ${files.length} images',
         'LocalGalleryService',
       );
+      int? unparsedImageCount;
+      try {
+        final metadataCounts = await _dataSource.countImagesByMetadataStatus();
+        unparsedImageCount = metadataCounts['none'];
+      } catch (error) {
+        AppLogger.w(
+          'Metadata status count unavailable; running startup scan: $error',
+          'LocalGalleryService',
+        );
+      }
       final action = chooseStartupIndexAction(
         databaseImageCount: existingCount,
         fileSystemImageCount: files.length,
+        unparsedImageCount: unparsedImageCount,
       );
       if (action == GalleryStartupIndexAction.none) {
         AppLogger.i(
@@ -204,9 +218,11 @@ class GalleryScanCoordinator {
     }
 
     AppLogger.i('[UGS] 开始执行${full ? '全量' : ''}流式扫描', 'LocalGalleryService');
-    await GalleryStreamScanner(
-      dataSource: _dataSource,
-    ).startScanning(Directory(rootPath), fileSnapshot: files);
+    await GalleryStreamScanner(dataSource: _dataSource).startScanning(
+      Directory(rootPath),
+      retryMissingMetadata: true,
+      fileSnapshot: files,
+    );
     AppLogger.i('[UGS] ${full ? '全量' : ''}流式扫描完成', 'LocalGalleryService');
   }
 }

--- a/lib/data/services/gallery/gallery_stream_scanner.dart
+++ b/lib/data/services/gallery/gallery_stream_scanner.dart
@@ -182,7 +182,7 @@ class GalleryStreamScanner {
   ///
   /// [onFileProcessed] - 每个文件处理完成时的回调
   /// [checkConsistency] - 是否在扫描前检查数据一致性（删除不存在的文件记录）
-  /// [retryMissingMetadata] - 是否重新尝试历史上标记为无元数据的文件
+  /// [retryMissingMetadata] - 是否重新尝试尚未解析元数据的历史文件
   /// [retryFailedMetadata] - 是否重新尝试历史上提取失败的文件
   /// [fileSnapshot] - 调用方已枚举时复用同一份文件快照
   ///

--- a/lib/data/services/gallery/local_gallery_repository.dart
+++ b/lib/data/services/gallery/local_gallery_repository.dart
@@ -195,32 +195,36 @@ class LocalGalleryRepository {
 
   Future<bool> addImage(File file, {NaiImageMetadata? metadata}) async {
     final stat = await file.stat();
-    final metadataStatus = metadata != null && metadata.hasData
-        ? MetadataStatus.success
-        : MetadataStatus.none;
+    final resolvedMetadata = metadata?.hasData == true
+        ? metadata
+        : await getMetadata(file.path);
+    final hasMetadata = resolvedMetadata?.hasData == true;
     final imageId = await _dataSource.upsertImage(
       filePath: file.path,
       fileName: p.basename(file.path),
       fileSize: stat.size,
-      width: metadata?.width,
-      height: metadata?.height,
+      width: resolvedMetadata?.width,
+      height: resolvedMetadata?.height,
       aspectRatio:
-          metadata?.width != null &&
-              metadata?.height != null &&
-              metadata!.height! > 0
-          ? metadata.width! / metadata.height!
+          resolvedMetadata?.width != null &&
+              resolvedMetadata?.height != null &&
+              resolvedMetadata!.height! > 0
+          ? resolvedMetadata.width! / resolvedMetadata.height!
           : null,
       createdAt: stat.modified,
       modifiedAt: stat.modified,
-      resolutionKey: metadata?.width != null && metadata?.height != null
-          ? '${metadata!.width}x${metadata.height}'
+      resolutionKey:
+          resolvedMetadata?.width != null && resolvedMetadata?.height != null
+          ? '${resolvedMetadata!.width}x${resolvedMetadata.height}'
           : null,
-      lastScannedAt: DateTime.now(),
-      metadataStatus: metadataStatus,
+      lastScannedAt: hasMetadata ? DateTime.now() : null,
+      metadataStatus: hasMetadata
+          ? MetadataStatus.success
+          : MetadataStatus.none,
     );
-    if (metadata != null && metadata.hasData) {
-      await _dataSource.upsertMetadata(imageId, metadata);
-      ImageMetadataService().cacheMetadata(file.path, metadata);
+    if (hasMetadata) {
+      await _dataSource.upsertMetadata(imageId, resolvedMetadata!);
+      ImageMetadataService().cacheMetadata(file.path, resolvedMetadata);
     }
     AppLogger.i(
       '[AddNewImage] Added new image immediately: ${p.basename(file.path)} '

--- a/test/data/services/gallery/gallery_stream_scanner_retry_test.dart
+++ b/test/data/services/gallery/gallery_stream_scanner_retry_test.dart
@@ -18,6 +18,7 @@ import 'package:nai_launcher/data/services/gallery/gallery_stream_scanner.dart'
         GalleryStreamScanner,
         StreamScanStats,
         buildRetryPriorityPaths;
+import 'package:nai_launcher/data/services/gallery/local_gallery_repository.dart';
 import 'package:nai_launcher/data/services/image_metadata_service.dart';
 import 'package:nai_launcher/data/services/metadata/isolate_metadata_service.dart';
 import 'package:nai_launcher/data/services/metadata/unified_metadata_parser.dart';
@@ -70,42 +71,12 @@ void main() {
     });
 
     test(
-      'should skip stale none records during default incremental scan',
+      'retry scan indexes NovelAI tags from stale unparsed records',
       () async {
         final file = await _createWrappedNovelAiPng(
           tempDir,
-          'stale_skip.png',
-          prompt: 'artist:shycocoa, 1girl, solo',
-        );
-
-        final imageId = await _seedStaleNoneRecord(dataSource, file);
-        final scanner = GalleryStreamScanner(dataSource: dataSource);
-
-        await scanner.startScanning(tempDir);
-
-        final imageRecord = await dataSource.getImageById(imageId);
-        final metadata = (await dataSource.getMetadataByImageIds([
-          imageId,
-        ]))[imageId];
-        final results = await dataSource.advancedSearch(
-          textQuery: 'shycocoa',
-          limit: 10,
-        );
-
-        expect(imageRecord, isNotNull);
-        expect(imageRecord!.metadataStatus, MetadataStatus.none);
-        expect(metadata, isNull);
-        expect(results, isNot(contains(imageId)));
-      },
-    );
-
-    test(
-      'should retry stale none records when retryMissingMetadata is enabled',
-      () async {
-        final file = await _createWrappedNovelAiPng(
-          tempDir,
-          'stale_retry.png',
-          prompt: 'artist:shycocoa, 1girl, solo',
+          'evil_neuro_sama.png',
+          prompt: '1girl, evil_neuro-sama, solo',
         );
 
         final imageId = await _seedStaleNoneRecord(dataSource, file);
@@ -117,18 +88,76 @@ void main() {
         final metadata = (await dataSource.getMetadataByImageIds([
           imageId,
         ]))[imageId];
-        final results = await dataSource.advancedSearch(
-          textQuery: 'shycocoa',
-          limit: 10,
-        );
 
         expect(imageRecord, isNotNull);
         expect(imageRecord!.metadataStatus, MetadataStatus.success);
-        expect(metadata, isNotNull);
-        expect(metadata!.prompt, contains('artist:shycocoa'));
-        expect(results, contains(imageId));
+        expect(metadata?.prompt, contains('evil_neuro-sama'));
+        for (final query in const [
+          'evil_neuro-sama',
+          'EVIL_NEURO-SAMA',
+          'evil neuro-sama',
+          'evil-neuro-sama',
+        ]) {
+          final results = await dataSource.advancedSearch(
+            textQuery: query,
+            limit: 10,
+          );
+          expect(results, contains(imageId), reason: 'query=$query');
+        }
       },
     );
+
+    test('immediate gallery add parses and indexes NovelAI tags', () async {
+      final file = await _createWrappedNovelAiPng(
+        tempDir,
+        'immediate_add.png',
+        prompt: '1girl, evil_neuro-sama, solo',
+      );
+      final repository = LocalGalleryRepository(dataSource: dataSource);
+
+      await repository.addImage(file);
+
+      final imageId = await dataSource.getImageIdByPath(file.path);
+      expect(imageId, isNotNull);
+      final imageRecord = await dataSource.getImageById(imageId!);
+      final metadata = (await dataSource.getMetadataByImageIds([
+        imageId,
+      ]))[imageId];
+      final results = await dataSource.advancedSearch(
+        textQuery: 'evil_neuro-sama',
+        limit: 10,
+      );
+
+      expect(imageRecord?.metadataStatus, MetadataStatus.success);
+      expect(metadata?.prompt, contains('evil_neuro-sama'));
+      expect(results, contains(imageId));
+    });
+
+    test('can explicitly skip stale unparsed records', () async {
+      final file = await _createWrappedNovelAiPng(
+        tempDir,
+        'stale_skip.png',
+        prompt: 'artist:shycocoa, 1girl, solo',
+      );
+
+      final imageId = await _seedStaleNoneRecord(dataSource, file);
+      final scanner = GalleryStreamScanner(dataSource: dataSource);
+
+      await scanner.startScanning(tempDir, retryMissingMetadata: false);
+
+      final imageRecord = await dataSource.getImageById(imageId);
+      final metadata = (await dataSource.getMetadataByImageIds([
+        imageId,
+      ]))[imageId];
+      final results = await dataSource.advancedSearch(
+        textQuery: 'shycocoa',
+        limit: 10,
+      );
+
+      expect(imageRecord?.metadataStatus, MetadataStatus.none);
+      expect(metadata, isNull);
+      expect(results, isNot(contains(imageId)));
+    });
 
     test(
       'should mark stale none records as failed when retry finds no metadata',

--- a/test/data/services/gallery/unified_gallery_service_scan_policy_test.dart
+++ b/test/data/services/gallery/unified_gallery_service_scan_policy_test.dart
@@ -13,6 +13,28 @@ void main() {
       );
     });
 
+    test('runs startup scan when matching records remain unparsed', () {
+      expect(
+        chooseStartupIndexAction(
+          databaseImageCount: 43568,
+          fileSystemImageCount: 43568,
+          unparsedImageCount: 3,
+        ),
+        GalleryStartupIndexAction.fullScan,
+      );
+    });
+
+    test('runs startup scan when metadata status count is unavailable', () {
+      expect(
+        chooseStartupIndexAction(
+          databaseImageCount: 43568,
+          fileSystemImageCount: 43568,
+          unparsedImageCount: null,
+        ),
+        GalleryStartupIndexAction.fullScan,
+      );
+    });
+
     test('runs startup scan when database has not indexed the gallery', () {
       expect(
         chooseStartupIndexAction(


### PR DESCRIPTION
## 用户可见问题

本地画廊中，图片的 NovelAI 元数据明明包含 `evil_neuro-sama`，但在本地画廊搜索框输入该 Tag 时没有结果。

## 根因

- 新生成图片通过“即时加入画廊”路径落库时，调用方未传入元数据；旧实现仍把图片标记为已扫描，却没有解析或写入 `gallery_metadata` / FTS 索引。
- 这些记录保持 `MetadataStatus.none`。启动时只比较数据库与文件系统图片数量；数量相同就跳过扫描，因此缺失索引会长期保留。
- 实际 PNG 的 NovelAI `Comment` 中存在目标 Tag；下划线、连字符和大小写不是本次目标图片失败的根因。

## 改动

- 即时加入本地画廊时，缺少调用方元数据就从图片文件解析 NovelAI 元数据，再同步写入图片记录、metadata 表和搜索索引。
- 解析未成功时不再伪造“已扫描”时间，保留后续扫描修复机会。
- 启动索引策略纳入未解析记录数：即使文件总数相同，只要存在 `MetadataStatus.none` 也会启动修复扫描。
- coordinator 的扫描显式重试未解析记录；元数据状态统计失败时保守执行扫描，不静默跳过。
- 保持 scanner 公共默认行为和现有搜索语义不变。

## 验证

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1 -Path "lib/core/database/datasources/gallery_image_repository.dart,lib/data/services/gallery/local_gallery_repository.dart,lib/data/services/gallery/gallery_stream_scanner.dart,lib/data/services/gallery/gallery_scan_coordinator.dart" -Include "test/data/services/gallery/gallery_stream_scanner_retry_test.dart,test/data/services/gallery/unified_gallery_service_scan_policy_test.dart"`
  - 17 tests passed
- `dart analyze lib/core/database/datasources/gallery_image_repository.dart lib/data/services/gallery/gallery_scan_coordinator.dart lib/data/services/gallery/gallery_stream_scanner.dart lib/data/services/gallery/local_gallery_repository.dart test/data/services/gallery/gallery_stream_scanner_retry_test.dart test/data/services/gallery/unified_gallery_service_scan_policy_test.dart`
  - No issues found

回归覆盖真实 NovelAI PNG 元数据解析、即时加入后查询、既有未解析记录修复，以及 `evil_neuro-sama`、大小写、空格/下划线/连字符边界。
