### PR TITLE
feat(generation): 添加流式预览开关

### DIFF
--- a/lib/core/constants/storage_keys.dart
+++ b/lib/core/constants/storage_keys.dart
@@ -118,6 +118,8 @@ class StorageKeys {
   static const String ucPresetCustomIds = 'uc_preset_custom_ids'; // 自定义条目ID列表
   static const String randomPromptMode = 'random_prompt_mode';
   static const String showRandomPromptTools = 'show_random_prompt_tools';
+  static const String generationStreamPreviewEnabled =
+      'generation_stream_preview_enabled';
   static const String randomGenerationMode = 'random_generation_mode';
   static const String imagesPerRequest = 'images_per_request';
   static const String enableAutocomplete = 'enable_autocomplete';

--- a/lib/core/storage/local_storage_service.dart
+++ b/lib/core/storage/local_storage_service.dart
@@ -392,6 +392,20 @@ class LocalStorageService {
     await setSetting(StorageKeys.showRandomPromptTools, value);
   }
 
+  /// 获取生成时是否启用流式预览（默认开启）
+  bool getGenerationStreamPreviewEnabled() {
+    return getSetting<bool>(
+          StorageKeys.generationStreamPreviewEnabled,
+          defaultValue: true,
+        ) ??
+        true;
+  }
+
+  /// 保存生成时是否启用流式预览
+  Future<void> setGenerationStreamPreviewEnabled(bool value) async {
+    await setSetting(StorageKeys.generationStreamPreviewEnabled, value);
+  }
+
   /// 获取随机生成算法模式
   String getRandomGenerationMode() {
     return getSetting<String>(

--- a/lib/data/cloud_sync/app_cloud_sync_adapters.dart
+++ b/lib/data/cloud_sync/app_cloud_sync_adapters.dart
@@ -121,6 +121,7 @@ const portableSettingKeys = <String>{
   StorageKeys.ucPresetCustomIds,
   StorageKeys.randomPromptMode,
   StorageKeys.showRandomPromptTools,
+  StorageKeys.generationStreamPreviewEnabled,
   StorageKeys.randomGenerationMode,
   StorageKeys.imagesPerRequest,
   StorageKeys.enableAutocomplete,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -227,6 +227,8 @@
   "settings_generationOutputSection": "Image Output",
   "settings_generationRetrySection": "Retry on Failure",
   "settings_generationFeedbackSection": "Completion Alert",
+  "settings_generationStreamPreview": "Streaming preview",
+  "settings_generationStreamPreviewSubtitle": "Show intermediate images while generating. Turn this off to wait for the final image instead.",
   "settings_alphaModeTitle": "Alpha mode for transparent images",
   "settings_alphaModeStraight": "Straight",
   "settings_alphaModePremultiplied": "Premultiplied",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -219,6 +219,8 @@
   "settings_generationOutputSection": "画像出力",
   "settings_generationRetrySection": "失敗時リトライ",
   "settings_generationFeedbackSection": "完了通知",
+  "settings_generationStreamPreview": "ストリーミングプレビュー",
+  "settings_generationStreamPreviewSubtitle": "生成中に途中画像を表示します。オフにすると最終画像が完成するまで待機します。",
   "settings_alphaModeTitle": "透過画像のアルファモード",
   "settings_alphaModeStraight": "ストレート",
   "settings_alphaModePremultiplied": "乗算済み",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1235,6 +1235,18 @@ abstract class AppLocalizations {
   /// **'Completion Alert'**
   String get settings_generationFeedbackSection;
 
+  /// No description provided for @settings_generationStreamPreview.
+  ///
+  /// In en, this message translates to:
+  /// **'Streaming preview'**
+  String get settings_generationStreamPreview;
+
+  /// No description provided for @settings_generationStreamPreviewSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Show intermediate images while generating. Turn this off to wait for the final image instead.'**
+  String get settings_generationStreamPreviewSubtitle;
+
   /// No description provided for @settings_alphaModeTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -616,6 +616,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_generationFeedbackSection => 'Completion Alert';
 
   @override
+  String get settings_generationStreamPreview => 'Streaming preview';
+
+  @override
+  String get settings_generationStreamPreviewSubtitle =>
+      'Show intermediate images while generating. Turn this off to wait for the final image instead.';
+
+  @override
   String get settings_alphaModeTitle => 'Alpha mode for transparent images';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -606,6 +606,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_generationFeedbackSection => '完了通知';
 
   @override
+  String get settings_generationStreamPreview => 'ストリーミングプレビュー';
+
+  @override
+  String get settings_generationStreamPreviewSubtitle =>
+      '生成中に途中画像を表示します。オフにすると最終画像が完成するまで待機します。';
+
+  @override
   String get settings_alphaModeTitle => '透過画像のアルファモード';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -592,6 +592,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_generationFeedbackSection => '完成提醒';
 
   @override
+  String get settings_generationStreamPreview => '流式预览';
+
+  @override
+  String get settings_generationStreamPreviewSubtitle =>
+      '生成时显示中间图像；关闭后将直接等待最终图像。';
+
+  @override
   String get settings_alphaModeTitle => '透明图像 Alpha 模式';
 
   @override
@@ -13735,6 +13742,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get settings_generationFeedbackSection => '完成提醒';
+
+  @override
+  String get settings_generationStreamPreview => '串流預覽';
+
+  @override
+  String get settings_generationStreamPreviewSubtitle =>
+      '生成時顯示中間圖像；關閉後將直接等待最終圖像。';
 
   @override
   String get settings_alphaModeTitle => '透明影象 Alpha 模式';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -227,6 +227,8 @@
   "settings_generationOutputSection": "图像输出",
   "settings_generationRetrySection": "失败重试",
   "settings_generationFeedbackSection": "完成提醒",
+  "settings_generationStreamPreview": "流式预览",
+  "settings_generationStreamPreviewSubtitle": "生成时显示中间图像；关闭后将直接等待最终图像。",
   "settings_alphaModeTitle": "透明图像 Alpha 模式",
   "settings_alphaModeStraight": "直通（Straight）",
   "settings_alphaModePremultiplied": "预乘（Premultiplied）",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -222,6 +222,8 @@
   "settings_generationOutputSection": "影象輸出",
   "settings_generationRetrySection": "失敗重試",
   "settings_generationFeedbackSection": "完成提醒",
+  "settings_generationStreamPreview": "串流預覽",
+  "settings_generationStreamPreviewSubtitle": "生成時顯示中間圖像；關閉後將直接等待最終圖像。",
   "settings_alphaModeTitle": "透明影象 Alpha 模式",
   "settings_alphaModeStraight": "直通（Straight）",
   "settings_alphaModePremultiplied": "預乘（Premultiplied）",

--- a/lib/presentation/providers/generation/batch_generation_notifier.dart
+++ b/lib/presentation/providers/generation/batch_generation_notifier.dart
@@ -7,6 +7,7 @@ import '../../../core/utils/app_logger.dart';
 import '../../../data/datasources/remote/nai_image_generation_api_service.dart';
 import '../../../data/models/image/image_params.dart';
 import 'generation_models.dart';
+import 'generation_settings_notifiers.dart';
 import 'image_generation_service.dart';
 
 part 'batch_generation_notifier.g.dart';
@@ -327,6 +328,7 @@ class BatchGenerationNotifier extends _$BatchGenerationNotifier {
 
       final service = ImageGenerationService(
         apiService: ref.read(naiImageGenerationApiServiceProvider),
+        streamPreviewEnabled: ref.read(generationStreamPreviewSettingsProvider),
       );
       _activeServices.add(service);
       late final ImageGenerationResult result;

--- a/lib/presentation/providers/generation/generation_command.dart
+++ b/lib/presentation/providers/generation/generation_command.dart
@@ -20,6 +20,7 @@ class GenerationCommand {
     this.materializeRandomSeed = true,
     this.requestEachImage = false,
     this.cancellableFallback = true,
+    this.streamPreviewEnabled = true,
   });
 
   final int runId;
@@ -34,6 +35,7 @@ class GenerationCommand {
   final bool materializeRandomSeed;
   final bool requestEachImage;
   final bool cancellableFallback;
+  final bool streamPreviewEnabled;
 
   int get totalImages => batchCount * batchSize;
 }

--- a/lib/presentation/providers/generation/generation_settings_notifiers.dart
+++ b/lib/presentation/providers/generation/generation_settings_notifiers.dart
@@ -187,6 +187,52 @@ class RandomPromptToolsVisibility extends _$RandomPromptToolsVisibility {
   }
 }
 
+/// 生成时流式预览设置 Notifier
+@Riverpod(keepAlive: true)
+class GenerationStreamPreviewSettings
+    extends _$GenerationStreamPreviewSettings {
+  LocalStorageService get _storage => ref.read(localStorageServiceProvider);
+
+  Future<void> _writeQueue = Future<void>.value();
+  late bool _lastConfirmedValue;
+  int _latestRevision = 0;
+
+  @override
+  bool build() {
+    final storedValue = _storage.getGenerationStreamPreviewEnabled();
+    _lastConfirmedValue = storedValue;
+    return storedValue;
+  }
+
+  Future<void> set(bool value) {
+    final revision = ++_latestRevision;
+    state = value;
+
+    final operation = _writeQueue.then<void>((_) async {
+      try {
+        await _storage.setGenerationStreamPreviewEnabled(value);
+        _lastConfirmedValue = value;
+      } catch (error, stackTrace) {
+        if (revision == _latestRevision) {
+          state = _lastConfirmedValue;
+        }
+        AppLogger.e(
+          'Failed to persist generation stream preview setting',
+          error,
+          stackTrace,
+        );
+        rethrow;
+      }
+    });
+
+    _writeQueue = operation.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace _) {},
+    );
+    return operation;
+  }
+}
+
 /// 每次请求生成图片数量设置 Notifier（1-4张）
 @Riverpod(keepAlive: true)
 class ImagesPerRequest extends _$ImagesPerRequest {

--- a/lib/presentation/providers/generation/generation_settings_notifiers.g.dart
+++ b/lib/presentation/providers/generation/generation_settings_notifiers.g.dart
@@ -176,6 +176,25 @@ final randomPromptToolsVisibilityProvider =
 );
 
 typedef _$RandomPromptToolsVisibility = Notifier<bool>;
+String _$generationStreamPreviewSettingsHash() =>
+    r'03edb441a44b619fbd2ada4e448d9bbb2d00dc81';
+
+/// 生成时流式预览设置 Notifier
+///
+/// Copied from [GenerationStreamPreviewSettings].
+@ProviderFor(GenerationStreamPreviewSettings)
+final generationStreamPreviewSettingsProvider =
+    NotifierProvider<GenerationStreamPreviewSettings, bool>.internal(
+  GenerationStreamPreviewSettings.new,
+  name: r'generationStreamPreviewSettingsProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$generationStreamPreviewSettingsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$GenerationStreamPreviewSettings = Notifier<bool>;
 String _$imagesPerRequestHash() => r'1100f132419f744de697cc84ea53fe27a258abbd';
 
 /// 每次请求生成图片数量设置 Notifier（1-4张）

--- a/lib/presentation/providers/generation/image_generation_coordinator.dart
+++ b/lib/presentation/providers/generation/image_generation_coordinator.dart
@@ -273,8 +273,9 @@ class ImageGenerationCoordinator {
     required bool retryStreamFailures,
   }) async* {
     DateTime? concurrencyDeadline;
-    var mode = nonStreamOnly ? _RequestMode.fallback : _RequestMode.stream;
-    var persistFallbackMode = nonStreamOnly;
+    final startWithFallback = nonStreamOnly || !command.streamPreviewEnabled;
+    var mode = startWithFallback ? _RequestMode.fallback : _RequestMode.stream;
+    var persistFallbackMode = startWithFallback;
 
     for (var attempt = 0; ; attempt++) {
       if (_aborted(handle) || _skipCurrentRequest) return;

--- a/lib/presentation/providers/generation/image_generation_service.dart
+++ b/lib/presentation/providers/generation/image_generation_service.dart
@@ -53,6 +53,7 @@ class ImageGenerationService {
       Duration(seconds: 4),
     ],
     Future<void> Function(Duration) delay = Future<void>.delayed,
+    this.streamPreviewEnabled = true,
   }) : _apiService = apiService,
        _coordinator = ImageGenerationCoordinator(
          apiService: apiService,
@@ -62,6 +63,7 @@ class ImageGenerationService {
 
   final NAIImageGenerationApiService _apiService;
   final ImageGenerationCoordinator _coordinator;
+  final bool streamPreviewEnabled;
   GenerationRunHandle? _activeRun;
   var _runCounter = 0;
   var _cancelled = false;
@@ -144,6 +146,7 @@ class ImageGenerationService {
       materializeRandomSeed: false,
       requestEachImage: true,
       cancellableFallback: false,
+      streamPreviewEnabled: streamPreviewEnabled,
     );
     final handle = _coordinator.start(command);
     _activeRun = handle;

--- a/lib/presentation/providers/generation/stream_generation_notifier.dart
+++ b/lib/presentation/providers/generation/stream_generation_notifier.dart
@@ -6,6 +6,7 @@ import '../../../core/utils/app_logger.dart';
 import '../../../data/datasources/remote/nai_image_generation_api_service.dart';
 import '../../../data/models/image/image_params.dart';
 import 'generation_models.dart';
+import 'generation_settings_notifiers.dart';
 import 'image_generation_service.dart';
 
 part 'stream_generation_notifier.g.dart';
@@ -112,6 +113,7 @@ class StreamGenerationNotifier extends _$StreamGenerationNotifier {
     }
     final service = ImageGenerationService(
       apiService: ref.read(naiImageGenerationApiServiceProvider),
+      streamPreviewEnabled: ref.read(generationStreamPreviewSettingsProvider),
     );
     _service = service;
     state = StreamGenerationState(

--- a/lib/presentation/providers/image_generation_provider.dart
+++ b/lib/presentation/providers/image_generation_provider.dart
@@ -343,6 +343,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         minimumContextMegaPixels:
             prepared.focusedSnapshot.minimumContextMegaPixels,
         focusedSelectionRect: prepared.focusedSnapshot.selectionRect,
+        streamPreviewEnabled: ref.read(generationStreamPreviewSettingsProvider),
       );
       final handle = coordinator.start(command);
       _activeRun = handle;

--- a/lib/presentation/providers/krita/krita_bridge_notifier.dart
+++ b/lib/presentation/providers/krita/krita_bridge_notifier.dart
@@ -294,6 +294,8 @@ final kritaBridgeNotifierProvider =
               .round()
               .clamp(16, 192)
               .toInt(),
+          readStreamPreviewEnabled: () =>
+              ref.read(generationStreamPreviewSettingsProvider),
           send: server.send,
           isUiGenerating: () =>
               ref.read(imageGenerationNotifierProvider).isGenerating,

--- a/lib/presentation/providers/krita/krita_bridge_service.dart
+++ b/lib/presentation/providers/krita/krita_bridge_service.dart
@@ -19,6 +19,7 @@ typedef KritaBridgePromptSnapshotReader =
     KritaBridgePromptSnapshot Function(ImageParams params);
 typedef KritaBridgeMinimumContextReader = int Function();
 typedef KritaBridgeBusyReader = bool Function();
+typedef KritaBridgeStreamPreviewReader = bool Function();
 typedef KritaBridgeAuthGuard = bool Function();
 typedef KritaBridgeSender = void Function(Map<String, dynamic> message);
 typedef KritaBridgeStreamGenerator =
@@ -75,6 +76,7 @@ class KritaBridgeService implements KritaBridgeMessageService {
     KritaBridgePostBillingRefresh? schedulePostBillingRefresh,
     KritaBridgePromptSnapshotReader? readPromptSnapshot,
     KritaBridgeMinimumContextReader? readMinimumContextPixels,
+    KritaBridgeStreamPreviewReader? readStreamPreviewEnabled,
     KritaBridgeClock? clock,
     Duration failureCooldown = const Duration(seconds: 2),
   }) : _readBaseParams = readBaseParams,
@@ -92,11 +94,13 @@ class KritaBridgeService implements KritaBridgeMessageService {
        _schedulePostBillingRefresh = schedulePostBillingRefresh ?? _noop,
        _clock = clock ?? DateTime.now,
        _failureCooldown = failureCooldown,
-       _readMinimumContextPixels = readMinimumContextPixels ?? (() => 88);
+       _readMinimumContextPixels = readMinimumContextPixels ?? (() => 88),
+       _readStreamPreviewEnabled = readStreamPreviewEnabled ?? (() => true);
 
   final KritaBridgeBaseParamsReader _readBaseParams;
   final KritaBridgePromptSnapshotReader _readPromptSnapshot;
   final KritaBridgeMinimumContextReader _readMinimumContextPixels;
+  final KritaBridgeStreamPreviewReader _readStreamPreviewEnabled;
   final KritaBridgeSender _send;
   final KritaBridgeBusyReader _isUiGenerating;
   final KritaBridgeAuthGuard _authGuard;
@@ -337,7 +341,7 @@ class KritaBridgeService implements KritaBridgeMessageService {
   Future<ImageGenerationArtifact?> _generateImage(
     KritaBridgeGenerateRequest request,
   ) async {
-    if (_shouldUseDirectFallback(request)) {
+    if (!_readStreamPreviewEnabled() || _shouldUseDirectFallback(request)) {
       final fallback = await _generateFallback(request);
       return fallback.isEmpty ? null : fallback.first;
     }

--- a/lib/presentation/screens/settings/sections/generation_settings_section.dart
+++ b/lib/presentation/screens/settings/sections/generation_settings_section.dart
@@ -131,6 +131,9 @@ class _GenerationSettingsSectionState
     final straightAlpha = ref.watch(
       generationParamsNotifierProvider.select((params) => params.straightAlpha),
     );
+    final streamPreviewEnabled = ref.watch(
+      generationStreamPreviewSettingsProvider,
+    );
     final storage = ref.watch(localStorageServiceProvider);
     final notificationSettings = ref.watch(
       notificationSettingsNotifierProvider,
@@ -203,58 +206,83 @@ class _GenerationSettingsSectionState
         ),
         SettingsCard(
           title: l10n.settings_generationOutputSection,
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final selector = SegmentedButton<bool>(
-                key: const Key('settings-alpha-mode-selector'),
-                segments: [
-                  ButtonSegment<bool>(
-                    value: true,
-                    label: Text(l10n.settings_alphaModeStraight),
-                  ),
-                  ButtonSegment<bool>(
-                    value: false,
-                    label: Text(l10n.settings_alphaModePremultiplied),
-                  ),
-                ],
-                selected: {straightAlpha},
-                showSelectedIcon: false,
-                onSelectionChanged: (selection) {
-                  ref
-                      .read(generationParamsNotifierProvider.notifier)
-                      .updateStraightAlpha(selection.single);
-                },
-              );
-              final tile = ListTile(
-                leading: const Icon(Icons.layers_outlined),
-                title: Text(l10n.settings_alphaModeTitle),
-                subtitle: Text(
-                  straightAlpha
-                      ? l10n.settings_alphaModeStraightDescription
-                      : l10n.settings_alphaModePremultipliedDescription,
-                ),
-                trailing: constraints.maxWidth >= 680 ? selector : null,
-              );
-
-              if (constraints.maxWidth >= 680) {
-                return tile;
-              }
-              return Column(
-                children: [
-                  tile,
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
-                    child: Align(
-                      alignment: Alignment.centerRight,
-                      child: SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        child: selector,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              SwitchListTile(
+                secondary: const Icon(Icons.preview_outlined),
+                title: Text(l10n.settings_generationStreamPreview),
+                subtitle: Text(l10n.settings_generationStreamPreviewSubtitle),
+                value: streamPreviewEnabled,
+                onChanged: (value) async {
+                  final messenger = ScaffoldMessenger.maybeOf(context);
+                  try {
+                    await ref
+                        .read(generationStreamPreviewSettingsProvider.notifier)
+                        .set(value);
+                  } catch (error) {
+                    messenger?.showSnackBar(
+                      SnackBar(
+                        content: Text(l10n.globalSettings_saveFailed('$error')),
                       ),
+                    );
+                  }
+                },
+              ),
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  final selector = SegmentedButton<bool>(
+                    key: const Key('settings-alpha-mode-selector'),
+                    segments: [
+                      ButtonSegment<bool>(
+                        value: true,
+                        label: Text(l10n.settings_alphaModeStraight),
+                      ),
+                      ButtonSegment<bool>(
+                        value: false,
+                        label: Text(l10n.settings_alphaModePremultiplied),
+                      ),
+                    ],
+                    selected: {straightAlpha},
+                    showSelectedIcon: false,
+                    onSelectionChanged: (selection) {
+                      ref
+                          .read(generationParamsNotifierProvider.notifier)
+                          .updateStraightAlpha(selection.single);
+                    },
+                  );
+                  final tile = ListTile(
+                    leading: const Icon(Icons.layers_outlined),
+                    title: Text(l10n.settings_alphaModeTitle),
+                    subtitle: Text(
+                      straightAlpha
+                          ? l10n.settings_alphaModeStraightDescription
+                          : l10n.settings_alphaModePremultipliedDescription,
                     ),
-                  ),
-                ],
-              );
-            },
+                    trailing: constraints.maxWidth >= 680 ? selector : null,
+                  );
+
+                  if (constraints.maxWidth >= 680) {
+                    return tile;
+                  }
+                  return Column(
+                    children: [
+                      tile,
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: SingleChildScrollView(
+                            scrollDirection: Axis.horizontal,
+                            child: selector,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
           ),
         ),
         SettingsCard(

--- a/test/presentation/providers/generation/image_generation_coordinator_test.dart
+++ b/test/presentation/providers/generation/image_generation_coordinator_test.dart
@@ -50,6 +50,57 @@ void main() {
     );
   });
 
+  test(
+    'disabled stream preview uses the non-stream endpoint directly',
+    () async {
+      final apiService = _MockNAIImageGenerationApiService();
+      final image = Uint8List.fromList([1, 2, 3]);
+      when(
+        () => apiService.generateImage(
+          any(),
+          onProgress: any(named: 'onProgress'),
+          focusedInpaintEnabled: any(named: 'focusedInpaintEnabled'),
+          minimumContextMegaPixels: any(named: 'minimumContextMegaPixels'),
+          focusedSelectionRect: any(named: 'focusedSelectionRect'),
+        ),
+      ).thenAnswer((_) async => (<Uint8List>[image], <int, String>{}));
+
+      final coordinator = ImageGenerationCoordinator(apiService: apiService);
+      final command = GenerationCommand(
+        runId: 1,
+        params: const ImageParams(prompt: 'test'),
+        batchCount: 1,
+        batchSize: 1,
+        prepareBatch: (_, params) async => params,
+        streamPreviewEnabled: false,
+      );
+      final handle = coordinator.start(command);
+
+      final events = await coordinator.execute(command, handle).toList();
+
+      expect(events.whereType<GenerationPreviewReceived>(), isEmpty);
+      expect(events.whereType<GenerationRequestCompleted>(), hasLength(1));
+      expect(events.last, isA<GenerationCompleted>());
+      verifyNever(
+        () => apiService.generateImageStream(
+          any(),
+          focusedInpaintEnabled: any(named: 'focusedInpaintEnabled'),
+          minimumContextMegaPixels: any(named: 'minimumContextMegaPixels'),
+          focusedSelectionRect: any(named: 'focusedSelectionRect'),
+        ),
+      );
+      verify(
+        () => apiService.generateImage(
+          any(),
+          onProgress: any(named: 'onProgress'),
+          focusedInpaintEnabled: any(named: 'focusedInpaintEnabled'),
+          minimumContextMegaPixels: any(named: 'minimumContextMegaPixels'),
+          focusedSelectionRect: any(named: 'focusedSelectionRect'),
+        ),
+      ).called(1);
+    },
+  );
+
   test('cancel interrupts an injected 429 concurrency retry delay', () async {
     final apiService = _MockNAIImageGenerationApiService();
     final delayStarted = Completer<void>();

--- a/test/presentation/providers/krita/krita_bridge_service_test.dart
+++ b/test/presentation/providers/krita/krita_bridge_service_test.dart
@@ -514,6 +514,52 @@ void main() {
     });
 
     test(
+      'disabled stream preview sends Krita generation directly to fallback',
+      () async {
+        final sent = <Map<String, dynamic>>[];
+        final finalImage = Uint8List.fromList([7, 8, 9]);
+        var streamCalls = 0;
+        var fallbackCalls = 0;
+
+        final service = KritaBridgeService(
+          readBaseParams: () => const ImageParams(),
+          readStreamPreviewEnabled: () => false,
+          send: sent.add,
+          isUiGenerating: () => false,
+          authGuard: () => true,
+          generateStream: (_) {
+            streamCalls++;
+            return const Stream.empty();
+          },
+          generateFallback: (_) async {
+            fallbackCalls++;
+            return [ImageGenerationArtifact(displayImageBytes: finalImage)];
+          },
+          registerExternalImage: (_, {required params, addToDisplay}) async =>
+              null,
+          cancelGeneration: () {},
+        );
+
+        await service.handle(
+          KritaImg2ImgMessage(
+            id: 'img-no-preview',
+            image: Uint8List.fromList([1, 2, 3]),
+            prompt: 'cat',
+            negativePrompt: '',
+            strength: 0.5,
+            noise: 0,
+          ),
+        );
+
+        expect(streamCalls, 0);
+        expect(fallbackCalls, 1);
+        expect(sent, hasLength(1));
+        expect(sent.single['type'], 'result');
+        expect(base64Decode(sent.single['image'] as String), finalImage);
+      },
+    );
+
+    test(
       'relays stream progress, result, and registers history image',
       () async {
         final sent = <Map<String, dynamic>>[];

--- a/test/presentation/screens/settings/sections/generation_settings_section_test.dart
+++ b/test/presentation/screens/settings/sections/generation_settings_section_test.dart
@@ -71,6 +71,36 @@ void main() {
     expect(storage.values, isEmpty);
   });
 
+  testWidgets('流式预览默认开启并可持久化关闭', (tester) async {
+    final storage = _MemoryLocalStorageService();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+        child: const MaterialApp(
+          locale: Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(child: GenerationSettingsSection()),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final tileFinder = find.widgetWithText(SwitchListTile, '流式预览');
+    expect(tileFinder, findsOneWidget);
+    expect(tester.widget<SwitchListTile>(tileFinder).value, isTrue);
+    expect(find.textContaining('直接等待最终图像'), findsOneWidget);
+
+    await tester.tap(find.text('流式预览'));
+    await tester.pump();
+
+    expect(tester.widget<SwitchListTile>(tileFinder).value, isFalse);
+    expect(storage.values[StorageKeys.generationStreamPreviewEnabled], isFalse);
+  });
+
   testWidgets('按任务流展示输入、输出、重试、提醒四个小节', (tester) async {
     final storage = _MemoryLocalStorageService();
     await tester.binding.setSurfaceSize(const Size(1000, 1600));


### PR DESCRIPTION
## 变更内容

- 在生成设置中新增“流式预览”开关，默认保持开启
- 关闭后普通生成、批量生成和 Krita Bridge 直接使用非流式接口，不再请求中间预览
- 持久化该设置并纳入云同步
- 补齐简体中文、繁体中文、英文和日文本地化
- 增加设置交互、生成端点选择及 Krita Bridge 回归测试

## 验证

- `scripts/test_affected.ps1`：9 个相关测试文件全部通过
- 针对受影响文件运行 `flutter analyze`：无问题
- `git diff --check`：通过

Closes #119
