### PR TITLE
fix(gallery): 修复 AI TAG 缩略图加载停滞

### DIFF
--- a/lib/core/cache/online_gallery_prefetch_coordinator.dart
+++ b/lib/core/cache/online_gallery_prefetch_coordinator.dart
@@ -66,6 +66,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
   int _generation = 0;
   int _active = 0;
   int _interactiveStreak = 0;
+  bool _notificationScheduled = false;
   bool _disposed = false;
   int debugRequestCount = 0;
   int debugDeduplicatedCount = 0;
@@ -116,7 +117,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
     if (_disposed) return;
     _generation++;
     _cancelWhere((_) => true, reason: 'generation-rotated');
-    notifyListeners();
+    _scheduleNotification();
   }
 
   void setScrolling(bool scrolling) => _setPause(
@@ -151,10 +152,26 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
   /// Downloads already handed to the image pipeline are allowed to finish so
   /// the shared disk cache is not left with a partially consumed response.
   void cancelPending(GalleryImageRequest request) {
-    final task = _pending.remove(request.stableRequestKey);
+    final task = _pending[request.stableRequestKey];
     if (task == null) return;
+    task.coordinatorOwned = false;
+    if (task.consumers.isNotEmpty) return;
+    _pending.remove(request.stableRequestKey);
     _removeFromQueue(task);
     _completeCancelled(task);
+    _scheduleNotification();
+  }
+
+  /// Releases one widget's interest without cancelling a request still used
+  /// by another card or by the moving prefetch window.
+  void releasePending(GalleryImageRequest request, Object consumer) {
+    final task = _pending[request.stableRequestKey];
+    if (task == null || !task.consumers.remove(consumer)) return;
+    if (task.coordinatorOwned || task.consumers.isNotEmpty) return;
+    _pending.remove(request.stableRequestKey);
+    _removeFromQueue(task);
+    _completeCancelled(task);
+    _scheduleNotification();
   }
 
   /// Keeps the moving thumbnail window bounded while a user scrolls through
@@ -168,20 +185,31 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
               !stableRequestKeys.contains(task.request.stableRequestKey),
         )
         .toList(growable: false);
+    var cancelled = false;
     for (final task in stale) {
+      task.coordinatorOwned = false;
+      if (task.consumers.isNotEmpty) continue;
       _pending.remove(task.request.stableRequestKey);
       _removeFromQueue(task);
       _completeCancelled(task);
+      cancelled = true;
     }
+    if (cancelled) _scheduleNotification();
   }
 
   Future<bool> submit(
     GalleryImageRequest request, {
     required GalleryImagePriority priority,
     bool retry = false,
+    Object? consumer,
   }) {
     if (_disposed || !_accepts(priority)) return Future.value(false);
-    if (retry) _failures.remove(request.stableRequestKey);
+    if (retry) {
+      final key = request.stableRequestKey;
+      _failures.remove(key);
+      _completedThumbnails.remove(key);
+      _completedSamples.remove(key);
+    }
     if (!retry && isNegativelyCached(request)) {
       debugNegativeCacheHitCount++;
       return Future.value(false);
@@ -192,6 +220,11 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
     final key = request.stableRequestKey;
     final existing = _pending[key] ?? _inFlight[key];
     if (existing != null && !existing.cancelled) {
+      if (consumer == null) {
+        existing.coordinatorOwned = true;
+      } else {
+        existing.consumers.add(consumer);
+      }
       debugDeduplicatedCount++;
       if (_pending[key] != null && priority.index < existing.priority.index) {
         _queues[existing.priority]!.remove(existing);
@@ -209,7 +242,9 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
       request: request,
       priority: priority,
       generation: _generation,
+      coordinatorOwned: consumer == null,
     );
+    if (consumer != null) task.consumers.add(consumer);
     _pending[key] = task;
     _queues[priority]!.add(task);
     _pump();
@@ -260,7 +295,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
     } else {
       _pump();
     }
-    notifyListeners();
+    _scheduleNotification();
     AppLogger.d(
       'Gallery prefetch ${paused ? 'paused' : 'resumed'}: '
           'reason=${reason.name}, queue=$queueDepth, active=$activeCount, '
@@ -384,6 +419,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
       if (_inFlight[key] == task) _inFlight.remove(key);
       _active--;
       _pump();
+      _scheduleNotification();
     }
   }
 
@@ -392,6 +428,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
     required String reason,
   }) {
     var cancelled = 0;
+    var pendingCapacityChanged = false;
     for (final task in _pending.values.toList()) {
       if (!predicate(task)) continue;
       _pending.remove(task.request.stableRequestKey);
@@ -399,6 +436,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
       task.cancelled = true;
       _completeCancelled(task);
       cancelled++;
+      pendingCapacityChanged = true;
     }
     for (final task in _inFlight.values.toList()) {
       if (!predicate(task) || task.cancelled) continue;
@@ -409,12 +447,22 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
     }
     if (cancelled > 0) {
       debugCancelledCount += cancelled;
+      if (pendingCapacityChanged) _scheduleNotification();
       AppLogger.d(
         'Gallery prefetch cancelled: reason=$reason, count=$cancelled, '
             'queue=$queueDepth, active=$activeCount',
         'GalleryPrefetch',
       );
     }
+  }
+
+  void _scheduleNotification() {
+    if (_disposed || _notificationScheduled) return;
+    _notificationScheduled = true;
+    scheduleMicrotask(() {
+      _notificationScheduled = false;
+      if (!_disposed) notifyListeners();
+    });
   }
 
   void _rememberCompleted(GalleryImageRequest request) {
@@ -437,11 +485,14 @@ class _PrefetchTask {
     required this.request,
     required this.priority,
     required this.generation,
+    required this.coordinatorOwned,
   });
 
   final GalleryImageRequest request;
   GalleryImagePriority priority;
   final int generation;
