### PR TITLE
fix(agent): 修复画廊工具卡死与停止失效

### DIFF
--- a/lib/core/cache/online_gallery_detail_coordinator.dart
+++ b/lib/core/cache/online_gallery_detail_coordinator.dart
@@ -100,8 +100,12 @@ class OnlineGalleryDetailCoordinator {
     _cancelVisibleTasks(includeActive: false);
   }
 
-  void cancelVisible() {
-    _cancelVisibleTasks(includeActive: true);
+  void cancelVisible({String reason = 'Gallery scope changed'}) {
+    _cancelTasks(
+      (task) => task.priority == GalleryDetailPriority.visible,
+      includeActive: true,
+      reason: reason,
+    );
   }
 
   void cancelLookahead() {
@@ -131,6 +135,7 @@ class OnlineGalleryDetailCoordinator {
   void _cancelTasks(
     bool Function(_DetailTask task) predicate, {
     required bool includeActive,
+    String reason = 'Gallery scope changed',
   }) {
     final tasks = _tasks.values
         .where((task) => predicate(task) && (includeActive || !task.started))
@@ -143,10 +148,10 @@ class OnlineGalleryDetailCoordinator {
         _tasks.remove(task.item.detailStableKey);
       }
       if (!task.cancelToken.isCancelled) {
-        task.cancelToken.cancel('Gallery scope changed');
+        task.cancelToken.cancel(reason);
       }
       if (!task.completer.isCompleted) {
-        task.completer.completeError(_cancelled(task.item, 'Gallery paused'));
+        task.completer.completeError(_cancelled(task.item, reason));
       }
     }
     _pump();

--- a/lib/data/datasources/remote/online_gallery/ai_tag_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/ai_tag_gallery_source_adapter.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';
 import 'dart:math';
@@ -310,8 +311,10 @@ class AiTagGallerySourceAdapter implements GallerySourceAdapter {
       // Some works contain many embedded metadata blobs. Keep JSON metadata
       // parsing off the UI isolate so a completed detail request cannot stall
       // an active masonry-grid fling.
-      final parsedBatch = await Isolate.run(
-        () => _parseAiTagMediaRows(copiedImageRows, config.assetBaseUrl),
+      final parsedBatch = await _parseAiTagMediaRowsCancellable(
+        copiedImageRows,
+        config.assetBaseUrl,
+        cancelToken,
       );
       if (cancelToken?.isCancelled ?? false) {
         throw DioException.requestCancelled(
@@ -881,6 +884,85 @@ String? _normalizeAiTagAssetBaseUrl(String raw) {
     port: uri.hasPort ? uri.port : null,
     pathSegments: pathSegments,
   ).toString();
+}
+
+Future<_ParsedAiTagMediaBatch> _parseAiTagMediaRowsCancellable(
+  List<Map<String, dynamic>> rows,
+  String assetBaseUrl,
+  CancelToken? cancelToken,
+) async {
+  if (cancelToken?.isCancelled ?? false) {
+    throw DioException.requestCancelled(
+      requestOptions: RequestOptions(path: '/api/work'),
+      reason: cancelToken?.cancelError,
+    );
+  }
+
+  final resultPort = ReceivePort();
+  final errorPort = ReceivePort();
+  final exitPort = ReceivePort();
+  final completer = Completer<_ParsedAiTagMediaBatch>();
+  final resultSubscription = resultPort.listen((message) {
+    if (!completer.isCompleted && message is _ParsedAiTagMediaBatch) {
+      completer.complete(message);
+    }
+  });
+  final errorSubscription = errorPort.listen((message) {
+    if (completer.isCompleted) return;
+    final values = message is List ? message : const [];
+    completer.completeError(
+      RemoteError(
+        values.isNotEmpty ? values.first.toString() : 'AI TAG parse failed',
+        values.length > 1 ? values[1].toString() : '',
+      ),
+    );
+  });
+  final exitSubscription = exitPort.listen((_) {
+    scheduleMicrotask(() {
+      if (!completer.isCompleted) {
+        completer.completeError(
+          StateError('AI TAG metadata parser exited without a result'),
+        );
+      }
+    });
+  });
+  Isolate? isolate;
+  try {
+    isolate = await Isolate.spawn<List<Object?>>(
+      _parseAiTagMediaRowsEntry,
+      [resultPort.sendPort, rows, assetBaseUrl],
+      onError: errorPort.sendPort,
+      onExit: exitPort.sendPort,
+      errorsAreFatal: true,
+    );
+    if (cancelToken != null) {
+      final activeIsolate = isolate;
+      unawaited(
+        cancelToken.whenCancel.then((error) {
+          if (!completer.isCompleted) {
+            activeIsolate.kill(priority: Isolate.immediate);
+            completer.completeError(error);
+          }
+        }),
+      );
+    }
+    return await completer.future;
+  } finally {
+    isolate?.kill(priority: Isolate.immediate);
+    await resultSubscription.cancel();
+    await errorSubscription.cancel();
+    await exitSubscription.cancel();
+    resultPort.close();
+    errorPort.close();
+    exitPort.close();
+  }
+}
+
+void _parseAiTagMediaRowsEntry(List<Object?> message) {
+  final port = message[0] as SendPort;
+  final rows = (message[1] as List).cast<Map<String, dynamic>>();
+  final assetBaseUrl = message[2] as String;
+  port.send(_parseAiTagMediaRows(rows, assetBaseUrl));
 }
 
 _ParsedAiTagMediaBatch _parseAiTagMediaRows(

--- a/lib/data/models/online_gallery/gallery_source.dart
+++ b/lib/data/models/online_gallery/gallery_source.dart
@@ -244,7 +244,7 @@ gallerySourceCapabilities = {
     randomFeeds: {GalleryFeedKind.search, GalleryFeedKind.ranking},
     tagSearch: GalleryTagSearchCapabilities(
       strategy: GalleryTagSearchStrategy.fixedSeedResidual,
-      anonymousLimit: 1,
+      anonymousLimit: 6,
       listTagsComplete: false,
       supportsNegativePushdown: false,
       rankingAppliesOrdinaryQuery: true,

--- a/lib/presentation/agent_chat/services/online_gallery_toolbox.dart
+++ b/lib/presentation/agent_chat/services/online_gallery_toolbox.dart
@@ -50,6 +50,7 @@ class OnlineGalleryToolbox {
     label: 'Browse Online Gallery',
     description:
         'Browse an online gallery and return structured stable resource_ref objects only; this tool never displays images. '
+        'When source is omitted, the request uses danbooru; an explicit valid source is always respected. '
         'A query may contain at most 6 ordinary tags globally. Sources can enforce lower server limits, so the client pushes down a supported seed and applies remaining tags as residual local filters. '
         'When random=true, limit=N means randomly sample exactly N items from the matching feed (when available); never fetch a larger page and choose items yourself. '
         'To show returned media, pass 1-12 resource_ref objects to display_images.',
@@ -58,6 +59,8 @@ class OnlineGalleryToolbox {
         'source': {
           'type': 'string',
           'enum': GallerySourceId.values.map((value) => value.key).toList(),
+          'description':
+              'Defaults to danbooru when omitted; explicit valid values select their matching adapter.',
         },
         'mode': {
           'type': 'string',
@@ -100,44 +103,58 @@ class OnlineGalleryToolbox {
               'Maximum returned items. With random=true this is the requested random sample size, not a candidate-page size.',
         },
       },
-      required: const ['source', 'mode'],
+      required: const ['mode'],
     ),
-    executeFn: (_, params) async {
-      final source = _source(params['source']);
-      if (source == null) {
-        return agentToolError('unknown_source', 'Unknown gallery source.');
-      }
-      final mode = params['mode'] as String;
-      final capabilities = source.capabilities;
-      if ((mode == 'ranking' && !capabilities.supportsRanking) ||
-          (mode == 'favorites' && !capabilities.supportsFavorites)) {
-        return agentToolError(
-          'unsupported_mode',
-          '${source.label} does not support $mode.',
-        );
-      }
-      final query = GalleryTagQueryParser.parse(
-        params['query'] as String? ?? '',
+    executeWithControl: (_, params, signal, __) =>
+        _executeBrowse(params, signal),
+  );
+
+  Future<AgentToolResult> _executeBrowse(
+    Map<String, dynamic> params,
+    AbortSignal? signal,
+  ) async {
+    final source = _browseSource(params['source']);
+    if (source == null) {
+      return agentToolError('unknown_source', 'Unknown gallery source.');
+    }
+    final mode = params['mode'] as String;
+    final capabilities = source.capabilities;
+    if ((mode == 'ranking' && !capabilities.supportsRanking) ||
+        (mode == 'favorites' && !capabilities.supportsFavorites)) {
+      return agentToolError(
+        'unsupported_mode',
+        '${source.label} does not support $mode.',
       );
-      if (!query.isValid) {
-        return agentToolError(
-          'too_many_query_tags',
-          'Online gallery queries support at most $maxGallerySearchTags ordinary tags; received ${query.ordinaryTagCount}.',
-        );
-      }
-      final feed = switch (mode) {
-        'ranking' => GalleryFeedKind.ranking,
-        'favorites' => GalleryFeedKind.favorites,
-        _ => GalleryFeedKind.search,
-      };
-      if (params['random'] == true && !capabilities.supportsRandomFeed(feed)) {
-        return agentToolError(
-          'unsupported_random_feed',
-          '${source.label} does not support random ${feed.name} results.',
-        );
-      }
-      final notifier = _ref.read(onlineGalleryNotifierProvider.notifier);
-      return notifier.runWithExplicitNetworkAccess(() async {
+    }
+    final query = GalleryTagQueryParser.parse(params['query'] as String? ?? '');
+    if (!query.isValid) {
+      return agentToolError(
+        'too_many_query_tags',
+        'Online gallery queries support at most $maxGallerySearchTags ordinary tags; received ${query.ordinaryTagCount}.',
+      );
+    }
+    final feed = switch (mode) {
+      'ranking' => GalleryFeedKind.ranking,
+      'favorites' => GalleryFeedKind.favorites,
+      _ => GalleryFeedKind.search,
+    };
+    if (params['random'] == true && !capabilities.supportsRandomFeed(feed)) {
+      return agentToolError(
+        'unsupported_random_feed',
+        '${source.label} does not support random ${feed.name} results.',
+      );
+    }
+
+    final notifier = _ref.read(onlineGalleryNotifierProvider.notifier);
+    void abortGallery(String? reason) => notifier.cancelActiveRequests(
+      reason: reason ?? 'Agent gallery tool cancelled',
+      cancelDetails: true,
+    );
+
+    signal?.addListener(abortGallery);
+    try {
+      throwIfAborted(signal);
+      return await notifier.runWithExplicitNetworkAccess(() async {
         final limit = (params['limit'] as int? ?? 30).clamp(1, 100);
         if (params['load_more'] == true) {
           final state = _ref.read(onlineGalleryNotifierProvider);
@@ -149,8 +166,9 @@ class OnlineGalleryToolbox {
           }
           await notifier.loadMore();
         } else {
-          await _configureBrowse(notifier, source, mode, params);
+          await _configureBrowse(notifier, source, mode, params, signal);
         }
+        throwIfAborted(signal);
         var state = _ref.read(onlineGalleryNotifierProvider);
         if (state.errorCode != null || state.error != null) {
           return agentToolError(
@@ -162,6 +180,7 @@ class OnlineGalleryToolbox {
           while (state.posts.length < limit && state.hasMore) {
             final previousCount = state.posts.length;
             await notifier.loadMore();
+            throwIfAborted(signal);
             state = _ref.read(onlineGalleryNotifierProvider);
             if (state.errorCode != null || state.error != null) {
               return agentToolError(
@@ -183,6 +202,7 @@ class OnlineGalleryToolbox {
             );
           }
         }
+        throwIfAborted(signal);
         return agentToolJsonResult({
           'ok': true,
           'source': source.key,
@@ -197,27 +217,31 @@ class OnlineGalleryToolbox {
           ],
         });
       });
-    },
-  );
+    } finally {
+      signal?.removeListener(abortGallery);
+    }
+  }
 
   DefinedAgentTool _searchCompatibility() => DefinedAgentTool(
     name: 'search_online_gallery',
     label: 'Search Online Gallery',
     description:
-        'Compatibility search entry point; use browse_online_gallery for all modes and filters.',
+        'Compatibility search entry point; source defaults to danbooru when omitted. Use browse_online_gallery for all modes and filters.',
     parameters: toolboxObject(
       properties: {
         'source': {
           'type': 'string',
           'enum': GallerySourceId.values.map((value) => value.key).toList(),
+          'description':
+              'Defaults to danbooru when omitted; explicit valid values select their matching adapter.',
         },
         'query': {'type': 'string'},
         'limit': {'type': 'integer', 'minimum': 1, 'maximum': 100},
       },
-      required: const ['source', 'query'],
+      required: const ['query'],
     ),
-    executeFn: (id, params) =>
-        _browse().execute(id, {...params, 'mode': 'search'}),
+    executeWithControl: (id, params, signal, onUpdate) =>
+        _browse().execute(id, {...params, 'mode': 'search'}, signal, onUpdate),
   );
 
   DefinedAgentTool _detail() => DefinedAgentTool(
@@ -226,7 +250,7 @@ class OnlineGalleryToolbox {
     description:
         'Load complete metadata and character prompts for a currently browsed stable work.',
     parameters: _identitySchema,
-    executeFn: (_, params) async {
+    executeWithControl: (_, params, signal, __) async {
       final item = _find(params);
       if (item == null) {
         return agentToolError(
@@ -235,38 +259,47 @@ class OnlineGalleryToolbox {
         );
       }
       final notifier = _ref.read(onlineGalleryNotifierProvider.notifier);
-      return notifier.runWithExplicitNetworkAccess(() async {
-        final detail = await notifier.loadDetail(item);
-        return agentToolJsonResult({
-          'ok': true,
-          'item': _itemJson(detail.item),
-          'prompt': detail.prompt,
-          'negative_prompt': detail.negativePrompt,
-          'description': detail.description,
-          'tags': detail.rawTags,
-          'character_prompts': [
-            for (final value in detail.characterPrompts)
-              {
-                'label': value.label,
-                'prompt': value.prompt,
-                'negative_prompt': value.negativePrompt,
-              },
-          ],
-          'contributors': [
-            for (final contributor in detail.contributors)
-              {'name': contributor.name, 'role': contributor.role},
-          ],
-          'media': [
-            for (final media in detail.media)
-              _mediaJson(
-                media,
-                source: detail.item.sourceId,
-                workId: detail.item.sourceWorkId,
-                title: detail.item.title,
-              ),
-          ],
+      void abortDetail(String? _) => notifier.cancelDetail(item);
+
+      signal?.addListener(abortDetail);
+      try {
+        throwIfAborted(signal);
+        return await notifier.runWithExplicitNetworkAccess(() async {
+          final detail = await notifier.loadDetail(item);
+          throwIfAborted(signal);
+          return agentToolJsonResult({
+            'ok': true,
+            'item': _itemJson(detail.item),
+            'prompt': detail.prompt,
+            'negative_prompt': detail.negativePrompt,
+            'description': detail.description,
+            'tags': detail.rawTags,
+            'character_prompts': [
+              for (final value in detail.characterPrompts)
+                {
+                  'label': value.label,
+                  'prompt': value.prompt,
+                  'negative_prompt': value.negativePrompt,
+                },
+            ],
+            'contributors': [
+              for (final contributor in detail.contributors)
+                {'name': contributor.name, 'role': contributor.role},
+            ],
+            'media': [
+              for (final media in detail.media)
+                _mediaJson(
+                  media,
+                  source: detail.item.sourceId,
+                  workId: detail.item.sourceWorkId,
+                  title: detail.item.title,
+                ),
+            ],
+          });
         });
-      });
+      } finally {
+        signal?.removeListener(abortDetail);
+      }
     },
   );
 
@@ -390,52 +423,57 @@ class OnlineGalleryToolbox {
     GallerySourceId source,
     String mode,
     Map<String, dynamic> params,
+    AbortSignal? signal,
   ) async {
     final ratings = toolboxStrings(params['ratings']);
     final random = params['random'] as bool? ?? false;
-    // A prior random session belongs to its original query and source. Leave it
-    // before configuring a new request so enabling random always resamples.
-    await notifier.setRandomEnabled(false);
-    await notifier.setRatings(ratings.toSet());
-    await notifier.setFuzzySearchEnabled(params['fuzzy'] as bool? ?? false);
-    if (mode == 'ranking') {
-      await notifier.setPopularSource(source);
-      await notifier.switchToPopular();
-      final scaleName = params['ranking_scale'] as String?;
-      if (scaleName != null) {
-        await notifier.setPopularScale(
-          PopularScale.values.firstWhere((value) => value.name == scaleName),
+    await notifier.runWithDeferredLoading(() async {
+      // A prior random session belongs to its original query and source. Leave
+      // it before configuring a new request so enabling random resamples.
+      await notifier.setRandomEnabled(false);
+      await notifier.setRatings(ratings.toSet());
+      await notifier.setFuzzySearchEnabled(params['fuzzy'] as bool? ?? false);
+      if (mode == 'ranking') {
+        await notifier.setPopularSource(source);
+        await notifier.switchToPopular();
+        final scaleName = params['ranking_scale'] as String?;
+        if (scaleName != null) {
+          await notifier.setPopularScale(
+            PopularScale.values.firstWhere((value) => value.name == scaleName),
+          );
+        }
+        final date = params['ranking_date'] as String?;
+        if (date != null) await notifier.setPopularDate(DateTime.parse(date));
+        if (params['ai_tag_period'] case final String period) {
+          await notifier.setAiTagPopularPeriod(period);
+        }
+        await notifier.searchPopular(
+          query: params['query'] as String? ?? '',
+          prompt: params['prompt'] as String? ?? '',
         );
-      }
-      final date = params['ranking_date'] as String?;
-      if (date != null) await notifier.setPopularDate(DateTime.parse(date));
-      if (params['ai_tag_period'] case final String period) {
-        await notifier.setAiTagPopularPeriod(period);
-      }
-      await notifier.searchPopular(
-        query: params['query'] as String? ?? '',
-        prompt: params['prompt'] as String? ?? '',
-      );
-    } else if (mode == 'favorites') {
-      await notifier.setFavoritesSource(source);
-      await notifier.switchToFavorites();
-      await notifier.searchFavorites(params['query'] as String? ?? '');
-    } else {
-      await notifier.setSource(source);
-      await notifier.switchToSearch();
-      if (params['ai_tag_time_range'] case final String range) {
-        await notifier.setAiTagTimeRange(range);
-      }
-      if ((params['prompt'] as String? ?? '').isNotEmpty) {
-        await notifier.searchWithPrompt(
-          params['query'] as String? ?? '',
-          prompt: params['prompt'] as String,
-        );
+      } else if (mode == 'favorites') {
+        await notifier.setFavoritesSource(source);
+        await notifier.switchToFavorites();
+        await notifier.searchFavorites(params['query'] as String? ?? '');
       } else {
-        await notifier.search(params['query'] as String? ?? '');
+        await notifier.setSource(source);
+        await notifier.switchToSearch();
+        if (params['ai_tag_time_range'] case final String range) {
+          await notifier.setAiTagTimeRange(range);
+        }
+        if ((params['prompt'] as String? ?? '').isNotEmpty) {
+          await notifier.searchWithPrompt(
+            params['query'] as String? ?? '',
+            prompt: params['prompt'] as String,
+          );
+        } else {
+          await notifier.search(params['query'] as String? ?? '');
+        }
       }
-    }
-    if (random) await notifier.setRandomEnabled(true);
+      if (random) await notifier.setRandomEnabled(true);
+    });
+    throwIfAborted(signal);
+    await notifier.loadPosts(refresh: true);
   }
 
   GalleryItem? _find(Map<String, dynamic> params) {
@@ -449,6 +487,9 @@ class OnlineGalleryToolbox {
         .firstOrNull;
   }
 }
+
+GallerySourceId? _browseSource(dynamic value) =>
+    value == null ? GallerySourceId.danbooru : _source(value);
 
 GallerySourceId? _source(dynamic value) =>
     GallerySourceId.values.where((source) => source.key == value).firstOrNull;

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -113,6 +113,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   int _loadMoreClaimRevision = 0;
   bool _backgroundNetworkPaused = false;
   int _explicitNetworkAccessCount = 0;
+  int _deferredLoadCount = 0;
   bool _resumeInitialLoadAfterBackgroundPause = false;
   bool _resumeAppendAfterBackgroundPause = false;
 
@@ -136,6 +137,31 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
       if (_explicitNetworkAccessCount == 0) {
         _detailCoordinator?.setBackgroundPaused(_backgroundNetworkPaused);
       }
+    }
+  }
+
+  Future<T> runWithDeferredLoading<T>(Future<T> Function() action) async {
+    _deferredLoadCount++;
+    try {
+      return await action();
+    } finally {
+      _deferredLoadCount--;
+    }
+  }
+
+  void cancelActiveRequests({
+    String reason = 'Gallery request cancelled',
+    bool cancelDetails = false,
+  }) {
+    _loadCoordinator.cancel(reason);
+    _loadMoreClaimRevision++;
+    _loadMoreClaimed = false;
+    _detailRequestScopeRevision++;
+    if (cancelDetails) {
+      _detailCoordinator?.cancelVisible(reason: reason);
+    }
+    if (state.isLoading || state.isLoadingMore) {
+      state = state.copyWith(isLoading: false, isLoadingMore: false);
     }
   }
 
@@ -379,6 +405,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     bool restart = false,
   }) async {
     if (_networkRequestsPaused ||
+        _deferredLoadCount > 0 ||
         !state.randomEnabled ||
         !state.supportsRandom) {
       return;
@@ -831,7 +858,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   }
 
   Future<void> loadPosts({bool refresh = false}) async {
-    if (_networkRequestsPaused) return;
+    if (_networkRequestsPaused || _deferredLoadCount > 0) return;
     if (state.randomEnabled) {
       await _loadRandom(replace: refresh);
       return;

--- a/test/core/cache/online_gallery_detail_coordinator_test.dart
+++ b/test/core/cache/online_gallery_detail_coordinator_test.dart
@@ -235,6 +235,38 @@ void main() {
   );
 
   test(
+    'cancelVisible stops active visible detail and keeps retryable',
+    () async {
+      final item = _item(8);
+      var calls = 0;
+      var loaderCancelled = false;
+      final coordinator = OnlineGalleryDetailCoordinator(
+        loader: (requested, cancelToken) async {
+          calls++;
+          if (calls == 1) {
+            final error = await cancelToken.whenCancel;
+            loaderCancelled = true;
+            throw error;
+          }
+          return _detail(requested, 'after-cancel');
+        },
+      );
+
+      final active = coordinator.request(
+        item,
+        priority: GalleryDetailPriority.visible,
+      );
+      coordinator.cancelVisible(reason: 'agent stopped');
+
+      await expectLater(active, throwsA(isA<DioException>()));
+      await Future<void>.delayed(Duration.zero);
+      expect(loaderCancelled, isTrue);
+      expect((await coordinator.request(item)).description, 'after-cancel');
+      expect(calls, 2);
+    },
+  );
+
+  test(
     'obsolete force-refresh failure cannot remove the newer request',
     () async {
       final item = _item(1);

--- a/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
+++ b/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
@@ -714,6 +714,53 @@ void main() {
       expect(detail.item.tagsComplete, isFalse);
     });
 
+    test('cancels a detail while media metadata is being decoded', () async {
+      final cancelToken = CancelToken();
+      final http = _RecordingHttpAdapter((request) {
+        if (request.uri.path == '/api/config') return _configJson;
+        if (request.uri.path == '/api/work/503') {
+          Timer(
+            const Duration(milliseconds: 5),
+            () => cancelToken.cancel('Agent stopped'),
+          );
+          return {
+            'work': _aiWork(503),
+            'images': [
+              for (var index = 0; index < 10000; index++)
+                _aiImage('503_p$index'),
+            ],
+          };
+        }
+        throw StateError('Unexpected request ${request.uri}');
+      });
+      final adapter = AiTagGallerySourceAdapter(
+        dio: Dio()..httpClientAdapter = http,
+      );
+      const item = GalleryItem(
+        id: 503,
+        sourceId: GallerySourceId.aiTag,
+        createdAt: '',
+        uploaderId: 9,
+        cover: GalleryMedia(
+          id: 'pending',
+          previewUrl: '',
+          displayUrl: '',
+          downloadUrl: '',
+        ),
+      );
+
+      await expectLater(
+        adapter.detail(item, cancelToken: cancelToken),
+        throwsA(
+          isA<DioException>().having(
+            (error) => error.type,
+            'type',
+            DioExceptionType.cancel,
+          ),
+        ),
+      );
+    });
+
     test(
       'normalizes NovelAI and SD prompt weights into searchable tags',
       () async {

--- a/test/presentation/agent_chat/services/online_gallery_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/online_gallery_toolbox_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -24,11 +26,15 @@ void main() {
 
   AgentTool tool(String name) => tools.singleWhere((tool) => tool.name == name);
 
-  test('browse contract defines bounded tags and random sample limit', () {
+  test('browse contract defines bounded tags and danbooru default', () {
     final browse = tool('browse_online_gallery');
     final properties = browse.parameters['properties'] as Map;
+    final required = browse.parameters['required'] as List;
 
     expect(browse.description, contains('at most 6 ordinary tags'));
+    expect(browse.description, contains('source is omitted'));
+    expect(required, isNot(contains('source')));
+    expect(properties['source']['description'], contains('danbooru'));
     expect(browse.description, contains('random=true, limit=N'));
     expect(browse.description, contains('display_images'));
     expect(properties['query']['description'], contains('at most 6'));
@@ -117,7 +123,257 @@ void main() {
     expect((result.details['items'] as List), hasLength(1));
     expect(adapter.queries, ['blue_archive']);
   });
+
+  test(
+    'screenshot AI TAG parameters complete with one configured load',
+    () async {
+      final aiTag = _ScriptedGalleryAdapter(
+        GallerySourceId.aiTag,
+        (request, _) async => _page(request, [
+          _item(GallerySourceId.aiTag, 101, const ['ibuki', 'blue', 'archive']),
+        ]),
+      );
+      final danbooru = _ScriptedGalleryAdapter(
+        GallerySourceId.danbooru,
+        (request, _) async => _page(request, const []),
+      );
+      final harness = _createHarness({
+        GallerySourceId.aiTag: aiTag,
+        GallerySourceId.danbooru: danbooru,
+      });
+      addTearDown(harness.container.dispose);
+
+      final result = await harness.browse.execute('screenshot', {
+        'source': 'ai_tag',
+        'mode': 'search',
+        'query': 'ibuki blue archive',
+        'ratings': ['s'],
+        'limit': 6,
+      });
+
+      expect(result.isError, isFalse);
+      expect(result.details['source'], 'ai_tag');
+      expect(result.details['requested_limit'], 6);
+      expect(result.details['items'], hasLength(1));
+      expect(aiTag.requests, hasLength(1));
+      expect(aiTag.requests.single.query, 'archive blue ibuki');
+      expect(
+        harness.container.read(onlineGalleryNotifierProvider).searchQuery,
+        'ibuki blue archive',
+      );
+      expect(danbooru.requests, isEmpty);
+    },
+  );
+
+  test('omitted source uses danbooru adapter', () async {
+    final danbooru = _ScriptedGalleryAdapter(
+      GallerySourceId.danbooru,
+      (request, _) async => _page(request, const []),
+    );
+    final aiTag = _ScriptedGalleryAdapter(
+      GallerySourceId.aiTag,
+      (request, _) async => _page(request, const []),
+    );
+    final harness = _createHarness({
+      GallerySourceId.danbooru: danbooru,
+      GallerySourceId.aiTag: aiTag,
+    });
+    addTearDown(harness.container.dispose);
+
+    final result = await harness.browse.execute('default-source', {
+      'mode': 'search',
+      'query': 'ibuki',
+    });
+
+    expect(result.isError, isFalse);
+    expect(result.details['source'], 'danbooru');
+    expect(danbooru.requests, hasLength(1));
+    expect(aiTag.requests, isEmpty);
+  });
+
+  test(
+    'explicit source selects its adapter and empty results complete',
+    () async {
+      final gelbooru = _ScriptedGalleryAdapter(
+        GallerySourceId.gelbooru,
+        (request, _) async => _page(request, const []),
+      );
+      final danbooru = _ScriptedGalleryAdapter(
+        GallerySourceId.danbooru,
+        (request, _) async => _page(request, const []),
+      );
+      final harness = _createHarness({
+        GallerySourceId.gelbooru: gelbooru,
+        GallerySourceId.danbooru: danbooru,
+      });
+      addTearDown(harness.container.dispose);
+
+      final result = await harness.browse.execute('explicit-source', {
+        'source': 'gelbooru',
+        'mode': 'search',
+        'query': 'nothing',
+      });
+
+      expect(result.isError, isFalse);
+      expect(result.details['source'], 'gelbooru');
+      expect(result.details['items'], isEmpty);
+      expect(gelbooru.requests, hasLength(1));
+      expect(danbooru.requests, isEmpty);
+    },
+  );
+
+  test('network and parse errors complete with diagnostic result', () async {
+    for (final code in [
+      GallerySourceErrorCode.network,
+      GallerySourceErrorCode.malformedResponse,
+    ]) {
+      final adapter = _ScriptedGalleryAdapter(
+        GallerySourceId.aiTag,
+        (_, __) => throw GallerySourceException(
+          code,
+          source: GallerySourceId.aiTag,
+          message: 'diagnostic ${code.name}',
+        ),
+      );
+      final harness = _createHarness({GallerySourceId.aiTag: adapter});
+      addTearDown(harness.container.dispose);
+
+      final result = await harness.browse.execute('error-${code.name}', {
+        'source': 'ai_tag',
+        'mode': 'search',
+        'query': 'ibuki',
+      });
+
+      expect(result.isError, isTrue);
+      expect(result.details['code'], code.name);
+    }
+  });
+
+  test('stop cancels network, exits loading, and permits a new call', () async {
+    final adapter = _CancellableGalleryAdapter();
+    final harness = _createHarness({GallerySourceId.aiTag: adapter});
+    addTearDown(harness.container.dispose);
+    final firstAbort = AbortController();
+
+    final first = harness.browse.execute('cancel-first', {
+      'source': 'ai_tag',
+      'mode': 'search',
+      'query': 'ibuki blue archive',
+    }, firstAbort.signal);
+    await adapter.firstStarted.future;
+    firstAbort.abort('user stopped');
+
+    await expectLater(first, throwsA(anything));
+    expect(adapter.cancelledRequests, 1);
+    expect(
+      harness.container.read(onlineGalleryNotifierProvider).isLoading,
+      isFalse,
+    );
+
+    final second = await harness.browse.execute('after-stop', {
+      'source': 'ai_tag',
+      'mode': 'search',
+      'query': 'second',
+    });
+    expect(second.isError, isFalse);
+    expect((second.details['items'] as List).single['work_id'], '202');
+
+    adapter.completeLateFirst();
+    await Future<void>.delayed(Duration.zero);
+    final state = harness.container.read(onlineGalleryNotifierProvider);
+    expect(state.posts.single.id, 202);
+  });
+
+  test(
+    'duplicate append page terminates and other source remains usable',
+    () async {
+      final item = _item(GallerySourceId.gelbooru, 303, const ['ibuki']);
+      final adapter = _ScriptedGalleryAdapter(
+        GallerySourceId.gelbooru,
+        (request, _) async => GalleryPage(
+          items: [item],
+          cursor: request.cursor,
+          nextCursor: '${int.parse(request.cursor) + 1}',
+          hasMore: true,
+          total: 10,
+          rawItemCount: 1,
+        ),
+      );
+      final harness = _createHarness({GallerySourceId.gelbooru: adapter});
+      addTearDown(harness.container.dispose);
+
+      final first = await harness.browse.execute('duplicate-first', {
+        'source': 'gelbooru',
+        'mode': 'search',
+        'query': 'ibuki',
+      });
+      final second = await harness.browse.execute('duplicate-next', {
+        'source': 'gelbooru',
+        'mode': 'search',
+        'query': 'ibuki',
+        'load_more': true,
+      });
+
+      expect(first.isError, isFalse);
+      expect(second.isError, isFalse);
+      expect(second.details['has_more'], isFalse);
+      expect(adapter.requests, hasLength(2));
+    },
+  );
 }
+
+({ProviderContainer container, AgentTool browse}) _createHarness(
+  Map<GallerySourceId, GallerySourceAdapter> overrides,
+) {
+  final container = ProviderContainer(
+    overrides: [
+      localStorageServiceProvider.overrideWithValue(_MemoryStorage()),
+      onlineGalleryTagMetadataLoaderProvider.overrideWithValue(
+        (_) async => const {},
+      ),
+      onlineGallerySourceAdaptersProvider.overrideWithValue({
+        for (final source in GallerySourceId.values)
+          source: overrides[source] ?? _EmptyGalleryAdapter(source),
+      }),
+    ],
+  );
+  final browse = OnlineGalleryToolbox(
+    container.read(_refProvider),
+  ).tools().singleWhere((tool) => tool.name == 'browse_online_gallery');
+  return (container: container, browse: browse);
+}
+
+GalleryPage _page(GallerySearchRequest request, List<GalleryItem> items) =>
+    GalleryPage(
+      items: items,
+      cursor: request.cursor,
+      nextCursor: null,
+      hasMore: false,
+      total: items.length,
+      rawItemCount: items.length,
+    );
+
+GalleryItem _item(GallerySourceId source, int id, List<String> tags) =>
+    GalleryItem(
+      id: id,
+      sourceId: source,
+      createdAt: '2026-08-30',
+      uploaderId: 1,
+      width: 768,
+      height: 1024,
+      rating: 'g',
+      tags: tags,
+      tagsComplete: true,
+      cover: GalleryMedia(
+        id: '$id',
+        previewUrl: 'https://example.test/$id-preview.webp',
+        displayUrl: 'https://example.test/$id.webp',
+        downloadUrl: 'https://example.test/$id.webp',
+        width: 768,
+        height: 1024,
+        extension: 'webp',
+      ),
+    );
 
 class _MemoryStorage extends LocalStorageService {
   final Map<String, Object?> _values = {};
@@ -174,6 +430,67 @@ class _ToolGalleryAdapter extends GallerySourceAdapter {
       nextCursor: null,
       hasMore: false,
       rawItemCount: 1,
+    );
+  }
+}
+
+class _ScriptedGalleryAdapter extends GallerySourceAdapter {
+  _ScriptedGalleryAdapter(this.sourceId, this.handler);
+
+  @override
+  final GallerySourceId sourceId;
+  final FutureOr<GalleryPage> Function(
+    GallerySearchRequest request,
+    CancelToken? cancelToken,
+  )
+  handler;
+  final List<GallerySearchRequest> requests = [];
+
+  @override
+  Future<GalleryPage> search(
+    GallerySearchRequest request, {
+    CancelToken? cancelToken,
+  }) async {
+    requests.add(request);
+    return handler(request, cancelToken);
+  }
+}
+
+class _CancellableGalleryAdapter extends GallerySourceAdapter {
+  final firstStarted = Completer<void>();
+  final Completer<GalleryPage> _lateFirst = Completer<GalleryPage>();
+  int calls = 0;
+  int cancelledRequests = 0;
+
+  @override
+  GallerySourceId get sourceId => GallerySourceId.aiTag;
+
+  @override
+  Future<GalleryPage> search(
+    GallerySearchRequest request, {
+    CancelToken? cancelToken,
+  }) async {
+    calls++;
+    if (calls > 1) {
+      return _page(request, [
+        _item(sourceId, 202, const ['second']),
+      ]);
+    }
+    firstStarted.complete();
+    return Future.any([
+      _lateFirst.future,
+      cancelToken!.whenCancel.then<GalleryPage>((error) {
+        cancelledRequests++;
+        throw error;
+      }),
+    ]);
+  }
+
+  void completeLateFirst() {
+    _lateFirst.complete(
+      _page(const GallerySearchRequest(cursor: '1', pageSize: 60), [
+        _item(sourceId, 201, const ['ibuki', 'blue', 'archive']),
+      ]),
     );
   }
 }


### PR DESCRIPTION
## 用户可见变化
- 修复 Agent 调用在线画廊时长期停留在“调用工具中”的问题；AI TAG 多标签搜索现在一次配置后只发起最终查询，并将最多 6 个标签完整下推到 AI TAG。
- Agent 的停止操作会真实取消当前画廊列表请求、分页请求、可见详情补全和 AI TAG metadata isolate，退出加载状态；停止后可继续发消息并再次调用，迟到结果不会覆盖新调用。
- `browse_online_gallery` 与兼容搜索工具省略 `source` 时统一默认 `danbooru`；显式 `ai_tag`、`gelbooru` 等合法来源仍路由到对应 adapter。
- 网络失败与响应解析失败返回结构化错误；空结果、重复分页和取消均可确定结束。

## 根因
- Tool 逐项调用来源、模式、评级、模糊搜索、时间范围等 setter；每个 setter 都可能立即触发加载，单次 Agent 调用叠加了多轮相互取消但仍在清理的请求。
- AI TAG 被错误声明为只能下推 1 个普通标签。`ibuki blue archive` 实际只向上游发送宽泛的 `archive`，再对大量作品逐个加载详情做剩余标签过滤，造成长时间网络与 metadata 解析。
- Tool 没有消费 Agent runtime 已传入的 `AbortSignal`；AI TAG 使用的 `Isolate.run` 也无法在停止时终止 isolate。

## 实现
- 新增 notifier 的 deferred-loading 配置作用域，配置完成后只执行一次最终加载。
- 按 AI TAG 真实 API 契约将 server tag limit 修正为 6，保留现有完整本地校验和超过来源能力时的 residual 机制。
- 将 AbortSignal 接入 browse/detail Tool，贯通请求 coordinator、分页 revision、可见详情 coordinator 与 AI TAG cancellable isolate，并保证端口、subscription 和 isolate 在成功、失败、取消及 spawn 失败时清理。
- schema、参数解析、描述与测试统一 `danbooru` 默认来源。

## 验证
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run_flutter_tests.ps1 -Path "test/presentation/agent_chat/services/online_gallery_toolbox_test.dart,test/core/cache/online_gallery_detail_coordinator_test.dart,test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart,test/presentation/providers/online_gallery_pagination_test.dart,test/core/agent/agent_loop_test.dart" -TimeoutSeconds 180 -Concurrency 4`：99 tests passed
- 后续取消链路复核：Toolbox + detail coordinator + adapter 44 tests passed
- 最终 Toolbox 回归：11 tests passed
- 真实 AI TAG 契约复现（`source=ai_tag, mode=search, query="ibuki blue archive", ratings=["s"], limit=6`）：成功返回，耗时 1644 ms
- `flutter analyze`：本次改动无新增问题；仓库既有 `lib/core/agent/context_usage.dart:70` 的 `unnecessary_null_comparison` warning 仍存在
- `git diff --check`：通过

未运行真实 UI 自动化；未发起任何消耗 Anlas 的操作；未更新 CHANGELOG.md。
