### PR TITLE
fix(update): 优化 Android 更新弹窗布局

### DIFF
--- a/lib/presentation/widgets/common/update_check_dialog.dart
+++ b/lib/presentation/widgets/common/update_check_dialog.dart
@@ -28,11 +28,30 @@ class UpdateCheckDialog extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(updateStateProvider);
+    final actions = _buildActions(context, ref, state);
+    final compact = MediaQuery.sizeOf(context).width < 600;
 
     return AlertDialog(
+      insetPadding: compact
+          ? const EdgeInsets.symmetric(horizontal: 16, vertical: 12)
+          : null,
+      contentPadding: compact
+          ? const EdgeInsets.fromLTRB(20, 12, 20, 12)
+          : null,
+      actionsPadding: compact ? const EdgeInsets.fromLTRB(16, 0, 16, 12) : null,
       title: Text(_getTitle(context, state)),
       content: SizedBox(width: 620, child: _buildContent(context, ref, state)),
-      actions: _buildActions(context, ref, state),
+      actions: actions.isEmpty
+          ? null
+          : [
+              SizedBox(
+                width: double.infinity,
+                child: _ResponsiveDialogActions(
+                  compact: compact,
+                  children: actions,
+                ),
+              ),
+            ],
     );
   }
 
@@ -97,68 +116,80 @@ class UpdateCheckDialog extends ConsumerWidget {
     final releaseNotesBackground = theme.colorScheme.surfaceContainerLowest;
     final releaseNotesForeground = _readableForeground(releaseNotesBackground);
 
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // 版本信息
-          Row(
-            children: [
-              Expanded(
-                child: _buildVersionInfoTile(
-                  context,
-                  label: context.l10n.currentVersion,
-                  value: versionInfo.displayCurrentVersion,
-                ),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: _buildVersionInfoTile(
-                  context,
-                  label: context.l10n.latestVersion,
-                  value: versionInfo.displayVersion,
-                  isHighlighted: true,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
-          if (versionInfo.primaryAsset != null) ...[
-            ListTile(
-              contentPadding: EdgeInsets.zero,
-              leading: Icon(
-                versionInfo.supportsInAppInstall
-                    ? Icons.system_update_alt
-                    : Icons.open_in_new,
-              ),
-              title: Text(
-                versionInfo.primaryAsset!.label ?? context.l10n.common_download,
-              ),
-              subtitle: Text(
-                versionInfo.primaryAsset!.description ??
-                    context.l10n.updatePortableManualHint,
+    final versionSummary = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: _buildVersionInfoTile(
+                context,
+                label: context.l10n.currentVersion,
+                value: versionInfo.displayCurrentVersion,
               ),
             ),
-            const SizedBox(height: 8),
+            const SizedBox(width: 16),
+            Expanded(
+              child: _buildVersionInfoTile(
+                context,
+                label: context.l10n.latestVersion,
+                value: versionInfo.displayVersion,
+                isHighlighted: true,
+              ),
+            ),
           ],
-          // 更新日志
-          if (releaseNotes.isNotEmpty) ...[
-            Text(
-              context.l10n.releaseNotes,
-              style: theme.textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
+        ),
+        if (versionInfo.primaryAsset != null) ...[
+          const SizedBox(height: 8),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: Icon(
+              versionInfo.supportsInAppInstall
+                  ? Icons.system_update_alt
+                  : Icons.open_in_new,
             ),
-            const SizedBox(height: 8),
-            Container(
-              constraints: const BoxConstraints(maxHeight: 380),
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: releaseNotesBackground,
-                borderRadius: BorderRadius.circular(8),
-              ),
+            title: Text(
+              versionInfo.primaryAsset!.label ?? context.l10n.common_download,
+            ),
+            subtitle: Text(
+              versionInfo.primaryAsset!.description ??
+                  context.l10n.updatePortableManualHint,
+            ),
+          ),
+        ],
+      ],
+    );
+
+    if (releaseNotes.isEmpty) {
+      return SingleChildScrollView(child: versionSummary);
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        versionSummary,
+        const SizedBox(height: 12),
+        Text(
+          context.l10n.releaseNotes,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Flexible(
+          child: Container(
+            key: const ValueKey('update-release-notes-region'),
+            constraints: const BoxConstraints(maxHeight: 380),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: releaseNotesBackground,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Scrollbar(
               child: SingleChildScrollView(
+                key: const ValueKey('update-release-notes-scroll-view'),
                 child: _buildReleaseNotes(
                   context,
                   versionInfo,
@@ -168,9 +199,9 @@ class UpdateCheckDialog extends ConsumerWidget {
                 ),
               ),
             ),
-          ],
-        ],
-      ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -766,6 +797,79 @@ class UpdateCheckDialog extends ConsumerWidget {
       context: context,
       barrierDismissible: false,
       builder: (context) => const UpdateCheckDialog(),
+    );
+  }
+}
+
+class _ResponsiveDialogActions extends StatelessWidget {
+  const _ResponsiveDialogActions({
+    required this.compact,
+    required this.children,
+  });
+
+  final bool compact;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    const spacing = 8.0;
+    if (!compact || children.length <= 2) {
+      return Wrap(
+        key: const ValueKey('update-dialog-actions'),
+        alignment: WrapAlignment.end,
+        runAlignment: WrapAlignment.end,
+        spacing: spacing,
+        runSpacing: spacing,
+        children: children,
+      );
+    }
+
+    final theme = Theme.of(context);
+    ButtonStyle withTouchHeight(ButtonStyle? style) =>
+        (style ?? const ButtonStyle()).copyWith(
+          minimumSize: const WidgetStatePropertyAll(Size(0, 48)),
+        );
+
+    return Theme(
+      data: theme.copyWith(
+        textButtonTheme: TextButtonThemeData(
+          style: withTouchHeight(theme.textButtonTheme.style),
+        ),
+        outlinedButtonTheme: OutlinedButtonThemeData(
+          style: withTouchHeight(theme.outlinedButtonTheme.style),
+        ),
+        filledButtonTheme: FilledButtonThemeData(
+          style: withTouchHeight(theme.filledButtonTheme.style),
+        ),
+      ),
+      child: Column(
+        key: const ValueKey('update-dialog-actions'),
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _ActionRow(children: children.take(2).toList()),
+          const SizedBox(height: spacing),
+          _ActionRow(children: children.skip(2).toList()),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionRow extends StatelessWidget {
+  const _ActionRow({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (var index = 0; index < children.length; index++) ...[
+          if (index > 0) const SizedBox(width: 8),
+          Expanded(child: children[index]),
+        ],
+      ],
     );
   }
 }

--- a/test/presentation/widgets/update_check_dialog_test.dart
+++ b/test/presentation/widgets/update_check_dialog_test.dart
@@ -169,6 +169,171 @@ print('updated');
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('uses a compact action grid on a narrow Android-sized view', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(360, 640);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = const FakeViewPadding(top: 24, bottom: 24);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPadding);
+
+    const info = VersionInfo(
+      version: '2.0.0',
+      currentVersion: '1.0.0',
+      isNewer: true,
+      htmlUrl: 'https://example.com/release',
+      downloadUrl: 'https://example.com/update.apk',
+      releaseNotes: '''
+## 新機能
+
+- 長い更新内容でも独立してスクロールできます。
+- 操作ボタンはすべて表示されたままです。
+- 狭い画面でも更新履歴を読みやすくします。
+- セーフエリアとタッチ操作に対応します。
+- 追加のリリースノートです。
+- さらに長いリリースノートです。
+''',
+    );
+    const state = UpdateState(
+      status: UpdateStatus.available,
+      versionInfo: info,
+      notificationVisible: true,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          updateStateNotifierProvider.overrideWith(
+            () => _DialogUpdateNotifier(state),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('ja'),
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: FilledButton(
+                  onPressed: () => UpdateCheckDialog.show(context),
+                  child: const Text('show'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('show'));
+    await tester.pumpAndSettle();
+
+    const labels = ['4時間後に通知', 'このバージョンをスキップ', 'Release を表示', 'ダウンロードに移動'];
+    for (final label in labels) {
+      expect(find.text(label), findsOneWidget);
+      expect(find.text(label).hitTestable(), findsOneWidget);
+    }
+
+    Rect buttonRect(String label) => tester.getRect(
+      find.ancestor(
+        of: find.text(label),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is ButtonStyleButton,
+        ),
+      ),
+    );
+
+    final firstRowLeft = buttonRect(labels[0]);
+    final firstRowRight = buttonRect(labels[1]);
+    final secondRowLeft = buttonRect(labels[2]);
+    final secondRowRight = buttonRect(labels[3]);
+    expect(firstRowLeft.top, closeTo(firstRowRight.top, 0.1));
+    expect(secondRowLeft.top, closeTo(secondRowRight.top, 0.1));
+    expect(firstRowLeft.left, lessThan(firstRowRight.left));
+    expect(secondRowLeft.left, lessThan(secondRowRight.left));
+    expect(firstRowLeft.height, greaterThanOrEqualTo(48));
+    expect(secondRowLeft.height, greaterThanOrEqualTo(48));
+
+    final actionRect = tester.getRect(
+      find.byKey(const ValueKey('update-dialog-actions')),
+    );
+    final notesRect = tester.getRect(
+      find.byKey(const ValueKey('update-release-notes-region')),
+    );
+    expect(actionRect.height, lessThanOrEqualTo(144));
+    expect(notesRect.height, greaterThan(actionRect.height));
+    expect(
+      find.byKey(const ValueKey('update-release-notes-scroll-view')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('keeps desktop update actions horizontally grouped', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const info = VersionInfo(
+      version: '2.0.0',
+      currentVersion: '1.0.0',
+      isNewer: true,
+      htmlUrl: 'https://example.com/release',
+      downloadUrl: 'https://example.com/update.zip',
+      releaseNotes: '- Desktop release note',
+    );
+    const state = UpdateState(
+      status: UpdateStatus.available,
+      versionInfo: info,
+      notificationVisible: true,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          updateStateNotifierProvider.overrideWith(
+            () => _DialogUpdateNotifier(state),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('en'),
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: Scaffold(body: UpdateCheckDialog()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final actionButtons = find.descendant(
+      of: find.byKey(const ValueKey('update-dialog-actions')),
+      matching: find.byWidgetPredicate((widget) => widget is ButtonStyleButton),
+    );
+    expect(actionButtons, findsNWidgets(4));
+    final buttonRects = [
+      for (var index = 0; index < 4; index++)
+        tester.getRect(actionButtons.at(index)),
+    ];
+    final rowTops = buttonRects.map((rect) => rect.top).toSet();
+    expect(rowTops.length, lessThanOrEqualTo(2));
+    expect(
+      buttonRects.any(
+        (left) => buttonRects.any(
+          (right) =>
+              left != right &&
+              (left.top - right.top).abs() < 0.1 &&
+              left.left < right.left,
+        ),
+      ),
+      isTrue,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('shows changelog content without release download sections', (
     tester,
   ) async {


### PR DESCRIPTION
## 用户可见变化

- Android 手机窄屏下将“稍后提醒 / 跳过版本 / 查看 Release / 下载”整理为紧凑的两行双列触屏操作区，保留全部操作与原有行为。
- 紧凑布局扩大弹窗可用宽高并保证 48px 最小触摸高度，长本地化文案可换行且不产生 overflow。
- 更新日志改为优先占用剩余高度的独立滚动区域，不再随整个内容一起滚动或被四个纵向按钮过度挤压。
- 桌面与宽屏仍按横向 Wrap 排列操作按钮，不引入平台判断。

## 验证

- `flutter test --no-pub test/presentation/widgets/update_check_dialog_test.dart` ✅（6 tests）
- `flutter analyze --no-pub lib/presentation/widgets/common/update_check_dialog.dart test/presentation/widgets/update_check_dialog_test.dart` ✅
- `git diff --check` ✅
- `flutter analyze --no-pub` ⚠️ 仅命中既有无关 warning：`lib/core/agent/context_usage.dart:70:44 unnecessary_null_comparison`