+  bool coordinatorOwned;
+  final Set<Object> consumers = {};
   final Completer<bool> completer = Completer<bool>();
   GalleryImagePreloadOperation? operation;
   bool cancelled = false;

--- a/lib/presentation/screens/online_gallery/gallery_grid_item.dart
+++ b/lib/presentation/screens/online_gallery/gallery_grid_item.dart
@@ -58,6 +58,7 @@ class GalleryGridItem extends StatefulWidget {
     double itemWidth, {
     required double layoutAspectRatio,
     required bool loadMedia,
+    required bool mediaRequestActive,
     GalleryDetail? detail,
   })
   buildCard;
@@ -105,7 +106,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
       setState(() {
         _detailFuture = _loadDetail();
       });
-    } else if (visibilityChanged && _needsDetail) {
+    } else if (visibilityChanged) {
       setState(() {});
     }
   }
@@ -125,6 +126,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
     GalleryItem item,
     double layoutAspectRatio, {
     required bool loadMedia,
+    required bool mediaRequestActive,
     GalleryDetail? detail,
   }) {
     return AgentResourceDragSource(
@@ -146,6 +148,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
         widget.itemWidth,
         layoutAspectRatio: layoutAspectRatio,
         loadMedia: loadMedia,
+        mediaRequestActive: mediaRequestActive,
         detail: detail,
       ),
     );
@@ -171,6 +174,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
               post,
               layoutAspectRatio,
               loadMedia: hasBeenVisible || isVisible,
+              mediaRequestActive: isVisible,
             );
           }
           if (!hasBeenVisible) {
@@ -252,6 +256,7 @@ class _GalleryGridItemState extends State<GalleryGridItem> {
                   resolved,
                   resolvedAspectRatio,
                   loadMedia: true,
+                  mediaRequestActive: isVisible,
                   detail: detail,
                 );
               },

--- a/lib/presentation/screens/online_gallery/online_gallery_content.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_content.dart
@@ -323,6 +323,7 @@ class _OnlineGalleryContentPresenter {
             width, {
             required layoutAspectRatio,
             required loadMedia,
+            required mediaRequestActive,
             detail,
           }) => _buildResolvedPostCard(
             state,
@@ -330,6 +331,7 @@ class _OnlineGalleryContentPresenter {
             width,
             layoutAspectRatio: layoutAspectRatio,
             loadMedia: loadMedia,
+            mediaRequestActive: mediaRequestActive,
             detail: detail,
           ),
     );
