### PR TITLE
fix(update): 修复预发布版本检测

### DIFF
--- a/lib/data/datasources/remote/github_api_service.dart
+++ b/lib/data/datasources/remote/github_api_service.dart
@@ -5,7 +5,6 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:xml/xml.dart';
 
 import '../../models/version/release_asset_info.dart';
 import '../../models/version/version_info.dart';
@@ -45,6 +44,7 @@ class GitHubApiService {
   static const String defaultBaseUrl = 'https://github.com';
 
   static const String _githubWebBaseUrl = 'https://github.com';
+  static const String _githubApiBaseUrl = 'https://api.github.com';
 
   /// 连接超时时间
   static const Duration connectTimeout = Duration(seconds: 10);
@@ -72,7 +72,7 @@ class GitHubApiService {
   }) async {
     try {
       final tag = includePrerelease
-          ? await _fetchLatestApplicationTagFromFeed(owner, repo)
+          ? await _fetchLatestApplicationTagFromReleases(owner, repo)
           : null;
       return await _fetchReleaseManifest(
         owner: owner,
@@ -137,61 +137,48 @@ class GitHubApiService {
     );
   }
 
-  Future<String?> _fetchLatestApplicationTagFromFeed(
+  Future<String?> _fetchLatestApplicationTagFromReleases(
     String owner,
     String repo,
   ) async {
-    final response = await _dio.get<String>(
-      '$_githubWebBaseUrl/$owner/$repo/releases.atom',
-      options: Options(
-        responseType: ResponseType.plain,
-        connectTimeout: connectTimeout,
-        receiveTimeout: receiveTimeout,
-        headers: {'Accept': 'application/atom+xml'},
-      ),
-    );
-    final body = response.data;
-    if (body == null || body.trim().isEmpty) {
-      throw GitHubApiException(
-        'Release feed is empty for $owner/$repo',
-        type: GitHubReleaseErrorType.invalidResponse,
+    const pageSize = 100;
+    for (var page = 1; ; page++) {
+      final response = await _dio.get<Object?>(
+        '$_githubApiBaseUrl/repos/$owner/$repo/releases',
+        queryParameters: {'per_page': pageSize, 'page': page},
+        options: Options(
+          connectTimeout: connectTimeout,
+          receiveTimeout: receiveTimeout,
+          headers: const {
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'Aaalice-NAI-Launcher',
+          },
+        ),
       );
-    }
+      final responseData = response.data;
+      if (responseData is! List<dynamic>) {
+        throw GitHubApiException(
+          'Release list has an invalid response for $owner/$repo',
+          type: GitHubReleaseErrorType.invalidResponse,
+        );
+      }
+      final releases = responseData;
 
-    final document = XmlDocument.parse(body);
-    Version? latestVersion;
-    String? latestTag;
-    final entries = document.descendants.whereType<XmlElement>().where(
-      (element) => element.name.local == 'entry',
-    );
-    for (final entry in entries) {
-      final links = entry.descendants.whereType<XmlElement>().where(
-        (element) => element.name.local == 'link',
-      );
-      for (final link in links) {
-        final href = link.getAttribute('href');
-        final uri = href == null ? null : Uri.tryParse(href);
-        if (uri == null) continue;
-        final tagIndex = uri.pathSegments.indexOf('tag');
-        if (tagIndex < 0 || tagIndex + 1 >= uri.pathSegments.length) continue;
-        final tag = uri.pathSegments[tagIndex + 1];
-        if (!_isApplicationTag(tag)) continue;
-        Version version;
-        try {
-          version = Version.parse(tag.substring(1));
-        } on FormatException {
+      // 保留 GitHub Release 的顺序，直接使用第一个非草稿应用版本，
+      // 不再根据 tag 的 SemVer 对发布顺序做二次重排。
+      for (final release in releases) {
+        if (release is! Map<String, dynamic> || release['draft'] == true) {
           continue;
         }
-        if (latestVersion == null || version > latestVersion) {
-          latestVersion = version;
-          latestTag = tag;
-        }
+        final tag = release['tag_name'];
+        if (tag is String && _isApplicationTag(tag)) return tag;
       }
+      if (releases.length < pageSize) break;
     }
 
-    // GitHub feed 仅保留最近若干条，独立数据包可能挤掉应用版本。
-    // 此时退回 stable 的 latest manifest，至少不会漏掉正式更新。
-    return latestTag;
+    // 仓库可能暂时只有独立数据包 Release；此时仍检查最新正式版。
+    return null;
   }
 
   Options _releaseAssetOptions() {
@@ -403,9 +390,17 @@ class GitHubApiService {
   }
 
   static bool _isApplicationTag(String tag) {
-    return RegExp(
+    if (!RegExp(
       r'^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$',
-    ).hasMatch(tag);
+    ).hasMatch(tag)) {
+      return false;
+    }
+    try {
+      Version.parse(tag.substring(1));
+      return true;
+    } on FormatException {
+      return false;
+    }
   }
 }
 

--- a/test/core/services/update_check_service_test.dart
+++ b/test/core/services/update_check_service_test.dart
@@ -10,6 +10,7 @@ class _FakeGitHubApiService extends GitHubApiService {
   _FakeGitHubApiService(this.handler) : super(dio: Dio());
 
   final Future<VersionInfo> Function(String currentVersion) handler;
+  bool? lastIncludePrerelease;
 
   @override
   Future<VersionInfo> fetchLatestRelease({
@@ -19,6 +20,7 @@ class _FakeGitHubApiService extends GitHubApiService {
     String platform = 'windows',
     bool includePrerelease = false,
   }) {
+    lastIncludePrerelease = includePrerelease;
     return handler(currentVersion);
   }
 }
@@ -80,6 +82,7 @@ class _FakeUpdateStorage implements UpdateCheckStorage {
 void main() {
   late DateTime now;
   late _FakeUpdateStorage storage;
+  late _FakeGitHubApiService api;
 
   PackageInfo packageInfo() => PackageInfo(
     appName: 'NAI Launcher',
@@ -91,8 +94,9 @@ void main() {
   UpdateCheckService buildService(
     Future<VersionInfo> Function(String currentVersion) handler,
   ) {
+    api = _FakeGitHubApiService(handler);
     return UpdateCheckService(
-      gitHubApiService: _FakeGitHubApiService(handler),
+      gitHubApiService: api,
       packageInfo: packageInfo(),
       installationService: _FakeInstallationService(),
       checkStorage: storage,
@@ -103,6 +107,24 @@ void main() {
   setUp(() {
     now = DateTime.utc(2026, 3, 1, 8);
     storage = _FakeUpdateStorage();
+  });
+
+  test('passes the persisted prerelease preference to GitHub', () async {
+    final service = buildService(
+      (current) async => VersionInfo(
+        version: '1.0.0+1',
+        currentVersion: current,
+        isNewer: false,
+      ),
+    );
+
+    await service.checkForUpdates();
+    expect(api.lastIncludePrerelease, isFalse);
+
+    await service.setIncludePrerelease(true);
+    await service.checkForUpdates();
+    expect(api.lastIncludePrerelease, isTrue);
+    expect(storage.prerelease, isTrue);
   });
 
   test(

--- a/test/core/storage/local_storage_service_test.dart
+++ b/test/core/storage/local_storage_service_test.dart
@@ -45,4 +45,27 @@ void main() {
 
     expect(storage.getDefaultSteps(), 31);
   });
+
+  test('prerelease updates are disabled when no preference is stored', () {
+    final storage = LocalStorageService();
+
+    expect(storage.getIncludePrereleaseUpdates(), isFalse);
+    expect(
+      Hive.box(
+        StorageKeys.settingsBox,
+      ).containsKey(StorageKeys.includePrereleaseUpdates),
+      isFalse,
+    );
+  });
+
+  test('keeps the stored prerelease update preference', () async {
+    final storage = LocalStorageService();
+
+    await storage.setIncludePrereleaseUpdates(true);
+    final restoredStorage = LocalStorageService();
+    expect(restoredStorage.getIncludePrereleaseUpdates(), isTrue);
+
+    await restoredStorage.setIncludePrereleaseUpdates(false);
+    expect(storage.getIncludePrereleaseUpdates(), isFalse);
+  });
 }

--- a/test/data/datasources/remote/github_api_service_test.dart
+++ b/test/data/datasources/remote/github_api_service_test.dart
@@ -87,9 +87,10 @@ void main() {
     );
   });
 
-  test('prerelease lookup skips malformed and non-v data releases', () async {
+  test('prerelease lookup follows the GitHub release list contract', () async {
+    final adapter = _MixedReleaseDioAdapter();
     final dio = Dio(BaseOptions(baseUrl: GitHubApiService.defaultBaseUrl))
-      ..httpClientAdapter = _MixedReleaseDioAdapter();
+      ..httpClientAdapter = adapter;
     final service = GitHubApiService(dio: dio);
 
     final info = await service.fetchLatestRelease(
@@ -99,19 +100,67 @@ void main() {
       includePrerelease: true,
     );
 
-    expect(info.version, '1.8.2-beta.1');
+    expect(info.version, '1.8.2-beta.1+33');
     expect(info.primaryAsset?.type, ReleaseAssetType.windowsPortable);
+    expect(adapter.releaseListRequests, 1);
+    expect(adapter.atomRequests, 0);
+  });
+
+  test('prerelease lookup continues past a full data release page', () async {
+    final adapter = _PaginatedReleaseDioAdapter();
+    final dio = Dio(BaseOptions(baseUrl: GitHubApiService.defaultBaseUrl))
+      ..httpClientAdapter = adapter;
+    final service = GitHubApiService(dio: dio);
+
+    final info = await service.fetchLatestRelease(
+      owner: 'Aaalice233',
+      repo: 'Aaalice_NAI_Launcher',
+      currentVersion: '1.8.0',
+      includePrerelease: true,
+    );
+
+    expect(info.version, '1.8.2-beta.1+33');
+    expect(adapter.requestedPages, [1, 2]);
+  });
+
+  test('prerelease lookup rejects a non-list API response', () async {
+    final dio = Dio(BaseOptions(baseUrl: GitHubApiService.defaultBaseUrl))
+      ..httpClientAdapter = _InvalidReleaseListDioAdapter();
+    final service = GitHubApiService(dio: dio);
+
+    await expectLater(
+      service.fetchLatestRelease(
+        owner: 'Aaalice233',
+        repo: 'Aaalice_NAI_Launcher',
+        currentVersion: '1.8.0',
+        includePrerelease: true,
+      ),
+      throwsA(
+        isA<GitHubApiException>().having(
+          (error) => error.type,
+          'type',
+          GitHubReleaseErrorType.invalidResponse,
+        ),
+      ),
+    );
   });
 
   test(
-    'prerelease lookup falls back to stable when feed has only data packs',
+    'prerelease lookup falls back to stable when list has only data packs',
     () async {
       final adapter = _StableReleaseDioAdapter(
-        feedBody: '''<?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <entry><link href="https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/tag/autocomplete-data-one" /></entry>
-  <entry><link href="https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/tag/autocomplete-data-two" /></entry>
-</feed>''',
+        releases: const [
+          {
+            'tag_name': 'autocomplete-data-one',
+            'draft': false,
+            'prerelease': true,
+          },
+          {
+            'tag_name': 'autocomplete-data-two',
+            'draft': false,
+            'prerelease': true,
+          },
+        ],
       );
       final dio = Dio(BaseOptions(baseUrl: GitHubApiService.defaultBaseUrl))
         ..httpClientAdapter = adapter;
@@ -130,7 +179,7 @@ void main() {
   );
 
   test(
-    'prerelease manifest must match the tag selected from the feed',
+    'prerelease manifest must match the tag selected from the release list',
     () async {
       final dio = Dio(BaseOptions(baseUrl: GitHubApiService.defaultBaseUrl))
         ..httpClientAdapter = _MismatchedPrereleaseDioAdapter();
@@ -168,10 +217,10 @@ class _StableReleaseDioAdapter implements HttpClientAdapter {
   static const setupSha256 =
       '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
-  _StableReleaseDioAdapter({this.manifestOverride, this.feedBody});
+  _StableReleaseDioAdapter({this.manifestOverride, this.releases});
 
   final Map<String, dynamic>? manifestOverride;
-  final String? feedBody;
+  final List<dynamic>? releases;
   RequestOptions? manifestRequest;
   int apiRequests = 0;
 
@@ -181,12 +230,13 @@ class _StableReleaseDioAdapter implements HttpClientAdapter {
     Stream<Uint8List>? requestStream,
     Future<void>? cancelFuture,
   ) async {
-    if (options.uri.path.endsWith('/releases.atom') && feedBody != null) {
+    if (options.uri.host == 'api.github.com' && releases != null) {
+      apiRequests++;
       return ResponseBody.fromString(
-        feedBody!,
+        jsonEncode(releases),
         200,
         headers: {
-          Headers.contentTypeHeader: ['application/atom+xml'],
+          Headers.contentTypeHeader: ['application/json'],
         },
       );
     }
@@ -260,31 +310,45 @@ class _MixedReleaseDioAdapter implements HttpClientAdapter {
       'https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/'
       'download/$betaTag/NAI_Launcher_Windows_Beta_Portable.zip';
 
+  int releaseListRequests = 0;
+  int atomRequests = 0;
+
   @override
   Future<ResponseBody> fetch(
     RequestOptions options,
     Stream<Uint8List>? requestStream,
     Future<void>? cancelFuture,
   ) async {
-    if (options.uri.path.endsWith('/releases.atom')) {
+    if (options.uri.host == 'api.github.com' &&
+        options.uri.path.endsWith('/releases')) {
+      releaseListRequests++;
+      expect(options.uri.queryParameters['per_page'], '100');
+      expect(options.uri.queryParameters['page'], '1');
+      expect(options.headers['Accept'], 'application/vnd.github+json');
+      expect(options.headers['User-Agent'], 'Aaalice-NAI-Launcher');
       return ResponseBody.fromString(
-        '''<?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <entry><link href="https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/tag/autocomplete-data-cooccurrence-2dadc5bf-v2" /></entry>
-  <entry><link href="https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/tag/v1.8.2-.." /></entry>
-  <entry><link href="https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/tag/$betaTag" /></entry>
-  <entry><link href="https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/tag/v1.8.1" /></entry>
-</feed>''',
+        jsonEncode([
+          {
+            'tag_name': 'autocomplete-data-cooccurrence-2dadc5bf-v2',
+            'draft': false,
+            'prerelease': true,
+          },
+          {'tag_name': 'v1.8.2-..', 'draft': false, 'prerelease': true},
+          {'tag_name': 'v1.8.3-beta.1', 'draft': true, 'prerelease': true},
+          {'tag_name': betaTag, 'draft': false, 'prerelease': true},
+          {'tag_name': 'v1.8.1', 'draft': false, 'prerelease': false},
+        ]),
         200,
         headers: {
-          Headers.contentTypeHeader: ['application/atom+xml'],
+          Headers.contentTypeHeader: ['application/json'],
         },
       );
     }
+    if (options.uri.path.endsWith('/releases.atom')) atomRequests++;
     if (options.uri.toString() == betaManifestUrl) {
       return ResponseBody.fromString(
         jsonEncode({
-          'version': '1.8.2-beta.1',
+          'version': '1.8.2-beta.1+33',
           'tag': betaTag,
           'name': 'NAI Launcher $betaTag',
           'publishedAt': '2026-08-22T00:00:00Z',
@@ -307,7 +371,68 @@ class _MixedReleaseDioAdapter implements HttpClientAdapter {
         },
       );
     }
-    return ResponseBody.fromString('not found', 404);
+    throw StateError('Unexpected prerelease request: ${options.uri}');
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _PaginatedReleaseDioAdapter extends _MixedReleaseDioAdapter {
+  final List<int> requestedPages = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (options.uri.host == 'api.github.com' &&
+        options.uri.path.endsWith('/releases')) {
+      final page = int.parse(options.uri.queryParameters['page']!);
+      requestedPages.add(page);
+      final releases = page == 1
+          ? List.generate(
+              100,
+              (index) => {
+                'tag_name': 'autocomplete-data-$index',
+                'draft': false,
+                'prerelease': true,
+              },
+            )
+          : [
+              {
+                'tag_name': _MixedReleaseDioAdapter.betaTag,
+                'draft': false,
+                'prerelease': true,
+              },
+            ];
+      return ResponseBody.fromString(
+        jsonEncode(releases),
+        200,
+        headers: {
+          Headers.contentTypeHeader: ['application/json'],
+        },
+      );
+    }
+    return super.fetch(options, requestStream, cancelFuture);
+  }
+}
+
+class _InvalidReleaseListDioAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString(
+      jsonEncode({'message': 'unexpected object'}),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
   }
 
   @override
@@ -324,18 +449,23 @@ class _MismatchedPrereleaseDioAdapter implements HttpClientAdapter {
     Stream<Uint8List>? requestStream,
     Future<void>? cancelFuture,
   ) async {
-    if (options.uri.path.endsWith('/releases.atom')) {
+    if (options.uri.host == 'api.github.com' &&
+        options.uri.path.endsWith('/releases')) {
       return ResponseBody.fromString(
-        '''<?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <entry><link href="https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/tag/$selectedTag" /></entry>
-</feed>''',
+        jsonEncode([
+          {'tag_name': selectedTag, 'draft': false, 'prerelease': true},
+        ]),
         200,
         headers: {
-          Headers.contentTypeHeader: ['application/atom+xml'],
+          Headers.contentTypeHeader: ['application/json'],
         },
       );
     }
+    expect(
+      options.uri.toString(),
+      'https://github.com/Aaalice233/Aaalice_NAI_Launcher/'
+      'releases/download/$selectedTag/release_manifest.json',
+    );
     return ResponseBody.fromString(
       jsonEncode({
         'version': '1.8.3-beta.1',


### PR DESCRIPTION
## 问题

Beta 检测原先通过 GitHub Atom feed 解析 tag，再手工按 SemVer 重排。该路径不是 Releases JSON 契约，预发布检测会在 feed 获取/解析阶段失败，无法继续读取已经发布的 `release_manifest.json`，最终显示“获取更新信息失败”。正式版路径不经过该分支。

## 修改

- Beta 开启时改用官方 `GET /repos/{owner}/{repo}/releases` 契约，按 GitHub 返回顺序分页跳过草稿、数据包和非法 tag
- 保留 manifest/tag/asset 的现有完整校验与错误类型，不把真实失败伪装成“没有更新”
- 保持正式版 `/releases/latest/download/release_manifest.json` 直连路径不变
- 缺省/新用户的 Beta 检测保持关闭；已有用户保存的 true/false 不被覆盖
- 补充真实响应结构、分页、非法响应、稳定版回退、tag 匹配、默认值与持久化链路测试

## 验证

- `scripts/run_flutter_tests.ps1`：4 个相关测试文件，共 25 项通过
- `dart analyze`：4 个变更相关文件无问题
- 实际请求 GitHub Releases API 并解析当前 release manifest：通过
- `git diff --check`：通过

未修改 `CHANGELOG.md`。