### PR TITLE
fix(agent): 修复流式回复抢夺滚动位置

### DIFF
--- a/lib/presentation/agent_chat/widgets/agent_chat_history.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_history.dart
@@ -57,7 +57,6 @@ class _AgentChatThreadViewportState extends State<AgentChatThreadViewport> {
   static const _historyPageSize = 8;
   static const _overscanExtent = 900.0;
   static const _estimatedTurnHeight = 180.0;
-  static final Map<String, double> _sessionOffsets = {};
 
   final Map<Object, GlobalKey> _turnKeys = {};
   final Map<Object, double> _measuredHeights = {};
@@ -74,7 +73,6 @@ class _AgentChatThreadViewportState extends State<AgentChatThreadViewport> {
   void didUpdateWidget(covariant AgentChatThreadViewport oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.sessionId != widget.sessionId) {
-      _saveOffset(oldWidget.sessionId);
       _visibleTurnCount = _initialVisibleCount;
       _turnKeys.clear();
       _measuredHeights.clear();
@@ -103,21 +101,12 @@ class _AgentChatThreadViewportState extends State<AgentChatThreadViewport> {
   int get _hiddenCount => widget.turns.length - _visibleTurnCount;
 
   void _saveOffset(String sessionId) {
-    final scroll = widget.controller.scrollController;
-    if (sessionId.isEmpty || !scroll.hasClients) return;
-    _sessionOffsets.remove(sessionId);
-    _sessionOffsets[sessionId] = scroll.offset;
-    while (_sessionOffsets.length > 32) {
-      _sessionOffsets.remove(_sessionOffsets.keys.first);
-    }
+    widget.controller.saveSessionOffset(sessionId);
   }
 
   void _restoreOffset() {
-    final scroll = widget.controller.scrollController;
-    if (!mounted || !scroll.hasClients) return;
-    final saved = _sessionOffsets[widget.sessionId];
-    if (saved == null) return;
-    scroll.jumpTo(saved.clamp(0, scroll.position.maxScrollExtent));
+    if (!mounted) return;
+    widget.controller.restoreSessionOffset(widget.sessionId);
   }
 
   Object _identityFor(AgentChatTurnModel turn) =>
@@ -127,6 +116,13 @@ class _AgentChatThreadViewportState extends State<AgentChatThreadViewport> {
       _turnKeys.putIfAbsent(_identityFor(turn), GlobalKey.new);
 
   Future<void> _jumpTo(AgentChatTurnModel turn) async {
+    final index = widget.turns.indexOf(turn);
+    if (index < 0) return;
+    if (index == widget.turns.length - 1) {
+      widget.controller.followLatest();
+      return;
+    }
+    widget.controller.pauseFollowingLatest();
     final context = _keyFor(turn).currentContext;
     if (context != null) {
       await Scrollable.ensureVisible(
@@ -138,8 +134,7 @@ class _AgentChatThreadViewportState extends State<AgentChatThreadViewport> {
       return;
     }
     final scroll = widget.controller.scrollController;
-    final index = widget.turns.indexOf(turn);
-    if (!scroll.hasClients || index < 0) return;
+    if (!scroll.hasClients) return;
     var estimatedOffset = 0.0;
     for (var later = widget.turns.length - 1; later > index; later--) {
       estimatedOffset +=
@@ -170,7 +165,7 @@ class _AgentChatThreadViewportState extends State<AgentChatThreadViewport> {
     // Keep the exact pixel anchor if the framework performs any correction.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (before == null || !scroll.hasClients) return;
-      scroll.jumpTo(before.clamp(0, scroll.position.maxScrollExtent));
+      widget.controller.jumpToPreservingFollow(before);
     });
   }
 
@@ -192,79 +187,97 @@ class _AgentChatThreadViewportState extends State<AgentChatThreadViewport> {
       children: [
         NotificationListener<ScrollNotification>(
           onNotification: widget.controller.handleScrollNotification,
-          child: CustomScrollView(
-            key: PageStorageKey('agent-chat-thread-${widget.sessionId}'),
-            controller: widget.controller.scrollController,
-            reverse: true,
-            scrollCacheExtent: const ScrollCacheExtent.pixels(_overscanExtent),
-            slivers: [
-              SliverPadding(
-                padding: EdgeInsets.symmetric(
-                  horizontal: widget.horizontalPadding,
-                  vertical: 12,
+          // Keyboard and scrollbar track moves are driven scroll activities,
+          // so arm their user intent before notifications change the offset.
+          child: Focus(
+            onKeyEvent: widget.controller.handleViewportKeyEvent,
+            child: Listener(
+              onPointerDown: (_) =>
+                  widget.controller.beginPotentialUserScroll(),
+              onPointerUp: (_) => widget.controller.cancelPotentialUserScroll(),
+              onPointerCancel: (_) =>
+                  widget.controller.cancelPotentialUserScroll(),
+              child: CustomScrollView(
+                key: PageStorageKey('agent-chat-thread-${widget.sessionId}'),
+                controller: widget.controller.scrollController,
+                reverse: true,
+                scrollCacheExtent: const ScrollCacheExtent.pixels(
+                  _overscanExtent,
                 ),
-                sliver: SliverList.builder(
-                  itemCount: itemCount,
-                  itemBuilder: (context, index) {
-                    if (index == 0) {
-                      return _bounded(widget.live);
-                    }
-                    final reverseTurnIndex = index - 1;
-                    if (reverseTurnIndex < _visibleTurnCount) {
-                      final turnIndex =
-                          widget.turns.length - 1 - reverseTurnIndex;
-                      final turn = widget.turns[turnIndex];
-                      final identity = _identityFor(turn);
-                      return _MeasureSize(
-                        key: _keyFor(turn),
-                        onChange: (size) =>
-                            _measuredHeights[identity] = size.height,
-                        child: RepaintBoundary(
-                          key: ValueKey(
-                            'agent-turn-${turn.timeline?.id ?? turnIndex}',
-                          ),
-                          child: _bounded(
-                            widget.turnBuilder(
-                              context,
-                              turn,
-                              turnIndex == widget.turns.length - 1,
+                slivers: [
+                  SliverPadding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: widget.horizontalPadding,
+                      vertical: 12,
+                    ),
+                    sliver: SliverList.builder(
+                      itemCount: itemCount,
+                      itemBuilder: (context, index) {
+                        if (index == 0) {
+                          return _bounded(widget.live);
+                        }
+                        final reverseTurnIndex = index - 1;
+                        if (reverseTurnIndex < _visibleTurnCount) {
+                          final turnIndex =
+                              widget.turns.length - 1 - reverseTurnIndex;
+                          final turn = widget.turns[turnIndex];
+                          final identity = _identityFor(turn);
+                          return _MeasureSize(
+                            key: _keyFor(turn),
+                            onChange: (size) =>
+                                _measuredHeights[identity] = size.height,
+                            child: RepaintBoundary(
+                              key: ValueKey(
+                                'agent-turn-${turn.timeline?.id ?? turnIndex}',
+                              ),
+                              child: _bounded(
+                                widget.turnBuilder(
+                                  context,
+                                  turn,
+                                  turnIndex == widget.turns.length - 1,
+                                ),
+                              ),
+                            ),
+                          );
+                        }
+                        return _bounded(
+                          Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 8),
+                            child: TextButton.icon(
+                              key: const ValueKey(
+                                'agent-chat-earlier-messages',
+                              ),
+                              onPressed: widget.historyLoading
+                                  ? null
+                                  : _showEarlier,
+                              icon: widget.historyLoading
+                                  ? const SizedBox.square(
+                                      dimension: 16,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 1.7,
+                                      ),
+                                    )
+                                  : const Icon(Icons.history_rounded, size: 17),
+                              label: Text(
+                                widget.historyLoading
+                                    ? context.l10n.common_loading
+                                    : _hiddenCount > 0
+                                    ? context.l10n.agentChat_earlierMessages(
+                                        _hiddenCount,
+                                      )
+                                    : context
+                                          .l10n
+                                          .agentChat_loadEarlierMessages,
+                              ),
                             ),
                           ),
-                        ),
-                      );
-                    }
-                    return _bounded(
-                      Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 8),
-                        child: TextButton.icon(
-                          key: const ValueKey('agent-chat-earlier-messages'),
-                          onPressed: widget.historyLoading
-                              ? null
-                              : _showEarlier,
-                          icon: widget.historyLoading
-                              ? const SizedBox.square(
-                                  dimension: 16,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 1.7,
-                                  ),
-                                )
-                              : const Icon(Icons.history_rounded, size: 17),
-                          label: Text(
-                            widget.historyLoading
-                                ? context.l10n.common_loading
-                                : _hiddenCount > 0
-                                ? context.l10n.agentChat_earlierMessages(
-                                    _hiddenCount,
-                                  )
-                                : context.l10n.agentChat_loadEarlierMessages,
-                          ),
-                        ),
-                      ),
-                    );
-                  },
-                ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
         if (!widget.mobile &&

--- a/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
@@ -146,7 +146,7 @@ class AgentChatMessages extends StatelessWidget {
             bottom: 10,
             child: FilledButton.tonalIcon(
               key: const ValueKey('agent-chat-jump-to-latest'),
-              onPressed: () => controller.scrollToBottom(force: true),
+              onPressed: controller.followLatest,
               icon: const Icon(Icons.arrow_downward_rounded, size: 16),
               label: Text(context.l10n.agentChat_jumpToLatest),
               style: FilledButton.styleFrom(

--- a/lib/presentation/agent_chat/widgets/agent_chat_panel_controller.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_panel_controller.dart
@@ -2,6 +2,9 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollDirection;
+import 'package:flutter/services.dart'
+    show KeyDownEvent, KeyEvent, KeyRepeatEvent, KeyUpEvent, LogicalKeyboardKey;
 
 import '../../../core/agent/agent_types.dart';
 import '../../../core/utils/nai_resolution_adapter.dart';
@@ -32,7 +35,19 @@ class AgentChatPanelController extends ChangeNotifier {
     scrollController.addListener(_handleScrollPositionChanged);
   }
 
-  static const double _bottomTolerance = 2.0;
+  static const double _atBottomTolerance = 2.0;
+  static const double _nearBottomTolerance = 48.0;
+  static const double _scrollMovementTolerance = 0.01;
+  static const int _retainedSessionOffsetCount = 32;
+  static final Set<LogicalKeyboardKey> _viewportScrollKeys = {
+    LogicalKeyboardKey.arrowUp,
+    LogicalKeyboardKey.arrowDown,
+    LogicalKeyboardKey.pageUp,
+    LogicalKeyboardKey.pageDown,
+    LogicalKeyboardKey.home,
+    LogicalKeyboardKey.end,
+    LogicalKeyboardKey.space,
+  };
 
   late final AgentChatInputController inputController;
   final ScrollController scrollController = ScrollController();
@@ -41,10 +56,15 @@ class AgentChatPanelController extends ChangeNotifier {
   final Map<ImageSource, Uint8List> messageImageBytes = {};
   final Map<ImageSource, Size> messageImageSizes = {};
   final Map<String, Uint8List> markdownDataImageBytes = {};
+  final Map<String, ({double offset, bool autoScroll})> _sessionOffsets = {};
 
   OverlayEntry? _inlineImagePreview;
   BuildContext? _overlayContext;
   bool _autoScroll = true;
+  bool _userScrollActive = false;
+  bool _potentialUserScroll = false;
+  bool _programmaticScrollActive = false;
+  double? _lastUserScrollPixels;
   bool _scrollToBottomScheduled = false;
   int _lastScrollMessageCount = -1;
   String _lastScrollSessionId = '';
@@ -66,11 +86,16 @@ class AgentChatPanelController extends ChangeNotifier {
   void attachOverlayContext(BuildContext context) => _overlayContext = context;
 
   void observe(AgentChatState state) {
-    final sessionChanged = state.activeSessionId != _lastScrollSessionId;
+    final previousSessionId = _lastScrollSessionId;
+    final sessionChanged = state.activeSessionId != previousSessionId;
     final contentChanged =
         state.messages.length != _lastScrollMessageCount ||
         !identical(state.streamingMessage, _lastStreamingMessage) ||
         !identical(state.activities, _lastActivities);
+    if (sessionChanged && previousSessionId.isNotEmpty) {
+      saveSessionOffset(previousSessionId);
+      _endUserScroll();
+    }
     _lastScrollSessionId = state.activeSessionId;
     _lastScrollMessageCount = state.messages.length;
     _lastStreamingMessage = state.streamingMessage;
@@ -321,36 +346,175 @@ class AgentChatPanelController extends ChangeNotifier {
   }
 
   void _handleScrollPositionChanged() {
-    if (!scrollController.hasClients) return;
+    if (!scrollController.hasClients || _programmaticScrollActive) return;
     final position = scrollController.position;
     if (!position.hasPixels || !position.hasContentDimensions) return;
-    if (position.pixels <= position.minScrollExtent + _bottomTolerance &&
-        !_autoScroll) {
-      _autoScroll = true;
-      notifyListeners();
+    if (_isAtBottom(position) && !_autoScroll) {
+      _setAutoScroll(true);
     }
   }
 
   bool handleScrollNotification(ScrollNotification notification) {
-    if (notification case ScrollUpdateNotification(
-      :final dragDetails,
-    ) when dragDetails != null) {
-      final atBottom =
-          notification.metrics.pixels <=
-          notification.metrics.minScrollExtent + _bottomTolerance;
-      if (_autoScroll != atBottom) {
-        _autoScroll = atBottom;
-        notifyListeners();
-      }
+    if (notification.depth != 0 || _programmaticScrollActive) return false;
+
+    switch (notification) {
+      case UserScrollNotification(:final direction):
+        if (direction == ScrollDirection.idle) {
+          _endUserScroll();
+        } else {
+          _beginUserScroll(notification.metrics);
+        }
+      case ScrollStartNotification(:final dragDetails)
+          when dragDetails != null || _potentialUserScroll:
+        _beginUserScroll(notification.metrics);
+      case ScrollUpdateNotification(:final dragDetails, :final scrollDelta)
+          when dragDetails != null || _userScrollActive || _potentialUserScroll:
+        _beginUserScroll(notification.metrics, preserveBaseline: true);
+        _updateUserScrollIntent(notification.metrics, scrollDelta: scrollDelta);
+      case ScrollEndNotification():
+        _endUserScroll();
+      default:
+        break;
     }
     return false;
   }
 
-  void scrollToBottom({bool force = false}) {
-    if (force && !_autoScroll) {
-      _autoScroll = true;
-      notifyListeners();
+  void beginPotentialUserScroll() {
+    if (_programmaticScrollActive) return;
+    _potentialUserScroll = true;
+    if (scrollController.hasClients) {
+      _lastUserScrollPixels = scrollController.position.pixels;
     }
+  }
+
+  void cancelPotentialUserScroll() {
+    _potentialUserScroll = false;
+    if (!_userScrollActive) _lastUserScrollPixels = null;
+  }
+
+  KeyEventResult handleViewportKeyEvent(FocusNode _, KeyEvent event) {
+    if (!_viewportScrollKeys.contains(event.logicalKey)) {
+      return KeyEventResult.ignored;
+    }
+    if (event is KeyDownEvent || event is KeyRepeatEvent) {
+      beginPotentialUserScroll();
+    } else if (event is KeyUpEvent) {
+      cancelPotentialUserScroll();
+    }
+    return KeyEventResult.ignored;
+  }
+
+  void _beginUserScroll(
+    ScrollMetrics metrics, {
+    bool preserveBaseline = false,
+  }) {
+    if (!_userScrollActive &&
+        (!preserveBaseline || _lastUserScrollPixels == null)) {
+      _lastUserScrollPixels = metrics.pixels;
+    }
+    _potentialUserScroll = false;
+    _userScrollActive = true;
+  }
+
+  void _endUserScroll() {
+    _potentialUserScroll = false;
+    _userScrollActive = false;
+    _lastUserScrollPixels = null;
+  }
+
+  void _updateUserScrollIntent(ScrollMetrics metrics, {double? scrollDelta}) {
+    final previousPixels = _lastUserScrollPixels;
+    final delta = previousPixels == null
+        ? scrollDelta ?? 0
+        : metrics.pixels - previousPixels;
+    _lastUserScrollPixels = metrics.pixels;
+    if (delta > _scrollMovementTolerance) {
+      _setAutoScroll(false);
+    } else if (delta < -_scrollMovementTolerance && _isNearBottom(metrics)) {
+      _setAutoScroll(true);
+    }
+  }
+
+  bool _isAtBottom(ScrollMetrics metrics) =>
+      metrics.pixels <= metrics.minScrollExtent + _atBottomTolerance;
+
+  bool _isNearBottom(ScrollMetrics metrics) =>
+      metrics.pixels <= metrics.minScrollExtent + _nearBottomTolerance;
+
+  void _setAutoScroll(bool value) {
+    if (_autoScroll == value) return;
+    _autoScroll = value;
+    notifyListeners();
+  }
+
+  void saveSessionOffset(String sessionId) {
+    if (sessionId.isEmpty ||
+        sessionId != _lastScrollSessionId ||
+        !scrollController.hasClients) {
+      return;
+    }
+    _sessionOffsets.remove(sessionId);
+    _sessionOffsets[sessionId] = (
+      offset: scrollController.offset,
+      autoScroll: _autoScroll,
+    );
+    while (_sessionOffsets.length > _retainedSessionOffsetCount) {
+      _sessionOffsets.remove(_sessionOffsets.keys.first);
+    }
+  }
+
+  void restoreSessionOffset(String sessionId) {
+    final saved = _sessionOffsets[sessionId];
+    if (sessionId != _lastScrollSessionId ||
+        saved == null ||
+        !scrollController.hasClients) {
+      return;
+    }
+    final target = saved.offset
+        .clamp(
+          scrollController.position.minScrollExtent,
+          scrollController.position.maxScrollExtent,
+        )
+        .toDouble();
+    _setAutoScroll(saved.autoScroll);
+    jumpToPreservingFollow(target);
+  }
+
+  void pauseFollowingLatest() {
+    _endUserScroll();
+    _setAutoScroll(false);
+  }
+
+  void jumpToPreservingFollow(double offset) {
+    if (!scrollController.hasClients) return;
+    _endUserScroll();
+    final target = offset
+        .clamp(
+          scrollController.position.minScrollExtent,
+          scrollController.position.maxScrollExtent,
+        )
+        .toDouble();
+    _programmaticScrollActive = true;
+    try {
+      scrollController.jumpTo(target);
+    } finally {
+      _programmaticScrollActive = false;
+    }
+  }
+
+  void followLatest() {
+    _setAutoScroll(true);
+    if (scrollController.hasClients) {
+      final position = scrollController.position;
+      if (position.hasPixels && position.hasContentDimensions) {
+        jumpToPreservingFollow(position.minScrollExtent);
+      }
+    }
+    scrollToBottom();
+  }
+
+  void scrollToBottom({bool force = false}) {
+    if (force) _setAutoScroll(true);
     if (!_autoScroll || _scrollToBottomScheduled) return;
     _scrollToBottomScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -359,8 +523,12 @@ class AgentChatPanelController extends ChangeNotifier {
       final position = scrollController.position;
       if (!position.hasPixels || !position.hasContentDimensions) return;
       final target = position.minScrollExtent;
-      if (target.isFinite && (target - position.pixels).abs() >= 0.5) {
+      if (!target.isFinite || (target - position.pixels).abs() < 0.5) return;
+      _programmaticScrollActive = true;
+      try {
         scrollController.jumpTo(target);
+      } finally {
+        _programmaticScrollActive = false;
       }
     });
   }

--- a/lib/presentation/agent_chat/widgets/agent_chat_panel_coordinator.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_panel_coordinator.dart
@@ -105,6 +105,7 @@ class AgentChatPanelCoordinator {
     final images = _controller.pendingImages;
     final content = _controller.buildInlineUserContent(text, images);
     if (content.isEmpty) return;
+    _controller.followLatest();
     _controller.takePendingImages();
     await _notifier.clearComposerText();
     await _notifier.sendContent(content, followUp: followUp);
@@ -250,6 +251,7 @@ class AgentChatPanelCoordinator {
   Future<void> _retryLastMessage() async {
     final message = await _notifier.rewindLastUserMessage();
     if (message == null || !_isMounted()) return;
+    _controller.followLatest();
     await _notifier.sendContent(message.content);
   }
 

--- a/test/presentation/agent_chat/widgets/agent_chat_scroll_follow_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_scroll_follow_test.dart
@@ -1,0 +1,418 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/agent_types.dart';
+import 'package:nai_launcher/presentation/agent_chat/providers/agent_chat_notifier.dart';
+import 'package:nai_launcher/presentation/agent_chat/widgets/agent_chat_panel_controller.dart';
+
+void main() {
+  testWidgets('streaming follows while the viewport remains at the bottom', (
+    tester,
+  ) async {
+    final controller = AgentChatPanelController();
+    addTearDown(controller.dispose);
+    var state = _streamingState('a');
+    var heights = _transcriptHeights();
+
+    await _pumpTranscript(tester, controller, state, heights);
+    await tester.pump();
+    expect(controller.scrollController.offset, 0);
+    expect(controller.showJumpToLatest, isFalse);
+
+    controller.jumpToPreservingFollow(30);
+    expect(controller.scrollController.offset, 30);
+
+    state = _streamingState('a', token: 'next token');
+    heights = [...heights]..[0] += 80;
+    await _pumpTranscript(tester, controller, state, heights);
+    await tester.pump();
+
+    expect(controller.scrollController.offset, 0);
+    expect(controller.showJumpToLatest, isFalse);
+  });
+
+  testWidgets(
+    'user scroll pauses streaming and asynchronous layout growth does not steal the viewport',
+    (tester) async {
+      final controller = AgentChatPanelController();
+      addTearDown(controller.dispose);
+      var state = _streamingState('a');
+      var heights = _transcriptHeights();
+
+      await _pumpTranscript(tester, controller, state, heights);
+      await tester.pump();
+      await tester.drag(
+        find.byKey(const ValueKey('transcript')),
+        const Offset(0, 420),
+      );
+      await tester.pumpAndSettle();
+      final userOffset = controller.scrollController.offset;
+      expect(userOffset, greaterThan(0));
+      expect(controller.showJumpToLatest, isTrue);
+
+      state = _streamingState('a', token: 'more streamed content');
+      heights = [...heights]..[0] += 120;
+      await _pumpTranscript(tester, controller, state, heights);
+      await tester.pump();
+      expect(controller.scrollController.offset, closeTo(userOffset, 0.01));
+      expect(controller.showJumpToLatest, isTrue);
+
+      heights = [...heights]..[1] += 160;
+      await _pumpTranscript(tester, controller, state, heights);
+      await tester.pump();
+      expect(controller.scrollController.offset, closeTo(userOffset, 0.01));
+      expect(controller.showJumpToLatest, isTrue);
+
+      state = state.copyWith(
+        status: AgentChatRunStatus.idle,
+        messages: [UserMessage.text('finalized response')],
+        clearStreamingMessage: true,
+      );
+      heights = [...heights]..[0] += 60;
+      await _pumpTranscript(tester, controller, state, heights);
+      await tester.pump();
+      expect(controller.scrollController.offset, closeTo(userOffset, 0.01));
+      expect(controller.showJumpToLatest, isTrue);
+    },
+  );
+
+  testWidgets('returning to the bottom or sending resumes streaming follow', (
+    tester,
+  ) async {
+    final controller = AgentChatPanelController();
+    addTearDown(controller.dispose);
+    var state = _streamingState('a');
+    final heights = _transcriptHeights();
+
+    await _pumpTranscript(tester, controller, state, heights);
+    await tester.pump();
+    await tester.drag(
+      find.byKey(const ValueKey('transcript')),
+      const Offset(0, 420),
+    );
+    await tester.pumpAndSettle();
+    expect(controller.showJumpToLatest, isTrue);
+
+    controller.scrollController.jumpTo(0);
+    await tester.pump();
+    expect(controller.showJumpToLatest, isFalse);
+
+    await tester.drag(
+      find.byKey(const ValueKey('transcript')),
+      const Offset(0, 420),
+    );
+    await tester.pumpAndSettle();
+    expect(controller.showJumpToLatest, isTrue);
+
+    controller.followLatest();
+    await tester.pumpAndSettle();
+    expect(controller.scrollController.offset, 0);
+    expect(controller.showJumpToLatest, isFalse);
+
+    state = _streamingState('a', token: 'after send');
+    await _pumpTranscript(tester, controller, state, [...heights]..[0] += 100);
+    await tester.pump();
+    expect(controller.scrollController.offset, 0);
+  });
+
+  testWidgets(
+    'session offsets and follow intent remain local to each viewport',
+    (tester) async {
+      final first = AgentChatPanelController();
+      final second = AgentChatPanelController();
+      addTearDown(first.dispose);
+      addTearDown(second.dispose);
+      final heights = _transcriptHeights();
+
+      await _pumpTranscript(tester, first, _streamingState('a'), heights);
+      await tester.pump();
+      await tester.drag(
+        find.byKey(const ValueKey('transcript')),
+        const Offset(0, 260),
+      );
+      await tester.pumpAndSettle();
+      final savedOffset = first.scrollController.offset;
+      expect(savedOffset, greaterThan(0));
+      expect(first.showJumpToLatest, isTrue);
+
+      await _pumpTranscript(tester, first, _streamingState('b'), heights);
+      await tester.pump();
+      expect(first.scrollController.offset, 0);
+      expect(first.showJumpToLatest, isFalse);
+
+      await _pumpTranscript(tester, first, _streamingState('a'), heights);
+      await tester.pump();
+      first.restoreSessionOffset('a');
+      expect(first.scrollController.offset, closeTo(savedOffset, 0.01));
+      expect(first.showJumpToLatest, isTrue);
+
+      await _pumpTranscript(tester, second, _streamingState('a'), heights);
+      await tester.pump();
+      second.restoreSessionOffset('a');
+      expect(second.scrollController.offset, 0);
+      expect(second.showJumpToLatest, isFalse);
+    },
+  );
+
+  testWidgets('mouse wheel scrolling pauses streaming follow immediately', (
+    tester,
+  ) async {
+    final controller = AgentChatPanelController();
+    addTearDown(controller.dispose);
+    await _pumpTranscript(
+      tester,
+      controller,
+      _streamingState('a'),
+      _transcriptHeights(),
+    );
+    await tester.pump();
+    final transcript = find.byKey(const ValueKey('transcript'));
+
+    await tester.sendEventToBinding(
+      PointerScrollEvent(
+        kind: PointerDeviceKind.mouse,
+        position: tester.getCenter(transcript),
+        scrollDelta: const Offset(0, -240),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(controller.scrollController.offset, greaterThan(0));
+    expect(controller.showJumpToLatest, isTrue);
+  });
+
+  testWidgets(
+    'driven user scrolls pause while controller-owned jumps preserve intent',
+    (tester) async {
+      final controller = AgentChatPanelController();
+      addTearDown(controller.dispose);
+      await _pumpTranscript(
+        tester,
+        controller,
+        _streamingState('a'),
+        _transcriptHeights(),
+      );
+      await tester.pump();
+
+      controller.jumpToPreservingFollow(120);
+      expect(controller.scrollController.offset, 120);
+      expect(controller.showJumpToLatest, isFalse);
+
+      controller.followLatest();
+      controller.beginPotentialUserScroll();
+      final drivenScroll = controller.scrollController.animateTo(
+        180,
+        duration: const Duration(milliseconds: 80),
+        curve: Curves.linear,
+      );
+      await tester.pumpAndSettle();
+      await drivenScroll;
+
+      expect(controller.scrollController.offset, 180);
+      expect(
+        controller.showJumpToLatest,
+        isTrue,
+        reason: 'keyboard and scrollbar actions use driven scroll activities',
+      );
+    },
+  );
+
+  testWidgets(
+    'user scroll notifications pause follow without misclassifying programmatic updates',
+    (tester) async {
+      final controller = AgentChatPanelController();
+      addTearDown(controller.dispose);
+      await _pumpTranscript(
+        tester,
+        controller,
+        _streamingState('a'),
+        _transcriptHeights(),
+      );
+      await tester.pump();
+      final context = tester.element(find.byKey(const ValueKey('transcript')));
+
+      controller.handleScrollNotification(
+        ScrollUpdateNotification(
+          metrics: _metrics(180),
+          context: context,
+          scrollDelta: 180,
+        ),
+      );
+      expect(
+        controller.showJumpToLatest,
+        isFalse,
+        reason: 'a notification without user activity can come from jumpTo',
+      );
+
+      controller.handleScrollNotification(
+        UserScrollNotification(
+          metrics: _metrics(0),
+          context: context,
+          direction: ScrollDirection.forward,
+        ),
+      );
+      controller.handleScrollNotification(
+        ScrollUpdateNotification(
+          metrics: _metrics(12),
+          context: context,
+          scrollDelta: 12,
+        ),
+      );
+      expect(controller.showJumpToLatest, isTrue);
+
+      controller.followLatest();
+      expect(controller.showJumpToLatest, isFalse);
+      controller.handleScrollNotification(
+        ScrollUpdateNotification(
+          metrics: _metrics(160),
+          context: context,
+          scrollDelta: 148,
+        ),
+      );
+      expect(
+        controller.showJumpToLatest,
+        isFalse,
+        reason: 'an explicit jump clears the preceding user scroll activity',
+      );
+
+      controller.handleScrollNotification(
+        UserScrollNotification(
+          metrics: _metrics(0),
+          context: context,
+          direction: ScrollDirection.forward,
+        ),
+      );
+      controller.handleScrollNotification(
+        ScrollUpdateNotification(
+          metrics: _metrics(12),
+          context: context,
+          scrollDelta: 12,
+        ),
+      );
+      expect(controller.showJumpToLatest, isTrue);
+
+      controller.handleScrollNotification(
+        ScrollUpdateNotification(
+          metrics: _metrics(40),
+          context: context,
+          scrollDelta: 28,
+        ),
+      );
+      expect(
+        controller.showJumpToLatest,
+        isTrue,
+        reason: 'moving away must remain paused even inside the threshold',
+      );
+
+      controller.handleScrollNotification(
+        ScrollUpdateNotification(
+          metrics: _metrics(20),
+          context: context,
+          scrollDelta: -20,
+        ),
+      );
+      expect(
+        controller.showJumpToLatest,
+        isFalse,
+        reason: 'returning toward the near-bottom range resumes follow',
+      );
+
+      controller.handleScrollNotification(
+        UserScrollNotification(
+          metrics: _metrics(20),
+          context: context,
+          direction: ScrollDirection.idle,
+        ),
+      );
+      controller.handleScrollNotification(
+        ScrollUpdateNotification(
+          metrics: _metrics(160),
+          context: context,
+          scrollDelta: 120,
+        ),
+      );
+      expect(controller.showJumpToLatest, isFalse);
+    },
+  );
+}
+
+List<double> _transcriptHeights() => List<double>.generate(
+  20,
+  (index) => index == 0 ? 120 : 80,
+  growable: false,
+);
+
+AgentChatState _streamingState(String sessionId, {String token = 'token'}) =>
+    AgentChatState(
+      initialized: true,
+      routeReady: true,
+      activeSessionId: sessionId,
+      status: AgentChatRunStatus.running,
+      streamingMessage: AssistantMessage(
+        content: [AssistantTextContent(token)],
+        stopReason: StopReason.stop,
+      ),
+    );
+
+FixedScrollMetrics _metrics(double pixels) => FixedScrollMetrics(
+  minScrollExtent: 0,
+  maxScrollExtent: 1200,
+  pixels: pixels,
+  viewportDimension: 300,
+  axisDirection: AxisDirection.up,
+  devicePixelRatio: 1,
+);
+
+Future<void> _pumpTranscript(
+  WidgetTester tester,
+  AgentChatPanelController controller,
+  AgentChatState state,
+  List<double> heights,
+) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          height: 300,
+          child: _Transcript(
+            controller: controller,
+            state: state,
+            heights: heights,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+class _Transcript extends StatelessWidget {
+  const _Transcript({
+    required this.controller,
+    required this.state,
+    required this.heights,
+  });
+
+  final AgentChatPanelController controller;
+  final AgentChatState state;
+  final List<double> heights;
+
+  @override
+  Widget build(BuildContext context) {
+    controller.observe(state);
+    return NotificationListener<ScrollNotification>(
+      onNotification: controller.handleScrollNotification,
+      child: ListView.builder(
+        key: const ValueKey('transcript'),
+        controller: controller.scrollController,
+        reverse: true,
+        itemCount: heights.length,
+        itemBuilder: (context, index) => SizedBox(
+          key: ValueKey('item-$index'),
+          height: heights[index],
+          child: Text('item $index'),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 用户可见变化
- Agent 回复流式输出时，用户主动上滚后不再被后续 token、工具状态或内容高度变化拉回底部
- 鼠标滚轮、触控拖动、滚动条/键盘驱动滚动与 Turn 导航都会正确暂停跟随
- 自然回到底部、点击“回到最新消息”、发送或重试后恢复跟随
- 切换会话时保存各自滚动位置与跟随意图；每个 sidebar/窗口视口独立维护滚动意图

## 根因
`AgentChatPanelController.observe()` 会在每次 `streamingMessage` / `activities` 更新后排队滚底，但旧逻辑只把带 `dragDetails` 的 `ScrollUpdateNotification` 视为用户滚动。鼠标滚轮、键盘、滚动条和部分程序性驱动活动无法关闭 `_autoScroll`，迟到的 post-frame `jumpTo` 因而持续抢回底部；会话 offset 还由静态 Map 跨视口共享。

## 修复
- 以每个 `AgentChatPanelController` 为单位维护 follow intent、用户/程序性滚动边界及 session viewport 状态
- 仅在用户向旧内容方向移动时暂停，在用户回到近底区域时恢复；controller 自有跳转不会被误判
- 合并每帧滚底任务，并在执行时再次校验 follow intent，避免迟到任务与用户滚动竞争
- 复用现有“回到最新消息”入口；发送、重试和最新 Turn 导航显式恢复，旧 Turn 导航显式暂停
- 历史加载的锚点恢复走同一 controller，不再跨 sidebar/窗口共享静态 offset

## 验证
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run_flutter_tests.ps1 -Path "test/presentation/agent_chat/widgets/agent_chat_scroll_follow_test.dart,test/presentation/agent_chat/widgets/agent_chat_panel_test.dart,test/presentation/agent_chat/widgets/agent_chat_turn_test.dart" -TimeoutSeconds 120 -Concurrency 3`（26 tests passed）
- `flutter analyze --no-pub lib/presentation/agent_chat/widgets`（No issues found）
- `flutter analyze --no-pub test/presentation/agent_chat/widgets`（No issues found）
- `git diff --check`

未更新 CHANGELOG，未执行真实生成或消耗 Anlas。
