### PR TITLE
fix(android): 防止单次主页面返回直接退出

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6083,6 +6083,7 @@
 
   "onlineGallery_videoLoadFailed": "Failed to load video",
   "vibe_releaseToAddStyleReference": "Release to add style reference",
+  "router_backAgainToExit": "Swipe or press back again to exit",
   "router_pageNotFound": "Page not found: {error}",
   "@router_pageNotFound": {
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -6108,6 +6108,7 @@
 
   "onlineGallery_videoLoadFailed": "動画を読み込めませんでした",
   "vibe_releaseToAddStyleReference": "離すとスタイル参照を追加",
+  "router_backAgainToExit": "もう一度スワイプするか戻るボタンを押すと終了します",
   "router_pageNotFound": "ページが見つかりません: {error}",
   "@router_pageNotFound": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -21688,6 +21688,12 @@ abstract class AppLocalizations {
   /// **'Release to add style reference'**
   String get vibe_releaseToAddStyleReference;
 
+  /// No description provided for @router_backAgainToExit.
+  ///
+  /// In en, this message translates to:
+  /// **'Swipe or press back again to exit'**
+  String get router_backAgainToExit;
+
   /// No description provided for @router_pageNotFound.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12422,6 +12422,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Release to add style reference';
 
   @override
+  String get router_backAgainToExit => 'Swipe or press back again to exit';
+
+  @override
   String router_pageNotFound(String error) {
     return 'Page not found: $error';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -12122,6 +12122,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get vibe_releaseToAddStyleReference => '離すとスタイル参照を追加';
 
   @override
+  String get router_backAgainToExit => 'もう一度スワイプするか戻るボタンを押すと終了します';
+
+  @override
   String router_pageNotFound(String error) {
     return 'ページが見つかりません: $error';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -11920,6 +11920,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get vibe_releaseToAddStyleReference => '松开后添加风格参考';
 
   @override
+  String get router_backAgainToExit => '再滑一次或按返回键退出应用';
+
+  @override
   String router_pageNotFound(String error) {
     return '页面未找到: $error';
   }
@@ -25065,6 +25068,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get vibe_releaseToAddStyleReference => '鬆開後新增風格參考';
+
+  @override
+  String get router_backAgainToExit => '再滑一次或按返回鍵退出應用';
 
   @override
   String router_pageNotFound(String error) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -6152,6 +6152,7 @@
 
   "onlineGallery_videoLoadFailed": "视频加载失败",
   "vibe_releaseToAddStyleReference": "松开后添加风格参考",
+  "router_backAgainToExit": "再滑一次或按返回键退出应用",
   "router_pageNotFound": "页面未找到: {error}",
   "@router_pageNotFound": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -6320,6 +6320,7 @@
   },
   "onlineGallery_videoLoadFailed": "影片載入失敗",
   "vibe_releaseToAddStyleReference": "鬆開後新增風格參考",
+  "router_backAgainToExit": "再滑一次或按返回鍵退出應用",
   "router_pageNotFound": "頁面未找到: {error}",
   "@router_pageNotFound": {
     "placeholders": {

--- a/lib/presentation/router/android_root_back_guard.dart
+++ b/lib/presentation/router/android_root_back_guard.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// Keeps the Android root route in the app until a second committed back
+/// action occurs within [exitWindow].
+class AndroidRootBackGuard extends StatefulWidget {
+  const AndroidRootBackGuard({
+    super.key,
+    required this.enabled,
+    required this.resetKey,
+    required this.onExitHint,
+    required this.child,
+    this.exitWindow = const Duration(seconds: 3),
+  });
+
+  final bool enabled;
+  final Object? resetKey;
+  final VoidCallback onExitHint;
+  final Widget child;
+  final Duration exitWindow;
+
+  @override
+  State<AndroidRootBackGuard> createState() => _AndroidRootBackGuardState();
+}
+
+class _AndroidRootBackGuardState extends State<AndroidRootBackGuard> {
+  Timer? _resetTimer;
+  bool _exitArmed = false;
+
+  @override
+  void didUpdateWidget(AndroidRootBackGuard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!widget.enabled || oldWidget.resetKey != widget.resetKey) {
+      _resetWithoutRebuild();
+    }
+  }
+
+  @override
+  void dispose() {
+    _resetTimer?.cancel();
+    super.dispose();
+  }
+
+  void _handlePop(bool didPop) {
+    if (didPop || !widget.enabled || _exitArmed) return;
+
+    setState(() => _exitArmed = true);
+    _resetTimer?.cancel();
+    _resetTimer = Timer(widget.exitWindow, _reset);
+    widget.onExitHint();
+  }
+
+  void _reset() {
+    if (!mounted || !_exitArmed) return;
+    setState(() => _exitArmed = false);
+    _resetTimer = null;
+  }
+
+  void _resetWithoutRebuild() {
+    _resetTimer?.cancel();
+    _resetTimer = null;
+    _exitArmed = false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope<void>(
+      // PopScope reads this before predictive back starts. Repeated callbacks
+      // from the blocked attempt cannot turn that same attempt into an exit.
+      canPop: !widget.enabled || _exitArmed,
+      onPopInvokedWithResult: (didPop, _) => _handlePop(didPop),
+      child: widget.child,
+    );
+  }
+}

--- a/lib/presentation/router/app_shell.dart
+++ b/lib/presentation/router/app_shell.dart
@@ -43,6 +43,7 @@ class MainShell extends ConsumerStatefulWidget {
 class _MainShellState extends ConsumerState<MainShell> {
   int? _previousIndex;
   bool _authPromptVisible = false;
+  final Map<int, bool> _branchCanHandlePop = <int, bool>{};
   ProviderSubscription<AuthPromptRequest?>? _authPromptSubscription;
 
   @override
@@ -113,12 +114,18 @@ class _MainShellState extends ConsumerState<MainShell> {
 
         // 分支根页面中的 PopScope 不能直接接收根 Router 的系统返回。
         // 由 Shell 把当前分支的返回能力提升到根路由，再交还对应 Navigator。
-        return NavigatorPopHandler<void>(
-          enabled: isActive,
-          onPopWithResult: (_) {
-            if (isActive) branchNavigator.currentState?.maybePop();
+        return NotificationListener<NavigationNotification>(
+          onNotification: (notification) {
+            _recordBranchCanHandlePop(index, notification.canHandlePop);
+            return false;
           },
-          child: branchContent,
+          child: NavigatorPopHandler<void>(
+            enabled: isActive,
+            onPopWithResult: (_) {
+              if (isActive) branchNavigator.currentState?.maybePop();
+            },
+            child: branchContent,
+          ),
         );
       }).toList(),
     );
@@ -161,10 +168,19 @@ class _MainShellState extends ConsumerState<MainShell> {
 
         return MobileShell(
           navigationShell: widget.navigationShell,
+          branchCanHandlePop: _branchCanHandlePop[currentIndex] ?? false,
           content: shortcutEnabledContent,
         );
       },
     );
+  }
+
+  void _recordBranchCanHandlePop(int index, bool canHandlePop) {
+    if (_branchCanHandlePop[index] == canHandlePop) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _branchCanHandlePop[index] == canHandlePop) return;
+      setState(() => _branchCanHandlePop[index] = canHandlePop);
+    });
   }
 
   Future<void> _showAuthPrompt(AuthPromptRequest request) async {

--- a/lib/presentation/router/mobile_shell.dart
+++ b/lib/presentation/router/mobile_shell.dart
@@ -3,10 +3,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/platform/platform_capabilities.dart';
 import '../../core/utils/localization_extension.dart';
 import '../providers/mobile_shell_overlay_provider.dart';
 import '../providers/replication_queue_provider.dart';
 import '../providers/update_provider.dart';
+import '../widgets/common/app_toast.dart';
+import 'android_root_back_guard.dart';
 import 'app_branch.dart';
 import 'global_status_banners.dart';
 import 'mobile_more_panel.dart';
@@ -16,11 +19,13 @@ import 'shell_panels_overlay.dart';
 /// labelled “more” panel instead of disappearing behind desktop-only routes.
 class MobileShell extends ConsumerWidget {
   final StatefulNavigationShell navigationShell;
+  final bool branchCanHandlePop;
   final Widget content;
 
   const MobileShell({
     super.key,
     required this.navigationShell,
+    required this.branchCanHandlePop,
     required this.content,
   });
 
@@ -44,6 +49,85 @@ class MobileShell extends ConsumerWidget {
       ref.read(shellPanelProvider.notifier).state = null;
     }
 
+    final scaffold = Scaffold(
+      body: SafeArea(
+        bottom: false,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            content,
+            const Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: GlobalStatusBanners(),
+            ),
+            ShellPanelsOverlay(
+              activePanel: activePanel,
+              desktop: false,
+              onClose: closePanel,
+              onQueueStarted: () =>
+                  navigationShell.goBranch(AppBranch.generation.index),
+              onOpenAgentSettings: () =>
+                  navigationShell.goBranch(AppBranch.settings.index),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: keyboardVisible || shellOverlayActive
+          ? null
+          : NavigationBar(
+              selectedIndex: activePanel != null
+                  ? mobileMoreNavigationIndex
+                  : mobileNavigationIndexForBranch(
+                      navigationShell.currentIndex,
+                    ),
+              onDestinationSelected: (index) =>
+                  _onNavigate(context, index, ref),
+              destinations: [
+                NavigationDestination(
+                  icon: const Icon(Icons.auto_awesome_outlined),
+                  selectedIcon: const Icon(Icons.auto_awesome),
+                  label: context.l10n.nav_generate,
+                ),
+                NavigationDestination(
+                  icon: const Icon(Icons.photo_library_outlined),
+                  selectedIcon: const Icon(Icons.photo_library),
+                  label: context.l10n.nav_gallery,
+                ),
+                NavigationDestination(
+                  icon: const Icon(Icons.travel_explore_outlined),
+                  selectedIcon: const Icon(Icons.travel_explore),
+                  label: context.l10n.nav_explore,
+                ),
+                NavigationDestination(
+                  icon: const Icon(Icons.library_books_outlined),
+                  selectedIcon: const Icon(Icons.library_books),
+                  label: context.l10n.nav_dictionary,
+                ),
+                NavigationDestination(
+                  icon: Badge(
+                    isLabelVisible: queueCount > 0 || showUpdateBadge,
+                    label: queueCount > 0
+                        ? Text(queueCount > 99 ? '99+' : queueCount.toString())
+                        : null,
+                    smallSize: 7,
+                    child: const Icon(Icons.apps_outlined),
+                  ),
+                  selectedIcon: Badge(
+                    isLabelVisible: queueCount > 0 || showUpdateBadge,
+                    label: queueCount > 0
+                        ? Text(queueCount > 99 ? '99+' : queueCount.toString())
+                        : null,
+                    smallSize: 7,
+                    child: const Icon(Icons.apps),
+                  ),
+                  label: context.l10n.nav_more,
+                ),
+              ],
+            ),
+    );
+
     return CallbackShortcuts(
       bindings: {
         if (activePanel != null)
@@ -54,87 +138,15 @@ class MobileShell extends ConsumerWidget {
         onPopInvokedWithResult: (didPop, _) {
           if (!didPop && activePanel != null) closePanel();
         },
-        child: Scaffold(
-          body: SafeArea(
-            bottom: false,
-            child: Stack(
-              clipBehavior: Clip.none,
-              children: [
-                content,
-                const Positioned(
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  child: GlobalStatusBanners(),
-                ),
-                ShellPanelsOverlay(
-                  activePanel: activePanel,
-                  desktop: false,
-                  onClose: closePanel,
-                  onQueueStarted: () =>
-                      navigationShell.goBranch(AppBranch.generation.index),
-                  onOpenAgentSettings: () =>
-                      navigationShell.goBranch(AppBranch.settings.index),
-                ),
-              ],
-            ),
-          ),
-          bottomNavigationBar: keyboardVisible || shellOverlayActive
-              ? null
-              : NavigationBar(
-                  selectedIndex: activePanel != null
-                      ? mobileMoreNavigationIndex
-                      : mobileNavigationIndexForBranch(
-                          navigationShell.currentIndex,
-                        ),
-                  onDestinationSelected: (index) =>
-                      _onNavigate(context, index, ref),
-                  destinations: [
-                    NavigationDestination(
-                      icon: const Icon(Icons.auto_awesome_outlined),
-                      selectedIcon: const Icon(Icons.auto_awesome),
-                      label: context.l10n.nav_generate,
-                    ),
-                    NavigationDestination(
-                      icon: const Icon(Icons.photo_library_outlined),
-                      selectedIcon: const Icon(Icons.photo_library),
-                      label: context.l10n.nav_gallery,
-                    ),
-                    NavigationDestination(
-                      icon: const Icon(Icons.travel_explore_outlined),
-                      selectedIcon: const Icon(Icons.travel_explore),
-                      label: context.l10n.nav_explore,
-                    ),
-                    NavigationDestination(
-                      icon: const Icon(Icons.library_books_outlined),
-                      selectedIcon: const Icon(Icons.library_books),
-                      label: context.l10n.nav_dictionary,
-                    ),
-                    NavigationDestination(
-                      icon: Badge(
-                        isLabelVisible: queueCount > 0 || showUpdateBadge,
-                        label: queueCount > 0
-                            ? Text(
-                                queueCount > 99 ? '99+' : queueCount.toString(),
-                              )
-                            : null,
-                        smallSize: 7,
-                        child: const Icon(Icons.apps_outlined),
-                      ),
-                      selectedIcon: Badge(
-                        isLabelVisible: queueCount > 0 || showUpdateBadge,
-                        label: queueCount > 0
-                            ? Text(
-                                queueCount > 99 ? '99+' : queueCount.toString(),
-                              )
-                            : null,
-                        smallSize: 7,
-                        child: const Icon(Icons.apps),
-                      ),
-                      label: context.l10n.nav_more,
-                    ),
-                  ],
-                ),
+        child: AndroidRootBackGuard(
+          enabled:
+              PlatformCapabilities.current.isAndroid &&
+              activePanel == null &&
+              !branchCanHandlePop,
+          resetKey: navigationShell.currentIndex,
+          onExitHint: () =>
+              AppToast.info(context, context.l10n.router_backAgainToExit),
+          child: scaffold,
         ),
       ),
     );

--- a/test/presentation/router/android_root_back_guard_test.dart
+++ b/test/presentation/router/android_root_back_guard_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/presentation/router/android_root_back_guard.dart';
+
+void main() {
+  late List<MethodCall> platformCalls;
+
+  setUp(() {
+    platformCalls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          platformCalls.add(call);
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  int exitCallCount() => platformCalls
+      .where((call) => call.method == 'SystemNavigator.pop')
+      .length;
+
+  testWidgets('首次返回提示且同一批重复回调不会退出', (tester) async {
+    var hintCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AndroidRootBackGuard(
+          enabled: true,
+          resetKey: 0,
+          onExitHint: () => hintCount++,
+          child: const Scaffold(body: Text('首页')),
+        ),
+      ),
+    );
+
+    await tester.binding.handlePopRoute();
+    await tester.binding.handlePopRoute();
+
+    expect(find.text('首页'), findsOneWidget);
+    expect(hintCount, 1);
+    expect(exitCallCount(), 0);
+  });
+
+  testWidgets('重新构建后第二次独立返回才退出', (tester) async {
+    var hintCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AndroidRootBackGuard(
+          enabled: true,
+          resetKey: 0,
+          onExitHint: () => hintCount++,
+          child: const Scaffold(body: Text('首页')),
+        ),
+      ),
+    );
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+    expect(exitCallCount(), 0);
+
+    await tester.binding.handlePopRoute();
+
+    expect(hintCount, 1);
+    expect(exitCallCount(), 1);
+  });
+
+  testWidgets('超时后恢复为首次返回', (tester) async {
+    var hintCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AndroidRootBackGuard(
+          enabled: true,
+          resetKey: 0,
+          exitWindow: const Duration(seconds: 2),
+          onExitHint: () => hintCount++,
+          child: const Scaffold(body: Text('首页')),
+        ),
+      ),
+    );
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
+    await tester.binding.handlePopRoute();
+
+    expect(hintCount, 2);
+    expect(exitCallCount(), 0);
+  });
+
+  testWidgets('切换模块或进入内部返回状态会重置保护', (tester) async {
+    final resetKey = ValueNotifier<int>(0);
+    final enabled = ValueNotifier<bool>(true);
+    var hintCount = 0;
+    addTearDown(resetKey.dispose);
+    addTearDown(enabled.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder<int>(
+          valueListenable: resetKey,
+          builder: (context, key, _) => ValueListenableBuilder<bool>(
+            valueListenable: enabled,
+            builder: (context, isEnabled, _) => AndroidRootBackGuard(
+              enabled: isEnabled,
+              resetKey: key,
+              onExitHint: () => hintCount++,
+              child: const Scaffold(body: Text('首页')),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+
+    resetKey.value = 1;
+    await tester.pump();
+    await tester.binding.handlePopRoute();
+    expect(hintCount, 2);
+    expect(exitCallCount(), 0);
+    await tester.pump();
+
+    enabled.value = false;
+    await tester.pump();
+    enabled.value = true;
+    await tester.pump();
+    await tester.binding.handlePopRoute();
+
+    expect(hintCount, 3);
+    expect(exitCallCount(), 0);
+  });
+
+  testWidgets('非根页面正常返回且不触发退出提示', (tester) async {
+    var hintCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AndroidRootBackGuard(
+          enabled: true,
+          resetKey: 0,
+          onExitHint: () => hintCount++,
+          child: Builder(
+            builder: (context) => Scaffold(
+              body: FilledButton(
+                onPressed: () => Navigator.of(context).push<void>(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const Scaffold(body: Text('详情')),
+                  ),
+                ),
+                child: const Text('打开详情'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开详情'));
+    await tester.pumpAndSettle();
+    expect(find.text('详情'), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.text('详情'), findsNothing);
+    expect(find.text('打开详情'), findsOneWidget);
+    expect(hintCount, 0);
+    expect(exitCallCount(), 0);
+  });
+}

--- a/test/presentation/router/main_shell_auth_prompt_test.dart
+++ b/test/presentation/router/main_shell_auth_prompt_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nai_launcher/core/constants/app_version.dart';
+import 'package:nai_launcher/core/platform/platform_capabilities.dart';
 import 'package:nai_launcher/core/shortcuts/shortcut_config.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/agent_chat/providers/agent_chat_notifier.dart';
@@ -437,6 +438,11 @@ void main() {
   });
 
   testWidgets('MainShell 将系统返回交给当前分支的 PopScope', (tester) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.android,
+    );
+    addTearDown(() => PlatformCapabilities.debugOverride = null);
+
     final container = ProviderContainer(
       overrides: [
         accountManagerNotifierProvider.overrideWith(
@@ -511,6 +517,16 @@ void main() {
 
     expect(find.text('分支详情'), findsNothing);
     expect(find.text('打开详情'), findsOneWidget);
+    expect(find.text('再滑一次或按返回键退出应用'), findsNothing);
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+
+    expect(find.text('打开详情'), findsOneWidget);
+    expect(find.text('再滑一次或按返回键退出应用'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pumpAndSettle();
   });
 }
 


### PR DESCRIPTION
## 用户可见变化
- Android 主页面首次返回只显示“再滑一次或按返回键退出应用”，应用保持前台。
- 仅在 3 秒窗口内完成第二次独立返回操作才退出。
- 切换底部模块、进入或退出子路由、打开或关闭 Shell 面板后会清除已解锁状态。
- 内部路由、弹窗/面板返回及桌面端行为保持原样。

## 根因
- 原实现仅用 `NavigatorPopHandler` 将系统返回转交给当前分支，并用 `MobileShell` 的 `PopScope` 关闭活动面板；当前分支位于根页面且无面板时，所有 `canPop` 均允许返回，根返回会直接冒泡到 `SystemNavigator.pop`。
- 仓库中没有应用自有的“双返回退出”状态或提示文案，因此截图中的平台提示不能保证 Flutter 根路由被拦截。
- Flutter predictive back 要求在手势开始前通过 `PopScope.canPop` 声明是否可返回；在完成回调里临时判断或直接退出无法可靠区分同一手势的阶段/重复通知。

## 修复
- 新增根路由返回保护：首次已提交返回提前保持 `canPop: false`，下一帧才为后续独立手势解锁；同一批重复回调只提示一次且不能退出。
- 监听当前分支 `NavigationNotification`，仅在分支无法处理返回、无活动面板且为 Android 时启用根保护，保留 predictive back。
- 以底部导航索引、分支返回能力和 3 秒窗口重置保护状态。
- 补齐中/英/日/繁中提示及生成的本地化代码。

## 验证
- `flutter test test/presentation/router/android_root_back_guard_test.dart test/presentation/router/main_shell_auth_prompt_test.dart`（9 tests passed）
- `dart analyze lib/presentation/router/android_root_back_guard.dart lib/presentation/router/app_shell.dart lib/presentation/router/mobile_shell.dart test/presentation/router/android_root_back_guard_test.dart test/presentation/router/main_shell_auth_prompt_test.dart`（No issues found）
- `flutter gen-l10n`
- `git diff --check`

未执行真实 UI 自动化，未修改 CHANGELOG.md。