@@ -341,6 +343,7 @@ class _OnlineGalleryContentPresenter {
     double itemWidth, {
     required double layoutAspectRatio,
     required bool loadMedia,
+    required bool mediaRequestActive,
     GalleryDetail? detail,
   }) {
     final capabilities = gallerySourceCapabilities[post.sourceId]!;
@@ -418,6 +421,7 @@ class _OnlineGalleryContentPresenter {
           itemWidth: itemWidth,
           layoutAspectRatio: layoutAspectRatio,
           loadMedia: loadMedia,
+          mediaRequestActive: mediaRequestActive,
           isFavorited: isFavorited,
           isFavoriteLoading: favoriteState.$3,
           showFavoriteAction: canWriteFavorite,

--- a/lib/presentation/widgets/danbooru_post_card.dart
+++ b/lib/presentation/widgets/danbooru_post_card.dart
@@ -75,6 +75,7 @@ class DanbooruPostCard extends StatefulWidget {
   final VoidCallback? onHoverDismiss;
   final OnlineGalleryPrefetchCoordinator? imageCoordinator;
   final bool loadMedia;
+  final bool mediaRequestActive;
 
   const DanbooruPostCard({
     super.key,
@@ -108,6 +109,7 @@ class DanbooruPostCard extends StatefulWidget {
     this.onHoverDismiss,
     this.imageCoordinator,
     this.loadMedia = true,
+    this.mediaRequestActive = true,
   });
 
   @override
@@ -444,9 +446,12 @@ class _DanbooruPostCardState extends State<DanbooruPostCard> {
                               placeholder: const OnlineGalleryImagePlaceholder(
                                 loading: true,
                               ),
-                              errorWidget: const OnlineGalleryImagePlaceholder(
-                                failed: true,
-                              ),
+                              enabled: widget.mediaRequestActive,
+                              errorBuilder: (context, retry) =>
+                                  OnlineGalleryImagePlaceholder(
+                                    failed: true,
+                                    onRetry: retry,
+                                  ),
                             )
                           else
                             CachedNetworkImage(

--- a/lib/presentation/widgets/online_gallery/coordinated_gallery_image.dart
+++ b/lib/presentation/widgets/online_gallery/coordinated_gallery_image.dart
@@ -8,6 +8,9 @@ import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
 import '../../../core/utils/app_logger.dart';
 import '../../themes/theme_extension.dart';
 
+typedef GalleryImageErrorBuilder =
+    Widget Function(BuildContext context, VoidCallback retry);
+
 /// Routes gallery image downloads through the shared network QoS coordinator.
 ///
 /// Already decoded pixels remain visible while critical requests pause gallery
@@ -22,6 +25,8 @@ class CoordinatedGalleryImage extends StatefulWidget {
     this.alignment = Alignment.center,
     this.placeholder,
     this.errorWidget,
+    this.errorBuilder,
+    this.enabled = true,
     this.fadeIn = true,
   });
 
@@ -32,6 +37,8 @@ class CoordinatedGalleryImage extends StatefulWidget {
   final AlignmentGeometry alignment;
   final Widget? placeholder;
   final Widget? errorWidget;
+  final GalleryImageErrorBuilder? errorBuilder;
+  final bool enabled;
   final bool fadeIn;
 
   @override
@@ -44,6 +51,7 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
   bool _failed = false;
   bool _requesting = false;
   bool _showImmediately = false;
+  Future<void> _failedImageEviction = Future<void>.value();
   int _revision = 0;
 
   @override
@@ -69,18 +77,24 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
     );
     final requestChanged =
         oldWidget.request.stableRequestKey != widget.request.stableRequestKey;
+    final enabledChanged = oldWidget.enabled != widget.enabled;
     if (coordinatorChanged) {
       oldWidget.coordinator.removeListener(_handleCoordinatorChanged);
       widget.coordinator.addListener(_handleCoordinatorChanged);
     }
-    if (coordinatorChanged || requestChanged) {
+    if (oldWidget.enabled &&
+        (coordinatorChanged || requestChanged || !widget.enabled)) {
+      oldWidget.coordinator.releasePending(oldWidget.request, this);
+    }
+    if (coordinatorChanged || requestChanged || enabledChanged) {
       _revision += 1;
       _requesting = false;
       if (requestChanged) {
         _ready = widget.coordinator.isReady(widget.request);
         _showImmediately = _ready;
         _failed = false;
-      } else if (!_ready) {
+        _failedImageEviction = Future<void>.value();
+      } else if (!_ready && widget.enabled) {
         _failed = false;
       }
       _requestImage();
@@ -91,34 +105,74 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
   void dispose() {
     _revision += 1;
     widget.coordinator.removeListener(_handleCoordinatorChanged);
+    if (widget.enabled) {
+      widget.coordinator.releasePending(widget.request, this);
+    }
     super.dispose();
   }
 
   void _handleCoordinatorChanged() {
-    if (!mounted || _ready || widget.coordinator.isPaused) return;
+    if (!mounted || !widget.enabled || _ready || widget.coordinator.isPaused) {
+      return;
+    }
     if (_failed && !widget.coordinator.isNegativelyCached(widget.request)) {
       setState(() => _failed = false);
     }
     if (!_failed) _requestImage();
   }
 
-  void _requestImage() {
-    if (_ready || _failed || _requesting || widget.request.url.isEmpty) return;
+  void _requestImage({bool retry = false}) {
+    if (!widget.enabled ||
+        _ready ||
+        _failed ||
+        _requesting ||
+        widget.request.url.isEmpty) {
+      return;
+    }
     _requesting = true;
     final revision = ++_revision;
-    widget.coordinator.submit(widget.request, priority: widget.priority).then((
-      loaded,
-    ) {
-      if (!mounted || revision != _revision) return;
-      final negativelyCached = widget.coordinator.isNegativelyCached(
-        widget.request,
-      );
-      setState(() {
-        _requesting = false;
-        _ready = loaded;
-        _failed = negativelyCached;
-      });
+    widget.coordinator
+        .submit(
+          widget.request,
+          priority: widget.priority,
+          retry: retry,
+          consumer: this,
+        )
+        .then((loaded) {
+          if (!mounted || revision != _revision) return;
+          final negativelyCached = widget.coordinator.isNegativelyCached(
+            widget.request,
+          );
+          setState(() {
+            _requesting = false;
+            _ready = loaded;
+            _failed = negativelyCached;
+          });
+        });
+  }
+
+  void _retryImage() {
+    if (_requesting) return;
+    final revision = ++_revision;
+    setState(() {
+      _failed = false;
+      _ready = false;
+      _requesting = true;
     });
+    unawaited(_retryAfterFailedImageEviction(revision));
+  }
+
+  Future<void> _retryAfterFailedImageEviction(int revision) async {
+    await _failedImageEviction;
+    if (!mounted || revision != _revision) return;
+    _requesting = false;
+    _requestImage(retry: true);
+  }
+
+  Widget _buildError(BuildContext context) {
+    final builder = widget.errorBuilder;
+    if (builder != null) return builder(context, _retryImage);
+    return widget.errorWidget ?? const SizedBox.shrink();
   }
 
   Future<void> _evictFailedImage(
@@ -148,7 +202,7 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
 
   @override
   Widget build(BuildContext context) {
-    if (_failed) return widget.errorWidget ?? const SizedBox.shrink();
+    if (_failed) return _buildError(context);
     if (!_ready) return widget.placeholder ?? const SizedBox.shrink();
     final placeholder = widget.placeholder ?? const SizedBox.shrink();
     final disableAnimations = MediaQuery.disableAnimationsOf(context);
@@ -196,14 +250,19 @@ class _CoordinatedGalleryImageState extends State<CoordinatedGalleryImage> {
         if (!_failed) {
           _failed = true;
           _ready = false;
-          unawaited(_evictFailedImage(imageProvider, request, coordinator));
+          _failedImageEviction = _evictFailedImage(
+            imageProvider,
+            request,
+            coordinator,
+          );
+          unawaited(_failedImageEviction);
           AppLogger.w(
             'Gallery image decode failed after coordinated preload: '
                 'source=${request.sourceKey}, errorType=${error.runtimeType}',
             'GalleryImage',
           );
         }
-        return widget.errorWidget ?? const SizedBox.shrink();
+        return _buildError(context);
       },
     );
   }

--- a/lib/presentation/widgets/online_gallery/online_gallery_image_placeholder.dart
+++ b/lib/presentation/widgets/online_gallery/online_gallery_image_placeholder.dart
@@ -1,15 +1,19 @@
 import 'package:flutter/material.dart';
 
+import '../../../core/utils/localization_extension.dart';
+
 /// Stable, low-contrast surface used while gallery media is unavailable.
 class OnlineGalleryImagePlaceholder extends StatelessWidget {
   const OnlineGalleryImagePlaceholder({
     super.key,
     this.failed = false,
     this.loading = false,
+    this.onRetry,
   });
 
   final bool failed;
   final bool loading;
+  final VoidCallback? onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -18,10 +22,19 @@ class OnlineGalleryImagePlaceholder extends StatelessWidget {
       color: colors.surfaceContainerLow,
       child: failed
           ? Center(
-              child: Icon(
-                Icons.image_not_supported_outlined,
-                color: colors.onSurfaceVariant.withValues(alpha: 0.38),
-              ),
+              child: onRetry == null
+                  ? Icon(
+                      Icons.image_not_supported_outlined,
+                      color: colors.onSurfaceVariant.withValues(alpha: 0.38),
+                    )
+                  : IconButton(
+                      onPressed: onRetry,
+                      tooltip: context.l10n.common_retry,
+                      icon: Icon(
+                        Icons.refresh_rounded,
+                        color: colors.onSurfaceVariant.withValues(alpha: 0.62),
+                      ),
+                    ),
             )
           : loading
           ? Center(

--- a/lib/presentation/widgets/online_gallery/progressive_gallery_image.dart
+++ b/lib/presentation/widgets/online_gallery/progressive_gallery_image.dart
@@ -28,6 +28,7 @@ class ProgressiveGalleryImage extends StatefulWidget {
 
 class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
   bool _sampleReady = false;
+  bool _sampleRequesting = false;
   bool _showSampleImmediately = false;
   int _revision = 0;
 
@@ -66,6 +67,7 @@ class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
     }
     if (coordinatorChanged || sampleChanged) {
       _revision++;
+      _sampleRequesting = false;
       _sampleReady = widget.coordinator.isSampleReady(widget.sample);
       _showSampleImmediately = _sampleReady;
       _requestSample();
@@ -77,12 +79,15 @@ class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
   }
 
   void _requestSample() {
-    if (_sampleReady || widget.sample.url.isEmpty) return;
+    if (_sampleReady || _sampleRequesting || widget.sample.url.isEmpty) return;
+    _sampleRequesting = true;
     final revision = ++_revision;
     widget.coordinator
         .submit(widget.sample, priority: GalleryImagePriority.hover)
         .then((loaded) {
-          if (!mounted || revision != _revision || !loaded) return;
+          if (!mounted || revision != _revision) return;
+          _sampleRequesting = false;
+          if (!loaded) return;
           setState(() {
             _sampleReady = true;
             _showSampleImmediately = false;
@@ -98,9 +103,14 @@ class _ProgressiveGalleryImageState extends State<ProgressiveGalleryImage> {
       priority: GalleryImagePriority.visible,
       fit: widget.fit,
       alignment: widget.alignment,
-      errorWidget: const ColoredBox(
+      errorBuilder: (_, retry) => ColoredBox(
         color: Colors.black12,
-        child: Center(child: Icon(Icons.broken_image_outlined)),
+        child: Center(
+          child: IconButton(
+            onPressed: retry,
+            icon: const Icon(Icons.refresh_rounded),
+          ),
+        ),
       ),
     );
     if (!_sampleReady ||

--- a/test/core/cache/cancellable_gallery_image_loader_test.dart
+++ b/test/core/cache/cancellable_gallery_image_loader_test.dart
@@ -324,6 +324,63 @@ void main() {
     },
   );
 
+  test(
+    '404 and 403 responses settle as failures without publishing cache',
+    () async {
+      for (final status in [HttpStatus.notFound, HttpStatus.forbidden]) {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        server.listen((request) async {
+          request.response.statusCode = status;
+          await request.response.close();
+        });
+        final cache = _RecordingCacheManager();
+        final loader = CancellableGalleryImageLoader(cacheManager: cache);
+        final operation = loader.start(
+          GalleryImageRequest(
+            sourceId: 'ai_tag',
+            url: 'http://${server.address.host}:${server.port}/$status.webp',
+            tier: GalleryImageTier.thumbnail,
+          ),
+        );
+
+        await expectLater(
+          operation.future.timeout(const Duration(seconds: 2)),
+          throwsA(isA<Exception>()),
+        );
+        expect(cache.putCalled, isFalse);
+        loader.dispose();
+        await server.close(force: true);
+      }
+    },
+  );
+
+  test(
+    'connection failure settles without leaving the operation pending',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final url = 'http://${server.address.host}:${server.port}/offline.webp';
+      await server.close(force: true);
+      final cache = _RecordingCacheManager();
+      final loader = CancellableGalleryImageLoader(cacheManager: cache);
+      addTearDown(loader.dispose);
+
+      await expectLater(
+        loader
+            .start(
+              GalleryImageRequest(
+                sourceId: 'ai_tag',
+                url: url,
+                tier: GalleryImageTier.thumbnail,
+              ),
+            )
+            .future
+            .timeout(const Duration(seconds: 2)),
+        throwsA(isA<Exception>()),
+      );
+      expect(cache.putCalled, isFalse);
+    },
+  );
+
   test('non-image responses are rejected without publishing cache', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(() => server.close(force: true));

--- a/test/core/cache/gallery_image_request_test.dart
+++ b/test/core/cache/gallery_image_request_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/cache/gallery_image_request.dart';
+import 'package:nai_launcher/data/models/online_gallery/gallery_source.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -243,6 +244,45 @@ void main() {
       expect(request1.hashCode, equals(request2.hashCode));
       expect(request1, isNot(equals(request3)));
     });
+
+    test(
+      'source URLs retain their transport identity and header contracts',
+      () {
+        const cases = <(GallerySourceId, String)>[
+          (GallerySourceId.danbooru, 'https://cdn.donmai.us/a.jpg'),
+          (GallerySourceId.safebooru, 'https://safebooru.org/a.jpg'),
+          (GallerySourceId.gelbooru, 'https://img4.gelbooru.com/a.jpg'),
+          (GallerySourceId.quickTagCloud, 'https://codex.example/a.webp'),
+        ];
+        for (final (sourceId, url) in cases) {
+          final request = GalleryImageRequest.forUrl(
+            sourceId: sourceId,
+            url: url,
+            tier: GalleryImageTier.thumbnail,
+            targetDecodeWidth: 320,
+          );
+          expect(request.sourceId, sourceId);
+          expect(request.url, url);
+          if (sourceId == GallerySourceId.gelbooru) {
+            expect(request.headers['Referer'], 'https://gelbooru.com/');
+            expect(request.cacheKey, 'gelbooru-image-v2:$url');
+          } else {
+            expect(request.headers, isEmpty);
+            expect(request.cacheKey, isNull);
+          }
+        }
+
+        final aiTag = GalleryImageRequest.forUrl(
+          sourceId: GallerySourceId.aiTag,
+          url: 'https://ai-img.10118899.xyz/NAI/1/work.webp',
+          tier: GalleryImageTier.thumbnail,
+          targetDecodeWidth: 320,
+        );
+        expect(aiTag.headers['Referer'], 'https://aitag.win/');
+        expect(aiTag.headers['Accept'], contains('image/webp'));
+        expect(aiTag.cacheKey, isNull);
+      },
+    );
 
     test('creates Gelbooru requests with correct headers and cache keys', () {
       const gelbooruUrl =

--- a/test/core/cache/online_gallery_prefetch_coordinator_test.dart
+++ b/test/core/cache/online_gallery_prefetch_coordinator_test.dart
@@ -236,6 +236,105 @@ void main() {
     expect(await low, isFalse);
   });
 
+  test(
+    'capacity notification follows same-turn queue rejection callbacks',
+    () async {
+      final blockerGate = Completer<void>();
+      final coordinator = OnlineGalleryPrefetchCoordinator(
+        maxConcurrent: 1,
+        maxQueued: 1,
+        preloader: (request) => _operation(
+          request.url.endsWith('/0.jpg')
+              ? blockerGate.future
+              : Future<void>.value(),
+        ),
+      );
+      final blocker = coordinator.submit(
+        _request(0),
+        priority: GalleryImagePriority.interactiveDetail,
+      );
+      final queued = coordinator.submit(
+        _request(1),
+        priority: GalleryImagePriority.interactiveDetail,
+      );
+      var requesting = true;
+      Future<bool>? retried;
+      coordinator.addListener(() {
+        if (!requesting && retried == null) {
+          retried = coordinator.submit(
+            _request(2),
+            priority: GalleryImagePriority.visible,
+          );
+        }
+      });
+      coordinator
+          .submit(_request(2), priority: GalleryImagePriority.visible)
+          .then((_) => requesting = false);
+
+      coordinator.cancelPending(_request(1));
+      expect(await queued, isFalse);
+      await Future<void>.delayed(Duration.zero);
+      expect(requesting, isFalse);
+      expect(retried, isNotNull);
+      expect(coordinator.queueDepth, 1);
+
+      blockerGate.complete();
+      expect(await blocker, isTrue);
+      expect(await retried, isTrue);
+    },
+  );
+
+  test(
+    'pending request stays queued until every card consumer releases it',
+    () async {
+      final blockerGate = Completer<void>();
+      final coordinator = OnlineGalleryPrefetchCoordinator(
+        maxConcurrent: 1,
+        preloader: (request) => _operation(
+          request.url.endsWith('/0.jpg')
+              ? blockerGate.future
+              : Future<void>.value(),
+        ),
+      );
+      final blocker = coordinator.submit(
+        _request(0),
+        priority: GalleryImagePriority.interactiveDetail,
+      );
+      final firstConsumer = Object();
+      final secondConsumer = Object();
+      final prefetch = coordinator.submit(
+        _request(1),
+        priority: GalleryImagePriority.lookahead,
+      );
+      final first = coordinator.submit(
+        _request(1),
+        priority: GalleryImagePriority.visible,
+        consumer: firstConsumer,
+      );
+      final second = coordinator.submit(
+        _request(1),
+        priority: GalleryImagePriority.visible,
+        consumer: secondConsumer,
+      );
+
+      coordinator.retainThumbnailWindow({});
+      expect(coordinator.queueDepth, 1);
+      coordinator.cancelPending(_request(1));
+      expect(coordinator.queueDepth, 1);
+      coordinator.releasePending(_request(1), firstConsumer);
+      expect(coordinator.queueDepth, 1);
+      coordinator.releasePending(_request(1), secondConsumer);
+      expect(coordinator.queueDepth, 0);
+      expect(
+        await Future.wait([prefetch, first, second]),
+        everyElement(isFalse),
+      );
+
+      blockerGate.complete();
+      expect(await blocker, isTrue);
+    },
+  );
+
   test('moving thumbnail window cancels stale queued requests', () async {
     final gate = Completer<void>();
     final coordinator = OnlineGalleryPrefetchCoordinator(
@@ -256,9 +355,13 @@ void main() {
       _request(2),
       priority: GalleryImagePriority.lookahead,
     );
+    var notifications = 0;
+    coordinator.addListener(() => notifications++);
 
     coordinator.retainThumbnailWindow({_request(2).stableRequestKey});
     expect(await stale, isFalse);
+    await Future<void>.delayed(Duration.zero);
+    expect(notifications, 1);
     expect(coordinator.queueDepth, 1);
 
     gate.complete();
@@ -605,6 +708,39 @@ void main() {
       expect(coordinator.isNegativelyCached(request), isFalse);
     },
   );
+
+  test('explicit retry invalidates a completed transfer', () async {
+    var attempts = 0;
+    final request = _request(1);
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (_) => _operation(
+        Future<void>.sync(() {
+          attempts++;
+        }),
+      ),
+    );
+    addTearDown(coordinator.dispose);
+
+    expect(
+      await coordinator.submit(request, priority: GalleryImagePriority.visible),
+      isTrue,
+    );
+    expect(
+      await coordinator.submit(request, priority: GalleryImagePriority.visible),
+      isTrue,
+    );
+    expect(attempts, 1);
+
+    expect(
+      await coordinator.submit(
+        request,
+        priority: GalleryImagePriority.visible,
+        retry: true,
+      ),
+      isTrue,
+    );
+    expect(attempts, 2);
+  });
 
   test('cancels one hover request without cancelling visible work', () async {
     final gates = <String, Completer<void>>{};

--- a/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
+++ b/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
@@ -505,7 +505,13 @@ void main() {
         if (request.uri.path == '/api/work/503') {
           return {
             'work': _aiWork(503),
-            'images': [_aiImage('503 p0')],
+            'images': [
+              {
+                ..._aiImage('503 p0?#'),
+                'image_type': 'Comfy UI/β',
+                'author_id': 'author name',
+              },
+            ],
           };
         }
         throw StateError('Unexpected request ${request.uri}');
@@ -520,10 +526,13 @@ void main() {
 
       expect(
         detail.media.single.previewUrl,
-        'https://cdn.example/root/SD/9/503%20p0.webp',
+        'https://cdn.example/root/Comfy%20UI%2F%CE%B2/author%20name/'
+        '503%20p0%3F%23.webp',
       );
+      expect(detail.media.single.displayUrl, detail.media.single.previewUrl);
+      expect(detail.media.single.downloadUrl, detail.media.single.previewUrl);
       expect(detail.media.single.previewUrl, isNot(contains('pximg.net')));
-      expect(detail.media.single.id, '503 p0');
+      expect(detail.media.single.id, '503 p0?#');
     });
 
     test('rejects non-HTTPS AI TAG asset bases', () async {

--- a/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
+++ b/test/presentation/screens/online_gallery/gallery_grid_item_test.dart
@@ -168,6 +168,58 @@ void main() {
     expect(find.text('Retry'), findsNothing);
   });
 
+  testWidgets('resolved cards stop and resume media requests with visibility', (
+    tester,
+  ) async {
+    final mediaRequestActiveValues = <bool>[];
+    final post = _item.copyWith(
+      sourceId: GallerySourceId.danbooru,
+      previewFileUrl: 'https://example.test/resolved.jpg',
+    );
+    await tester.pumpWidget(
+      _app(
+        post: post,
+        detailRequestScope: 1,
+        loadDetail: (_, {required priority, forceRefresh = false}) =>
+            Future.value(GalleryDetail(item: post, media: const [])),
+        onMediaRequestActive: mediaRequestActiveValues.add,
+      ),
+    );
+    final detector = tester.widget<VisibilityDetector>(
+      find.byType(VisibilityDetector),
+    );
+
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      ),
+    );
+    await tester.pump();
+    expect(mediaRequestActiveValues.last, isTrue);
+
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: Rect.zero,
+      ),
+    );
+    await tester.pump();
+    expect(mediaRequestActiveValues.last, isFalse);
+
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      ),
+    );
+    await tester.pump();
+    expect(mediaRequestActiveValues.last, isTrue);
+  });
+
   testWidgets(
     'missing dimensions keep stable geometry and reveal on visibility',
     (tester) async {
@@ -220,6 +272,7 @@ void main() {
       previewFileUrl: 'https://example.test/ai-tag-resolved.jpg',
     );
     final loadMediaValues = <bool>[];
+    final mediaRequestActiveValues = <bool>[];
     final layoutAspectRatios = <double>[];
     await tester.pumpWidget(
       _app(
@@ -227,6 +280,7 @@ void main() {
         loadDetail: (_, {required priority, forceRefresh = false}) =>
             Future.value(GalleryDetail(item: resolved, media: const [])),
         onBuildCard: loadMediaValues.add,
+        onMediaRequestActive: mediaRequestActiveValues.add,
         onLayoutAspectRatio: layoutAspectRatios.add,
       ),
     );
@@ -245,7 +299,29 @@ void main() {
     await tester.pump();
 
     expect(loadMediaValues.last, isTrue);
+    expect(mediaRequestActiveValues.last, isTrue);
     expect(layoutAspectRatios.last, 1.5);
+
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: Rect.zero,
+      ),
+    );
+    await tester.pump();
+    expect(loadMediaValues.last, isTrue);
+    expect(mediaRequestActiveValues.last, isFalse);
+
+    detector.onVisibilityChanged?.call(
+      VisibilityInfo(
+        key: detector.key!,
+        size: const Size(200, 200),
+        visibleBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      ),
+    );
+    await tester.pump();
+    expect(mediaRequestActiveValues.last, isTrue);
   });
 
   testWidgets('cancelled background detail stays quiet and scope resumes it', (
@@ -317,6 +393,7 @@ Widget _app({
   })
   loadDetail,
   ValueChanged<bool>? onBuildCard,
+  ValueChanged<bool>? onMediaRequestActive,
   ValueChanged<double>? onLayoutAspectRatio,
 }) {
   return MaterialApp(
@@ -344,9 +421,11 @@ Widget _app({
                 itemWidth, {
                 required layoutAspectRatio,
                 required loadMedia,
+                required mediaRequestActive,
                 detail,
               }) {
                 onBuildCard?.call(loadMedia);
+                onMediaRequestActive?.call(mediaRequestActive);
                 onLayoutAspectRatio?.call(layoutAspectRatio);
                 return SizedBox(
                   key: const ValueKey('resolved-card'),

--- a/test/presentation/widgets/online_gallery/progressive_gallery_image_test.dart
+++ b/test/presentation/widgets/online_gallery/progressive_gallery_image_test.dart
@@ -62,6 +62,31 @@ void main() {
     expect(transition.duration, const Duration(milliseconds: 120));
   });
 
+  testWidgets('unrelated completion does not duplicate an active sample wait', (
+    tester,
+  ) async {
+    final gates = <String, Completer<void>>{};
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (request) {
+        final gate = Completer<void>();
+        gates[request.url] = gate;
+        return GalleryImagePreloadOperation.fromFuture(gate.future);
+      },
+    );
+    addTearDown(coordinator.dispose);
+
+    await tester.pumpWidget(_app(coordinator));
+    expect(gates.keys, containsAll([_thumbnail.url, _sample.url]));
+    expect(coordinator.debugDeduplicatedCount, 0);
+
+    gates[_thumbnail.url]!.complete();
+    await tester.pump();
+    expect(coordinator.debugDeduplicatedCount, 0);
+
+    gates[_sample.url]!.complete();
+    await tester.pump();
+  });
+
   testWidgets('reduced motion promotes the sample immediately', (tester) async {
     final gate = Completer<void>();
     final coordinator = OnlineGalleryPrefetchCoordinator(
@@ -153,6 +178,134 @@ void main() {
     expect(sampleStarts, 2);
   });
 
+  testWidgets(
+    'queue rejection retries when cancellation frees pending capacity',
+    (tester) async {
+      final gates = <Completer<void>>[];
+      final starts = <String>[];
+      final coordinator = OnlineGalleryPrefetchCoordinator(
+        maxConcurrent: 1,
+        maxQueued: 1,
+        preloader: (request) {
+          starts.add(request.url);
+          final gate = Completer<void>();
+          gates.add(gate);
+          return GalleryImagePreloadOperation.fromFuture(gate.future);
+        },
+      );
+      addTearDown(coordinator.dispose);
+      final blocker = coordinator.submit(
+        const GalleryImageRequest(
+          sourceId: 'test',
+          url: 'https://example.test/blocker.jpg',
+          tier: GalleryImageTier.original,
+        ),
+        priority: GalleryImagePriority.interactiveDetail,
+      );
+      final queued = coordinator.submit(
+        const GalleryImageRequest(
+          sourceId: 'test',
+          url: 'https://example.test/queued.jpg',
+          tier: GalleryImageTier.original,
+        ),
+        priority: GalleryImagePriority.interactiveDetail,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: CoordinatedGalleryImage(
+            request: _thumbnail,
+            coordinator: coordinator,
+            placeholder: const Text('waiting'),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(starts, ['https://example.test/blocker.jpg']);
+      expect(find.text('waiting'), findsOneWidget);
+
+      coordinator.cancelPending(
+        const GalleryImageRequest(
+          sourceId: 'test',
+          url: 'https://example.test/queued.jpg',
+          tier: GalleryImageTier.original,
+        ),
+      );
+      expect(await queued, isFalse);
+      await tester.pump();
+      expect(coordinator.queueDepth, 1);
+
+      gates[0].complete();
+      expect(await blocker, isTrue);
+      await tester.pump();
+      expect(starts.last, _thumbnail.url);
+      gates[1].complete();
+      await tester.pump();
+      await tester.pump();
+      expect(find.byType(Image), findsOneWidget);
+    },
+  );
+
+  testWidgets('cancelled offscreen request resumes only when enabled again', (
+    tester,
+  ) async {
+    final blockerGate = Completer<void>();
+    final starts = <String>[];
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      maxConcurrent: 1,
+      preloader: (request) {
+        starts.add(request.url);
+        return GalleryImagePreloadOperation.fromFuture(
+          request.url.endsWith('blocker.jpg')
+              ? blockerGate.future
+              : Future<void>.value(),
+        );
+      },
+    );
+    addTearDown(coordinator.dispose);
+    final blocker = coordinator.submit(
+      const GalleryImageRequest(
+        sourceId: 'test',
+        url: 'https://example.test/blocker.jpg',
+        tier: GalleryImageTier.original,
+      ),
+      priority: GalleryImagePriority.interactiveDetail,
+    );
+    var enabled = true;
+    late StateSetter update;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            update = setState;
+            return CoordinatedGalleryImage(
+              request: _thumbnail,
+              coordinator: coordinator,
+              enabled: enabled,
+              placeholder: const Text('waiting'),
+            );
+          },
+        ),
+      ),
+    );
+    expect(coordinator.queueDepth, 1);
+
+    update(() => enabled = false);
+    await tester.pump();
+    expect(coordinator.queueDepth, 0);
+    blockerGate.complete();
+    expect(await blocker, isTrue);
+    await tester.pump();
+    expect(starts, ['https://example.test/blocker.jpg']);
+
+    update(() => enabled = true);
+    await tester.pump();
+    await tester.pump();
+    expect(starts.last, _thumbnail.url);
+    expect(find.byType(Image), findsOneWidget);
+  });
+
   testWidgets('failed coordinated download renders a stable error state', (
     tester,
   ) async {
@@ -177,6 +330,46 @@ void main() {
 
     expect(find.text('failed'), findsOneWidget);
     expect(find.text('waiting'), findsNothing);
+  });
+
+  testWidgets('explicit retry clears failure and starts a fresh request', (
+    tester,
+  ) async {
+    var attempts = 0;
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (_) => GalleryImagePreloadOperation.fromFuture(
+        Future<void>.sync(() {
+          attempts++;
+          if (attempts == 1) throw StateError('temporary failure');
+        }),
+      ),
+    );
+    addTearDown(coordinator.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CoordinatedGalleryImage(
+          request: _thumbnail,
+          coordinator: coordinator,
+          placeholder: const Text('waiting'),
+          errorBuilder: (_, retry) => TextButton(
+            key: const ValueKey('retry-image'),
+            onPressed: retry,
+            child: const Text('retry image'),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.byKey(const ValueKey('retry-image')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('retry-image')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(attempts, 2);
+    expect(find.byKey(const ValueKey('retry-image')), findsNothing);
+    expect(find.byType(Image), findsOneWidget);
   });
 
   testWidgets('request replacement clears a stale failure', (tester) async {


### PR DESCRIPTION
## 变更摘要

- 修复 AI TAG 搜索结果大量卡片滚动后长期停留在加载占位的问题
- 让卡片媒体请求严格跟随可见性，离屏释放 pending 所有权，回屏自动恢复
- 为队列容量变化、生成期取消/恢复、共享请求消费者和卡片复用增加确定性协调
- 下载失败或缓存内容无法解码时显示明确的可重试失败状态
- 保持现有图库布局、结果数量、分页与交互不变

## 根因

缩略图协调器在队列拒绝、pending 取消和生成期暂停后没有统一的可恢复状态通知；卡片离屏或复用时也缺少请求消费者所有权，导致仍可见请求可能错过重试机会，旧 Future 还可能回写已复用卡片。AI TAG 列表项需要详情补全媒体时，这些竞态会被大量卡片和快速滚动放大。

## 实现

- 协调器对容量/暂停变化采用合并的异步通知，避免同一轮 rejection 回调与通知乱序
- pending 请求区分滚动预取所有权和卡片 consumer，只有最后一个所有者释放后才取消
- 卡片请求增加 enabled 生命周期与 revision 隔离，离屏、request 替换、dispose 均安全释放
- retry 清除负缓存与已完成标记；解码失败先完成内存/磁盘缓存清理再重新下载
- Progressive sample 避免通知风暴下重复订阅同一个 Future

## 真实契约核验

- AI TAG 媒体继续只使用 `asset_base_url + image_type/author_id/file_name.webp` 构造的 HTTPS CDN WebP
- 实际 AI TAG CDN 样本响应为 HTTP 200、`content-type: image/webp`
- Pixiv original URL 未加入显示或下载 fallback

## 验证

- `scripts/test_affected.ps1`：149 tests passed（含 cache、source adapter、grid/card、布局与 progressive image 回归）
- 针对全部变更文件执行 `dart analyze`：No issues found
- `git diff --check`：通过
- 独立并发审查确认队列通知、共享请求取消、离屏恢复与旧响应隔离无高/中严重性问题

## 未执行

- 未启动 Windows/Android runner 或 UI 自动化；本次按要求仅做静态、单元与 widget 验证
- 未修改 CHANGELOG.md
