### PR TITLE
fix(agent): 修复角色自定义助手任务中断

### DIFF
--- a/lib/presentation/prompt_assistant/providers/prompt_assistant_history_provider.dart
+++ b/lib/presentation/prompt_assistant/providers/prompt_assistant_history_provider.dart
@@ -5,6 +5,12 @@ class PromptHistorySessionIds {
 
   static const String generationPrompt = 'generation_prompt_main';
   static const String generationNegative = 'generation_prompt_negative';
+
+  static String characterPrompt(String characterId) =>
+      'generation_character_${characterId}_prompt';
+
+  static String characterNegative(String characterId) =>
+      'generation_character_${characterId}_negative';
 }
 
 class PromptHistoryStack {

--- a/lib/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart
+++ b/lib/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart
@@ -31,6 +31,7 @@ class PromptAssistantOverlay extends ConsumerStatefulWidget {
     super.key,
     required this.sessionId,
     required this.controller,
+    this.onChanged,
     this.onOpenSettings,
     this.enabled = true,
     this.floatOverEditor = true,
@@ -39,6 +40,7 @@ class PromptAssistantOverlay extends ConsumerStatefulWidget {
 
   final String sessionId;
   final TextEditingController controller;
+  final ValueChanged<String>? onChanged;
   final VoidCallback? onOpenSettings;
   final bool enabled;
 
@@ -225,11 +227,7 @@ class _PromptAssistantOverlayState
       },
       onDone: () {
         if (buffer.isNotEmpty) {
-          final finalText = buffer.toString();
-          widget.controller.text = finalText;
-          widget.controller.selection = TextSelection.collapsed(
-            offset: widget.controller.text.length,
-          );
+          _replaceText(buffer.toString());
         }
         stateNotifier.finishProcessing(widget.sessionId);
         final afterText = widget.controller.text;
@@ -292,11 +290,7 @@ class _PromptAssistantOverlayState
           },
           onDone: () {
             if (buffer.isNotEmpty) {
-              final finalText = buffer.toString();
-              widget.controller.text = finalText;
-              widget.controller.selection = TextSelection.collapsed(
-                offset: widget.controller.text.length,
-              );
+              _replaceText(buffer.toString());
             }
             stateNotifier.finishProcessing(widget.sessionId);
             final afterText = widget.controller.text;
@@ -321,15 +315,18 @@ class _PromptAssistantOverlayState
         .stripFromPrompt(widget.controller.text);
   }
 
+  void _replaceText(String value) {
+    widget.controller.text = value;
+    widget.controller.selection = TextSelection.collapsed(offset: value.length);
+    widget.onChanged?.call(value);
+  }
+
   void _undo() {
     final value = ref
         .read(promptAssistantHistoryProvider.notifier)
         .undo(widget.sessionId, widget.controller.text);
     if (value != null) {
-      widget.controller.text = value;
-      widget.controller.selection = TextSelection.collapsed(
-        offset: value.length,
-      );
+      _replaceText(value);
     }
   }
 
@@ -338,10 +335,7 @@ class _PromptAssistantOverlayState
         .read(promptAssistantHistoryProvider.notifier)
         .redo(widget.sessionId, widget.controller.text);
     if (value != null) {
-      widget.controller.text = value;
-      widget.controller.selection = TextSelection.collapsed(
-        offset: value.length,
-      );
+      _replaceText(value);
     }
   }
 
@@ -359,10 +353,7 @@ class _PromptAssistantOverlayState
             return ListTile(
               title: Text(entry, maxLines: 2, overflow: TextOverflow.ellipsis),
               onTap: () {
-                widget.controller.text = entry;
-                widget.controller.selection = TextSelection.collapsed(
-                  offset: entry.length,
-                );
+                _replaceText(entry);
                 Navigator.pop(context);
               },
             );

--- a/lib/presentation/widgets/character/inline_character_card.dart
+++ b/lib/presentation/widgets/character/inline_character_card.dart
@@ -111,6 +111,10 @@ class _InlineCharacterCardState extends ConsumerState<InlineCharacterCard> {
     // 退出逻辑全权交给面板自己的 TapRegion
     if (!widget.inlineEditor) return;
     if (_modalOpen) return;
+    // 对话框属于独立 Route，点击其中的执行按钮也会被底层 TapRegion
+    // 视为卡外点击；此时卸载编辑器会连带取消正在启动的助手任务。
+    final route = ModalRoute.of(context);
+    if (route != null && !route.isCurrent) return;
     // 位置画布打开时，点画布拖锚点是位置编辑的一部分，不退出编辑态
     if (ref.read(characterPositionCanvasProvider)) return;
     // TapRegion 恒挂（结构稳定），非选中卡的外部点击直接忽略
@@ -118,6 +122,8 @@ class _InlineCharacterCardState extends ConsumerState<InlineCharacterCard> {
     // TapRegion 回调发生在指针按下时，等本帧手势与焦点变化尘埃落定再判断
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      final currentRoute = ModalRoute.of(context);
+      if (currentRoute != null && !currentRoute.isCurrent) return;
       // 用户点了另一张卡：选中已切换，别把新选择清掉
       if (ref.read(selectedCharacterIdProvider) != widget.character.id) {
         return;

--- a/lib/presentation/widgets/character/inline_character_editor.dart
+++ b/lib/presentation/widgets/character/inline_character_editor.dart
@@ -3,6 +3,7 @@ import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../data/models/character/character_prompt.dart';
+import '../../prompt_assistant/providers/prompt_assistant_history_provider.dart';
 import '../../providers/character_prompt_provider.dart';
 import '../../providers/image_generation_provider.dart';
 import '../prompt/toolbar/toolbar.dart';
@@ -176,6 +177,9 @@ class _CharacterPromptEditorState extends ConsumerState<CharacterPromptEditor> {
       inputConfig: inputConfig,
       controller: controller,
       focusNode: focusNode,
+      sessionId: _tabIndex == 0
+          ? PromptHistorySessionIds.characterPrompt(widget.character.id)
+          : PromptHistorySessionIds.characterNegative(widget.character.id),
       onChanged: onChanged,
       onCleared: () => onChanged(''),
       minLines: widget.compact ? 1 : 2,

--- a/lib/presentation/widgets/character/inline_character_row.dart
+++ b/lib/presentation/widgets/character/inline_character_row.dart
@@ -284,10 +284,16 @@ class _RowEditorPanelState extends ConsumerState<_RowEditorPanel> {
 
   void _handleTapOutside() {
     if (_modalOpen) return;
+    // 助手等子对话框位于独立 Route；点击其内容不能卸载底层编辑器，
+    // 否则编辑器持有的流订阅会在任务启动时被取消。
+    final route = ModalRoute.of(context);
+    if (route != null && !route.isCurrent) return;
     // 位置画布打开时，点画布拖锚点是位置编辑的一部分，不退出编辑态
     if (ref.read(characterPositionCanvasProvider)) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      final currentRoute = ModalRoute.of(context);
+      if (currentRoute != null && !currentRoute.isCurrent) return;
       if (ref.read(selectedCharacterIdProvider) != widget.character.id) {
         return;
       }

--- a/lib/presentation/widgets/prompt/toolbar/prompt_editor_with_toolbar.dart
+++ b/lib/presentation/widgets/prompt/toolbar/prompt_editor_with_toolbar.dart
@@ -40,6 +40,9 @@ class PromptEditorWithToolbar extends ConsumerStatefulWidget {
   /// 文本变化回调
   final ValueChanged<String>? onChanged;
 
+  /// 提示词助手的稳定会话标识
+  final String? sessionId;
+
   /// 随机按钮点击回调
   final VoidCallback? onRandomPressed;
 
@@ -84,6 +87,7 @@ class PromptEditorWithToolbar extends ConsumerStatefulWidget {
     this.focusNode,
     this.decoration,
     this.onChanged,
+    this.sessionId,
     this.onRandomPressed,
     this.onRandomLongPressed,
     this.onFullscreenPressed,
@@ -188,6 +192,7 @@ class _PromptEditorWithToolbarState
             focusNode: widget.focusNode,
             decoration: widget.decoration,
             onChanged: widget.onChanged,
+            sessionId: widget.sessionId,
             maxLines: widget.maxLines,
             minLines: widget.minLines,
             expands: widget.expands,

--- a/lib/presentation/widgets/prompt/unified/unified_prompt_input.dart
+++ b/lib/presentation/widgets/prompt/unified/unified_prompt_input.dart
@@ -406,6 +406,7 @@ class _UnifiedPromptInputState extends ConsumerState<UnifiedPromptInput> {
           _effectiveController.selection = TextSelection.collapsed(
             offset: _effectiveController.text.length,
           );
+          widget.onChanged?.call(finalText);
         }
         stateNotifier.finishProcessing(_sessionId);
         final afterText = _effectiveController.text;
@@ -1077,6 +1078,7 @@ class _UnifiedPromptInputState extends ConsumerState<UnifiedPromptInput> {
           PromptAssistantOverlay(
             sessionId: _sessionId,
             controller: _effectiveController,
+            onChanged: widget.onChanged,
             onOpenSettings: widget.onOpenAssistantSettings,
           ),
       ],

--- a/test/presentation/widgets/character/inline_character_card_test.dart
+++ b/test/presentation/widgets/character/inline_character_card_test.dart
@@ -7,6 +7,8 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:nai_launcher/core/constants/storage_keys.dart';
 import 'package:nai_launcher/data/models/character/character_prompt.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/providers/prompt_assistant_history_provider.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart';
 import 'package:nai_launcher/presentation/providers/character_prompt_provider.dart';
 import 'package:nai_launcher/presentation/widgets/character/inline_character_card.dart';
 
@@ -109,8 +111,77 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
 
       expect(capturedRef.read(selectedCharacterIdProvider), equals('char-1'));
-      // 编辑态显示输入框
+      // 编辑态显示输入框，并使用角色专属会话承载助手任务状态。
       expect(find.byType(TextField), findsWidgets);
+      expect(
+        tester
+            .widget<PromptAssistantOverlay>(find.byType(PromptAssistantOverlay))
+            .sessionId,
+        PromptHistorySessionIds.characterPrompt(character.id),
+      );
+    });
+
+    testWidgets('子对话框内点击不会退出角色编辑态', (tester) async {
+      late WidgetRef capturedRef;
+      late BuildContext pageContext;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  pageContext = context;
+                  return Consumer(
+                    builder: (context, ref, child) {
+                      capturedRef = ref;
+                      return const SizedBox(
+                        width: 400,
+                        child: SingleChildScrollView(
+                          child: InlineCharacterCard(
+                            character: character,
+                            index: 0,
+                            total: 1,
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('girl, silver hair, maid dress'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(capturedRef.read(selectedCharacterIdProvider), 'char-1');
+
+      final dialog = showDialog<void>(
+        context: pageContext,
+        builder: (context) => AlertDialog(
+          content: const Text('Custom assistant request'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Execute'),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Execute'));
+      await tester.pumpAndSettle();
+      await dialog;
+
+      expect(capturedRef.read(selectedCharacterIdProvider), 'char-1');
+      expect(find.byType(TextField), findsWidgets);
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
     });
 
     testWidgets('禁用的角色整卡半透明', (tester) async {


### PR DESCRIPTION
## 变更

- 修复角色自定义助手对话框执行时，底层 `TapRegion` 将点击误判为卡外点击并卸载编辑器的问题
- 为角色正向/负向提示词提供独立且稳定的助手会话 ID
- 统一助手结果、撤销、重做与历史恢复的文本写回，确保同步更新角色状态
- 补充子对话框交互和角色助手会话回归测试

## 验证

- `dart analyze`（8 个受影响文件）：通过
- 定向 Widget 回归断言：通过（`+1`）；Windows 测试进程随后卡在该测试文件既有的 `tearDownAll` / Hive 清理阶段并被 watchdog 终止
- `git diff --check`：通过

Closes #116
