### PR TITLE
perf(navigation): 优化主侧栏高频展开收起

### DIFF
--- a/lib/presentation/widgets/navigation/main_nav_rail.dart
+++ b/lib/presentation/widgets/navigation/main_nav_rail.dart
@@ -87,169 +87,161 @@ class MainNavRail extends ConsumerWidget {
     final motion = theme.appTheme;
     final animationDuration = _boundedMotionDuration(
       context,
-      motion.slowDuration,
-      minMilliseconds: 200,
-      maxMilliseconds: 280,
+      motion.normalDuration,
+      minMilliseconds: 120,
+      maxMilliseconds: 180,
     );
 
-    return _NavRailExpansionScope(
+    return _NavRailWidthTransition(
       isExpanded: isExpanded,
-      child: _NavRailWidthTransition(
-        isExpanded: isExpanded,
-        duration: animationDuration,
-        curve: isExpanded ? motion.enterCurve : motion.exitCurve,
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surface,
-          border: Border(
-            right: BorderSide(color: theme.dividerColor, width: 1),
-          ),
-        ),
-        child: Column(
-          children: [
-            const SizedBox(height: 16),
-            // 账户头像区域
-            _AccountAvatarButton(ref: ref),
+      duration: animationDuration,
+      curve: motion.standardCurve,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        border: Border(right: BorderSide(color: theme.dividerColor, width: 1)),
+      ),
+      child: Column(
+        children: [
+          const SizedBox(height: 16),
+          // 账户头像区域
+          _AccountAvatarButton(ref: ref),
 
-            Expanded(
-              child: SingleChildScrollView(
-                key: const Key('main-nav-primary-scroll'),
-                child: Column(
-                  children: [
-                    // Navigation Items
-                    _NavIcon(
-                      icon: Icons.brush, // Canvas/Edit
-                      label: context.l10n.nav_canvas,
-                      isSelected: selectedIndex == 0,
-                      onTap: () =>
-                          navigationShell.goBranch(AppBranch.generation.index),
-                    ),
+          Expanded(
+            child: SingleChildScrollView(
+              key: const Key('main-nav-primary-scroll'),
+              child: Column(
+                children: [
+                  // Navigation Items
+                  _NavIcon(
+                    icon: Icons.brush, // Canvas/Edit
+                    label: context.l10n.nav_canvas,
+                    isSelected: selectedIndex == 0,
+                    onTap: () =>
+                        navigationShell.goBranch(AppBranch.generation.index),
+                  ),
 
-                    // 本地图库（App生成的图片）
-                    _NavIcon(
-                      icon: Icons.folder, // Local Generated Images
-                      label: context.l10n.nav_localGallery,
-                      isSelected: selectedIndex == 1,
-                      onTap: () => navigationShell.goBranch(
-                        AppBranch.localGallery.index,
-                      ),
-                    ),
+                  // 本地图库（App生成的图片）
+                  _NavIcon(
+                    icon: Icons.folder, // Local Generated Images
+                    label: context.l10n.nav_localGallery,
+                    isSelected: selectedIndex == 1,
+                    onTap: () =>
+                        navigationShell.goBranch(AppBranch.localGallery.index),
+                  ),
 
-                    // 在线画廊
-                    _NavIcon(
-                      icon: Icons.photo_library, // Online Gallery
-                      label: context.l10n.nav_onlineGallery,
-                      isSelected: selectedIndex == 2,
-                      onTap: () => navigationShell.goBranch(
-                        AppBranch.onlineGallery.index,
-                      ),
-                    ),
+                  // 在线画廊
+                  _NavIcon(
+                    icon: Icons.photo_library, // Online Gallery
+                    label: context.l10n.nav_onlineGallery,
+                    isSelected: selectedIndex == 2,
+                    onTap: () =>
+                        navigationShell.goBranch(AppBranch.onlineGallery.index),
+                  ),
 
-                    // Vibe库
-                    _NavIcon(
-                      icon: Icons.auto_awesome, // Vibe Library
-                      label: context.l10n.vibeLibrary_title,
-                      isSelected: selectedIndex == 3,
-                      onTap: () =>
-                          navigationShell.goBranch(AppBranch.vibeLibrary.index),
-                    ),
+                  // Vibe库
+                  _NavIcon(
+                    icon: Icons.auto_awesome, // Vibe Library
+                    label: context.l10n.vibeLibrary_title,
+                    isSelected: selectedIndex == 3,
+                    onTap: () =>
+                        navigationShell.goBranch(AppBranch.vibeLibrary.index),
+                  ),
 
-                    // 精准参考库
-                    _NavIcon(
-                      icon: Icons.center_focus_strong,
-                      label: context.l10n.nav_preciseRefLibrary,
-                      isSelected: selectedIndex == 4,
-                      onTap: () => navigationShell.goBranch(
-                        AppBranch.preciseRefLibrary.index,
-                      ),
+                  // 精准参考库
+                  _NavIcon(
+                    icon: Icons.center_focus_strong,
+                    label: context.l10n.nav_preciseRefLibrary,
+                    isSelected: selectedIndex == 4,
+                    onTap: () => navigationShell.goBranch(
+                      AppBranch.preciseRefLibrary.index,
                     ),
+                  ),
 
-                    // 随机配置
-                    _NavIcon(
-                      icon: Icons.casino, // Random prompt config
-                      label: context.l10n.nav_randomConfig,
-                      isSelected: selectedIndex == 5,
-                      onTap: () => navigationShell.goBranch(
-                        AppBranch.promptConfig.index,
-                      ),
-                    ),
+                  // 随机配置
+                  _NavIcon(
+                    icon: Icons.casino, // Random prompt config
+                    label: context.l10n.nav_randomConfig,
+                    isSelected: selectedIndex == 5,
+                    onTap: () =>
+                        navigationShell.goBranch(AppBranch.promptConfig.index),
+                  ),
 
-                    // 词库
-                    _NavIcon(
-                      icon: Icons.book,
-                      label: context.l10n.nav_dictionary,
-                      isSelected: selectedIndex == 6,
-                      onTap: () =>
-                          navigationShell.goBranch(AppBranch.tagLibrary.index),
-                    ),
+                  // 词库
+                  _NavIcon(
+                    icon: Icons.book,
+                    label: context.l10n.nav_dictionary,
+                    isSelected: selectedIndex == 6,
+                    onTap: () =>
+                        navigationShell.goBranch(AppBranch.tagLibrary.index),
+                  ),
 
-                    // 统计
-                    _NavIcon(
-                      icon: Icons.bar_chart, // Gallery Statistics
-                      label: context.l10n.nav_statistics,
-                      isSelected: selectedIndex == 7,
-                      onTap: () =>
-                          navigationShell.goBranch(AppBranch.statistics.index),
-                    ),
-                  ],
-                ),
+                  // 统计
+                  _NavIcon(
+                    icon: Icons.bar_chart, // Gallery Statistics
+                    label: context.l10n.nav_statistics,
+                    isSelected: selectedIndex == 7,
+                    onTap: () =>
+                        navigationShell.goBranch(AppBranch.statistics.index),
+                  ),
+                ],
               ),
             ),
+          ),
 
-            // Discord 社群
-            _ExternalLinkIcon(
-              icon: Icons.discord,
-              label: context.l10n.nav_discordCommunity,
-              color: const Color(0xFF5865F2), // Discord 紫色
-              url: CommunityLinks.discord,
-            ),
+          // Discord 社群
+          _ExternalLinkIcon(
+            icon: Icons.discord,
+            label: context.l10n.nav_discordCommunity,
+            color: const Color(0xFF5865F2), // Discord 紫色
+            url: CommunityLinks.discord,
+          ),
 
-            // GitHub 仓库
-            _GitHubIcon(
-              url: CommunityLinks.github,
-              label: context.l10n.nav_githubRepo,
-            ),
+          // GitHub 仓库
+          _GitHubIcon(
+            url: CommunityLinks.github,
+            label: context.l10n.nav_githubRepo,
+          ),
 
-            _NavIcon(
-              key: const Key('queue-nav-item'),
-              icon: switch (queueExecutionStatus) {
-                QueueExecutionStatus.running => Icons.play_arrow_rounded,
-                QueueExecutionStatus.paused => Icons.pause_rounded,
-                _ => Icons.playlist_play_rounded,
-              },
-              label: context.l10n.queue_management,
-              isSelected: isQueueVisible,
-              badgeLabel: queueCount > 0
-                  ? (queueCount > 99 ? '99+' : queueCount.toString())
-                  : null,
-              onTap: () => onQueueVisibilityChanged(!isQueueVisible),
-            ),
+          _NavIcon(
+            key: const Key('queue-nav-item'),
+            icon: switch (queueExecutionStatus) {
+              QueueExecutionStatus.running => Icons.play_arrow_rounded,
+              QueueExecutionStatus.paused => Icons.pause_rounded,
+              _ => Icons.playlist_play_rounded,
+            },
+            label: context.l10n.queue_management,
+            isSelected: isQueueVisible,
+            badgeLabel: queueCount > 0
+                ? (queueCount > 99 ? '99+' : queueCount.toString())
+                : null,
+            onTap: () => onQueueVisibilityChanged(!isQueueVisible),
+          ),
 
-            // Bottom Settings
-            _NavIcon(
-              icon: Icons.settings,
-              label: context.l10n.nav_settings,
-              isSelected: selectedIndex == 8,
-              showBadge: showUpdateBadge,
-              onTap: () => navigationShell.goBranch(AppBranch.settings.index),
-            ),
-            const SizedBox(height: 2),
-            _NavRailToggle(
-              isExpanded: isExpanded,
-              onTap: () {
-                ref
-                    .read(layoutStateNotifierProvider.notifier)
-                    .toggleMainNavRail();
-              },
-            ),
-            const SizedBox(height: 6),
-          ],
-        ),
+          // Bottom Settings
+          _NavIcon(
+            icon: Icons.settings,
+            label: context.l10n.nav_settings,
+            isSelected: selectedIndex == 8,
+            showBadge: showUpdateBadge,
+            onTap: () => navigationShell.goBranch(AppBranch.settings.index),
+          ),
+          const SizedBox(height: 2),
+          _NavRailToggle(
+            isExpanded: isExpanded,
+            onTap: () {
+              ref
+                  .read(layoutStateNotifierProvider.notifier)
+                  .toggleMainNavRail();
+            },
+          ),
+          const SizedBox(height: 6),
+        ],
       ),
     );
   }
 }
 
-class _NavRailWidthTransition extends StatelessWidget {
+class _NavRailWidthTransition extends StatefulWidget {
   const _NavRailWidthTransition({
     required this.isExpanded,
     required this.duration,
@@ -265,21 +257,84 @@ class _NavRailWidthTransition extends StatelessWidget {
   final Widget child;
 
   @override
-  Widget build(BuildContext context) {
-    return TweenAnimationBuilder<double>(
-      tween: Tween<double>(end: isExpanded ? 1 : 0),
-      duration: duration,
+  State<_NavRailWidthTransition> createState() =>
+      _NavRailWidthTransitionState();
+}
+
+// 宽度与所有标签共享同一时间轴，避免高频切换同时启动多组 ticker。
+class _NavRailWidthTransitionState extends State<_NavRailWidthTransition>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late CurvedAnimation _expansion;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      value: widget.isExpanded ? 1 : 0,
+      duration: widget.duration,
+    );
+    _updateCurve();
+  }
+
+  @override
+  void didUpdateWidget(_NavRailWidthTransition oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _controller.duration = widget.duration;
+    if (oldWidget.curve != widget.curve) {
+      _expansion.dispose();
+      _updateCurve();
+    }
+    if (oldWidget.isExpanded != widget.isExpanded ||
+        oldWidget.duration != widget.duration) {
+      _animateToTarget();
+    }
+  }
+
+  void _updateCurve() {
+    final curve = _ClampedCurve(widget.curve);
+    _expansion = CurvedAnimation(
+      parent: _controller,
       curve: curve,
-      builder: (context, value, child) {
+      reverseCurve: curve,
+    );
+  }
+
+  void _animateToTarget() {
+    if (widget.duration == Duration.zero) {
+      _controller.value = widget.isExpanded ? 1 : 0;
+      return;
+    }
+    if (widget.isExpanded) {
+      _controller.forward();
+    } else {
+      _controller.reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    _expansion.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _expansion,
+      builder: (context, child) {
         final width =
             MainNavRail.collapsedWidth +
-            (MainNavRail.expandedWidth - MainNavRail.collapsedWidth) * value;
+            (MainNavRail.expandedWidth - MainNavRail.collapsedWidth) *
+                _expansion.value;
         return Container(
           key: const Key('main-nav-rail'),
           width: width,
           height: double.infinity,
           clipBehavior: Clip.hardEdge,
-          decoration: decoration,
+          decoration: widget.decoration,
           child: OverflowBox(
             alignment: Alignment.centerLeft,
             minWidth: MainNavRail.expandedWidth,
@@ -295,29 +350,45 @@ class _NavRailWidthTransition extends StatelessWidget {
           ),
         );
       },
-      child: child,
+      child: _NavRailExpansionScope(
+        isExpanded: widget.isExpanded,
+        expansion: _expansion,
+        child: widget.child,
+      ),
     );
   }
+}
+
+class _ClampedCurve extends Curve {
+  const _ClampedCurve(this.curve);
+
+  final Curve curve;
+
+  @override
+  double transformInternal(double t) => curve.transform(t).clamp(0.0, 1.0);
 }
 
 class _NavRailExpansionScope extends InheritedWidget {
   const _NavRailExpansionScope({
     required this.isExpanded,
+    required this.expansion,
     required super.child,
   });
 
   final bool isExpanded;
+  final Animation<double> expansion;
 
-  static bool isExpandedOf(BuildContext context) {
+  static _NavRailExpansionScope of(BuildContext context) {
     return context
-            .dependOnInheritedWidgetOfExactType<_NavRailExpansionScope>()
-            ?.isExpanded ??
-        false;
+        .dependOnInheritedWidgetOfExactType<_NavRailExpansionScope>()!;
   }
+
+  static bool isExpandedOf(BuildContext context) => of(context).isExpanded;
 
   @override
   bool updateShouldNotify(_NavRailExpansionScope oldWidget) {
-    return isExpanded != oldWidget.isExpanded;
+    return isExpanded != oldWidget.isExpanded ||
+        expansion != oldWidget.expansion;
   }
 }
 
@@ -328,21 +399,8 @@ class _ExpandedRailContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isExpanded = _NavRailExpansionScope.isExpandedOf(context);
-    final motion = Theme.of(context).appTheme;
-    final duration = _boundedMotionDuration(
-      context,
-      motion.normalDuration,
-      minMilliseconds: 120,
-      maxMilliseconds: 180,
-    );
-
-    return AnimatedOpacity(
-      opacity: isExpanded ? 1 : 0,
-      duration: duration,
-      curve: isExpanded ? motion.enterCurve : motion.exitCurve,
-      child: child,
-    );
+    final scope = _NavRailExpansionScope.of(context);
+    return FadeTransition(opacity: scope.expansion, child: child);
   }
 }
 

--- a/test/presentation/router/desktop_shell_sidebar_transition_test.dart
+++ b/test/presentation/router/desktop_shell_sidebar_transition_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nai_launcher/core/constants/app_version.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/providers/account_manager_provider.dart';
+import 'package:nai_launcher/presentation/providers/auth_provider.dart';
+import 'package:nai_launcher/presentation/providers/queue_execution_provider.dart';
+import 'package:nai_launcher/presentation/providers/replication_queue_provider.dart';
+import 'package:nai_launcher/presentation/router/desktop_shell.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class _MockNavigationShell extends Mock implements StatefulNavigationShell {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_MockNavigationShell';
+}
+
+class _FakeAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => const AuthState(status: AuthStatus.unauthenticated);
+}
+
+class _FakeAccountManagerNotifier extends AccountManagerNotifier {
+  @override
+  AccountManagerState build() => const AccountManagerState();
+}
+
+class _FakeQueueExecutionNotifier extends QueueExecutionNotifier {
+  @override
+  QueueExecutionState build() => const QueueExecutionState();
+}
+
+class _FakeReplicationQueueNotifier extends ReplicationQueueNotifier {
+  @override
+  ReplicationQueueState build() => const ReplicationQueueState();
+}
+
+class _FakeMainNavStorage extends LocalStorageService {
+  bool isExpanded = false;
+
+  @override
+  bool getMainNavRailExpanded() => isExpanded;
+
+  @override
+  Future<void> setMainNavRailExpanded(bool expanded) async {
+    isExpanded = expanded;
+  }
+}
+
+class _ContentLifecycle {
+  int initialized = 0;
+  int built = 0;
+  int disposed = 0;
+}
+
+class _TrackedContent extends StatefulWidget {
+  const _TrackedContent({required this.lifecycle});
+
+  final _ContentLifecycle lifecycle;
+
+  @override
+  State<_TrackedContent> createState() => _TrackedContentState();
+}
+
+class _TrackedContentState extends State<_TrackedContent> {
+  int value = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.lifecycle.initialized++;
+  }
+
+  @override
+  void dispose() {
+    widget.lifecycle.disposed++;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    widget.lifecycle.built++;
+    return Center(
+      child: FilledButton(
+        key: const Key('tracked-content-button'),
+        onPressed: () => setState(() => value++),
+        child: Text('content-$value'),
+      ),
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    PackageInfo.setMockInitialValues(
+      appName: 'NAI Launcher',
+      packageName: 'nai_launcher',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+    await AppVersion.initialize();
+  });
+
+  testWidgets('窄桌面侧栏动画不重建路由主体且主体保持可交互', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(620, 600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final navigationShell = _MockNavigationShell();
+    final storage = _FakeMainNavStorage();
+    final lifecycle = _ContentLifecycle();
+    when(() => navigationShell.currentIndex).thenReturn(0);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localStorageServiceProvider.overrideWith((ref) => storage),
+          authNotifierProvider.overrideWith(_FakeAuthNotifier.new),
+          accountManagerNotifierProvider.overrideWith(
+            _FakeAccountManagerNotifier.new,
+          ),
+          queueExecutionNotifierProvider.overrideWith(
+            _FakeQueueExecutionNotifier.new,
+          ),
+          replicationQueueNotifierProvider.overrideWith(
+            _FakeReplicationQueueNotifier.new,
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DesktopShell(
+            navigationShell: navigationShell,
+            content: _TrackedContent(lifecycle: lifecycle),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(lifecycle.initialized, 1);
+    expect(lifecycle.built, 1);
+    expect(find.text('content-0'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('main-nav-toggle')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 40));
+    expect(lifecycle.built, 1);
+
+    await tester.tap(find.byKey(const Key('tracked-content-button')));
+    await tester.pump();
+    expect(find.text('content-1'), findsOneWidget);
+    expect(lifecycle.built, 2);
+
+    await tester.pumpAndSettle();
+    expect(storage.isExpanded, isTrue);
+    expect(lifecycle.initialized, 1);
+    expect(lifecycle.built, 2);
+    expect(lifecycle.disposed, 0);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/presentation/widgets/main_nav_rail_test.dart
+++ b/test/presentation/widgets/main_nav_rail_test.dart
@@ -197,6 +197,15 @@ void main() {
     );
     expect(_railContentWidth(tester), MainNavRail.expandedWidth);
     expect(tester.getCenter(find.byIcon(Icons.brush)), collapsedIconCenter);
+    final sharedLabelAnimation = _labelFade(tester, '画布').opacity;
+    final sharedFadeCount = tester
+        .widgetList<FadeTransition>(
+          find.byType(FadeTransition, skipOffstage: false),
+        )
+        .where((fade) => identical(fade.opacity, sharedLabelAnimation))
+        .length;
+    expect(sharedFadeCount, greaterThan(5));
+    expect(find.byType(AnimatedOpacity), findsNothing);
 
     await tester.tap(find.byKey(const Key('main-nav-toggle')));
     await tester.pump();
@@ -215,6 +224,67 @@ void main() {
     expect(_railWidth(tester), MainNavRail.expandedWidth);
     expect(_labelOpacity(tester, '画布'), 1);
     expect(storage.isExpanded, isTrue);
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(find.byKey(const Key('main-nav-toggle')));
+    await tester.pump(const Duration(milliseconds: 40));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('disableAnimations 下切换首帧到达终态', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(620, 600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final navigationShell = _MockNavigationShell();
+    final storage = _FakeMainNavStorage();
+    when(() => navigationShell.currentIndex).thenReturn(1);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localStorageServiceProvider.overrideWith((ref) => storage),
+          authNotifierProvider.overrideWith(_FakeAuthNotifier.new),
+          accountManagerNotifierProvider.overrideWith(
+            _FakeAccountManagerNotifier.new,
+          ),
+          queueExecutionNotifierProvider.overrideWith(
+            _FakeQueueExecutionNotifier.new,
+          ),
+          replicationQueueNotifierProvider.overrideWith(
+            _FakeReplicationQueueNotifier.new,
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MediaQuery(
+            data: const MediaQueryData(
+              size: Size(620, 600),
+              disableAnimations: true,
+            ),
+            child: Scaffold(
+              body: MainNavRail(navigationShell: navigationShell),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final selectedBefore = tester.widget<Icon>(find.byIcon(Icons.folder)).color;
+    await tester.tap(find.byKey(const Key('main-nav-toggle')));
+    await tester.pump();
+
+    expect(_railWidth(tester), MainNavRail.expandedWidth);
+    expect(_labelOpacity(tester, '画布'), 1);
+    expect(
+      tester.widget<Icon>(find.byIcon(Icons.folder)).color,
+      selectedBefore,
+    );
+    verifyNever(() => navigationShell.goBranch(any()));
     expect(tester.takeException(), isNull);
   });
 
@@ -269,10 +339,13 @@ double _railWidth(WidgetTester tester) =>
 double _railContentWidth(WidgetTester tester) =>
     tester.getSize(find.byKey(const Key('main-nav-rail-content'))).width;
 
-double _labelOpacity(WidgetTester tester, String label) {
-  final opacity = find.ancestor(
+FadeTransition _labelFade(WidgetTester tester, String label) {
+  final fade = find.ancestor(
     of: find.text(label),
-    matching: find.byType(AnimatedOpacity),
+    matching: find.byType(FadeTransition),
   );
-  return tester.widget<AnimatedOpacity>(opacity.first).opacity;
+  return tester.widget<FadeTransition>(fade.first);
 }
+
+double _labelOpacity(WidgetTester tester, String label) =>
+    _labelFade(tester, label).opacity.value;


### PR DESCRIPTION
## 根因

- 主侧栏外层已经固定内部 `196px` 布局并仅裁剪可见宽度，但每个标签仍各自使用 `AnimatedOpacity`，一次展开/收起会同时启动多组隐式动画状态与 ticker。
- 宽度使用目标值驱动的隐式动画，快速反向时每次会重新建立 tween；宽度与标签透明度不是同一时间轴。
- 旧过渡使用 `slowDuration`（约 200–280ms），会延长 `DesktopShell` 的 `Row` 因可用宽度变化而必须执行的布局帧数。主内容宽度语义必须保持，因此不能用静态截图、覆盖层或禁止交互规避这段布局。

## 优化

- 改为一个可中途 `forward/reverse` 的 `AnimationController`，宽度和全部标签 `FadeTransition` 共享同一 `CurvedAnimation`，不再为每个标签创建独立隐式控制器。
- 继续保留固定宽度导航内容、`Clip.hardEdge`、`OverflowBox` 与 `RepaintBoundary`，图标、文本和点击区域不会逐帧重新排版。
- 使用现有 `normalDuration` / `standardCurve` token，并把高频过渡限制在 120–180ms；`MediaQuery.disableAnimations` 下直接到达终态。
- 正反方向共用同一曲线，从当前 controller value 连续反转；曲线输出做 0–1 限制，避免主题曲线过冲导致宽度或 opacity 越界。
- `DesktopShell` 路由主体保持稳定 widget/state 子树；动画期间不重建、不销毁且仍可点击。手机底部导航分支未改动。

## 可复现性能证据

在同一 widget 场景、同一点击后的首帧读取调度器 transient callbacks：

- 修改前：`6`
- 修改后：`2`

该数字仅作为本地前后测量记录；CI 使用结构性断言验证多个标签共享同一 animation，避免引入机器墙钟阈值或依赖全局 callback 数量。

## 交互与回归覆盖

- 展开、收起、动画中快速双向反转，最终 UI/持久化状态一致。
- 当前选中路由、图标位置、标签、tooltip、账号/外链/队列/设置入口保持不变。
- 620px 窄桌面宽度无 overflow；路由主体动画期间不重建、State 不丢失且可交互。
- `disableAnimations` 首帧到终态。
- 动画中卸载侧栏不产生 active ticker/assertion；控制器完整释放。

## 验证

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1 -Path "lib/presentation/widgets/navigation/main_nav_rail.dart,lib/presentation/router/desktop_shell.dart,lib/presentation/providers/layout_state_provider.dart" -Include "test/presentation/widgets/main_nav_rail_test.dart,test/presentation/router/desktop_shell_sidebar_transition_test.dart,test/presentation/providers/layout_state_provider_test.dart"`
  - 38 tests passed
- 基于最新 `origin/main` 复跑三个直接相关测试文件
  - 16 tests passed
- `dart analyze lib/presentation/widgets/navigation/main_nav_rail.dart test/presentation/widgets/main_nav_rail_test.dart test/presentation/router/desktop_shell_sidebar_transition_test.dart`
  - No issues found
- `flutter analyze`
  - 本次文件无问题；全仓仅有既有 warning：`lib/core/agent/context_usage.dart:70 unnecessary_null_comparison`
- `git diff --check`
  - passed

## 合并说明

本 PR 仅供审查，**不要自动合并**。
