### PR TITLE
fix(generation): 修复队列任务推进竞态

### DIFF
--- a/lib/presentation/providers/image_generation_provider.dart
+++ b/lib/presentation/providers/image_generation_provider.dart
@@ -83,6 +83,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
   Future<void>? _historyRestoreInFlight;
   bool _hasRestoredHistory = false;
   bool _generationInvocationStarting = false;
+  Completer<void>? _generationInvocationSettled;
   int _invocationCounter = 0;
   int _activeInvocationId = 0;
   int _runCounter = 0;
@@ -101,6 +102,12 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     ref.onDispose(() {
       _isDisposed = true;
       _lifecycleEpoch++;
+      _generationInvocationStarting = false;
+      final invocationSettled = _generationInvocationSettled;
+      _generationInvocationSettled = null;
+      if (invocationSettled != null && !invocationSettled.isCompleted) {
+        invocationSettled.complete();
+      }
       final coordinator = _coordinator;
       final handle = _activeRun;
       if (coordinator != null && handle != null) coordinator.cancel(handle);
@@ -221,11 +228,16 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     );
   }
 
+  Future<void> waitUntilGenerationInvocationSettled() =>
+      _generationInvocationSettled?.future ?? Future<void>.value();
+
   Future<void> generate(ImageParams params, {int? batchSizeOverride}) async {
     if (_isDisposed || _generationInvocationStarting || state.isGenerating) {
       return;
     }
     _generationInvocationStarting = true;
+    final invocationSettled = Completer<void>();
+    _generationInvocationSettled = invocationSettled;
     final epoch = _lifecycleEpoch;
     final lifecycle = _lifecycle();
     final subscription = ref.exists(subscriptionNotifierProvider)
@@ -324,6 +336,12 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
       if (_isCurrentLifecycle(epoch) && _activeInvocationId == invocationId) {
         _activeInvocationId = 0;
         _generationInvocationStarting = false;
+      }
+      if (!invocationSettled.isCompleted) {
+        invocationSettled.complete();
+      }
+      if (identical(_generationInvocationSettled, invocationSettled)) {
+        _generationInvocationSettled = null;
       }
       if (foregroundStarted) {
         _foregroundInvocationIds.remove(invocationId);

--- a/lib/presentation/providers/queue_execution_provider.dart
+++ b/lib/presentation/providers/queue_execution_provider.dart
@@ -430,6 +430,13 @@ class QueueExecutionNotifier extends _$QueueExecutionNotifier {
     try {
       await ref.read(generationCooldownProvider.notifier).waitUntilAvailable();
 
+      final generationNotifier = ref.read(
+        imageGenerationNotifierProvider.notifier,
+      );
+      // completed/error 会先于生成调用的 finally 对外可见。等待旧调用释放
+      // invocation 所有权，避免下一任务因 generate() 的并发保护而被静默丢弃。
+      await generationNotifier.waitUntilGenerationInvocationSettled();
+
       if (state.status != QueueExecutionStatus.ready) return;
       if (ref.read(imageGenerationNotifierProvider).isGenerating ||
           (PlatformCapabilities.current.supportsKritaBridge &&
@@ -477,9 +484,10 @@ class QueueExecutionNotifier extends _$QueueExecutionNotifier {
       // generate() 在首次异步让出前会把状态切到 generating；此后由生成状态
       // 本身阻止重复提交，不要让该锁跨越整次生成而吞掉下一任务的触发。
       _generationTriggerPending = false;
-      await ref
-          .read(imageGenerationNotifierProvider.notifier)
-          .generate(params, batchSizeOverride: batchSizeOverride);
+      await generationNotifier.generate(
+        params,
+        batchSizeOverride: batchSizeOverride,
+      );
     } on FormatException catch (error, stackTrace) {
       final taskId = state.currentTaskId;
       AppLogger.e(

--- a/test/presentation/providers/queue_execution_provider_test.dart
+++ b/test/presentation/providers/queue_execution_provider_test.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
 import 'package:nai_launcher/core/storage/queue_state_storage.dart';
 import 'package:nai_launcher/core/storage/replication_queue_storage.dart';
 import 'package:nai_launcher/data/models/character/character_prompt.dart';
@@ -101,6 +105,131 @@ void main() {
       task.id,
     );
     expect(container.read(authPromptRequestProvider), isNull);
+  });
+
+  test('三任务在旧生成完成事件先于调用释放时仍逐项立即推进', () async {
+    final tasks = [
+      ReplicationTask.create(prompt: 'first'),
+      ReplicationTask.create(prompt: 'second'),
+      ReplicationTask.create(prompt: 'third'),
+    ];
+    final generation = _ControlledImageGenerationNotifier();
+    final container = _buildControlledQueueContainer(tasks, generation);
+    addTearDown(container.dispose);
+
+    expect(
+      await container
+          .read(queueExecutionNotifierProvider.notifier)
+          .startQueue(),
+      QueueStartResult.started,
+    );
+    await generation.waitForStart(0);
+
+    generation.complete(0);
+    await _waitForCurrentTask(container, tasks[1].id);
+    expect(generation.startedPrompts, ['first']);
+
+    generation.settle(0);
+    await generation.waitForStart(1);
+    expect(generation.startedPrompts, ['first', 'second']);
+
+    generation.complete(1);
+    generation.settle(1);
+    await generation.waitForStart(2);
+    expect(generation.startedPrompts, ['first', 'second', 'third']);
+
+    generation.complete(2);
+    await _waitForExecutionStatus(container, QueueExecutionStatus.completed);
+    generation.settle(2);
+    for (var index = 0; index < tasks.length; index++) {
+      generation.finishCleanup(index);
+      await generation.waitForCleanup(index);
+    }
+    final execution = container.read(queueExecutionNotifierProvider);
+    expect(execution.completedCount, 3);
+    expect(execution.failedCount, 0);
+    expect(container.read(replicationQueueNotifierProvider).tasks, isEmpty);
+  });
+
+  test('失败结算在旧调用释放后继续下一任务', () async {
+    final tasks = [
+      ReplicationTask.create(prompt: 'failed'),
+      ReplicationTask.create(prompt: 'next'),
+      ReplicationTask.create(prompt: 'last'),
+    ];
+    final generation = _ControlledImageGenerationNotifier();
+    final container = _buildControlledQueueContainer(
+      tasks,
+      generation,
+      localStorage: _NoRetryLocalStorageService(),
+    );
+    addTearDown(container.dispose);
+
+    await container.read(queueExecutionNotifierProvider.notifier).startQueue();
+    await generation.waitForStart(0);
+    generation.fail(0);
+    await _waitForCurrentTask(container, tasks[1].id);
+    expect(generation.startedPrompts, ['failed']);
+
+    generation.settle(0);
+    await generation.waitForStart(1);
+    expect(container.read(queueExecutionNotifierProvider).failedCount, 1);
+    expect(generation.startedPrompts, ['failed', 'next']);
+  });
+
+  test('取消会释放运行任务但不会启动下一任务', () async {
+    final tasks = [
+      ReplicationTask.create(prompt: 'cancelled'),
+      ReplicationTask.create(prompt: 'untouched'),
+      ReplicationTask.create(prompt: 'also untouched'),
+    ];
+    final generation = _ControlledImageGenerationNotifier();
+    final container = _buildControlledQueueContainer(tasks, generation);
+    addTearDown(container.dispose);
+
+    await container.read(queueExecutionNotifierProvider.notifier).startQueue();
+    await generation.waitForStart(0);
+    generation.emitCancelled(0);
+    await _waitForExecutionStatus(container, QueueExecutionStatus.idle);
+    await _waitForQueueTaskStatus(
+      container,
+      tasks.first.id,
+      ReplicationTaskStatus.pending,
+    );
+    generation.settle(0);
+
+    expect(generation.startedPrompts, ['cancelled']);
+    expect(
+      container.read(replicationQueueNotifierProvider).tasks.first.status,
+      ReplicationTaskStatus.pending,
+    );
+  });
+
+  test('调用释放后慢或失败的扣费后工作不阻塞下一任务', () async {
+    for (final cleanupError in [false, true]) {
+      final tasks = [
+        ReplicationTask.create(prompt: 'billing-$cleanupError'),
+        ReplicationTask.create(prompt: 'next-$cleanupError'),
+        ReplicationTask.create(prompt: 'last-$cleanupError'),
+      ];
+      final generation = _ControlledImageGenerationNotifier();
+      final container = _buildControlledQueueContainer(tasks, generation);
+
+      await container
+          .read(queueExecutionNotifierProvider.notifier)
+          .startQueue();
+      await generation.waitForStart(0);
+      generation.complete(0);
+      await _waitForCurrentTask(container, tasks[1].id);
+      generation.settle(0);
+      await generation.waitForStart(1);
+
+      expect(generation.cleanupFinished(0), isFalse);
+      generation.finishCleanup(0, fail: cleanupError);
+      await generation.waitForCleanup(0);
+      expect(generation.cleanupFailed(0), cleanupError);
+      container.dispose();
+    }
   });
 
   test('队列执行固定为单批并应用任务参数', () async {
@@ -326,6 +455,101 @@ void main() {
   });
 }
 
+ProviderContainer _buildControlledQueueContainer(
+  List<ReplicationTask> tasks,
+  _ControlledImageGenerationNotifier generation, {
+  LocalStorageService? localStorage,
+}) {
+  return ProviderContainer(
+    overrides: [
+      replicationQueueStorageProvider.overrideWithValue(
+        _MemoryReplicationQueueStorage(),
+      ),
+      queueStateStorageProvider.overrideWithValue(_MemoryQueueStateStorage()),
+      if (localStorage != null)
+        localStorageServiceProvider.overrideWithValue(localStorage),
+      notificationSettingsNotifierProvider.overrideWith(
+        _DisabledNotificationSettingsNotifier.new,
+      ),
+      authNotifierProvider.overrideWith(
+        () => _TestAuthNotifier(AuthStatus.authenticated),
+      ),
+      replicationQueueNotifierProvider.overrideWith(
+        () => _TestReplicationQueueNotifier(tasks),
+      ),
+      queueExecutionNotifierProvider.overrideWith(
+        _TestQueueExecutionNotifier.new,
+      ),
+      generationParamsNotifierProvider.overrideWith(
+        _TestGenerationParamsNotifier.new,
+      ),
+      characterPromptNotifierProvider.overrideWith(
+        () => _TestCharacterPromptNotifier(const []),
+      ),
+      imageGenerationNotifierProvider.overrideWith(() => generation),
+      kritaBridgeNotifierProvider.overrideWith((ref) => KritaBridgeNotifier()),
+    ],
+  );
+}
+
+Future<void> _waitForCurrentTask(
+  ProviderContainer container,
+  String taskId,
+) async {
+  if (container.read(queueExecutionNotifierProvider).currentTaskId == taskId) {
+    return;
+  }
+  final completer = Completer<void>();
+  late final ProviderSubscription<QueueExecutionState> subscription;
+  subscription = container.listen(queueExecutionNotifierProvider, (_, next) {
+    if (next.currentTaskId == taskId && !completer.isCompleted) {
+      completer.complete();
+    }
+  });
+  try {
+    await completer.future;
+  } finally {
+    subscription.close();
+  }
+}
+
+Future<void> _waitForExecutionStatus(
+  ProviderContainer container,
+  QueueExecutionStatus status,
+) async {
+  if (container.read(queueExecutionNotifierProvider).status == status) return;
+  final completer = Completer<void>();
+  late final ProviderSubscription<QueueExecutionState> subscription;
+  subscription = container.listen(queueExecutionNotifierProvider, (_, next) {
+    if (next.status == status && !completer.isCompleted) completer.complete();
+  });
+  try {
+    await completer.future;
+  } finally {
+    subscription.close();
+  }
+}
+
+Future<void> _waitForQueueTaskStatus(
+  ProviderContainer container,
+  String taskId,
+  ReplicationTaskStatus status,
+) async {
+  bool hasStatus(ReplicationQueueState queue) =>
+      queue.tasks.any((task) => task.id == taskId && task.status == status);
+  if (hasStatus(container.read(replicationQueueNotifierProvider))) return;
+  final completer = Completer<void>();
+  late final ProviderSubscription<ReplicationQueueState> subscription;
+  subscription = container.listen(replicationQueueNotifierProvider, (_, next) {
+    if (hasStatus(next) && !completer.isCompleted) completer.complete();
+  });
+  try {
+    await completer.future;
+  } finally {
+    subscription.close();
+  }
+}
+
 ProviderContainer _buildStartContainer(
   ReplicationTask task,
   AuthStatus authStatus, {
@@ -414,6 +638,100 @@ class _TestGenerationParamsNotifier extends GenerationParamsNotifier {
   @override
   void updateNegativePrompt(String negativePrompt) {
     state = state.copyWith(negativePrompt: negativePrompt);
+  }
+}
+
+class _ControlledImageGenerationNotifier extends ImageGenerationNotifier {
+  final List<String> startedPrompts = [];
+  final List<_ControlledGenerationInvocation> _invocations = [];
+  final List<Completer<void>> _startSignals = List.generate(
+    10,
+    (_) => Completer<void>(),
+  );
+  _ControlledGenerationInvocation? _activeInvocation;
+
+  @override
+  ImageGenerationState build() => const ImageGenerationState();
+
+  @override
+  Future<void> waitUntilGenerationInvocationSettled() =>
+      _activeInvocation?.settled.future ?? Future<void>.value();
+
+  @override
+  Future<void> generate(ImageParams params, {int? batchSizeOverride}) async {
+    if (_activeInvocation != null) return;
+    final invocation = _ControlledGenerationInvocation();
+    _activeInvocation = invocation;
+    _invocations.add(invocation);
+    final index = _invocations.length - 1;
+    startedPrompts.add(params.prompt);
+    state = state.copyWith(status: GenerationStatus.generating);
+    _startSignals[index].complete();
+
+    await invocation.settled.future;
+    if (identical(_activeInvocation, invocation)) {
+      _activeInvocation = null;
+    }
+    await invocation.cleanup.future;
+    invocation.cleanupFinished.complete();
+  }
+
+  Future<void> waitForStart(int index) => _startSignals[index].future;
+
+  void complete(int index) {
+    expect(_invocations[index], same(_activeInvocation));
+    state = state.copyWith(status: GenerationStatus.completed);
+  }
+
+  void fail(int index) {
+    expect(_invocations[index], same(_activeInvocation));
+    state = state.copyWith(
+      status: GenerationStatus.error,
+      errorMessage: 'controlled failure',
+    );
+  }
+
+  void emitCancelled(int index) {
+    expect(_invocations[index], same(_activeInvocation));
+    state = state.copyWith(status: GenerationStatus.cancelled);
+  }
+
+  void settle(int index) {
+    final invocation = _invocations[index];
+    if (identical(_activeInvocation, invocation)) {
+      _activeInvocation = null;
+    }
+    if (!invocation.settled.isCompleted) invocation.settled.complete();
+  }
+
+  void finishCleanup(int index, {bool fail = false}) {
+    final invocation = _invocations[index];
+    invocation.cleanupFailed = fail;
+    if (!invocation.cleanup.isCompleted) invocation.cleanup.complete();
+  }
+
+  bool cleanupFinished(int index) =>
+      _invocations[index].cleanupFinished.isCompleted;
+
+  bool cleanupFailed(int index) => _invocations[index].cleanupFailed;
+
+  Future<void> waitForCleanup(int index) =>
+      _invocations[index].cleanupFinished.future;
+}
+
+class _ControlledGenerationInvocation {
+  final Completer<void> settled = Completer<void>();
+  final Completer<void> cleanup = Completer<void>();
+  final Completer<void> cleanupFinished = Completer<void>();
+  bool cleanupFailed = false;
+}
+
+class _NoRetryLocalStorageService extends LocalStorageService {
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) {
+    if (key == StorageKeys.queueRetryCount) return 0 as T;
+    if (key == StorageKeys.queueRetryInterval) return 0.0 as T;
+    return defaultValue;
   }
 }
 


### PR DESCRIPTION
## 现象

一次向生成队列加入多张图时，第一项成功后，下一项可能长期停在 ready 而不开始。

## 根因

`GenerationCompleted` / `GenerationFailed` 状态会在上一轮 `ImageGenerationNotifier.generate()` 的 `finally` 释放 invocation 所有权之前对队列可见。队列完成回调立即准备下一项并再次调用 `generate()`，会被 `_generationInvocationStarting` 并发保护静默拒绝；原实现没有在旧 invocation 释放后重新唤醒，形成 lost wakeup。自动保存、持久化写入等异步时序会改变复现概率，但不是根因。

余额刷新通过 `SubscriptionNotifier.schedulePostBillingRefresh()` 异步调度，不是阻塞源；网络 request/lease 的成功、失败、取消路径均有既有 finally 释放。

## 修复

- 为唯一的 `ImageGenerationNotifier` invocation 生命周期增加可等待的 settled Completer。
- 队列提交下一任务前等待旧 invocation 精确释放，再重新检查队列与生成状态后调用现有 `generate()`。
- settled 在生成 finally 最前段、余额刷新及后续清理之前完成，慢或失败的扣费后工作不会阻塞下一项。
- dispose 时显式完成并清理 Completer，避免遗留等待者。
- 未增加超时、轮询、第二套队列或状态来源；未改变 generation state schema v2 与扣费后余额刷新契约。

## 回归覆盖

- 三任务成功路径：第一项先发布 completed、旧调用稍后释放，第二/第三项仍立即逐项启动并最终完成。
- 失败且不重试后继续下一项。
- 取消后当前任务恢复 pending，队列停止且不误启下一项。
- invocation 释放后，慢或失败的完成后/扣费后工作不阻塞下一项。
- 既有队列参数、快照、失败策略、角色提示词测试。

所有测试均使用 fake notifier、Completer、内存 storage 与 ProviderContainer；未发起任何真实生成、Vibe、Director、upscale 或扣 Anlas 请求。

## 验证

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1 -Path "lib/presentation/providers/image_generation_provider.dart,lib/presentation/providers/queue_execution_provider.dart" -Include "test/presentation/providers/queue_execution_provider_test.dart,test/presentation/providers/subscription_provider_test.dart"`（272 tests passed）
- `flutter test test/presentation/providers/queue_execution_provider_test.dart --reporter compact`（16 tests passed）
- `flutter test test/presentation/providers/image_generation_provider_test.dart --reporter compact`（17 tests passed）
- `flutter analyze lib/presentation/providers/image_generation_provider.dart lib/presentation/providers/queue_execution_provider.dart test/presentation/providers/queue_execution_provider_test.dart`（No issues found）
- `git diff --check`