### PR TITLE
perf(gallery): 优化在线画廊图片加载

### DIFF
--- a/lib/core/cache/cancellable_gallery_image_loader.dart
+++ b/lib/core/cache/cancellable_gallery_image_loader.dart
@@ -36,6 +36,7 @@ class CancellableGalleryImageLoader {
   final BaseCacheManager _cacheManager;
   final Dio _dio;
   final bool _ownsDio;
+  final Map<String, _SharedGalleryTransfer> _transfers = {};
   bool _disposed = false;
 
   GalleryImagePreloadOperation start(GalleryImageRequest request) {
@@ -43,21 +44,80 @@ class CancellableGalleryImageLoader {
       return GalleryImagePreloadOperation.fromFuture(Future<void>.value());
     }
 
-    final completer = Completer<void>();
-    final cancelToken = CancelToken();
+    final transferKey = request.transportKey;
+    final existing = _transfers[transferKey];
+    if (existing != null && existing.canAcceptConsumer) {
+      return existing.addConsumer();
+    }
 
-    Future<void> run() async {
-      try {
-        final cacheKey = request.canonicalCacheKey;
-        final cached = await _cacheManager.getFileFromCache(cacheKey);
-        if (cached != null &&
-            cached.validTill.isAfter(DateTime.now()) &&
-            await cached.file.exists()) {
-          if (!completer.isCompleted) completer.complete();
-          return;
+    final transfer = _SharedGalleryTransfer();
+    _transfers[transferKey] = transfer;
+    unawaited(
+      _run(request, transfer).whenComplete(() {
+        if (_transfers[transferKey] == transfer) {
+          _transfers.remove(transferKey);
         }
+      }),
+    );
+    return transfer.addConsumer();
+  }
 
-        final response = await _dio.get<List<int>>(
+  Future<void> _run(
+    GalleryImageRequest request,
+    _SharedGalleryTransfer transfer,
+  ) async {
+    try {
+      final cacheKey = request.canonicalCacheKey;
+      final cached = await _cacheManager.getFileFromCache(cacheKey);
+      if (cached != null &&
+          cached.validTill.isAfter(DateTime.now()) &&
+          await cached.file.exists()) {
+        transfer.complete();
+        return;
+      }
+
+      final response = await _downloadWithRetry(request, transfer.cancelToken);
+      if (transfer.cancelToken.isCancelled) {
+        throw const _GalleryDownloadCancelled();
+      }
+      final bytes = response.data;
+      if (bytes == null || bytes.isEmpty) {
+        throw StateError('Gallery image response was empty');
+      }
+      final contentType = response.headers
+          .value(Headers.contentTypeHeader)
+          ?.split(';')
+          .first
+          .trim()
+          .toLowerCase();
+      if (contentType != null && !contentType.startsWith('image/')) {
+        throw StateError(
+          'Gallery image response had invalid content type: $contentType',
+        );
+      }
+
+      await _cacheManager.putFile(
+        request.url,
+        bytes is Uint8List ? bytes : Uint8List.fromList(bytes),
+        key: cacheKey,
+        eTag: response.headers.value('etag'),
+        maxAge: const Duration(days: 7),
+        fileExtension: _fileExtension(request.url, contentType),
+      );
+      transfer.complete();
+    } catch (error, stackTrace) {
+      transfer.completeError(error, stackTrace);
+    }
+  }
+
+  Future<Response<List<int>>> _downloadWithRetry(
+    GalleryImageRequest request,
+    CancelToken cancelToken,
+  ) async {
+    DioException? lastError;
+    for (var attempt = 0; attempt < 2; attempt++) {
+      try {
+        return await _dio.get<List<int>>(
           request.url,
           cancelToken: cancelToken,
           options: Options(
@@ -67,50 +127,28 @@ class CancellableGalleryImageLoader {
             validateStatus: (status) => status != null && status < 400,
           ),
         );
-        if (cancelToken.isCancelled) throw const _GalleryDownloadCancelled();
-        final bytes = response.data;
-        if (bytes == null || bytes.isEmpty) {
-          throw StateError('Gallery image response was empty');
-        }
-        final contentType = response.headers
-            .value(Headers.contentTypeHeader)
-            ?.split(';')
-            .first
-            .trim()
-            .toLowerCase();
-        if (contentType != null && !contentType.startsWith('image/')) {
-          throw StateError(
-            'Gallery image response had invalid content type: $contentType',
-          );
-        }
-
-        await _cacheManager.putFile(
-          request.url,
-          bytes is Uint8List ? bytes : Uint8List.fromList(bytes),
-          key: cacheKey,
-          eTag: response.headers.value('etag'),
-          maxAge: const Duration(days: 7),
-          fileExtension: _fileExtension(request.url, contentType),
-        );
-        if (!completer.isCompleted) completer.complete();
-      } catch (error, stackTrace) {
-        if (!completer.isCompleted) {
-          completer.completeError(error, stackTrace);
+      } on DioException catch (error) {
+        lastError = error;
+        if (cancelToken.isCancelled || attempt > 0 || !_isTransient(error)) {
+          rethrow;
         }
       }
     }
+    throw lastError!;
+  }
 
-    unawaited(run());
-    return GalleryImagePreloadOperation(
-      future: completer.future,
-      cancel: () {
-        if (cancelToken.isCancelled) return;
-        cancelToken.cancel(const _GalleryDownloadCancelled());
-        if (!completer.isCompleted) {
-          completer.completeError(const _GalleryDownloadCancelled());
-        }
-      },
-    );
+  bool _isTransient(DioException error) {
+    if (error.type == DioExceptionType.connectionError ||
+        error.type == DioExceptionType.connectionTimeout ||
+        error.type == DioExceptionType.receiveTimeout ||
+        error.type == DioExceptionType.sendTimeout) {
+      return true;
+    }
+    final status = error.response?.statusCode;
+    return status == 408 ||
+        status == 425 ||
+        status == 429 ||
+        (status ?? 0) >= 500;
   }
 
   String _fileExtension(String url, String? contentType) {
@@ -132,7 +170,76 @@ class CancellableGalleryImageLoader {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    for (final transfer in _transfers.values.toList(growable: false)) {
+      transfer.abort();
+    }
+    _transfers.clear();
     if (_ownsDio) _dio.close(force: true);
+  }
+}
+
+class _SharedGalleryTransfer {
+  final CancelToken cancelToken = CancelToken();
+  final Set<Completer<void>> _consumers = {};
+  bool _completed = false;
+  Object? _error;
+  StackTrace? _stackTrace;
+
+  bool get canAcceptConsumer =>
+      !cancelToken.isCancelled && (!_completed || _error == null);
+
+  GalleryImagePreloadOperation addConsumer() {
+    final completer = Completer<void>();
+    if (_completed) {
+      final error = _error;
+      if (error == null) {
+        completer.complete();
+      } else {
+        completer.completeError(error, _stackTrace ?? StackTrace.current);
+      }
+    } else {
+      _consumers.add(completer);
+    }
+    return GalleryImagePreloadOperation(
+      future: completer.future,
+      cancel: () {
+        if (!_consumers.remove(completer) || completer.isCompleted) return;
+        completer.completeError(const _GalleryDownloadCancelled());
+        if (_consumers.isEmpty && !_completed && !cancelToken.isCancelled) {
+          cancelToken.cancel(const _GalleryDownloadCancelled());
+        }
+      },
+    );
+  }
+
+  void complete() {
+    if (_completed) return;
+    _completed = true;
+    final consumers = _consumers.toList(growable: false);
+    _consumers.clear();
+    for (final consumer in consumers) {
+      if (!consumer.isCompleted) consumer.complete();
+    }
+  }
+
+  void completeError(Object error, StackTrace stackTrace) {
+    if (_completed) return;
+    _completed = true;
+    _error = error;
+    _stackTrace = stackTrace;
+    final consumers = _consumers.toList(growable: false);
+    _consumers.clear();
+    for (final consumer in consumers) {
+      if (!consumer.isCompleted) consumer.completeError(error, stackTrace);
+    }
+  }
+
+  void abort() {
+    if (_completed) return;
+    if (!cancelToken.isCancelled) {
+      cancelToken.cancel(const _GalleryDownloadCancelled());
+    }
+    completeError(const _GalleryDownloadCancelled(), StackTrace.current);
   }
 }
 

--- a/lib/core/cache/gallery_image_request.dart
+++ b/lib/core/cache/gallery_image_request.dart
@@ -167,10 +167,15 @@ class GalleryImageRequest {
       ? (sourceId as GallerySourceId).key
       : sourceId.toString();
 
-  String get stableRequestKey =>
-      '$sourceKey:$canonicalCacheKey:${tier.name}:${targetDecodeWidth ?? 'auto'}';
+  /// Network and disk identity, intentionally independent from decode size.
+  /// Thumbnail/sample widgets may request different decoded widths while still
+  /// sharing one bounded transfer of the same source bytes.
+  String get transportKey => '$sourceKey:$canonicalCacheKey';
 
-  ImageProvider<Object> createImageProvider(CacheManager cacheManager) {
+  String get stableRequestKey =>
+      '$transportKey:${tier.name}:${targetDecodeWidth ?? 'auto'}';
+
+  ImageProvider<Object> createImageProvider(BaseCacheManager cacheManager) {
     final provider = CachedNetworkImageProvider(
       url,
       cacheManager: cacheManager,

--- a/lib/core/cache/online_gallery_prefetch_coordinator.dart
+++ b/lib/core/cache/online_gallery_prefetch_coordinator.dart
@@ -91,6 +91,17 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
     GalleryImageTier.original => false,
   };
 
+  /// Forgets a transport completion whose cached bytes could not be decoded.
+  /// The next mount will pass through the normal bounded loader again instead
+  /// of repeatedly trusting the stale completion marker.
+  void invalidateCompleted(GalleryImageRequest request) {
+    final transportPrefix = '${request.transportKey}:';
+    _completedThumbnails.removeWhere(
+      (key, _) => key.startsWith(transportPrefix),
+    );
+    _completedSamples.removeWhere((key, _) => key.startsWith(transportPrefix));
+  }
+
   bool isNegativelyCached(GalleryImageRequest request) {
     final failedAt = _failures[request.stableRequestKey];
     if (failedAt == null) return false;

--- a/lib/data/datasources/remote/online_gallery/ai_tag_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/ai_tag_gallery_source_adapter.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:isolate';
 import 'dart:math';
 
 import 'package:dio/dio.dart';
@@ -67,9 +68,9 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
         );
       }
       final json = Map<String, dynamic>.from(response.data as Map);
-      final assetBaseUrl = json['asset_base_url']?.toString().trim() ?? '';
-      if (Uri.tryParse(assetBaseUrl)?.isAbsolute != true ||
-          assetBaseUrl.isEmpty) {
+      final rawAssetBaseUrl = json['asset_base_url']?.toString().trim() ?? '';
+      final assetBaseUrl = _normalizeAiTagAssetBaseUrl(rawAssetBaseUrl);
+      if (assetBaseUrl == null) {
         throw const GallerySourceException(
           GallerySourceErrorCode.configurationUnavailable,
           source: GallerySourceId.aiTag,
@@ -77,9 +78,7 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
         );
       }
       final config = AiTagSourceConfig(
-        assetBaseUrl: assetBaseUrl.endsWith('/')
-            ? assetBaseUrl
-            : '$assetBaseUrl/',
+        assetBaseUrl: assetBaseUrl,
         pageSize: (_asInt(json['page_size']) ?? 60).clamp(60, 200),
         availableYears: _parseIntList(json['available_years']),
         availableMonths: _parseStringList(json['available_months'])
@@ -304,25 +303,29 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
       }
       final work = Map<String, dynamic>.from(payload['work'] as Map);
       final imageRows = payload['images'] as List;
-      final media = <GalleryMedia>[];
-      for (final raw in imageRows) {
-        if (raw is! Map) continue;
-        try {
-          media.add(
-            _parseMedia(Map<String, dynamic>.from(raw), config.assetBaseUrl),
-          );
-        } catch (error) {
-          final fileName = raw['file_name']?.toString() ?? '<unknown>';
-          AppLogger.w(
-            'Skipped malformed AI TAG media (source=ai_tag, work=${item.id}, file=$fileName): $error',
-            'AiTagGallery',
-          );
-        }
-      }
-      media.sort(
-        (left, right) =>
-            _mediaPageIndex(left.id).compareTo(_mediaPageIndex(right.id)),
+      final copiedImageRows = imageRows
+          .whereType<Map>()
+          .map((row) => Map<String, dynamic>.from(row))
+          .toList(growable: false);
+      // Some works contain many embedded metadata blobs. Keep JSON metadata
+      // parsing off the UI isolate so a completed detail request cannot stall
+      // an active masonry-grid fling.
+      final parsedBatch = await Isolate.run(
+        () => _parseAiTagMediaRows(copiedImageRows, config.assetBaseUrl),
       );
+      if (cancelToken?.isCancelled ?? false) {
+        throw DioException.requestCancelled(
+          requestOptions: response.requestOptions,
+          reason: 'AI TAG detail parsing cancelled',
+        );
+      }
+      for (final failure in parsedBatch.failures) {
+        AppLogger.w(
+          'Skipped malformed AI TAG media (source=ai_tag, work=${item.id}, file=${failure.fileName}): ${failure.error}',
+          'AiTagGallery',
+        );
+      }
+      final media = parsedBatch.media;
       if (media.isEmpty) {
         throw const GallerySourceException(
           GallerySourceErrorCode.imageUnavailable,
@@ -436,36 +439,10 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     );
   }
 
-  GalleryMedia _parseMedia(Map<String, dynamic> json, String assetBaseUrl) {
-    final imageType = json['image_type']?.toString().trim() ?? '';
-    final authorId = json['author_id']?.toString().trim() ?? '';
-    final fileName = json['file_name']?.toString().trim() ?? '';
-    if (imageType.isEmpty || authorId.isEmpty || fileName.isEmpty) {
-      throw const FormatException('AI TAG image path fields are incomplete');
-    }
-    final url = '$assetBaseUrl$imageType/$authorId/$fileName.webp';
-    final rawAiJson = _rawJsonString(json['ai_json']);
-    final promptText = json['prompt_text']?.toString();
-    final parsed = _parseMetadata(rawAiJson, promptText);
-    return GalleryMedia(
-      id: fileName,
-      previewUrl: url,
-      displayUrl: url,
-      downloadUrl: url,
-      width: parsed.metadata?.width ?? 0,
-      height: parsed.metadata?.height ?? 0,
-      extension: 'webp',
-      mediaType: 'image',
-      prompt: parsed.metadata?.prompt,
-      negativePrompt: parsed.metadata?.negativePrompt,
-      rawMetadata: rawAiJson ?? promptText,
-      metadataFormat: parsed.sourceFormat,
-      metadataError: parsed.success ? null : parsed.errorMessage,
-      metadata: _metadataMap(parsed.metadata, json),
-    );
-  }
-
-  MetadataParseResult _parseMetadata(String? rawAiJson, String? promptText) {
+  static MetadataParseResult _parseMetadata(
+    String? rawAiJson,
+    String? promptText,
+  ) {
     if ((rawAiJson == null || rawAiJson.isEmpty) &&
         (promptText == null || promptText.isEmpty)) {
       return MetadataParseResult.failed(
@@ -509,7 +486,7 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     });
   }
 
-  Map<String, Object?> _metadataMap(
+  static Map<String, Object?> _metadataMap(
     NaiImageMetadata? metadata,
     Map<String, dynamic> raw,
   ) {
@@ -541,7 +518,7 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     return html_parser.parseFragment(withBreaks).text?.trim() ?? '';
   }
 
-  String? _rawJsonString(Object? value) {
+  static String? _rawJsonString(Object? value) {
     if (value == null) return null;
     if (value is String) return value;
     try {
@@ -551,7 +528,7 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     }
   }
 
-  int _mediaPageIndex(String value) {
+  static int _mediaPageIndex(String value) {
     final match = RegExp(r'_p(\d+)(?:\D|$)').firstMatch(value);
     return int.tryParse(match?.group(1) ?? '') ?? 0;
   }
@@ -883,4 +860,115 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
     }
     return const [];
   }
+}
+
+String? _normalizeAiTagAssetBaseUrl(String raw) {
+  final uri = Uri.tryParse(raw);
+  if (uri == null ||
+      uri.scheme.toLowerCase() != 'https' ||
+      uri.host.isEmpty ||
+      uri.userInfo.isNotEmpty) {
+    return null;
+  }
+  final pathSegments = uri.pathSegments
+      .where((segment) => segment.isNotEmpty && segment != '.')
+      .toList(growable: true);
+  if (pathSegments.any((segment) => segment == '..')) return null;
+  pathSegments.add('');
+  return Uri(
+    scheme: uri.scheme,
+    host: uri.host,
+    port: uri.hasPort ? uri.port : null,
+    pathSegments: pathSegments,
+  ).toString();
+}
+
+_ParsedAiTagMediaBatch _parseAiTagMediaRows(
+  List<Map<String, dynamic>> rows,
+  String assetBaseUrl,
+) {
+  final media = <GalleryMedia>[];
+  final failures = <_AiTagMediaFailure>[];
+  for (final row in rows) {
+    final fileName = row['file_name']?.toString().trim() ?? '';
+    try {
+      final imageType = row['image_type']?.toString().trim() ?? '';
+      final authorId = row['author_id']?.toString().trim() ?? '';
+      if (imageType.isEmpty || authorId.isEmpty || fileName.isEmpty) {
+        throw const FormatException('AI TAG image path fields are incomplete');
+      }
+      final baseUri = Uri.parse(assetBaseUrl);
+      final baseSegments = baseUri.pathSegments
+          .where((segment) => segment.isNotEmpty)
+          .toList(growable: false);
+      final url = baseUri
+          .replace(
+            pathSegments: [
+              ...baseSegments,
+              imageType,
+              authorId,
+              '$fileName.webp',
+            ],
+            query: null,
+            fragment: null,
+          )
+          .toString();
+      final rawAiJson = AiTagGallerySourceAdapter._rawJsonString(
+        row['ai_json'],
+      );
+      final promptText = row['prompt_text']?.toString();
+      final parsed = AiTagGallerySourceAdapter._parseMetadata(
+        rawAiJson,
+        promptText,
+      );
+      media.add(
+        GalleryMedia(
+          id: fileName,
+          previewUrl: url,
+          displayUrl: url,
+          downloadUrl: url,
+          width: parsed.metadata?.width ?? 0,
+          height: parsed.metadata?.height ?? 0,
+          extension: 'webp',
+          mediaType: 'image',
+          prompt: parsed.metadata?.prompt,
+          negativePrompt: parsed.metadata?.negativePrompt,
+          rawMetadata: rawAiJson ?? promptText,
+          metadataFormat: parsed.sourceFormat,
+          metadataError: parsed.success ? null : parsed.errorMessage,
+          metadata: AiTagGallerySourceAdapter._metadataMap(
+            parsed.metadata,
+            row,
+          ),
+        ),
+      );
+    } catch (error) {
+      failures.add(
+        _AiTagMediaFailure(
+          fileName: fileName.isEmpty ? '<unknown>' : fileName,
+          error: error.toString(),
+        ),
+      );
+    }
+  }
+  media.sort(
+    (left, right) => AiTagGallerySourceAdapter._mediaPageIndex(
+      left.id,
+    ).compareTo(AiTagGallerySourceAdapter._mediaPageIndex(right.id)),
+  );
+  return _ParsedAiTagMediaBatch(media: media, failures: failures);
+}
+
+class _ParsedAiTagMediaBatch {
+  const _ParsedAiTagMediaBatch({required this.media, required this.failures});
+
+  final List<GalleryMedia> media;
+  final List<_AiTagMediaFailure> failures;
+}
+
+class _AiTagMediaFailure {
+  const _AiTagMediaFailure({required this.fileName, required this.error});
+
+  final String fileName;
+  final String error;
 }

--- a/lib/presentation/screens/online_gallery/gallery_grid_item.dart
+++ b/lib/presentation/screens/online_gallery/gallery_grid_item.dart
@@ -105,7 +105,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
       setState(() {
         _detailFuture = _loadDetail();
       });
-    } else if (visibilityChanged) {
+    } else if (visibilityChanged && _needsDetail) {
       setState(() {});
     }
   }
@@ -164,13 +164,13 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
         visibilityKey: post.stableKey,
         scrolling: widget.scrolling,
         onVisibilityChanged: _handleVisibility,
-        builder: (context, hasBeenVisible, isScrolling) {
+        builder: (context, hasBeenVisible, isScrolling, isVisible) {
           if (!_needsDetail) {
             return _buildResourceCard(
               context,
               post,
               layoutAspectRatio,
-              loadMedia: hasBeenVisible,
+              loadMedia: hasBeenVisible || isVisible,
             );
           }
           if (!hasBeenVisible) {

--- a/lib/presentation/screens/online_gallery/online_gallery_grid.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_grid.dart
@@ -22,6 +22,7 @@ typedef OnlineGalleryVisibilityItemBuilder =
       BuildContext context,
       bool hasBeenVisible,
       bool isScrolling,
+      bool isVisible,
     );
 
 /// Responsive masonry grid. Item interaction is supplied as commands so this
@@ -260,13 +261,21 @@ class OnlineGalleryVisibilityDrivenItemState
           widget.onVisibilityChanged(false, 0);
         }
         if (_isVisible == visible) return;
-        _isVisible = visible;
         if (visible && !_hasBeenVisible && !_isScrolling && mounted) {
           _stopListeningForScrolling();
-          setState(() => _hasBeenVisible = true);
+          setState(() {
+            _isVisible = true;
+            _hasBeenVisible = true;
+          });
+        } else if (!_hasBeenVisible && mounted) {
+          // A currently visible card may resolve a memory/disk hit even during
+          // a fling. The image coordinator still bounds new network work.
+          setState(() => _isVisible = visible);
+        } else {
+          _isVisible = visible;
         }
       },
-      child: widget.builder(context, _hasBeenVisible, _isScrolling),
+      child: widget.builder(context, _hasBeenVisible, _isScrolling, _isVisible),
     );
   }
 }

--- a/lib/presentation/widgets/danbooru_post_card.dart
+++ b/lib/presentation/widgets/danbooru_post_card.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:math';
 
 import 'package:cached_network_image/cached_network_image.dart';
@@ -116,16 +115,8 @@ class DanbooruPostCard extends StatefulWidget {
 }
 
 class _DanbooruPostCardState extends State<DanbooruPostCard> {
-  static final LinkedHashMap<String, double> _aspectRatioCache =
-      LinkedHashMap<String, double>();
-  static const int _maxAspectRatioEntries = 1000;
-
   bool _isHovering = false;
   bool _isFocused = false;
-  double? _resolvedAspectRatio;
-  String? _dimensionRequestUrl;
-  ImageStream? _dimensionStream;
-  ImageStreamListener? _dimensionListener;
   late final OnlineGalleryHoverController _ownedHoverController;
   final _layerLink = LayerLink();
 
@@ -139,12 +130,6 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _resolveUnknownDimensions();
-  }
-
-  @override
   void didUpdateWidget(covariant DanbooruPostCard oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.post.stableKey != widget.post.stableKey) {
@@ -153,78 +138,10 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
       );
       _isHovering = false;
     }
-    if (oldWidget.post.previewUrl != widget.post.previewUrl ||
-        oldWidget.post.width != widget.post.width ||
-        oldWidget.post.height != widget.post.height ||
-        oldWidget.loadMedia != widget.loadMedia) {
-      _resolvedAspectRatio = null;
-      _resolveUnknownDimensions();
-    }
-  }
-
-  void _resolveUnknownDimensions() {
-    final post = widget.post;
-    if (!widget.loadMedia ||
-        (post.width > 0 && post.height > 0) ||
-        _resolvedAspectRatio != null ||
-        !post.mediaCapability.canPrefetchPreview) {
-      _detachDimensionListener();
-      return;
-    }
-    final url = post.previewUrl;
-    final request = GalleryImageRequest.forUrl(
-      sourceId: post.sourceId,
-      url: url,
-      tier: GalleryImageTier.thumbnail,
-      targetDecodeWidth: GalleryImageSizing.gridTargetWidth(
-        layoutWidth: widget.itemWidth,
-        devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
-      ),
-    );
-    final cachedRatio = _aspectRatioCache.remove(request.stableRequestKey);
-    if (cachedRatio != null) {
-      _aspectRatioCache[request.stableRequestKey] = cachedRatio;
-      _resolvedAspectRatio = cachedRatio;
-      return;
-    }
-    if (_dimensionRequestUrl == request.stableRequestKey) return;
-    _detachDimensionListener();
-    _dimensionRequestUrl = request.stableRequestKey;
-    final provider = request.createImageProvider(
-      OnlineGalleryImageCacheManager.instance,
-    );
-    final stream = provider.resolve(createLocalImageConfiguration(context));
-    late final ImageStreamListener listener;
-    listener = ImageStreamListener((imageInfo, _) {
-      if (!mounted || widget.post.previewUrl != url) return;
-      final width = imageInfo.image.width;
-      final height = imageInfo.image.height;
-      if (width > 0 && height > 0) {
-        final ratio = width / height;
-        _aspectRatioCache[request.stableRequestKey] = ratio;
-        while (_aspectRatioCache.length > _maxAspectRatioEntries) {
-          _aspectRatioCache.remove(_aspectRatioCache.keys.first);
-        }
-        setState(() => _resolvedAspectRatio = ratio);
-      }
-      _detachDimensionListener();
-    }, onError: (_, __) => _detachDimensionListener());
-    _dimensionStream = stream;
-    _dimensionListener = listener;
-    stream.addListener(listener);
-  }
-
-  void _detachDimensionListener() {
-    final listener = _dimensionListener;
-    if (listener != null) _dimensionStream?.removeListener(listener);
-    _dimensionStream = null;
-    _dimensionListener = null;
-    _dimensionRequestUrl = null;
   }
 
   @override
   void dispose() {
-    _detachDimensionListener();
     _hoverController.dismissFor(widget.post.stableKey);
     _ownedHoverController.dispose();
     super.dispose();
@@ -251,11 +168,9 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
       onDismissIntent: widget.onHoverDismiss,
       builder: (_) => _HoverPreviewCardInner(
         post: widget.post,
-        aspectRatio:
-            _resolvedAspectRatio ??
-            (widget.post.width > 0 && widget.post.height > 0
-                ? widget.post.width / widget.post.height
-                : null),
+        aspectRatio: widget.post.width > 0 && widget.post.height > 0
+            ? widget.post.width / widget.post.height
+            : null,
         maxWidth: previewSize.width,
         maxHeight: previewSize.height,
         imageCoordinator: widget.imageCoordinator,
@@ -424,7 +339,7 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
 
     final aspectRatio = widget.post.width > 0 && widget.post.height > 0
         ? widget.post.width / widget.post.height
-        : _resolvedAspectRatio ?? 1.0;
+        : 1.0;
     final layoutAspectRatio = widget.layoutAspectRatio;
     final stableAspectRatio = layoutAspectRatio != null && layoutAspectRatio > 0
         ? layoutAspectRatio

--- a/lib/presentation/widgets/online_gallery/coordinated_gallery_image.dart
+++ b/lib/presentation/widgets/online_gallery/coordinated_gallery_image.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../../core/cache/gallery_image_request.dart';
 import '../../../core/cache/online_gallery_image_cache_manager.dart';
 import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
 import '../../../core/utils/app_logger.dart';
+import '../../themes/theme_extension.dart';
 
 /// Routes gallery image downloads through the shared network QoS coordinator.
 ///
@@ -19,6 +22,7 @@ class CoordinatedGalleryImage extends StatefulWidget {
     this.alignment = Alignment.center,
     this.placeholder,
     this.errorWidget,
+    this.fadeIn = true,
   });
 
   final GalleryImageRequest request;
@@ -28,6 +32,7 @@ class CoordinatedGalleryImage extends StatefulWidget {
   final AlignmentGeometry alignment;
   final Widget? placeholder;
   final Widget? errorWidget;
+  final bool fadeIn;
 
   @override
   State<CoordinatedGalleryImage> createState() =>
@@ -38,12 +43,14 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
   bool _ready = false;
   bool _failed = false;
   bool _requesting = false;
+  bool _showImmediately = false;
   int _revision = 0;
 
   @override
   void initState() {
     super.initState();
     _ready = widget.coordinator.isReady(widget.request);
+    _showImmediately = _ready;
     widget.coordinator.addListener(_handleCoordinatorChanged);
   }
 
@@ -71,6 +78,7 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
       _requesting = false;
       if (requestChanged) {
         _ready = widget.coordinator.isReady(widget.request);
+        _showImmediately = _ready;
         _failed = false;
       } else if (!_ready) {
         _failed = false;
@@ -87,7 +95,7 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
   }
 
   void _handleCoordinatorChanged() {
-    if (_ready || widget.coordinator.isPaused) return;
+    if (!mounted || _ready || widget.coordinator.isPaused) return;
     if (_failed && !widget.coordinator.isNegativelyCached(widget.request)) {
       setState(() => _failed = false);
     }
@@ -113,29 +121,65 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
     });
   }
 
+  Future<void> _evictFailedImage(
+    ImageProvider<Object> imageProvider,
+    GalleryImageRequest request,
+    OnlineGalleryPrefetchCoordinator coordinator,
+  ) async {
+    try {
+      await Future.wait([
+        imageProvider.evict(),
+        OnlineGalleryImageCacheManager.instance.removeFile(
+          request.canonicalCacheKey,
+        ),
+      ]);
+    } catch (error) {
+      AppLogger.w(
+        'Failed to evict undecodable gallery image: '
+            'source=${request.sourceKey}, error=$error',
+        'GalleryImage',
+      );
+    } finally {
+      // Keep the completion marker until cleanup finishes so a retry cannot
+      // publish fresh bytes before this eviction has finished.
+      coordinator.invalidateCompleted(request);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_failed) return widget.errorWidget ?? const SizedBox.shrink();
     if (!_ready) return widget.placeholder ?? const SizedBox.shrink();
     final placeholder = widget.placeholder ?? const SizedBox.shrink();
     final disableAnimations = MediaQuery.disableAnimationsOf(context);
+    final motion = Theme.of(context).appTheme;
+    final fadeDuration = Duration(
+      milliseconds: motion.fastDuration.inMilliseconds.clamp(120, 160),
+    );
+    final cacheManager = OnlineGalleryImageCacheManager.instance;
+    final request = widget.request;
+    final coordinator = widget.coordinator;
+    final imageProvider = request.createImageProvider(cacheManager);
     return Image(
-      image: widget.request.createImageProvider(
-        OnlineGalleryImageCacheManager.instance,
-      ),
+      image: imageProvider,
       fit: widget.fit,
       alignment: widget.alignment,
       gaplessPlayback: true,
       frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
         if (frame == null) return placeholder;
-        if (wasSynchronouslyLoaded || disableAnimations) return child;
+        if (!widget.fadeIn ||
+            wasSynchronouslyLoaded ||
+            disableAnimations ||
+            _showImmediately) {
+          return child;
+        }
         return Stack(
           fit: StackFit.expand,
           children: [
             placeholder,
             TweenAnimationBuilder<double>(
               tween: Tween(begin: 0, end: 1),
-              duration: const Duration(milliseconds: 160),
+              duration: fadeDuration,
               curve: Curves.easeOutCubic,
               builder: (_, opacity, image) =>
                   Opacity(opacity: opacity, child: image),
@@ -145,11 +189,17 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
         );
       },
       errorBuilder: (_, error, __) {
+        if (request.stableRequestKey != widget.request.stableRequestKey ||
+            !identical(coordinator, widget.coordinator)) {
+          return placeholder;
+        }
         if (!_failed) {
           _failed = true;
+          _ready = false;
+          unawaited(_evictFailedImage(imageProvider, request, coordinator));
           AppLogger.w(
             'Gallery image decode failed after coordinated preload: '
-                'source=${widget.request.sourceKey}, errorType=${error.runtimeType}',
+                'source=${request.sourceKey}, errorType=${error.runtimeType}',
             'GalleryImage',
           );
         }

--- a/lib/presentation/widgets/online_gallery/progressive_gallery_image.dart
+++ b/lib/presentation/widgets/online_gallery/progressive_gallery_image.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 import '../../../core/cache/gallery_image_request.dart';
-import '../../../core/cache/online_gallery_image_cache_manager.dart';
 import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
+import '../../themes/theme_extension.dart';
 import 'coordinated_gallery_image.dart';
 
 class ProgressiveGalleryImage extends StatefulWidget {
@@ -92,7 +92,6 @@ class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
 
   @override
   Widget build(BuildContext context) {
-    final manager = OnlineGalleryImageCacheManager.instance;
     final thumbnail = CoordinatedGalleryImage(
       request: widget.thumbnail,
       coordinator: widget.coordinator,
@@ -111,6 +110,10 @@ class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
     }
 
     final disableAnimations = MediaQuery.disableAnimationsOf(context);
+    final motion = Theme.of(context).appTheme;
+    final fadeDuration = Duration(
+      milliseconds: motion.fastDuration.inMilliseconds.clamp(120, 160),
+    );
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -119,15 +122,17 @@ class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
           tween: Tween<double>(begin: 0, end: 1),
           duration: disableAnimations || _showSampleImmediately
               ? Duration.zero
-              : const Duration(milliseconds: 140),
+              : fadeDuration,
+          curve: Curves.easeOutCubic,
           builder: (_, opacity, child) =>
               Opacity(opacity: opacity, child: child),
-          child: Image(
-            image: widget.sample.createImageProvider(manager),
+          child: CoordinatedGalleryImage(
+            request: widget.sample,
+            coordinator: widget.coordinator,
+            priority: GalleryImagePriority.hover,
             fit: widget.fit,
             alignment: widget.alignment,
-            gaplessPlayback: true,
-            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+            fadeIn: false,
           ),
         ),
       ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -402,7 +402,7 @@ packages:
     source: hosted
     version: "2.2.0"
   file:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -144,6 +144,8 @@ dev_dependencies:
   hive_generator: ^2.0.1
   # Mock 测试
   mocktail: ^1.0.3
+  # 文件缓存测试
+  file: ^7.0.1
   # 集成测试
   integration_test:
     sdk: flutter

--- a/test/core/cache/cancellable_gallery_image_loader_test.dart
+++ b/test/core/cache/cancellable_gallery_image_loader_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:file/file.dart' as fs;
+import 'package:file/memory.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/cache/cancellable_gallery_image_loader.dart';
@@ -49,6 +51,56 @@ void main() {
       finishResponse.complete();
       await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(cache.putCalled, isFalse);
+    },
+  );
+
+  test(
+    'cancelled transport can be retried before old cleanup finishes',
+    () async {
+      final firstRequestArrived = Completer<void>();
+      final releaseFirstResponse = Completer<void>();
+      addTearDown(() {
+        if (!releaseFirstResponse.isCompleted) releaseFirstResponse.complete();
+      });
+      var requestCount = 0;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        requestCount++;
+        if (requestCount == 1) {
+          firstRequestArrived.complete();
+          await releaseFirstResponse.future;
+          try {
+            await request.response.close();
+          } on Object {
+            // The first consumer intentionally aborted this transport.
+          }
+          return;
+        }
+        request.response.headers.contentType = ContentType('image', 'webp');
+        request.response.add([0x52, 0x49, 0x46, 0x46]);
+        await request.response.close();
+      });
+      final cache = _RecordingCacheManager(allowPut: true);
+      final loader = CancellableGalleryImageLoader(cacheManager: cache);
+      addTearDown(loader.dispose);
+      final request = GalleryImageRequest(
+        sourceId: 'test',
+        url: 'http://${server.address.host}:${server.port}/retry-cancel.webp',
+        tier: GalleryImageTier.thumbnail,
+      );
+
+      final cancelled = loader.start(request);
+      await firstRequestArrived.future.timeout(const Duration(seconds: 2));
+      cancelled.cancel();
+      await expectLater(cancelled.future, throwsA(isA<Exception>()));
+
+      final retry = loader.start(request);
+      await retry.future.timeout(const Duration(seconds: 2));
+      releaseFirstResponse.complete();
+
+      expect(requestCount, 2);
+      expect(cache.putCount, 1);
     },
   );
 
@@ -163,6 +215,115 @@ void main() {
     expect(cache.putCalled, isFalse);
   });
 
+  test(
+    'shares one transport across decode tiers and keeps remaining consumer',
+    () async {
+      final requestArrived = Completer<void>();
+      final finishResponse = Completer<void>();
+      var requestCount = 0;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        requestCount++;
+        if (!requestArrived.isCompleted) requestArrived.complete();
+        await finishResponse.future;
+        request.response.headers.contentType = ContentType('image', 'webp');
+        request.response.add([0x52, 0x49, 0x46, 0x46]);
+        await request.response.close();
+      });
+      final cache = _RecordingCacheManager(allowPut: true);
+      final loader = CancellableGalleryImageLoader(cacheManager: cache);
+      addTearDown(loader.dispose);
+      final url = 'http://${server.address.host}:${server.port}/shared.webp';
+      final thumbnail = GalleryImageRequest(
+        sourceId: 'ai_tag',
+        url: url,
+        tier: GalleryImageTier.thumbnail,
+        targetDecodeWidth: 320,
+      );
+      final sample = GalleryImageRequest(
+        sourceId: 'ai_tag',
+        url: url,
+        tier: GalleryImageTier.sample,
+        targetDecodeWidth: 960,
+      );
+
+      final first = loader.start(thumbnail);
+      final second = loader.start(sample);
+      await requestArrived.future.timeout(const Duration(seconds: 2));
+      first.cancel();
+      await expectLater(first.future, throwsA(isA<Exception>()));
+      finishResponse.complete();
+      await second.future;
+
+      expect(requestCount, 1);
+      expect(cache.putCount, 1);
+    },
+  );
+
+  test('valid disk cache hit completes without opening the network', () async {
+    final file = MemoryFileSystem().file('cached.webp')..writeAsBytesSync([1]);
+    final cache = _RecordingCacheManager(
+      cached: FileInfo(
+        file,
+        FileSource.Cache,
+        DateTime.now().add(const Duration(days: 1)),
+        'http://gallery.invalid/cached.webp',
+      ),
+    );
+    final loader = CancellableGalleryImageLoader(cacheManager: cache);
+    addTearDown(loader.dispose);
+
+    await loader
+        .start(
+          const GalleryImageRequest(
+            sourceId: 'test',
+            url: 'http://gallery.invalid/cached.webp',
+            tier: GalleryImageTier.thumbnail,
+          ),
+        )
+        .future;
+
+    expect(cache.cacheLookups, 1);
+    expect(cache.putCount, 0);
+  });
+
+  test(
+    'retries one transient response without publishing a failed body',
+    () async {
+      var requestCount = 0;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        requestCount++;
+        if (requestCount == 1) {
+          request.response.statusCode = HttpStatus.serviceUnavailable;
+          await request.response.close();
+          return;
+        }
+        request.response.headers.contentType = ContentType('image', 'webp');
+        request.response.add([0x52, 0x49, 0x46, 0x46]);
+        await request.response.close();
+      });
+      final cache = _RecordingCacheManager(allowPut: true);
+      final loader = CancellableGalleryImageLoader(cacheManager: cache);
+      addTearDown(loader.dispose);
+
+      await loader
+          .start(
+            GalleryImageRequest(
+              sourceId: 'ai_tag',
+              url: 'http://${server.address.host}:${server.port}/retry.webp',
+              tier: GalleryImageTier.thumbnail,
+            ),
+          )
+          .future;
+
+      expect(requestCount, 2);
+      expect(cache.putCount, 1);
+    },
+  );
+
   test('non-image responses are rejected without publishing cache', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(() => server.close(force: true));
@@ -189,19 +350,31 @@ void main() {
 }
 
 class _RecordingCacheManager implements BaseCacheManager {
-  bool putCalled = false;
+  _RecordingCacheManager({this.allowPut = false, this.cached});
+
+  final bool allowPut;
+  final FileInfo? cached;
+  int putCount = 0;
+  int cacheLookups = 0;
+  bool get putCalled => putCount > 0;
 
   @override
   Future<FileInfo?> getFileFromCache(
     String key, {
     bool ignoreMemCache = false,
-  }) async => null;
+  }) async {
+    cacheLookups++;
+    return cached;
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) {
     if (invocation.memberName == #putFile) {
-      putCalled = true;
-      return Future<Object>.error(
+      putCount++;
+      if (allowPut) {
+        return Future<fs.File>.value(MemoryFileSystem().file('unused-cache'));
+      }
+      return Future<fs.File>.error(
         StateError('Cancelled responses must not be cached'),
       );
     }

--- a/test/core/cache/gallery_image_request_test.dart
+++ b/test/core/cache/gallery_image_request_test.dart
@@ -1,9 +1,13 @@
 // ignore_for_file: prefer_const_constructors
 
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/cache/gallery_image_request.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('GalleryImageTier', () {
     test('has correct enum values', () {
       expect(GalleryImageTier.values.length, 3);
@@ -173,6 +177,43 @@ void main() {
       );
     });
 
+    test('transport identity ignores tier and decode width', () {
+      const url = 'https://example.com/image.webp';
+      final thumbnail = GalleryImageRequest(
+        sourceId: 'ai_tag',
+        url: url,
+        tier: GalleryImageTier.thumbnail,
+        targetDecodeWidth: 320,
+      );
+      final sample = GalleryImageRequest(
+        sourceId: 'ai_tag',
+        url: url,
+        tier: GalleryImageTier.sample,
+        targetDecodeWidth: 960,
+      );
+
+      expect(thumbnail.transportKey, sample.transportKey);
+      expect(thumbnail.stableRequestKey, isNot(sample.stableRequestKey));
+    });
+
+    test('provider identity is stable and decode width remains bounded', () {
+      final request = GalleryImageRequest(
+        sourceId: 'ai_tag',
+        url: 'https://example.com/image.webp',
+        tier: GalleryImageTier.thumbnail,
+        targetDecodeWidth: 960,
+      );
+      final cacheManager = _NoopCacheManager();
+      final first = request.createImageProvider(cacheManager);
+      final second = request.createImageProvider(cacheManager);
+
+      expect(first, isA<ResizeImage>());
+      expect(first, second);
+      final resized = first as ResizeImage;
+      expect(resized.width, 960);
+      expect(resized.imageProvider, isA<CachedNetworkImageProvider>());
+    });
+
     test('equality is based on stable request key', () {
       final request1 = GalleryImageRequest(
         sourceId: 'test',
@@ -275,4 +316,9 @@ void main() {
       );
     });
   });
+}
+
+class _NoopCacheManager implements BaseCacheManager {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/core/cache/online_gallery_prefetch_coordinator_test.dart
+++ b/test/core/cache/online_gallery_prefetch_coordinator_test.dart
@@ -155,6 +155,39 @@ void main() {
     },
   );
 
+  test('invalidated decode completion uses the bounded loader again', () async {
+    var starts = 0;
+    final request = _request(1);
+    final sampleRequest = _request(1, tier: GalleryImageTier.sample);
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (_) {
+        starts++;
+        return _operation(Future<void>.value());
+      },
+    );
+    addTearDown(coordinator.dispose);
+
+    expect(
+      await coordinator.submit(request, priority: GalleryImagePriority.visible),
+      isTrue,
+    );
+    expect(
+      await coordinator.submit(
+        sampleRequest,
+        priority: GalleryImagePriority.visible,
+      ),
+      isTrue,
+    );
+    coordinator.invalidateCompleted(request);
+    expect(coordinator.isReady(request), isFalse);
+    expect(coordinator.isReady(sampleRequest), isFalse);
+    expect(
+      await coordinator.submit(request, priority: GalleryImagePriority.visible),
+      isTrue,
+    );
+    expect(starts, 3);
+  });
+
   test(
     'generation rotation rejects old queued and in-flight results',
     () async {

--- a/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
+++ b/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
@@ -494,6 +494,58 @@ void main() {
       },
     );
 
+    test('normalizes the HTTPS CDN base before building media URLs', () async {
+      final http = _RecordingHttpAdapter((request) {
+        if (request.uri.path == '/api/config') {
+          return {
+            ..._configJson,
+            'asset_base_url': 'https://CDN.example/root/?v=1#old',
+          };
+        }
+        if (request.uri.path == '/api/work/503') {
+          return {
+            'work': _aiWork(503),
+            'images': [_aiImage('503 p0')],
+          };
+        }
+        throw StateError('Unexpected request ${request.uri}');
+      });
+      final adapter = AiTagGallerySourceAdapter(
+        dio: Dio()..httpClientAdapter = http,
+      );
+
+      final detail = await adapter.detail(
+        const GalleryItem(id: 503, sourceId: GallerySourceId.aiTag),
+      );
+
+      expect(
+        detail.media.single.previewUrl,
+        'https://cdn.example/root/SD/9/503%20p0.webp',
+      );
+      expect(detail.media.single.previewUrl, isNot(contains('pximg.net')));
+      expect(detail.media.single.id, '503 p0');
+    });
+
+    test('rejects non-HTTPS AI TAG asset bases', () async {
+      final http = _RecordingHttpAdapter(
+        (_) => {..._configJson, 'asset_base_url': 'http://cdn.example/'},
+      );
+      final adapter = AiTagGallerySourceAdapter(
+        dio: Dio()..httpClientAdapter = http,
+      );
+
+      await expectLater(
+        adapter.getConfig(),
+        throwsA(
+          isA<GallerySourceException>().having(
+            (error) => error.code,
+            'code',
+            GallerySourceErrorCode.configurationUnavailable,
+          ),
+        ),
+      );
+    });
+
     test('random page one reuses the exact total probe response', () async {
       var listRequests = 0;
       final http = _RecordingHttpAdapter((request) {

--- a/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
@@ -46,6 +46,7 @@ void main() {
     var builds = 0;
     var lastHasBeenVisible = false;
     var lastIsScrolling = false;
+    var lastIsVisible = false;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -54,10 +55,11 @@ void main() {
             visibilityKey: 'post-1',
             scrolling: scrolling,
             onVisibilityChanged: (_, __) {},
-            builder: (context, hasBeenVisible, isScrolling) {
+            builder: (context, hasBeenVisible, isScrolling, isVisible) {
               builds++;
               lastHasBeenVisible = hasBeenVisible;
               lastIsScrolling = isScrolling;
+              lastIsVisible = isVisible;
               return const SizedBox.square(dimension: 100);
             },
           ),
@@ -81,15 +83,18 @@ void main() {
       ),
     );
     await tester.pump();
-    expect((builds, lastHasBeenVisible, lastIsScrolling), (2, false, true));
+    expect(
+      (builds, lastHasBeenVisible, lastIsScrolling, lastIsVisible),
+      (3, false, true, true),
+    );
 
     scrolling.value = false;
     await tester.pump();
-    expect((builds, lastHasBeenVisible, lastIsScrolling), (3, true, false));
+    expect((builds, lastHasBeenVisible, lastIsScrolling), (4, true, false));
 
     scrolling.value = true;
     await tester.pump();
-    expect(builds, 3);
+    expect(builds, 4);
   });
 
   test('repeated visibility updates only enter the viewport once', () {

--- a/test/presentation/widgets/online_gallery/progressive_gallery_image_test.dart
+++ b/test/presentation/widgets/online_gallery/progressive_gallery_image_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/cache/gallery_image_request.dart';
 import 'package:nai_launcher/core/cache/online_gallery_prefetch_coordinator.dart';
+import 'package:nai_launcher/presentation/themes/theme_extension.dart';
 import 'package:nai_launcher/presentation/widgets/online_gallery/coordinated_gallery_image.dart';
 import 'package:nai_launcher/presentation/widgets/online_gallery/progressive_gallery_image.dart';
 
@@ -40,7 +41,9 @@ void main() {
     expect(transition.duration, Duration.zero);
   });
 
-  testWidgets('sample promotion fades for 140ms after loading', (tester) async {
+  testWidgets('sample promotion uses the bounded fast motion token', (
+    tester,
+  ) async {
     final gate = Completer<void>();
     final coordinator = OnlineGalleryPrefetchCoordinator(
       preloader: (_) => GalleryImagePreloadOperation.fromFuture(gate.future),
@@ -56,7 +59,7 @@ void main() {
     final transition = tester.widget<TweenAnimationBuilder<double>>(
       find.byType(TweenAnimationBuilder<double>),
     );
-    expect(transition.duration, const Duration(milliseconds: 140));
+    expect(transition.duration, const Duration(milliseconds: 120));
   });
 
   testWidgets('reduced motion promotes the sample immediately', (tester) async {
@@ -176,6 +179,44 @@ void main() {
     expect(find.text('waiting'), findsNothing);
   });
 
+  testWidgets('request replacement clears a stale failure', (tester) async {
+    var request = _thumbnail;
+    late StateSetter update;
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (candidate) => GalleryImagePreloadOperation.fromFuture(
+        candidate == _thumbnail
+            ? Future<void>.error(StateError('bad image'))
+            : Future<void>.value(),
+      ),
+    );
+    addTearDown(coordinator.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            update = setState;
+            return CoordinatedGalleryImage(
+              request: request,
+              coordinator: coordinator,
+              placeholder: const Text('waiting'),
+              errorWidget: const Text('failed'),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('failed'), findsOneWidget);
+
+    update(() => request = _sample);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('failed'), findsNothing);
+    expect(find.byType(Image), findsOneWidget);
+  });
+
   testWidgets('coordinated images keep the placeholder until the first frame', (
     tester,
   ) async {
@@ -200,14 +241,69 @@ void main() {
     final frameBuilder = image.frameBuilder!;
     final context = tester.element(find.byType(Image));
     expect(frameBuilder(context, const SizedBox(), null, false), isA<Text>());
-    final firstFrame = frameBuilder(
-      context,
-      const SizedBox(key: ValueKey('decoded-image')),
-      0,
-      false,
-    );
+    const decoded = SizedBox(key: ValueKey('decoded-image'));
+    final firstFrame = frameBuilder(context, decoded, 0, false);
     expect(firstFrame, isA<Stack>());
+    final stack = firstFrame as Stack;
+    final fade = stack.children.last as TweenAnimationBuilder<double>;
+    expect(fade.duration, const Duration(milliseconds: 120));
   });
+
+  testWidgets('gallery fade clamps long theme motion to 160ms', (tester) async {
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (_) =>
+          GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
+    );
+    addTearDown(coordinator.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          extensions: const [
+            AppThemeExtension(fastDuration: Duration(milliseconds: 400)),
+          ],
+        ),
+        home: CoordinatedGalleryImage(
+          request: _thumbnail,
+          coordinator: coordinator,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final image = tester.widget<Image>(find.byType(Image));
+    final context = tester.element(find.byType(Image));
+    final result = image.frameBuilder!(context, const SizedBox(), 0, false);
+    final fade =
+        (result as Stack).children.last as TweenAnimationBuilder<double>;
+    expect(fade.duration, const Duration(milliseconds: 160));
+  });
+
+  testWidgets(
+    'synchronous cache frame bypasses fade and keeps gapless playback',
+    (tester) async {
+      final coordinator = OnlineGalleryPrefetchCoordinator(
+        preloader: (_) =>
+            GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
+      );
+      addTearDown(coordinator.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: CoordinatedGalleryImage(
+            request: _thumbnail,
+            coordinator: coordinator,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final image = tester.widget<Image>(find.byType(Image));
+      expect(image.gaplessPlayback, isTrue);
+      final context = tester.element(find.byType(Image));
+      const decoded = SizedBox(key: ValueKey('cached-frame'));
+      final result = image.frameBuilder!(context, decoded, 0, true);
+      expect(identical(result, decoded), isTrue);
+    },
+  );
 }
 
 Widget _app(


### PR DESCRIPTION
## 根因

- 快速滚动时，首次进入视口的卡片会等滚动结束才创建图片；即使磁盘已有缓存，滚回视口仍可能长期停留在空占位。
- 同一媒体的 thumbnail/sample 使用不同解码尺寸时会各自启动传输；取消其中一个请求也无法安全保留其他消费者，造成重复 CDN 请求与无效重试。
- 未知尺寸卡片会在协调器之外额外 resolve 图片 provider，绕开并发/取消策略并增加重复下载、解码与 rebuild 风险。
- AI TAG 详情中的多份 metadata 在 UI isolate 同步解析，CDN URL 也依赖字符串拼接，复杂作品会放大卡顿与路径不稳定问题。
- 图片首帧缺少统一、可减弱的轻量过渡，缓存命中与首次加载也没有明确区分。

## 改动

### 缓存、网络与取消

- 新增与 decode tier/尺寸无关的 transport identity；同一规范化资源只传输一次，多个消费者独立取消，最后一个消费者离开后才中止底层请求。
- 网络前先校验磁盘缓存；仅对连接错误、超时、408/425/429/5xx 做一次瞬时重试，失败、取消和非图片响应均不写入缓存。
- 解码失败会清理 Flutter image cache 与对应磁盘对象，再失效协调器完成标记，避免损坏缓存持续回放或删除新重试结果。
- 保留现有边界：最多 4 个并发、64 个排队任务、0.75 屏 cache extent、12–48 个 lookahead；没有扩大 Flutter ImageCache、保活全量卡片或截断记录。

### 解码、滚动与 Widget 生命周期

- 视口内卡片在 fling 期间也可立即走内存/磁盘命中路径，新网络工作仍由共享协调器限流。
- provider identity 继续使用规范化 cache key；目标解码宽度继续由实际卡片宽度与 DPR 计算并设置 cacheWidth。
- 删除卡片层绕过协调器的未知尺寸 provider resolve，保持稳定方形 fallback/服务端尺寸布局，减少额外下载、解码和尺寸回流。
- 复用稳定 item key、`RepaintBoundary`、虚拟化网格和分页契约；未修改工具栏、筛选、收藏、顺序或完整数据加载语义。

### AI TAG

- 只接受 HTTPS `asset_base_url`，规范化后严格按 `image_type/author_id/file_name.webp` 构造唯一 CDN WebP URL。
- 没有 Pixiv URL fallback；相关测试显式拒绝 Pixiv 路径。
- 将批量 metadata 解析移到 isolate，并在解析后再次检查取消状态；保留全部有效 media、原有 media ID、`_pN` 顺序和 metadata。

### 淡入

- 首次占位到图片只做 opacity 淡入，时长使用主题 fast token 并限制在 120–160ms，曲线为 `easeOutCubic`。
- `MediaQuery.disableAnimations`、同步缓存帧和已完成的缓存请求立即显示；不创建逐卡 AnimationController，不动画布局。
- progressive sample 复用同一协调图片组件，解码失败时保留 thumbnail 并清理损坏缓存。

## 验证

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1 -Concurrency 4 -TimeoutSeconds 120`
- 针对 loader、prefetch coordinator、AI TAG adapter、grid 与 progressive image 的后续聚焦回归均通过。
- `dart analyze <15 个变更源码/测试文件>`：No issues found。
- `flutter analyze`：变更文件无问题；全仓仅剩既有 `lib/core/agent/context_usage.dart:70` 的 `unnecessary_null_comparison` warning，与本 PR 无关。
- 仓库未提供在线画廊专用 benchmark/profile 测试入口，因此采用并发上限、队列/LRU 边界、稳定 key、下载计数、可见区构建和无 overflow 等确定性结构断言，未加入墙钟阈值测试。

未启动 Windows/Android runner，未使用 Computer Use，未更新 CHANGELOG.md。