### PR TITLE
fix(agent): 统一多角色场景编排快照

### DIFF
--- a/lib/core/agent/permissions/tool_permission_catalog.dart
+++ b/lib/core/agent/permissions/tool_permission_catalog.dart
@@ -197,7 +197,10 @@ AgentToolPermissionDescriptor describeAgentToolPermission(String toolName) {
     'set_negative_prompt' ||
     'add_character' ||
     'update_character' ||
-    'remove_character' => AgentPermissionDomain.prompt,
+    'remove_character' ||
+    'set_character_layout_mode' ||
+    'reorder_characters' ||
+    'clear_characters' => AgentPermissionDomain.prompt,
     'read_skill' ||
     'read_skill_resource' ||
     'reload_skills' ||

--- a/lib/core/constants/model_capabilities.dart
+++ b/lib/core/constants/model_capabilities.dart
@@ -171,6 +171,9 @@ class ModelCapabilities {
 class ModelCapabilityRegistry {
   ModelCapabilityRegistry._();
 
+  /// JSON Schema 等无法按当前模型动态变化的入口使用的全局安全上限。
+  static const int maximumCharacterCount = 22;
+
   static const ModelCapabilities v1 = ModelCapabilities(
     id: ImageModels.animeFull,
     promptStructure: PromptStructure.legacy,
@@ -306,7 +309,7 @@ class ModelCapabilityRegistry {
     defaultScale: 4.0,
     defaultSteps: 28,
     randomPromptProfile: RandomPromptProfile.characterPrompts,
-    maxCharacters: 32,
+    maxCharacters: maximumCharacterCount,
     supportsImg2ImgInpainting: true,
     supportsTransparentBackground: true,
     supportsMaxEnhance: true,
@@ -332,7 +335,7 @@ class ModelCapabilityRegistry {
     defaultScale: 4.0,
     defaultSteps: 28,
     randomPromptProfile: RandomPromptProfile.characterPrompts,
-    maxCharacters: 32,
+    maxCharacters: maximumCharacterCount,
     supportsImg2ImgInpainting: true,
     supportsTransparentBackground: true,
     supportsMaxEnhance: true,

--- a/lib/core/network/request_builders/nai_image_request_builder.dart
+++ b/lib/core/network/request_builders/nai_image_request_builder.dart
@@ -5,13 +5,12 @@ import 'dart:typed_data';
 import '../../constants/api_constants.dart';
 import '../../enums/precise_ref_type.dart';
 import '../../utils/app_logger.dart';
+import '../../utils/character_center_resolver.dart';
 import '../../utils/inpaint_mask_utils.dart';
 import '../../utils/nai_resolution_adapter.dart';
 import '../../utils/nai_api_utils.dart';
 import '../../utils/novelai_auto_text.dart';
 import '../../utils/prompt_semantics_utils.dart';
-import '../../../data/models/character/character_prompt.dart'
-    show CharacterPositionLayout;
 import '../../../data/models/image/image_params.dart';
 
 /// Variety+ sigma 缩放的基准潜空间体积：4 通道 × 104 × 152（832×1216 的潜空间）。
@@ -276,19 +275,11 @@ class NAIImageRequestBuilder {
   }
 
   ({double x, double y}) _resolveCharacterCenter(int index) {
-    final character = params.characters[index];
-    if (character.positionX != null && character.positionY != null) {
-      return (
-        x: character.positionX!.clamp(0.0, 1.0),
-        y: character.positionY!.clamp(0.0, 1.0),
-      );
-    }
-
-    final fallback = CharacterPositionLayout.positionForIndex(
-      index,
-      params.characters.length,
+    return CharacterCenterResolver.resolve(
+      params.characters[index],
+      index: index,
+      total: params.characters.length,
     );
-    return (x: fallback.column, y: fallback.row);
   }
 
   List<NovelAiAutoTextCharacter> _buildAutoTextCharacters() {
@@ -554,12 +545,40 @@ class NAIImageRequestBuilder {
     }
 
     final characterLimit = params.capabilities.maxCharacters;
-    if (characterLimit > 0 && params.characters.length > characterLimit) {
+    if (params.characters.isNotEmpty && characterLimit == 0) {
+      throw ArgumentError.value(
+        params.characters.length,
+        'characters',
+        'Model ${params.model} does not support character prompts',
+      );
+    }
+    if (params.characters.length > characterLimit) {
       throw ArgumentError.value(
         params.characters.length,
         'characters',
         'Model ${params.model} supports at most $characterLimit characters',
       );
+    }
+    if (params.useCoords) {
+      for (var index = 0; index < params.characters.length; index++) {
+        final character = params.characters[index];
+        final x = character.positionX;
+        final y = character.positionY;
+        if (x == null ||
+            y == null ||
+            !x.isFinite ||
+            !y.isFinite ||
+            x < 0 ||
+            x > 1 ||
+            y < 0 ||
+            y > 1) {
+          throw ArgumentError.value(
+            character,
+            'characters[$index]',
+            'Coordinate mode requires finite x/y centers between 0 and 1',
+          );
+        }
+      }
     }
 
     final seed = params.seed == -1 ? Random().nextInt(4294967295) : params.seed;

--- a/lib/core/network/request_builders/nai_image_request_builder.dart
+++ b/lib/core/network/request_builders/nai_image_request_builder.dart
@@ -279,6 +279,7 @@ class NAIImageRequestBuilder {
       params.characters[index],
       index: index,
       total: params.characters.length,
+      useCoords: params.useCoords,
     );
   }
 

--- a/lib/core/utils/character_center_resolver.dart
+++ b/lib/core/utils/character_center_resolver.dart
@@ -1,0 +1,20 @@
+import '../../data/models/character/character_prompt.dart'
+    show CharacterPositionLayout;
+import '../../data/models/image/image_params.dart';
+
+/// Resolves the single center used by every request and metadata projection.
+/// Validation belongs at preparation/request boundaries; this function only
+/// applies the shared deterministic fallback used when AI layout ignores it.
+abstract final class CharacterCenterResolver {
+  static ({double x, double y}) resolve(
+    CharacterPrompt character, {
+    required int index,
+    required int total,
+  }) {
+    if (character.positionX != null && character.positionY != null) {
+      return (x: character.positionX!, y: character.positionY!);
+    }
+    final fallback = CharacterPositionLayout.positionForIndex(index, total);
+    return (x: fallback.column, y: fallback.row);
+  }
+}

--- a/lib/core/utils/character_center_resolver.dart
+++ b/lib/core/utils/character_center_resolver.dart
@@ -3,16 +3,34 @@ import '../../data/models/character/character_prompt.dart'
 import '../../data/models/image/image_params.dart';
 
 /// Resolves the single center used by every request and metadata projection.
-/// Validation belongs at preparation/request boundaries; this function only
-/// applies the shared deterministic fallback used when AI layout ignores it.
+/// AI layout preserves valid stored centers for round trips, but replaces stale
+/// or malformed values because the server ignores them while `use_coords=false`.
 abstract final class CharacterCenterResolver {
   static ({double x, double y}) resolve(
     CharacterPrompt character, {
     required int index,
     required int total,
+    required bool useCoords,
   }) {
-    if (character.positionX != null && character.positionY != null) {
-      return (x: character.positionX!, y: character.positionY!);
+    final x = character.positionX;
+    final y = character.positionY;
+    final hasValidCenter =
+        x != null &&
+        y != null &&
+        x.isFinite &&
+        y.isFinite &&
+        x >= 0 &&
+        x <= 1 &&
+        y >= 0 &&
+        y <= 1;
+    if (hasValidCenter) return (x: x, y: y);
+
+    if (useCoords) {
+      throw ArgumentError.value(
+        character,
+        'character',
+        'Coordinate mode requires finite x/y centers between 0 and 1',
+      );
     }
     final fallback = CharacterPositionLayout.positionForIndex(index, total);
     return (x: fallback.column, y: fallback.row);

--- a/lib/presentation/agent_chat/services/generation_character_orchestration.dart
+++ b/lib/presentation/agent_chat/services/generation_character_orchestration.dart
@@ -1,0 +1,241 @@
+import '../../../core/constants/model_capabilities.dart';
+import '../../../data/models/character/character_prompt.dart'
+    show CharacterPositionLayout;
+import '../../../data/models/image/image_params.dart';
+
+enum GenerationCharacterLayoutMode { aiChoice, custom }
+
+extension GenerationCharacterLayoutModeName on GenerationCharacterLayoutMode {
+  String get schemaName => switch (this) {
+    GenerationCharacterLayoutMode.aiChoice => 'ai_choice',
+    GenerationCharacterLayoutMode.custom => 'custom',
+  };
+}
+
+class GenerationCharacterSnapshot {
+  const GenerationCharacterSnapshot({
+    required this.characters,
+    required this.layoutMode,
+  });
+
+  final List<CharacterPrompt> characters;
+  final GenerationCharacterLayoutMode layoutMode;
+
+  bool get useCoords =>
+      characters.isNotEmpty &&
+      layoutMode == GenerationCharacterLayoutMode.custom;
+}
+
+class GenerationCharacterValidationException implements Exception {
+  const GenerationCharacterValidationException(this.code, this.message);
+
+  final String code;
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+abstract final class GenerationCharacterOrchestrator {
+  static GenerationCharacterSnapshot normalizeExplicit({
+    required Object? rawCharacters,
+    required Object? rawLayoutMode,
+    required String model,
+  }) {
+    if (rawCharacters is! List) {
+      throw const GenerationCharacterValidationException(
+        'invalid_characters',
+        'Parameter "characters" must be an array.',
+      );
+    }
+
+    final capabilities = ModelCapabilityRegistry.of(model);
+    if (rawCharacters.isNotEmpty && capabilities.maxCharacters == 0) {
+      throw GenerationCharacterValidationException(
+        'model_character_unsupported',
+        'Model $model does not support character prompts.',
+      );
+    }
+    if (rawCharacters.length > capabilities.maxCharacters) {
+      throw GenerationCharacterValidationException(
+        'model_character_limit',
+        'Model $model supports at most ${capabilities.maxCharacters} '
+            'characters; ${rawCharacters.length} were provided.',
+      );
+    }
+
+    final parsed = <_ParsedCharacter>[];
+    var hasManualPosition = false;
+    for (var index = 0; index < rawCharacters.length; index++) {
+      final value = rawCharacters[index];
+      if (value is! Map) {
+        throw GenerationCharacterValidationException(
+          'invalid_character',
+          'Character ${index + 1} must be an object.',
+        );
+      }
+      final promptValue = value['prompt'];
+      if (promptValue is! String || promptValue.trim().isEmpty) {
+        throw GenerationCharacterValidationException(
+          'invalid_character_prompt',
+          'Character ${index + 1} requires a non-empty prompt.',
+        );
+      }
+      final negativeValue = value['negative_prompt'];
+      if (negativeValue != null && negativeValue is! String) {
+        throw GenerationCharacterValidationException(
+          'invalid_character_negative_prompt',
+          'Character ${index + 1} negative_prompt must be a string.',
+        );
+      }
+
+      final hasX = value.containsKey('position_x');
+      final hasY = value.containsKey('position_y');
+      if (hasX != hasY) {
+        throw GenerationCharacterValidationException(
+          'partial_character_coordinates',
+          'Character ${index + 1} must provide position_x and position_y '
+              'together.',
+        );
+      }
+      final gridValue = value['position'];
+      if (gridValue != null && gridValue is! String) {
+        throw GenerationCharacterValidationException(
+          'invalid_character_position',
+          'Character ${index + 1} position must be an A1-E5 grid string.',
+        );
+      }
+      if (gridValue != null && hasX) {
+        throw GenerationCharacterValidationException(
+          'character_position_conflict',
+          'Character ${index + 1} cannot combine position with continuous '
+              'coordinates.',
+        );
+      }
+
+      double? x;
+      double? y;
+      if (hasX) {
+        x = _coordinate(value['position_x'], index: index, axis: 'x');
+        y = _coordinate(value['position_y'], index: index, axis: 'y');
+        hasManualPosition = true;
+      } else if (gridValue != null) {
+        final grid = _parseLegacyGrid(gridValue, index);
+        x = grid.x;
+        y = grid.y;
+        hasManualPosition = true;
+      }
+      parsed.add(
+        _ParsedCharacter(
+          prompt: promptValue.trim(),
+          negativePrompt: (negativeValue as String?)?.trim() ?? '',
+          x: x,
+          y: y,
+        ),
+      );
+    }
+
+    final layoutMode = _parseLayoutMode(
+      rawLayoutMode,
+      inferredCustom: hasManualPosition,
+    );
+    if (layoutMode == GenerationCharacterLayoutMode.aiChoice &&
+        hasManualPosition) {
+      throw const GenerationCharacterValidationException(
+        'character_layout_conflict',
+        'AI layout cannot include position, position_x, or position_y.',
+      );
+    }
+
+    final defaults = layoutMode == GenerationCharacterLayoutMode.custom
+        ? CharacterPositionLayout.positionsForCount(parsed.length)
+        : const [];
+    return GenerationCharacterSnapshot(
+      layoutMode: layoutMode,
+      characters: [
+        for (var index = 0; index < parsed.length; index++)
+          CharacterPrompt(
+            prompt: parsed[index].prompt,
+            negativePrompt: parsed[index].negativePrompt,
+            positionX: layoutMode == GenerationCharacterLayoutMode.custom
+                ? parsed[index].x ?? defaults[index].column
+                : null,
+            positionY: layoutMode == GenerationCharacterLayoutMode.custom
+                ? parsed[index].y ?? defaults[index].row
+                : null,
+          ),
+      ],
+    );
+  }
+
+  static GenerationCharacterLayoutMode _parseLayoutMode(
+    Object? value, {
+    required bool inferredCustom,
+  }) {
+    if (value == null) {
+      return inferredCustom
+          ? GenerationCharacterLayoutMode.custom
+          : GenerationCharacterLayoutMode.aiChoice;
+    }
+    return switch (value) {
+      'ai_choice' => GenerationCharacterLayoutMode.aiChoice,
+      'custom' => GenerationCharacterLayoutMode.custom,
+      _ => throw const GenerationCharacterValidationException(
+        'invalid_character_layout_mode',
+        'character_layout_mode must be "ai_choice" or "custom".',
+      ),
+    };
+  }
+
+  static double _coordinate(
+    Object? value, {
+    required int index,
+    required String axis,
+  }) {
+    if (value is! num) {
+      throw GenerationCharacterValidationException(
+        'invalid_character_coordinate',
+        'Character ${index + 1} position_$axis must be a finite number '
+            'between 0 and 1.',
+      );
+    }
+    final coordinate = value.toDouble();
+    if (!coordinate.isFinite || coordinate < 0 || coordinate > 1) {
+      throw GenerationCharacterValidationException(
+        'invalid_character_coordinate',
+        'Character ${index + 1} position_$axis must be a finite number '
+            'between 0 and 1.',
+      );
+    }
+    return coordinate;
+  }
+
+  static ({double x, double y}) _parseLegacyGrid(String value, int index) {
+    final normalized = value.trim().toUpperCase();
+    final match = RegExp(r'^([A-E])([1-5])$').firstMatch(normalized);
+    if (match == null) {
+      throw GenerationCharacterValidationException(
+        'invalid_character_position',
+        'Character ${index + 1} position must be a valid A1-E5 grid value.',
+      );
+    }
+    final column = match.group(1)!.codeUnitAt(0) - 'A'.codeUnitAt(0);
+    final row = int.parse(match.group(2)!) - 1;
+    // The legacy selector denotes cells, while the API consumes their centers.
+    return (x: (column + 0.5) / 5, y: (row + 0.5) / 5);
+  }
+}
+
+class _ParsedCharacter {
+  const _ParsedCharacter({
+    required this.prompt,
+    required this.negativePrompt,
+    this.x,
+    this.y,
+  });
+
+  final String prompt;
+  final String negativePrompt;
+  final double? x;
+  final double? y;
+}

--- a/lib/presentation/agent_chat/services/generation_execution_service.dart
+++ b/lib/presentation/agent_chat/services/generation_execution_service.dart
@@ -183,7 +183,11 @@ class GenerationExecutionService {
       var lastProgress = -1;
       final invocation = _ref
           .read(imageGenerationNotifierProvider.notifier)
-          .generate(params, batchSizeOverride: prepared.batchSize);
+          .generate(
+            params,
+            batchSizeOverride: prepared.batchSize,
+            preserveCharacterSnapshot: true,
+          );
       final finished = await _waitForCompletion(
         invocation: invocation,
         expectedImages: count,

--- a/lib/presentation/agent_chat/services/generation_preparation_runtime.dart
+++ b/lib/presentation/agent_chat/services/generation_preparation_runtime.dart
@@ -57,6 +57,21 @@ class GenerationPreparation {
       'scale': params.scale,
       'seed': params.seed,
       'action': params.action.value,
+      'character_layout_mode': params.useCoords ? 'custom' : 'ai_choice',
+      'character_count': params.characters.length,
+      'characters': [
+        for (var index = 0; index < params.characters.length; index++)
+          {
+            'order': index,
+            'prompt': params.characters[index].prompt,
+            'negative_prompt': params.characters[index].negativePrompt,
+            if (params.useCoords)
+              'center': {
+                'x': params.characters[index].positionX,
+                'y': params.characters[index].positionY,
+              },
+          },
+      ],
       if (sourceImage != null) 'has_source_image': true,
       if (maskImage != null) 'has_mask_image': true,
     },

--- a/lib/presentation/agent_chat/services/generation_preparation_schema.dart
+++ b/lib/presentation/agent_chat/services/generation_preparation_schema.dart
@@ -1,3 +1,5 @@
+import '../../../core/constants/model_capabilities.dart';
+
 Map<String, dynamic> generationPreparationProperties({
   required bool includeOperation,
 }) => {
@@ -36,20 +38,58 @@ Map<String, dynamic> generationPreparationProperties({
     'items': {'type': 'object'},
     'maxItems': 16,
   },
+  'character_layout_mode': {
+    'type': 'string',
+    'enum': ['ai_choice', 'custom'],
+    'description':
+        'Layout for an explicitly provided characters snapshot. ai_choice '
+        'lets NovelAI place every character and forbids coordinates. custom '
+        'uses continuous centers where x is left-to-right and y is '
+        'top-to-bottom, both 0..1. Omit to infer custom when any character '
+        'has a position, otherwise ai_choice.',
+  },
   'characters': {
     'type': 'array',
+    'description':
+        'Complete ordered character snapshot for this call. Omit to inherit '
+        'the current character editor state. In custom mode, a complete x/y '
+        'pair or legacy A1-E5 position is accepted; characters with neither '
+        'receive stable non-overlapping defaults. Single-axis coordinates are '
+        'rejected. Legacy grid values map to continuous cell centers.',
     'items': {
       'type': 'object',
+      'additionalProperties': false,
       'properties': {
-        'prompt': {'type': 'string'},
-        'negative_prompt': {'type': 'string'},
-        'position': {'type': 'string'},
-        'position_x': {'type': 'number', 'minimum': 0, 'maximum': 1},
-        'position_y': {'type': 'number', 'minimum': 0, 'maximum': 1},
+        'prompt': {
+          'type': 'string',
+          'minLength': 1,
+          'description': 'Non-empty positive prompt for this character.',
+        },
+        'negative_prompt': {
+          'type': 'string',
+          'description': 'Independent undesired content for this character.',
+        },
+        'position': {
+          'type': 'string',
+          'pattern': r'^[A-Ea-e][1-5]$',
+          'description': 'Legacy A1-E5 grid position; do not combine with x/y.',
+        },
+        'position_x': {
+          'type': 'number',
+          'minimum': 0,
+          'maximum': 1,
+          'description': 'Horizontal center: 0 is left, 1 is right.',
+        },
+        'position_y': {
+          'type': 'number',
+          'minimum': 0,
+          'maximum': 1,
+          'description': 'Vertical center: 0 is top, 1 is bottom.',
+        },
       },
       'required': ['prompt'],
     },
-    'maxItems': 6,
+    'maxItems': ModelCapabilityRegistry.maximumCharacterCount,
   },
   'strength': {'type': 'number'},
   'noise': {'type': 'number'},

--- a/lib/presentation/agent_chat/services/generation_preparation_service.dart
+++ b/lib/presentation/agent_chat/services/generation_preparation_service.dart
@@ -2,9 +2,13 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/agent/agent_types.dart';
+import '../../../core/constants/model_capabilities.dart';
 import '../../../core/services/anlas_calculator.dart';
+import '../../../core/services/character_conversion_service.dart';
 import '../../../core/utils/nai_resolution_adapter.dart';
 import '../../../data/models/image/image_params.dart';
+import '../../../data/services/alias_resolver_service.dart';
+import '../../providers/character_prompt_provider.dart';
 import '../../providers/image_generation_provider.dart';
 import '../../providers/precise_ref_library_provider.dart';
 import '../../providers/replication_queue_provider.dart';
@@ -12,6 +16,7 @@ import '../../providers/vibe_library_provider.dart';
 import 'agent_resource_resolver.dart';
 import 'defined_agent_tool.dart';
 import 'generation_anlas_estimator.dart';
+import 'generation_character_orchestration.dart';
 import 'generation_preparation_runtime.dart';
 import 'generation_workspace_path_resolver.dart';
 
@@ -107,6 +112,7 @@ class GenerationPreparationService {
     GenerationPreparationKind kind,
     Map<String, dynamic> args, {
     ImageParams? baseOverride,
+    ImageParams? characterSnapshotOverride,
   }) async {
     final prompt = (args['prompt'] as String?)?.trim() ?? '';
     if (prompt.isEmpty) {
@@ -296,23 +302,57 @@ class GenerationPreparationService {
         return agentToolError('invalid_resource_ref', '$error');
       }
     }
-    final characters = <CharacterPrompt>[];
-    for (final value in args['characters'] as List? ?? const []) {
-      if (value is! Map || value['prompt'] is! String) {
+    final hasExplicitCharacters = args.containsKey('characters');
+    if (!hasExplicitCharacters && args.containsKey('character_layout_mode')) {
+      return agentToolError(
+        'character_layout_without_characters',
+        'character_layout_mode requires an explicit characters snapshot.',
+      );
+    }
+
+    late final List<CharacterPrompt> characters;
+    late final bool useCoords;
+    if (hasExplicitCharacters) {
+      try {
+        final snapshot = GenerationCharacterOrchestrator.normalizeExplicit(
+          rawCharacters: args['characters'],
+          rawLayoutMode: args['character_layout_mode'],
+          model: base.model,
+        );
+        characters = snapshot.characters;
+        useCoords = snapshot.useCoords;
+      } on GenerationCharacterValidationException catch (error) {
+        return agentToolError(error.code, error.message);
+      }
+    } else {
+      final override = characterSnapshotOverride;
+      if (override != null) {
+        characters = override.characters;
+        useCoords = override.useCoords;
+      } else {
+        final config = _ref.read(characterPromptNotifierProvider);
+        final conversion = CharacterConversionService(
+          aliasResolver: _ref
+              .read(aliasResolverServiceProvider.notifier)
+              .resolveAliases,
+        ).convert(config);
+        characters = conversion.characters;
+        useCoords = conversion.useCoords;
+      }
+      final limit = ModelCapabilityRegistry.of(base.model).maxCharacters;
+      if (characters.isNotEmpty && limit == 0) {
         return agentToolError(
-          'invalid_character',
-          'Each character requires a prompt.',
+          'model_character_unsupported',
+          'Model ${base.model} does not support character prompts.',
         );
       }
-      characters.add(
-        CharacterPrompt(
-          prompt: value['prompt'] as String,
-          negativePrompt: value['negative_prompt'] as String? ?? '',
-          position: value['position'] as String?,
-          positionX: (value['position_x'] as num?)?.toDouble(),
-          positionY: (value['position_y'] as num?)?.toDouble(),
-        ),
-      );
+      if (characters.length > limit) {
+        return agentToolError(
+          'model_character_limit',
+          'Model ${base.model} supports at most $limit characters; '
+              '${characters.length} enabled characters are configured.',
+        );
+      }
     }
 
     final params = base.copyWith(
@@ -332,7 +372,8 @@ class GenerationPreparationService {
       inpaintStrength: ratio('inpaint_strength', base.inpaintStrength),
       vibeReferencesV4: vibeReferences,
       preciseReferences: preciseReferences,
-      characters: characters.isEmpty ? base.characters : characters,
+      characters: characters,
+      useCoords: useCoords,
     );
     final batchSize = _anlasEstimator.currentBatchSize;
     final estimate = _anlasEstimator.estimate(
@@ -419,6 +460,7 @@ class GenerationPreparationService {
       current.kind,
       merged,
       baseOverride: current.baseParams,
+      characterSnapshotOverride: current.params,
     );
     if (!result.isError) _runtime.cancel(id);
     return result;

--- a/lib/presentation/agent_chat/services/generation_queue_task_service.dart
+++ b/lib/presentation/agent_chat/services/generation_queue_task_service.dart
@@ -1,10 +1,8 @@
 import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/agent/agent_types.dart';
-import '../../../data/models/image/image_params.dart';
 import '../../../data/models/queue/replication_task.dart';
 import '../../../data/models/queue/replication_task_generation_snapshot.dart';
-import '../../providers/character_prompt_provider.dart';
 import '../../providers/queue_execution_provider.dart';
 import '../../providers/replication_queue_provider.dart';
 import 'defined_agent_tool.dart';
@@ -22,7 +20,7 @@ class GenerationQueueTaskService {
   final int _maxQueueSnapshotBytes;
   final int _maxPersistedQueueSnapshotBytes;
   Future<AgentToolResult> queueTask(
-    Map<String, dynamic> args, {
+    Map<String, dynamic> _, {
     required GenerationPreparation prepared,
   }) async {
     final base = prepared.params;
@@ -53,40 +51,20 @@ class GenerationQueueTaskService {
     final count = requestedCount;
     final autoStart = prepared.autoStart;
     final negativePrompt = base.negativePrompt;
-    final explicitCharacters = args['characters'] is List;
-    final characterPrompts = explicitCharacters
-        ? base.characters
-              .map(
-                (character) => ReplicationCharacterPromptSnapshot(
-                  prompt: character.prompt,
-                  negativePrompt: character.negativePrompt,
-                  positionX: character.positionX,
-                  positionY: character.positionY,
-                ),
-              )
-              .toList(growable: false)
-        : _ref
-              .read(characterPromptNotifierProvider)
-              .characters
-              .map(ReplicationCharacterPromptSnapshot.fromCharacterPrompt)
-              .toList(growable: false);
+    final characterPrompts = base.characters
+        .map(
+          (character) => ReplicationCharacterPromptSnapshot(
+            prompt: character.prompt,
+            negativePrompt: character.negativePrompt,
+            positionX: base.useCoords ? character.positionX : null,
+            positionY: base.useCoords ? character.positionY : null,
+          ),
+        )
+        .toList(growable: false);
     final queuedParams = base.copyWith(
       prompt: prompt,
       negativePrompt: negativePrompt,
       nSamples: 1,
-      characters: explicitCharacters
-          ? base.characters
-          : characterPrompts
-                .where((character) => character.enabled)
-                .map(
-                  (character) => CharacterPrompt(
-                    prompt: character.prompt,
-                    negativePrompt: character.negativePrompt,
-                    positionX: character.positionX,
-                    positionY: character.positionY,
-                  ),
-                )
-                .toList(growable: false),
     );
     final generationSnapshot = ReplicationTaskGenerationSnapshot.encode(
       queuedParams,

--- a/lib/presentation/agent_chat/services/prompt_toolbox.dart
+++ b/lib/presentation/agent_chat/services/prompt_toolbox.dart
@@ -12,6 +12,7 @@ import '../../providers/generation/generation_params_notifier.dart';
 import 'defined_agent_tool.dart';
 import '../../../core/agent/harness/skills.dart';
 import '../../../core/agent/private_data_guard.dart';
+import '../../../core/constants/model_capabilities.dart';
 
 AgentToolResult _textResult(String text) {
   return AgentToolResult(
@@ -53,10 +54,12 @@ class PromptToolbox {
         name: 'get_prompt_state',
         label: 'Get Prompt State',
         description:
-            'Read the current NovelAI workspace state: positive '
-            'prompt, negative prompt, current model, and the full character '
-            'prompt list (id, name, gender, enabled, prompt, negative '
-            'prompt). Call this before editing anything.',
+            'Read the complete NovelAI prompt and character orchestration '
+            'state. Returns stable character IDs, exact order, independent '
+            'positive/negative prompts, enabled state, per-character saved '
+            'position mode and continuous x/y centers, global AI/custom '
+            'layout mode, current model, and its effective character limit. '
+            'Call this before editing anything.',
         parameters: const {
           'type': 'object',
           'properties': <String, dynamic>{},
@@ -64,24 +67,21 @@ class PromptToolbox {
         },
         executeFn: (_, __) async {
           final params = _ref.read(generationParamsNotifierProvider);
-          final characters = _ref
-              .read(characterPromptNotifierProvider)
-              .characters;
+          final config = _ref.read(characterPromptNotifierProvider);
+          final capabilities = ModelCapabilityRegistry.of(params.model);
           return _textResult(
             jsonEncode({
               'model': params.model,
+              'model_character_limit': capabilities.maxCharacters,
+              'supports_characters': capabilities.maxCharacters > 0,
+              'character_layout_mode': config.globalAiChoice
+                  ? 'ai_choice'
+                  : 'custom',
               'positive_prompt': params.prompt,
               'negative_prompt': params.negativePrompt,
               'characters': [
-                for (final c in characters)
-                  {
-                    'id': c.id,
-                    'name': c.name,
-                    'gender': c.gender.name,
-                    'enabled': c.enabled,
-                    'prompt': c.prompt,
-                    'negative_prompt': c.negativePrompt,
-                  },
+                for (var index = 0; index < config.characters.length; index++)
+                  _characterJson(config.characters[index], order: index),
               ],
             }),
           );
@@ -143,42 +143,43 @@ class PromptToolbox {
         name: 'update_character',
         label: 'Update Character',
         description:
-            'Update an existing character prompt entry matched by id '
-            'or name (case-insensitive). Only provided fields are changed. '
-            'Set "enabled" to false to temporarily exclude the character '
-            'from generation while keeping it in the list, and true to '
-            'include it again — use this to toggle characters on/off. '
-            'Characters only take effect on V4+ models.',
+            'Update one character matched by stable id or case-insensitive '
+            'name. Only provided fields change. position_mode ai_choice '
+            'keeps any saved custom point but lets AI choose while the global '
+            'layout is AI. position_mode custom may reuse the saved point or '
+            'accept both position_x and position_y. x is left-to-right and y '
+            'is top-to-bottom; both must be finite values from 0 to 1.',
         parameters: const {
           'type': 'object',
           'properties': {
-            'id': {'type': 'string', 'description': 'Character id.'},
+            'id': {'type': 'string', 'description': 'Stable character ID.'},
             'name': {
               'type': 'string',
-              'description':
-                  'Character name to match (or new name when renaming).',
+              'description': 'Existing character name to match.',
             },
-            'new_name': {
-              'type': 'string',
-              'description': 'Rename the character.',
-            },
+            'new_name': {'type': 'string', 'description': 'New display name.'},
             'gender': {
               'type': 'string',
               'enum': ['female', 'male', 'other'],
             },
-            'prompt': {
+            'prompt': {'type': 'string'},
+            'negative_prompt': {'type': 'string'},
+            'enabled': {'type': 'boolean'},
+            'position_mode': {
               'type': 'string',
-              'description': 'New positive prompt for the character.',
+              'enum': ['ai_choice', 'custom'],
             },
-            'negative_prompt': {
-              'type': 'string',
-              'description': 'New negative prompt for the character.',
+            'position_x': {
+              'type': 'number',
+              'minimum': 0,
+              'maximum': 1,
+              'description': 'Horizontal center: 0 left, 1 right.',
             },
-            'enabled': {
-              'type': 'boolean',
-              'description':
-                  'true to include the character in generation, '
-                  'false to disable it while keeping it in the list.',
+            'position_y': {
+              'type': 'number',
+              'minimum': 0,
+              'maximum': 1,
+              'description': 'Vertical center: 0 top, 1 bottom.',
             },
           },
           'required': <String>[],
@@ -189,32 +190,69 @@ class PromptToolbox {
         name: 'add_character',
         label: 'Add Character',
         description:
-            'Add a new character prompt entry (V4+ models support '
-            'multiple characters; there is a model-dependent limit).',
+            'Add one ordered character using the current model limit. Optional '
+            'custom coordinates require both axes (x left-to-right, y '
+            'top-to-bottom, finite 0..1). ai_choice conflicts with coordinates.',
         parameters: const {
           'type': 'object',
           'properties': {
-            'name': {
-              'type': 'string',
-              'description': 'Character display name.',
-            },
+            'name': {'type': 'string'},
             'gender': {
               'type': 'string',
               'enum': ['female', 'male', 'other'],
               'description': 'Default: female.',
             },
-            'prompt': {
+            'prompt': {'type': 'string'},
+            'negative_prompt': {'type': 'string'},
+            'enabled': {'type': 'boolean'},
+            'position_mode': {
               'type': 'string',
-              'description': 'Character positive prompt tags.',
+              'enum': ['ai_choice', 'custom'],
             },
-            'negative_prompt': {
-              'type': 'string',
-              'description': 'Character negative prompt tags.',
-            },
+            'position_x': {'type': 'number', 'minimum': 0, 'maximum': 1},
+            'position_y': {'type': 'number', 'minimum': 0, 'maximum': 1},
           },
           'required': ['name'],
         },
         executeFn: (_, params) => _addCharacter(params),
+      ),
+      DefinedAgentTool(
+        name: 'set_character_layout_mode',
+        label: 'Set Character Layout Mode',
+        description:
+            'Switch the whole scene between NovelAI AI placement and custom '
+            'continuous coordinates. Switching to custom assigns stable, '
+            'non-overlapping defaults only where needed. Switching to AI '
+            'preserves every saved custom point for later restoration.',
+        parameters: const {
+          'type': 'object',
+          'properties': {
+            'mode': {
+              'type': 'string',
+              'enum': ['ai_choice', 'custom'],
+            },
+          },
+          'required': ['mode'],
+        },
+        executeFn: (_, params) => _setCharacterLayoutMode(params),
+      ),
+      DefinedAgentTool(
+        name: 'reorder_characters',
+        label: 'Reorder Characters',
+        description:
+            'Set the exact character order using stable IDs. ordered_ids must '
+            'contain every current character ID exactly once.',
+        parameters: const {
+          'type': 'object',
+          'properties': {
+            'ordered_ids': {
+              'type': 'array',
+              'items': {'type': 'string'},
+            },
+          },
+          'required': ['ordered_ids'],
+        },
+        executeFn: (_, params) => _reorderCharacters(params),
       ),
       DefinedAgentTool(
         name: 'remove_character',
@@ -229,6 +267,17 @@ class PromptToolbox {
           'required': <String>[],
         },
         executeFn: (_, params) => _removeCharacter(params),
+      ),
+      DefinedAgentTool(
+        name: 'clear_characters',
+        label: 'Clear Characters',
+        description: 'Remove every character from the current scene.',
+        parameters: const {
+          'type': 'object',
+          'properties': <String, dynamic>{},
+          'required': <String>[],
+        },
+        executeFn: (_, params) => _clearCharacters(),
       ),
       if (_skills.isNotEmpty)
         DefinedAgentTool(
@@ -369,44 +418,64 @@ class PromptToolbox {
 
   CharacterPrompt? _findCharacter({String? id, String? name}) {
     final characters = _ref.read(characterPromptNotifierProvider).characters;
-    if (id != null && id.trim().isNotEmpty) {
-      final byId = characters.where((c) => c.id == id.trim()).toList();
-      if (byId.isNotEmpty) {
-        return byId.first;
+    final normalizedId = id?.trim() ?? '';
+    final normalizedName = name?.trim().toLowerCase() ?? '';
+
+    if (normalizedId.isNotEmpty) {
+      final byId = characters.where((c) => c.id == normalizedId).firstOrNull;
+      if (byId == null) return null;
+      if (normalizedName.isNotEmpty &&
+          byId.name.trim().toLowerCase() != normalizedName) {
+        throw const _PromptToolValidationException(
+          'invalid_character_selector',
+          'The supplied character id and name identify different characters.',
+        );
       }
+      return byId;
     }
-    if (name != null && name.trim().isNotEmpty) {
-      final lowered = name.trim().toLowerCase();
+
+    if (normalizedName.isNotEmpty) {
       final byName = characters
-          .where((c) => c.name.trim().toLowerCase() == lowered)
+          .where((c) => c.name.trim().toLowerCase() == normalizedName)
           .toList();
-      if (byName.isNotEmpty) {
-        return byName.first;
+      if (byName.length > 1) {
+        throw const _PromptToolValidationException(
+          'invalid_character_selector',
+          'Character name is ambiguous. Call get_prompt_state and use a stable id.',
+        );
       }
+      return byName.firstOrNull;
     }
     return null;
   }
 
   Future<AgentToolResult> _updateCharacter(Map<String, dynamic> args) async {
-    final target = _findCharacter(
-      id: args['id'] as String?,
-      name: args['name'] as String?,
-    );
+    late final CharacterPrompt? target;
+    late final _CharacterPositionChange positionChange;
+    try {
+      _validateCharacterStringFields(args);
+      target = _findCharacter(
+        id: args['id'] as String?,
+        name: args['name'] as String?,
+      );
+      positionChange = _parsePositionChange(args);
+    } on _PromptToolValidationException catch (error) {
+      return agentToolError(error.code, error.message);
+    }
     if (target == null) {
-      return _errorResult(
-        'Character not found. Call get_prompt_state to list valid ids and '
-        'names.',
+      return agentToolError(
+        'character_not_found',
+        'Character not found. Call get_prompt_state for stable IDs.',
       );
     }
+
     var updated = target;
     final newName = (args['new_name'] as String?)?.trim();
     if (newName != null && newName.isNotEmpty) {
       updated = updated.copyWith(name: newName);
     }
     final gender = _parseGender(args['gender']);
-    if (gender != null) {
-      updated = updated.copyWith(gender: gender);
-    }
+    if (gender != null) updated = updated.copyWith(gender: gender);
     if (args.containsKey('prompt')) {
       updated = updated.copyWith(prompt: (args['prompt'] as String?) ?? '');
     }
@@ -416,89 +485,312 @@ class PromptToolbox {
       );
     }
     if (args.containsKey('enabled')) {
-      updated = updated.copyWith(enabled: args['enabled'] as bool? ?? true);
+      final enabled = args['enabled'];
+      if (enabled is! bool) {
+        return agentToolError(
+          'invalid_character_enabled',
+          'enabled must be a boolean.',
+        );
+      }
+      updated = updated.copyWith(enabled: enabled);
     }
-    _ref
-        .read(characterPromptNotifierProvider.notifier)
-        .updateCharacter(updated);
-    await Future<void>.delayed(Duration.zero);
+    updated = _applyPositionChange(updated, positionChange);
+
+    final notifier = _ref.read(characterPromptNotifierProvider.notifier);
+    if (!await notifier.updateCharacterPersisted(updated)) {
+      return agentToolError(
+        'character_persistence_failed',
+        'The character changed in memory but could not be persisted.',
+      );
+    }
+    final applied = _findCharacter(id: updated.id)!;
+    final order = _ref
+        .read(characterPromptNotifierProvider)
+        .characters
+        .indexWhere((character) => character.id == applied.id);
     return _textResult(
       jsonEncode({
         'ok': true,
-        'character': {
-          'id': updated.id,
-          'name': updated.name,
-          'prompt': updated.prompt,
-          'negative_prompt': updated.negativePrompt,
-          'enabled': updated.enabled,
-        },
+        'character': _characterJson(applied, order: order),
       }),
     );
   }
 
   Future<AgentToolResult> _addCharacter(Map<String, dynamic> args) async {
+    late final _CharacterPositionChange positionChange;
+    try {
+      _validateCharacterStringFields(args);
+      positionChange = _parsePositionChange(args);
+    } on _PromptToolValidationException catch (error) {
+      return agentToolError(error.code, error.message);
+    }
     final name = (args['name'] as String?)?.trim() ?? '';
     if (name.isEmpty) {
-      return _errorResult('Parameter "name" is required.');
+      return agentToolError('invalid_character_name', 'name is required.');
     }
+
     final notifier = _ref.read(characterPromptNotifierProvider.notifier);
     final limit = notifier.characterLimit;
     final existingCharacters = _ref
         .read(characterPromptNotifierProvider)
         .characters;
-    final count = existingCharacters.length;
-    if (limit > 0 && count >= limit) {
-      return _errorResult(
-        'Character limit reached ($limit). Remove one first.',
+    if (limit == 0) {
+      final model = _ref.read(generationParamsNotifierProvider).model;
+      return agentToolError(
+        'model_character_unsupported',
+        'Model $model does not support character prompts.',
       );
     }
-    notifier.addCharacter(
+    if (existingCharacters.length >= limit) {
+      return agentToolError(
+        'model_character_limit',
+        'The current model supports at most $limit characters.',
+      );
+    }
+
+    final enabled = args['enabled'] ?? true;
+    if (enabled is! bool) {
+      return agentToolError(
+        'invalid_character_enabled',
+        'enabled must be a boolean.',
+      );
+    }
+    final positionMode = positionChange.mode ?? CharacterPositionMode.aiChoice;
+    final customPosition = positionChange.x == null
+        ? null
+        : CharacterPosition(
+            mode: CharacterPositionMode.custom,
+            row: positionChange.y!,
+            column: positionChange.x!,
+          );
+    final result = await notifier.addCharacterPersisted(
       _parseGender(args['gender']) ?? CharacterGender.female,
       name: name,
       prompt: (args['prompt'] as String?) ?? '',
+      negativePrompt: args.containsKey('negative_prompt')
+          ? (args['negative_prompt'] as String?) ?? ''
+          : null,
+      enabled: enabled,
+      positionMode: positionMode,
+      customPosition: customPosition,
     );
-    await Future<void>.delayed(Duration.zero);
-    final existingIds = existingCharacters
-        .map((character) => character.id)
-        .toSet();
-    var created = _ref
+    if (result == null) {
+      return agentToolError(
+        'character_add_failed',
+        'Character could not be added.',
+      );
+    }
+    if (!result.persisted) {
+      return agentToolError(
+        'character_persistence_failed',
+        'The character changed in memory but could not be persisted.',
+      );
+    }
+    final created = result.character;
+    final order = _ref
         .read(characterPromptNotifierProvider)
         .characters
-        .where((character) => !existingIds.contains(character.id))
-        .firstOrNull;
-    if (created == null) {
-      return _errorResult('Character could not be added.');
-    }
-    // addCharacter 生成默认负向后补充传入的负向词。
-    if (args.containsKey('negative_prompt')) {
-      final negative = (args['negative_prompt'] as String?) ?? '';
-      created = created.copyWith(negativePrompt: negative);
-      _ref
-          .read(characterPromptNotifierProvider.notifier)
-          .updateCharacter(created);
-    }
+        .indexWhere((character) => character.id == created.id);
     return _textResult(
       jsonEncode({
         'ok': true,
-        'character': {'id': created.id, 'name': name},
+        'character': _characterJson(created, order: order),
+      }),
+    );
+  }
+
+  Future<AgentToolResult> _setCharacterLayoutMode(
+    Map<String, dynamic> args,
+  ) async {
+    final mode = args['mode'];
+    if (mode != 'ai_choice' && mode != 'custom') {
+      return agentToolError(
+        'invalid_character_layout_mode',
+        'mode must be "ai_choice" or "custom".',
+      );
+    }
+    final notifier = _ref.read(characterPromptNotifierProvider.notifier);
+    if (!await notifier.setGlobalAiChoicePersisted(mode == 'ai_choice')) {
+      return agentToolError(
+        'character_persistence_failed',
+        'The layout changed in memory but could not be persisted.',
+      );
+    }
+    final config = _ref.read(characterPromptNotifierProvider);
+    return _textResult(
+      jsonEncode({
+        'ok': true,
+        'character_layout_mode': mode,
+        'characters': [
+          for (var index = 0; index < config.characters.length; index++)
+            _characterJson(config.characters[index], order: index),
+        ],
+      }),
+    );
+  }
+
+  Future<AgentToolResult> _reorderCharacters(Map<String, dynamic> args) async {
+    final rawIds = args['ordered_ids'];
+    if (rawIds is! List || rawIds.any((value) => value is! String)) {
+      return agentToolError(
+        'invalid_character_order',
+        'ordered_ids must be an array of stable character IDs.',
+      );
+    }
+    final ids = rawIds.cast<String>();
+    final notifier = _ref.read(characterPromptNotifierProvider.notifier);
+    try {
+      if (!await notifier.setCharacterOrderPersisted(ids)) {
+        return agentToolError(
+          'character_persistence_failed',
+          'The order changed in memory but could not be persisted.',
+        );
+      }
+    } on FormatException catch (error) {
+      return agentToolError('invalid_character_order', error.message);
+    }
+    final characters = _ref.read(characterPromptNotifierProvider).characters;
+    return _textResult(
+      jsonEncode({
+        'ok': true,
+        'characters': [
+          for (var index = 0; index < characters.length; index++)
+            _characterJson(characters[index], order: index),
+        ],
       }),
     );
   }
 
   Future<AgentToolResult> _removeCharacter(Map<String, dynamic> args) async {
-    final target = _findCharacter(
-      id: args['id'] as String?,
-      name: args['name'] as String?,
-    );
-    if (target == null) {
-      return _errorResult('Character not found.');
+    late final CharacterPrompt? target;
+    try {
+      _validateCharacterStringFields(args);
+      target = _findCharacter(
+        id: args['id'] as String?,
+        name: args['name'] as String?,
+      );
+    } on _PromptToolValidationException catch (error) {
+      return agentToolError(error.code, error.message);
     }
-    _ref
-        .read(characterPromptNotifierProvider.notifier)
-        .removeCharacter(target.id);
-    await Future<void>.delayed(Duration.zero);
+    if (target == null) {
+      return agentToolError('character_not_found', 'Character not found.');
+    }
+    final notifier = _ref.read(characterPromptNotifierProvider.notifier);
+    if (!await notifier.removeCharacterPersisted(target.id)) {
+      return agentToolError(
+        'character_persistence_failed',
+        'The character was removed in memory but could not be persisted.',
+      );
+    }
     return _textResult(jsonEncode({'ok': true, 'removed': target.name}));
   }
+
+  Future<AgentToolResult> _clearCharacters() async {
+    final notifier = _ref.read(characterPromptNotifierProvider.notifier);
+    if (!await notifier.clearAllCharactersPersisted()) {
+      return agentToolError(
+        'character_persistence_failed',
+        'Characters were cleared in memory but could not be persisted.',
+      );
+    }
+    return _textResult(jsonEncode({'ok': true, 'characters': <Object>[]}));
+  }
+
+  CharacterPrompt _applyPositionChange(
+    CharacterPrompt character,
+    _CharacterPositionChange change,
+  ) {
+    if (!change.hasChange) return character;
+    if (change.mode == CharacterPositionMode.aiChoice) {
+      return character.copyWith(positionMode: CharacterPositionMode.aiChoice);
+    }
+    final config = _ref.read(characterPromptNotifierProvider);
+    final position = change.x != null
+        ? CharacterPosition(
+            mode: CharacterPositionMode.custom,
+            row: change.y!,
+            column: change.x!,
+          )
+        : character.customPosition ?? config.resolvePosition(character);
+    return character.copyWith(
+      positionMode: CharacterPositionMode.custom,
+      customPosition: position,
+    );
+  }
+
+  _CharacterPositionChange _parsePositionChange(Map<String, dynamic> args) {
+    final rawMode = args['position_mode'];
+    final mode = switch (rawMode) {
+      null => null,
+      'ai_choice' => CharacterPositionMode.aiChoice,
+      'custom' => CharacterPositionMode.custom,
+      _ => throw const _PromptToolValidationException(
+        'invalid_character_position_mode',
+        'position_mode must be "ai_choice" or "custom".',
+      ),
+    };
+    final hasX = args.containsKey('position_x');
+    final hasY = args.containsKey('position_y');
+    if (hasX != hasY) {
+      throw const _PromptToolValidationException(
+        'partial_character_coordinates',
+        'position_x and position_y must be provided together.',
+      );
+    }
+    double? x;
+    double? y;
+    if (hasX) {
+      x = _validateCoordinate(args['position_x'], 'position_x');
+      y = _validateCoordinate(args['position_y'], 'position_y');
+      if (mode == CharacterPositionMode.aiChoice) {
+        throw const _PromptToolValidationException(
+          'character_position_conflict',
+          'ai_choice cannot be combined with coordinates.',
+        );
+      }
+    }
+    return _CharacterPositionChange(
+      hasChange: rawMode != null || hasX,
+      mode: mode ?? (hasX ? CharacterPositionMode.custom : null),
+      x: x,
+      y: y,
+    );
+  }
+
+  double _validateCoordinate(Object? value, String name) {
+    if (value is! num) {
+      throw _PromptToolValidationException(
+        'invalid_character_coordinate',
+        '$name must be a finite number between 0 and 1.',
+      );
+    }
+    final coordinate = value.toDouble();
+    if (!coordinate.isFinite || coordinate < 0 || coordinate > 1) {
+      throw _PromptToolValidationException(
+        'invalid_character_coordinate',
+        '$name must be a finite number between 0 and 1.',
+      );
+    }
+    return coordinate;
+  }
+
+  static Map<String, dynamic> _characterJson(
+    CharacterPrompt character, {
+    required int order,
+  }) => {
+    'id': character.id,
+    'order': order,
+    'name': character.name,
+    'gender': character.gender.name,
+    'enabled': character.enabled,
+    'prompt': character.prompt,
+    'negative_prompt': character.negativePrompt,
+    'position_mode': character.positionMode == CharacterPositionMode.aiChoice
+        ? 'ai_choice'
+        : 'custom',
+    'position_x': character.customPosition?.column,
+    'position_y': character.customPosition?.row,
+  };
 
   Future<AgentToolResult> _readSkill(Map<String, dynamic> args) async {
     final name = (args['name'] as String?)?.trim() ?? '';
@@ -576,18 +868,57 @@ class PromptToolbox {
     return '.../${segments.skip(start).join('/')}';
   }
 
-  CharacterGender? _parseGender(dynamic raw) {
-    switch (raw) {
-      case 'female':
-        return CharacterGender.female;
-      case 'male':
-        return CharacterGender.male;
-      case 'other':
-        return CharacterGender.other;
-      default:
-        return null;
+  void _validateCharacterStringFields(Map<String, dynamic> args) {
+    const fields = [
+      'id',
+      'name',
+      'new_name',
+      'gender',
+      'prompt',
+      'negative_prompt',
+    ];
+    for (final field in fields) {
+      if (args.containsKey(field) && args[field] is! String) {
+        throw _PromptToolValidationException(
+          'invalid_character_field',
+          '$field must be a string.',
+        );
+      }
     }
+    if (args.containsKey('gender')) _parseGender(args['gender']);
   }
+
+  CharacterGender? _parseGender(Object? raw) => switch (raw) {
+    null => null,
+    'female' => CharacterGender.female,
+    'male' => CharacterGender.male,
+    'other' => CharacterGender.other,
+    _ => throw const _PromptToolValidationException(
+      'invalid_character_gender',
+      'gender must be "female", "male", or "other".',
+    ),
+  };
+}
+
+class _CharacterPositionChange {
+  const _CharacterPositionChange({
+    required this.hasChange,
+    required this.mode,
+    required this.x,
+    required this.y,
+  });
+
+  final bool hasChange;
+  final CharacterPositionMode? mode;
+  final double? x;
+  final double? y;
+}
+
+class _PromptToolValidationException implements Exception {
+  const _PromptToolValidationException(this.code, this.message);
+
+  final String code;
+  final String message;
 }
 
 /// 按 NAI 逗号分隔习惯合并提示词文本。

--- a/lib/presentation/providers/character_prompt_provider.dart
+++ b/lib/presentation/providers/character_prompt_provider.dart
@@ -31,6 +31,7 @@ CharacterPromptConfig limitCharacterConfigForModel(
 @Riverpod(keepAlive: true)
 class CharacterPromptNotifier extends _$CharacterPromptNotifier {
   late final CharacterPromptRepository _repository;
+  Future<void> _saveTail = Future<void>.value();
 
   @override
   CharacterPromptConfig build() {
@@ -39,14 +40,95 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
     final loaded = _repository.load();
     final normalized = loaded.normalizeCustomPositions();
     if (normalized != loaded) {
-      unawaited(_repository.save(normalized));
+      unawaited(_saveSnapshot(normalized));
     }
     return normalized;
   }
 
-  /// 保存配置到本地存储
-  Future<void> _saveConfig() async {
-    await _repository.save(state);
+  Future<bool> _saveSnapshot(CharacterPromptConfig snapshot) {
+    final operation = _saveTail.then((_) => _repository.save(snapshot));
+    _saveTail = operation.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    return operation;
+  }
+
+  /// 保存按调用顺序串行落盘，避免较旧快照在较新快照之后完成。
+  Future<bool> _saveConfig() => _saveSnapshot(state);
+
+  /// Agent 入口使用可等待的原子修改，避免先报告成功再异步写盘失败。
+  Future<bool> updateCharacterPersisted(CharacterPrompt character) {
+    state = state.updateCharacter(character).normalizeCustomPositions();
+    return _saveConfig();
+  }
+
+  Future<bool> removeCharacterPersisted(String id) {
+    state = state.removeCharacter(id);
+    return _saveConfig();
+  }
+
+  Future<bool> clearAllCharactersPersisted() {
+    state = state.clearAllCharacters();
+    return _saveConfig();
+  }
+
+  Future<bool> setGlobalAiChoicePersisted(bool value) {
+    var newState = state.copyWith(globalAiChoice: value);
+    if (!value) newState = newState.normalizeCustomPositions();
+    state = newState;
+    return _saveConfig();
+  }
+
+  Future<bool> setCharacterOrderPersisted(List<String> orderedIds) {
+    final currentById = {
+      for (final character in state.characters) character.id: character,
+    };
+    if (orderedIds.length != currentById.length ||
+        orderedIds.toSet().length != orderedIds.length ||
+        !orderedIds.every(currentById.containsKey)) {
+      throw const FormatException(
+        'orderedIds must contain every current character ID exactly once',
+      );
+    }
+    state = state.copyWith(
+      characters: [for (final id in orderedIds) currentById[id]!],
+    );
+    return _saveConfig();
+  }
+
+  Future<({CharacterPrompt character, bool persisted})?> addCharacterPersisted(
+    CharacterGender gender, {
+    required String name,
+    required String prompt,
+    String? negativePrompt,
+    required bool enabled,
+    required CharacterPositionMode positionMode,
+    CharacterPosition? customPosition,
+  }) async {
+    if (isAtCharacterLimit || characterLimit == 0) return null;
+    final existingIds = state.characters
+        .map((character) => character.id)
+        .toSet();
+    state = state.addCharacter(
+      gender: gender,
+      name: name,
+      prompt: prompt,
+      negativePrompt: negativePrompt,
+    );
+    var created = state.characters.firstWhere(
+      (character) => !existingIds.contains(character.id),
+    );
+    created = created.copyWith(
+      enabled: enabled,
+      positionMode: positionMode,
+      customPosition: customPosition,
+    );
+    state = state.updateCharacter(created).normalizeCustomPositions();
+    final applied = state.characters.firstWhere(
+      (character) => character.id == created.id,
+    );
+    return (character: applied, persisted: await _saveConfig());
   }
 
   /// 添加新角色
@@ -66,7 +148,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
     String? thumbnailPath,
   }) {
     if (isAtCharacterLimit) {
-      // 官方上限：V5 为 32、V4/V4.5 为 6。到顶后静默拒绝，
+      // 官方上限：V5 为 22、V4/V4.5 为 6。到顶后静默拒绝，
       // 添加入口会按同一判定禁用并给出提示。
       AppLogger.w(
         'Character limit reached ($characterLimit), ignoring addCharacter',
@@ -81,7 +163,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
       negativePrompt: negativePrompt,
       thumbnailPath: thumbnailPath,
     );
-    _saveConfig();
+    unawaited(_saveConfig());
   }
 
   /// 当前模型的官方角色数量上限。
@@ -103,7 +185,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
   /// Requirements: 4.2
   void removeCharacter(String id) {
     state = state.removeCharacter(id);
-    _saveConfig();
+    unawaited(_saveConfig());
   }
 
   /// 更新角色
@@ -113,7 +195,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
   /// Requirements: 2.2, 2.3, 2.4, 2.5
   void updateCharacter(CharacterPrompt character) {
     state = state.updateCharacter(character).normalizeCustomPositions();
-    _saveConfig();
+    unawaited(_saveConfig());
   }
 
   /// 重新排序角色
@@ -124,7 +206,25 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
   /// Requirements: 4.1, 4.3
   void reorderCharacters(int oldIndex, int newIndex) {
     state = state.reorderCharacters(oldIndex, newIndex);
-    _saveConfig();
+    unawaited(_saveConfig());
+  }
+
+  /// 按稳定角色 ID 设置完整顺序。
+  void setCharacterOrder(List<String> orderedIds) {
+    final currentById = {
+      for (final character in state.characters) character.id: character,
+    };
+    if (orderedIds.length != currentById.length ||
+        orderedIds.toSet().length != orderedIds.length ||
+        !orderedIds.every(currentById.containsKey)) {
+      throw const FormatException(
+        'orderedIds must contain every current character ID exactly once',
+      );
+    }
+    state = state.copyWith(
+      characters: [for (final id in orderedIds) currentById[id]!],
+    );
+    unawaited(_saveConfig());
   }
 
   /// 设置全局AI选择位置
@@ -141,7 +241,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
     }
 
     state = newState;
-    _saveConfig();
+    unawaited(_saveConfig());
   }
 
   /// 清空所有角色
@@ -149,7 +249,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
   /// Requirements: 4.4
   void clearAllCharacters() {
     state = state.clearAllCharacters();
-    _saveConfig();
+    unawaited(_saveConfig());
   }
 
   /// 清空所有角色（别名）
@@ -172,7 +272,7 @@ class CharacterPromptNotifier extends _$CharacterPromptNotifier {
         'CharacterPrompt',
       );
     }
-    _saveConfig();
+    unawaited(_saveConfig());
   }
 
   /// 向上移动角色
@@ -246,7 +346,7 @@ int enabledCharacterCount(Ref ref) {
   return config.characters.where((c) => c.enabled).length;
 }
 
-/// 是否已达到当前模型的官方角色上限（V5 为 32、V4/V4.5 为 6）。
+/// 是否已达到当前模型的官方角色上限（V5 为 22、V4/V4.5 为 6）。
 @riverpod
 bool characterLimitReached(Ref ref) {
   final model = ref.watch(

--- a/lib/presentation/providers/generation/generation_request_preparation_service.dart
+++ b/lib/presentation/providers/generation/generation_request_preparation_service.dart
@@ -94,9 +94,17 @@ class GenerationPreparationResult {
 
 /// Produces request snapshots without reading Riverpod or writing UI state.
 class GenerationRequestPreparationService {
-  const GenerationRequestPreparationService(this.dependencies);
+  const GenerationRequestPreparationService(
+    this.dependencies, {
+    this.preserveCharacterSnapshot = false,
+  });
 
   final GenerationPreparationDependencies dependencies;
+
+  /// Agent confirmation and durable queue snapshots already contain the exact
+  /// normalized characters and layout mode. They must not be replaced from
+  /// the mutable character editor during execution.
+  final bool preserveCharacterSnapshot;
 
   Future<GenerationPreparationResult> prepareInitial(ImageParams params) async {
     final promptPreparation = dependencies.prompt;
@@ -123,7 +131,6 @@ class GenerationRequestPreparationService {
       negativePrompt: negativePromptWithFixedTags,
     );
     final presets = promptPreparation.resolvePresets(effective);
-    final characters = dependencies.characters.read(effective.model);
     effective = effective.copyWith(
       prompt: presets.prompt,
       negativePrompt: presets.negativePrompt,
@@ -131,9 +138,14 @@ class GenerationRequestPreparationService {
       ucPreset: presets.ucPreset,
       omitQualityTagHint: presets.omitQualityTagHint,
       omitUcPresetTagHint: presets.omitUcPresetTagHint,
-      characters: characters.characters,
-      useCoords: characters.useCoords,
     );
+    if (!preserveCharacterSnapshot) {
+      final characters = dependencies.characters.read(effective.model);
+      effective = effective.copyWith(
+        characters: characters.characters,
+        useCoords: characters.useCoords,
+      );
+    }
     effective = await dependencies.vibes.prepare(effective);
     return GenerationPreparationResult(
       params: effective,
@@ -161,6 +173,9 @@ class GenerationRequestPreparationService {
           currentParams.copyWith(prompt: preparedPrompt, negativePrompt: ''),
         )
         .prompt;
+    if (preserveCharacterSnapshot) {
+      return currentParams.copyWith(prompt: preparedPrompt);
+    }
     final characters = dependencies.characters.read(currentParams.model);
     return currentParams.copyWith(
       prompt: preparedPrompt,

--- a/lib/presentation/providers/image_generation_provider.dart
+++ b/lib/presentation/providers/image_generation_provider.dart
@@ -1032,6 +1032,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         character,
         index: index,
         total: effective.characters.length,
+        useCoords: effective.useCoords,
       );
       final x = center.x;
       final y = center.y;

--- a/lib/presentation/providers/image_generation_provider.dart
+++ b/lib/presentation/providers/image_generation_provider.dart
@@ -11,6 +11,7 @@ import '../../core/services/android_generation_foreground_service.dart';
 import '../../core/services/anlas_calculator.dart';
 import '../../core/services/character_conversion_service.dart';
 import '../../core/utils/app_logger.dart';
+import '../../core/utils/character_center_resolver.dart';
 import '../../core/utils/image_save_utils.dart';
 import '../../core/utils/image_share_sanitizer.dart';
 import '../../core/utils/inpaint_mask_utils.dart';
@@ -231,7 +232,11 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
   Future<void> waitUntilGenerationInvocationSettled() =>
       _generationInvocationSettled?.future ?? Future<void>.value();
 
-  Future<void> generate(ImageParams params, {int? batchSizeOverride}) async {
+  Future<void> generate(
+    ImageParams params, {
+    int? batchSizeOverride,
+    bool preserveCharacterSnapshot = false,
+  }) async {
     if (_isDisposed || _generationInvocationStarting || state.isGenerating) {
       return;
     }
@@ -299,7 +304,9 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         return;
       }
 
-      final preparation = _preparationService();
+      final preparation = _preparationService(
+        preserveCharacterSnapshot: preserveCharacterSnapshot,
+      );
       late final GenerationPreparationResult prepared;
       try {
         prepared = await preparation.prepareInitial(effectiveParams);
@@ -390,7 +397,9 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     }
   }
 
-  GenerationRequestPreparationService _preparationService() {
+  GenerationRequestPreparationService _preparationService({
+    bool preserveCharacterSnapshot = false,
+  }) {
     var queueExecuting = false;
     try {
       final queue = ref.read(queueExecutionNotifierProvider);
@@ -413,12 +422,9 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
           resolvePresets: _resolvePromptPresets,
         ),
         characters: GenerationCharacterPreparation(
-          read: (model) {
+          read: (_) {
             final config = ref.read(characterPromptNotifierProvider);
-            final characters = _convertCharactersToApiFormat(
-              config,
-              model: model,
-            );
+            final characters = _convertCharactersToApiFormat(config);
             return CharacterPreparationSnapshot(
               characters: characters,
               useCoords: characters.isNotEmpty && !config.globalAiChoice,
@@ -437,6 +443,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         ),
         vibes: GenerationVibePreparation(prepare: _prepareVibesForGeneration),
       ),
+      preserveCharacterSnapshot: preserveCharacterSnapshot,
     );
   }
 
@@ -847,7 +854,6 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
       return GenerationSaveResult(images, const []);
     }
     final fixed = ref.read(fixedTagsNotifierProvider);
-    final config = ref.read(characterPromptNotifierProvider);
     final lifecycle = _lifecycle();
     final result = await lifecycle.saveImages(
       images,
@@ -873,7 +879,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
             .map((entry) => entry.weightedContent)
             .where((content) => content.isNotEmpty)
             .toList(),
-        useCoords: !config.globalAiChoice,
+        useCoords: params.useCoords,
       ),
       directoryPath: directoryPath,
       syncToGalleryIndex: syncToGalleryIndex,
@@ -962,22 +968,13 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
   }
 
   List<CharacterPrompt> _convertCharactersToApiFormat(
-    ui_character.CharacterPromptConfig config, {
-    required String model,
-  }) {
-    final limited = limitCharacterConfigForModel(config, model);
-    if (limited.characters.length != config.characters.length) {
-      AppLogger.w(
-        'Character request truncated from ${config.characters.length} to '
-            '${limited.characters.length} for $model',
-        'CharacterPrompt',
-      );
-    }
+    ui_character.CharacterPromptConfig config,
+  ) {
     return CharacterConversionService(
       aliasResolver: ref
           .read(aliasResolverServiceProvider.notifier)
           .resolveAliases,
-    ).convert(limited).characters;
+    ).convert(config).characters;
   }
 
   Future<String> generateAndApplyRandomPrompt({
@@ -1029,13 +1026,15 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     final effective = params.copyWith(width: outputWidth, height: outputHeight);
     final charCaptions = <Map<String, dynamic>>[];
     final charNegCaptions = <Map<String, dynamic>>[];
-    for (final character in effective.characters) {
-      final positioned =
-          effective.useCoords &&
-          character.positionX != null &&
-          character.positionY != null;
-      final x = positioned ? character.positionX!.clamp(0.0, 1.0) : 0.5;
-      final y = positioned ? character.positionY!.clamp(0.0, 1.0) : 0.5;
+    for (var index = 0; index < effective.characters.length; index++) {
+      final character = effective.characters[index];
+      final center = CharacterCenterResolver.resolve(
+        character,
+        index: index,
+        total: effective.characters.length,
+      );
+      final x = center.x;
+      final y = center.y;
       charCaptions.add({
         'char_caption': character.prompt,
         'centers': [

--- a/lib/presentation/providers/queue_execution_provider.dart
+++ b/lib/presentation/providers/queue_execution_provider.dart
@@ -407,13 +407,20 @@ class QueueExecutionNotifier extends _$QueueExecutionNotifier {
 
     final characterPrompts = task.characterPrompts;
     if (characterPrompts != null) {
-      ref.read(characterPromptNotifierProvider.notifier).replaceAll([
+      final notifier = ref.read(characterPromptNotifierProvider.notifier);
+      notifier.replaceAll([
         for (var index = 0; index < characterPrompts.length; index++)
           characterPrompts[index].toCharacterPrompt(
             id: '${task.id}-character-$index',
             index: index,
           ),
       ]);
+      notifier.setGlobalAiChoice(
+        !characterPrompts.any(
+          (character) =>
+              character.positionX != null && character.positionY != null,
+        ),
+      );
     }
   }
 
@@ -487,6 +494,7 @@ class QueueExecutionNotifier extends _$QueueExecutionNotifier {
       await generationNotifier.generate(
         params,
         batchSizeOverride: batchSizeOverride,
+        preserveCharacterSnapshot: snapshot != null,
       );
     } on FormatException catch (error, stackTrace) {
       final taskId = state.currentTaskId;

--- a/test/core/agent/permissions/agent_permission_test.dart
+++ b/test/core/agent/permissions/agent_permission_test.dart
@@ -15,6 +15,20 @@ void main() {
       describeAgentToolPermission('delete_tag_library_category').operation,
       AgentPermissionOperation.delete,
     );
+    for (final toolName in [
+      'set_character_layout_mode',
+      'reorder_characters',
+      'clear_characters',
+    ]) {
+      expect(
+        describeAgentToolPermission(toolName).domain,
+        AgentPermissionDomain.prompt,
+      );
+    }
+    expect(
+      describeAgentToolPermission('clear_characters').operation,
+      AgentPermissionOperation.delete,
+    );
   });
 
   group('AgentPermissionPolicy', () {

--- a/test/core/constants/model_capabilities_test.dart
+++ b/test/core/constants/model_capabilities_test.dart
@@ -185,7 +185,7 @@ void main() {
       // 正式站关闭端到端 ×2，并保留增强 max 档。
       expect(caps.supportsE2eUpscale, isFalse);
       expect(caps.supportsMaxEnhance, isTrue);
-      expect(caps.maxCharacters, 32);
+      expect(caps.maxCharacters, 22);
       expect(caps.supportsAutoText, isTrue);
       expect(
         ModelCapabilityRegistry.of(

--- a/test/core/network/request_builders/nai_image_request_builder_test.dart
+++ b/test/core/network/request_builders/nai_image_request_builder_test.dart
@@ -372,11 +372,11 @@ void main() {
     });
 
     test(
-      'should keep explicit centers and give all six characters a fallback',
+      'should keep complete centers in AI layout while coordinates stay off',
       () async {
         final params = ImageParams(
           model: ImageModels.animeDiffusionV45Full,
-          useCoords: true,
+          useCoords: false,
           characters: [
             const CharacterPrompt(
               prompt: 'explicit',
@@ -405,6 +405,7 @@ void main() {
 
         expect(explicitCenter.single, equals({'x': 0.37, 'y': 0.64}));
         expect(lastCenter.single, equals({'x': 0.8, 'y': 0.75}));
+        expect(v4Prompt['use_coords'], isFalse);
         expect(
           result
               .requestParameters['v4_negative_prompt']['caption']['char_captions'][0]['centers'][0],
@@ -412,6 +413,55 @@ void main() {
         );
       },
     );
+
+    test('should reject incomplete centers in custom layout', () async {
+      const params = ImageParams(
+        model: ImageModels.animeDiffusionV45Full,
+        useCoords: true,
+        characters: [
+          CharacterPrompt(prompt: 'complete', positionX: 0.2, positionY: 0.8),
+          CharacterPrompt(prompt: 'missing'),
+        ],
+      );
+
+      await expectLater(
+        NAIImageRequestBuilder(
+          params: params,
+          encodeVibe: _fakeEncodeVibe,
+        ).build(sampler: 'k_euler'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('finite x/y centers'),
+          ),
+        ),
+      );
+    });
+
+    test('should reject V5 character counts above twenty-two', () async {
+      final params = ImageParams(
+        model: ImageModels.animeDiffusionV5Full,
+        characters: List<CharacterPrompt>.generate(
+          23,
+          (index) => CharacterPrompt(prompt: 'character $index'),
+        ),
+      );
+
+      await expectLater(
+        NAIImageRequestBuilder(
+          params: params,
+          encodeVibe: _fakeEncodeVibe,
+        ).build(sampler: 'k_euler'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('at most 22 characters'),
+          ),
+        ),
+      );
+    });
 
     test(
       'should apply native quality and UC presets only at request boundary',

--- a/test/core/network/request_builders/nai_image_request_builder_test.dart
+++ b/test/core/network/request_builders/nai_image_request_builder_test.dart
@@ -414,6 +414,30 @@ void main() {
       },
     );
 
+    test('should replace malformed centers in AI layout', () async {
+      const params = ImageParams(
+        model: ImageModels.animeDiffusionV45Full,
+        useCoords: false,
+        characters: [
+          CharacterPrompt(
+            prompt: 'stale center',
+            positionX: double.nan,
+            positionY: 2,
+          ),
+        ],
+      );
+
+      final result = await NAIImageRequestBuilder(
+        params: params,
+        encodeVibe: _fakeEncodeVibe,
+      ).build(sampler: 'k_euler');
+      final center = result
+          .requestParameters['v4_prompt']['caption']['char_captions'][0]['centers'][0];
+
+      expect(center, equals({'x': 0.5, 'y': 0.5}));
+      expect(result.requestParameters['v4_prompt']['use_coords'], isFalse);
+    });
+
     test('should reject incomplete centers in custom layout', () async {
       const params = ImageParams(
         model: ImageModels.animeDiffusionV45Full,

--- a/test/presentation/agent_chat/services/generation_character_orchestration_test.dart
+++ b/test/presentation/agent_chat/services/generation_character_orchestration_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/constants/api_constants.dart';
+import 'package:nai_launcher/core/constants/model_capabilities.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_character_orchestration.dart';
+
+void main() {
+  group('GenerationCharacterOrchestrator', () {
+    test('uses current V4/V4.5/V5 official character limits', () {
+      expect(
+        ModelCapabilityRegistry.of(
+          ImageModels.animeDiffusionV4Curated,
+        ).maxCharacters,
+        6,
+      );
+      expect(
+        ModelCapabilityRegistry.of(
+          ImageModels.animeDiffusionV45Curated,
+        ).maxCharacters,
+        6,
+      );
+      expect(
+        ModelCapabilityRegistry.of(
+          ImageModels.animeDiffusionV5Curated,
+        ).maxCharacters,
+        22,
+      );
+    });
+
+    test('normalizes legacy grid and deterministic custom defaults', () {
+      final snapshot = GenerationCharacterOrchestrator.normalizeExplicit(
+        model: ImageModels.animeDiffusionV5Curated,
+        rawLayoutMode: 'custom',
+        rawCharacters: const [
+          {'prompt': 'hero', 'position': 'B3'},
+          {'prompt': 'companion'},
+        ],
+      );
+
+      expect(snapshot.useCoords, isTrue);
+      expect(snapshot.characters.first.positionX, 0.3);
+      expect(snapshot.characters.first.positionY, 0.5);
+      expect(snapshot.characters.last.positionX, isNotNull);
+      expect(snapshot.characters.last.positionY, isNotNull);
+      expect(snapshot.characters.last.positionX, inInclusiveRange(0, 1));
+      expect(snapshot.characters.last.positionY, inInclusiveRange(0, 1));
+    });
+
+    test('AI layout rejects coordinates instead of silently ignoring them', () {
+      expect(
+        () => GenerationCharacterOrchestrator.normalizeExplicit(
+          model: ImageModels.animeDiffusionV5Curated,
+          rawLayoutMode: 'ai_choice',
+          rawCharacters: const [
+            {'prompt': 'hero', 'position_x': 0.25, 'position_y': 0.75},
+          ],
+        ),
+        throwsA(
+          isA<GenerationCharacterValidationException>().having(
+            (error) => error.code,
+            'code',
+            'character_layout_conflict',
+          ),
+        ),
+      );
+    });
+
+    test('rejects partial, non-finite, empty, and over-limit roles', () {
+      expect(
+        () => GenerationCharacterOrchestrator.normalizeExplicit(
+          model: ImageModels.animeDiffusionV5Curated,
+          rawLayoutMode: 'custom',
+          rawCharacters: const [
+            {'prompt': 'hero', 'position_x': 0.5},
+          ],
+        ),
+        throwsA(
+          isA<GenerationCharacterValidationException>().having(
+            (error) => error.code,
+            'code',
+            'partial_character_coordinates',
+          ),
+        ),
+      );
+      expect(
+        () => GenerationCharacterOrchestrator.normalizeExplicit(
+          model: ImageModels.animeDiffusionV5Curated,
+          rawLayoutMode: 'custom',
+          rawCharacters: [
+            {'prompt': 'hero', 'position_x': double.nan, 'position_y': 0.5},
+          ],
+        ),
+        throwsA(
+          isA<GenerationCharacterValidationException>().having(
+            (error) => error.code,
+            'code',
+            'invalid_character_coordinate',
+          ),
+        ),
+      );
+      expect(
+        () => GenerationCharacterOrchestrator.normalizeExplicit(
+          model: ImageModels.animeDiffusionV5Curated,
+          rawLayoutMode: 'ai_choice',
+          rawCharacters: const [
+            {'prompt': '   '},
+          ],
+        ),
+        throwsA(
+          isA<GenerationCharacterValidationException>().having(
+            (error) => error.code,
+            'code',
+            'invalid_character_prompt',
+          ),
+        ),
+      );
+      expect(
+        () => GenerationCharacterOrchestrator.normalizeExplicit(
+          model: ImageModels.animeDiffusionV5Curated,
+          rawLayoutMode: 'ai_choice',
+          rawCharacters: List.generate(
+            23,
+            (index) => {'prompt': 'role $index'},
+          ),
+        ),
+        throwsA(
+          isA<GenerationCharacterValidationException>().having(
+            (error) => error.code,
+            'code',
+            'model_character_limit',
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/presentation/agent_chat/services/generation_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/generation_toolbox_test.dart
@@ -8,6 +8,8 @@ import 'package:image/image.dart' as image_lib;
 import 'package:nai_launcher/core/agent/agent_types.dart';
 import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
 import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference_codec.dart';
+import 'package:nai_launcher/core/constants/api_constants.dart';
+import 'package:nai_launcher/core/network/request_builders/nai_image_request_builder.dart';
 import 'package:nai_launcher/core/services/anlas_calculator.dart';
 import 'package:nai_launcher/core/enums/precise_ref_type.dart';
 import 'package:nai_launcher/data/models/agent/agent_settings.dart';
@@ -38,6 +40,12 @@ Ref _makeRef(ProviderContainer container) => container.read(_refProvider);
 Map<String, dynamic> _json(AgentToolResult result) =>
     jsonDecode(result.content.whereType<ToolResultTextContent>().single.text)
         as Map<String, dynamic>;
+
+Future<String> _fakeEncodeVibe(
+  Uint8List image, {
+  required String model,
+  double informationExtracted = 1.0,
+}) async => 'encoded-vibe';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -450,6 +458,100 @@ void main() {
   );
 
   test(
+    'Agent custom characters reach the final request as one immutable scene',
+    () async {
+      final fake = _FakeImageGenerationNotifier();
+      final container = ProviderContainer(
+        overrides: [
+          imageGenerationNotifierProvider.overrideWith(() => fake),
+          generationParamsNotifierProvider.overrideWith(
+            _TestV5GenerationParamsNotifier.new,
+          ),
+          characterPromptNotifierProvider.overrideWith(
+            _TestCharacterPromptNotifier.new,
+          ),
+          subscriptionNotifierProvider.overrideWith(
+            _TestSubscriptionNotifier.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final tools = GenerationToolbox(_makeRef(container)).tools();
+      final prepare = tools.firstWhere(
+        (tool) => tool.name == 'prepare_generation',
+      );
+      final submit = tools.firstWhere(
+        (tool) => tool.name == 'submit_generation',
+      );
+
+      final prepared = await prepare.execute('prepare-characters', const {
+        'operation': 'generate',
+        'prompt': 'two friends',
+        'character_layout_mode': 'custom',
+        'characters': [
+          {
+            'prompt': 'hero, black hair',
+            'negative_prompt': 'red hair',
+            'position_x': 0.2,
+            'position_y': 0.75,
+          },
+          {
+            'prompt': 'companion, blonde hair',
+            'negative_prompt': 'black hair',
+            'position': 'E1',
+          },
+        ],
+      });
+      expect(prepared.isError, isFalse);
+      final payload = _json(prepared);
+      final preparedParams = payload['parameters'] as Map<String, dynamic>;
+      expect(preparedParams['character_layout_mode'], 'custom');
+      expect(preparedParams['character_count'], 2);
+      expect(preparedParams['characters'][0]['center'], {'x': 0.2, 'y': 0.75});
+      expect(preparedParams['characters'][1]['center'], {'x': 0.9, 'y': 0.1});
+
+      container
+          .read(characterPromptNotifierProvider.notifier)
+          .clearAllCharacters();
+      final submitted = await submit.execute('submit-characters', {
+        'preparation_id': payload['preparation_id'],
+        'confirmed': true,
+      });
+      expect(submitted.isError, isFalse);
+      expect(fake.preserveCharacterSnapshot, isTrue);
+      final params = fake.params!;
+      expect(params.useCoords, isTrue);
+      expect(params.characters.map((character) => character.prompt), [
+        'hero, black hair',
+        'companion, blonde hair',
+      ]);
+
+      final request = await NAIImageRequestBuilder(
+        params: params,
+        encodeVibe: _fakeEncodeVibe,
+      ).build(sampler: Samplers.kEulerAncestral);
+      final parameters = request.requestParameters;
+      expect(parameters['use_coords'], isTrue);
+      expect(parameters['v4_prompt']['use_coords'], isTrue);
+      expect(parameters['characterPrompts'][0]['center'], {
+        'x': 0.2,
+        'y': 0.75,
+      });
+      expect(parameters['characterPrompts'][1]['center'], {'x': 0.9, 'y': 0.1});
+      expect(
+        parameters['v4_prompt']['caption']['char_captions'][1]['centers'],
+        [
+          {'x': 0.9, 'y': 0.1},
+        ],
+      );
+      expect(
+        parameters['v4_negative_prompt']['caption']['char_captions'][0]['char_caption'],
+        'red hair',
+      );
+    },
+  );
+
+  test(
     'prepare lifecycle estimates before fake generation provider is called',
     () async {
       final fake = _FakeImageGenerationNotifier();
@@ -459,6 +561,9 @@ void main() {
           imagesPerRequestProvider.overrideWith(_TestImagesPerRequest.new),
           generationParamsNotifierProvider.overrideWith(
             _TestGenerationParamsNotifier.new,
+          ),
+          characterPromptNotifierProvider.overrideWith(
+            _TestCharacterPromptNotifier.new,
           ),
           subscriptionNotifierProvider.overrideWith(
             _TestSubscriptionNotifier.new,
@@ -537,6 +642,9 @@ void main() {
   test('update and cancel keep preparation lifecycle structured', () async {
     final container = ProviderContainer(
       overrides: [
+        characterPromptNotifierProvider.overrideWith(
+          _TestCharacterPromptNotifier.new,
+        ),
         subscriptionNotifierProvider.overrideWith(
           _TestSubscriptionNotifier.new,
         ),
@@ -608,6 +716,9 @@ void main() {
     () async {
       final container = ProviderContainer(
         overrides: [
+          characterPromptNotifierProvider.overrideWith(
+            _TestCharacterPromptNotifier.new,
+          ),
           subscriptionNotifierProvider.overrideWith(
             _TestSubscriptionNotifier.new,
           ),
@@ -832,6 +943,14 @@ class _TestGenerationParamsNotifier extends GenerationParamsNotifier {
   ImageParams build() => const ImageParams(negativePrompt: 'page negative');
 }
 
+class _TestV5GenerationParamsNotifier extends GenerationParamsNotifier {
+  @override
+  ImageParams build() => const ImageParams(
+    model: ImageModels.animeDiffusionV5Curated,
+    negativePrompt: 'page negative',
+  );
+}
+
 class _TestImagesPerRequest extends ImagesPerRequest {
   @override
   int build() => 2;
@@ -854,6 +973,11 @@ class _TestCharacterPromptNotifier extends CharacterPromptNotifier {
       ),
     ],
   );
+
+  @override
+  void clearAllCharacters() {
+    state = state.copyWith(characters: const []);
+  }
 }
 
 class _TestImageGenerationNotifier extends ImageGenerationNotifier {
@@ -868,14 +992,22 @@ class _TestImageGenerationNotifier extends ImageGenerationNotifier {
 class _FakeImageGenerationNotifier extends ImageGenerationNotifier {
   int generateCalls = 0;
   int? batchSize;
+  ImageParams? params;
+  bool? preserveCharacterSnapshot;
 
   @override
   ImageGenerationState build() => const ImageGenerationState();
 
   @override
-  Future<void> generate(ImageParams params, {int? batchSizeOverride}) async {
+  Future<void> generate(
+    ImageParams params, {
+    int? batchSizeOverride,
+    bool preserveCharacterSnapshot = false,
+  }) async {
     generateCalls++;
     batchSize = batchSizeOverride;
+    this.params = params;
+    this.preserveCharacterSnapshot = preserveCharacterSnapshot;
     state = ImageGenerationState(
       status: GenerationStatus.completed,
       currentImages: [

--- a/test/presentation/agent_chat/services/prompt_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/prompt_toolbox_test.dart
@@ -131,6 +131,132 @@ void main() {
     expect(_resultText(result), isNot(contains('C:/skills')));
   });
 
+  test(
+    'character tools expose, position, switch, and reorder full state',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          generationParamsNotifierProvider.overrideWith(
+            _TestGenerationParamsNotifier.new,
+          ),
+          characterPromptNotifierProvider.overrideWith(
+            _OrchestrationCharacterNotifier.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final tools = PromptToolbox(container.read(_refProvider)).tools();
+      AgentTool tool(String name) =>
+          tools.firstWhere((candidate) => candidate.name == name);
+
+      final initial = jsonDecode(
+        _resultText(await tool('get_prompt_state').execute('read', const {})),
+      );
+      expect(initial['character_layout_mode'], 'ai_choice');
+      expect(initial['characters'][0]['id'], 'first');
+      expect(initial['characters'][0]['order'], 0);
+      expect(initial['characters'][0]['position_x'], 0.2);
+
+      final partial = await tool(
+        'update_character',
+      ).execute('partial', const {'id': 'second', 'position_x': 0.5});
+      expect(partial.isError, isTrue);
+      expect(_resultText(partial), contains('partial_character_coordinates'));
+
+      final updated = await tool('update_character').execute('position', const {
+        'id': 'second',
+        'position_x': 0.8,
+        'position_y': 0.3,
+      });
+      expect(updated.isError, isFalse);
+      expect(
+        jsonDecode(_resultText(updated))['character']['position_mode'],
+        'custom',
+      );
+
+      await tool(
+        'set_character_layout_mode',
+      ).execute('custom', const {'mode': 'custom'});
+      final reordered = await tool('reorder_characters').execute(
+        'reorder',
+        const {
+          'ordered_ids': ['second', 'first'],
+        },
+      );
+      expect(reordered.isError, isFalse);
+      expect(
+        jsonDecode(_resultText(reordered))['characters'][0]['id'],
+        'second',
+      );
+
+      await tool(
+        'set_character_layout_mode',
+      ).execute('ai', const {'mode': 'ai_choice'});
+      final config = container.read(characterPromptNotifierProvider);
+      expect(config.globalAiChoice, isTrue);
+      expect(config.characters.first.customPosition?.column, 0.8);
+      expect(config.characters.first.customPosition?.row, 0.3);
+    },
+  );
+
+  test('rejects ambiguous or conflicting character selectors', () async {
+    final container = ProviderContainer(
+      overrides: [
+        generationParamsNotifierProvider.overrideWith(
+          _TestGenerationParamsNotifier.new,
+        ),
+        characterPromptNotifierProvider.overrideWith(
+          _DuplicateNameCharacterNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final tools = PromptToolbox(container.read(_refProvider)).tools();
+    AgentTool tool(String name) =>
+        tools.firstWhere((candidate) => candidate.name == name);
+    await tool(
+      'add_character',
+    ).execute('duplicate', const {'name': 'Alice', 'prompt': 'blue hair'});
+
+    final ambiguous = await tool(
+      'update_character',
+    ).execute('ambiguous', const {'name': 'Alice', 'prompt': 'changed'});
+    expect(ambiguous.isError, isTrue);
+    expect(_resultText(ambiguous), contains('invalid_character_selector'));
+
+    final conflicting = await tool('remove_character').execute(
+      'conflicting',
+      const {'id': 'old-character', 'name': 'Different'},
+    );
+    expect(conflicting.isError, isTrue);
+    expect(_resultText(conflicting), contains('invalid_character_selector'));
+
+    final missingId = await tool(
+      'remove_character',
+    ).execute('missing-id', const {'id': 'missing', 'name': 'Alice'});
+    expect(missingId.isError, isTrue);
+    expect(_resultText(missingId), contains('character_not_found'));
+
+    final invalidGender = await tool('update_character').execute(
+      'invalid-gender',
+      const {'id': 'old-character', 'gender': 'robot'},
+    );
+    expect(invalidGender.isError, isTrue);
+    expect(_resultText(invalidGender), contains('invalid_character_gender'));
+
+    final invalidPrompt = await tool(
+      'add_character',
+    ).execute('invalid-prompt', const {'name': 'Bob', 'prompt': 42});
+    expect(invalidPrompt.isError, isTrue);
+    expect(_resultText(invalidPrompt), contains('invalid_character_field'));
+
+    final invalidSelector = await tool(
+      'remove_character',
+    ).execute('invalid-selector', const {'id': 42});
+    expect(invalidSelector.isError, isTrue);
+    expect(_resultText(invalidSelector), contains('invalid_character_field'));
+  });
+
   test('add_character updates the newly created duplicate name', () async {
     final container = ProviderContainer(
       overrides: [
@@ -162,12 +288,59 @@ void main() {
     expect(characters, hasLength(2));
     expect(characters.first.negativePrompt, 'old negative');
     expect(characters.last.negativePrompt, 'red hair');
+    expect(characters.last.positionMode, CharacterPositionMode.aiChoice);
   });
 }
 
 class _TestGenerationParamsNotifier extends GenerationParamsNotifier {
   @override
   ImageParams build() => const ImageParams();
+}
+
+class _OrchestrationCharacterNotifier extends CharacterPromptNotifier {
+  @override
+  CharacterPromptConfig build() => const CharacterPromptConfig(
+    globalAiChoice: true,
+    characters: [
+      CharacterPrompt(
+        id: 'first',
+        name: 'First',
+        prompt: 'hero',
+        positionMode: CharacterPositionMode.aiChoice,
+        customPosition: CharacterPosition(
+          mode: CharacterPositionMode.custom,
+          row: 0.4,
+          column: 0.2,
+        ),
+      ),
+      CharacterPrompt(id: 'second', name: 'Second', prompt: 'companion'),
+    ],
+  );
+
+  @override
+  Future<bool> updateCharacterPersisted(CharacterPrompt character) async {
+    state = state.updateCharacter(character).normalizeCustomPositions();
+    return true;
+  }
+
+  @override
+  Future<bool> setGlobalAiChoicePersisted(bool value) async {
+    var next = state.copyWith(globalAiChoice: value);
+    if (!value) next = next.normalizeCustomPositions();
+    state = next;
+    return true;
+  }
+
+  @override
+  Future<bool> setCharacterOrderPersisted(List<String> orderedIds) async {
+    final byId = {
+      for (final character in state.characters) character.id: character,
+    };
+    state = state.copyWith(
+      characters: [for (final id in orderedIds) byId[id]!],
+    );
+    return true;
+  }
 }
 
 class _DuplicateNameCharacterNotifier extends CharacterPromptNotifier {
@@ -203,6 +376,30 @@ class _DuplicateNameCharacterNotifier extends CharacterPromptNotifier {
         ),
       ],
     );
+  }
+
+  @override
+  Future<({CharacterPrompt character, bool persisted})?> addCharacterPersisted(
+    CharacterGender gender, {
+    required String name,
+    required String prompt,
+    String? negativePrompt,
+    required bool enabled,
+    required CharacterPositionMode positionMode,
+    CharacterPosition? customPosition,
+  }) async {
+    final created = CharacterPrompt(
+      id: 'new-character',
+      name: name,
+      prompt: prompt,
+      negativePrompt: negativePrompt ?? '',
+      gender: gender,
+      enabled: enabled,
+      positionMode: positionMode,
+      customPosition: customPosition,
+    );
+    state = state.copyWith(characters: [...state.characters, created]);
+    return (character: created, persisted: true);
   }
 
   @override

--- a/test/presentation/providers/character_prompt_provider_test.dart
+++ b/test/presentation/providers/character_prompt_provider_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,6 +7,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:nai_launcher/core/constants/api_constants.dart';
 import 'package:nai_launcher/core/constants/storage_keys.dart';
 import 'package:nai_launcher/data/models/character/character_prompt.dart';
+import 'package:nai_launcher/data/repositories/character_prompt_repository.dart';
 import 'package:nai_launcher/presentation/providers/character_prompt_provider.dart';
 import 'package:nai_launcher/presentation/providers/image_generation_provider.dart';
 
@@ -65,7 +67,7 @@ void main() {
       expect(container.read(characterLimitReachedProvider), isTrue);
     });
 
-    test('allows up to 32 characters on V5', () {
+    test('allows up to 22 characters on V5', () {
       final notifier = container.read(characterPromptNotifierProvider.notifier);
       container
           .read(generationParamsNotifierProvider.notifier)
@@ -82,7 +84,7 @@ void main() {
 
       expect(
         container.read(characterPromptNotifierProvider).characters.length,
-        32,
+        22,
       );
       expect(container.read(characterLimitReachedProvider), isTrue);
     });
@@ -146,7 +148,7 @@ void main() {
     test('limits V5 character state for V4.5 without mutating the source', () {
       final v5Config = CharacterPromptConfig(
         characters: List<CharacterPrompt>.generate(
-          32,
+          22,
           (index) => CharacterPrompt(
             id: 'character-$index',
             name: 'Character $index',
@@ -160,9 +162,62 @@ void main() {
         ImageModels.animeDiffusionV45Curated,
       );
 
-      expect(v5Config.characters, hasLength(32));
+      expect(v5Config.characters, hasLength(22));
       expect(limited.characters, hasLength(6));
       expect(limited.characters.last.id, 'character-5');
     });
+
+    test('serializes persistence snapshots in mutation order', () async {
+      final repository = _ControlledCharacterPromptRepository();
+      final controlledContainer = ProviderContainer(
+        overrides: [
+          characterPromptRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(controlledContainer.dispose);
+      final notifier = controlledContainer.read(
+        characterPromptNotifierProvider.notifier,
+      );
+
+      final addFuture = notifier.addCharacterPersisted(
+        CharacterGender.female,
+        name: 'Alice',
+        prompt: '1girl',
+        enabled: true,
+        positionMode: CharacterPositionMode.aiChoice,
+      );
+      await Future<void>.delayed(Duration.zero);
+      final clearFuture = notifier.clearAllCharactersPersisted();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(repository.snapshots, hasLength(1));
+      expect(repository.snapshots.single.characters, hasLength(1));
+
+      repository.pendingSaves[0].complete();
+      await addFuture;
+      await Future<void>.delayed(Duration.zero);
+      expect(repository.snapshots, hasLength(2));
+      expect(repository.snapshots.last.characters, isEmpty);
+
+      repository.pendingSaves[1].complete();
+      expect(await clearFuture, isTrue);
+    });
   });
+}
+
+class _ControlledCharacterPromptRepository extends CharacterPromptRepository {
+  final snapshots = <CharacterPromptConfig>[];
+  final pendingSaves = <Completer<void>>[];
+
+  @override
+  CharacterPromptConfig load() => const CharacterPromptConfig();
+
+  @override
+  Future<bool> save(CharacterPromptConfig config) async {
+    snapshots.add(config);
+    final completer = Completer<void>();
+    pendingSaves.add(completer);
+    await completer.future;
+    return true;
+  }
 }

--- a/test/presentation/providers/queue_execution_provider_test.dart
+++ b/test/presentation/providers/queue_execution_provider_test.dart
@@ -658,7 +658,11 @@ class _ControlledImageGenerationNotifier extends ImageGenerationNotifier {
       _activeInvocation?.settled.future ?? Future<void>.value();
 
   @override
-  Future<void> generate(ImageParams params, {int? batchSizeOverride}) async {
+  Future<void> generate(
+    ImageParams params, {
+    int? batchSizeOverride,
+    bool preserveCharacterSnapshot = false,
+  }) async {
     if (_activeInvocation != null) return;
     final invocation = _ControlledGenerationInvocation();
     _activeInvocation = invocation;
@@ -740,14 +744,22 @@ class _TestImageGenerationNotifier extends ImageGenerationNotifier {
   ImageGenerationState build() => const ImageGenerationState();
 
   @override
-  Future<void> generate(ImageParams params, {int? batchSizeOverride}) async {}
+  Future<void> generate(
+    ImageParams params, {
+    int? batchSizeOverride,
+    bool preserveCharacterSnapshot = false,
+  }) async {}
 }
 
 class _CapturingImageGenerationNotifier extends _TestImageGenerationNotifier {
   ImageParams? generated;
 
   @override
-  Future<void> generate(ImageParams params, {int? batchSizeOverride}) async {
+  Future<void> generate(
+    ImageParams params, {
+    int? batchSizeOverride,
+    bool preserveCharacterSnapshot = false,
+  }) async {
     generated = params;
   }
 }
@@ -770,6 +782,11 @@ class _TestCharacterPromptNotifier extends CharacterPromptNotifier {
   @override
   void replaceAll(List<CharacterPrompt> characters) {
     state = state.copyWith(characters: characters);
+  }
+
+  @override
+  void setGlobalAiChoice(bool value) {
+    state = state.copyWith(globalAiChoice: value);
   }
 }
 


### PR DESCRIPTION
## 变更
- 为 Agent 补齐完整角色状态读取、增改、清空、全局 AI/custom 布局切换与稳定 ID 重排
- 统一 V4/V4.5 6 角色、V5 22 角色 capability，并严格校验模式冲突、坐标、空提示词、模型不支持和超限输入
- 将角色与布局固化为不可变生成快照，确认、执行、队列、重试、请求 captions/centers 与 metadata 使用同一顺序和坐标语义
- 串行化角色配置持久化，避免快速连续修改发生旧快照后写覆盖

## 验证
- scripts/test_affected.ps1：8 个相关测试文件，163 tests passed
- lutter analyze --no-fatal-warnings：仅保留 lib/core/agent/context_usage.dart:70 的既有 warning
- git diff --check：通过

## 已知主线问题
- 合并 #160 后，image_generation_provider_test.dart 中 2 个 Vibe 测试仍依赖旧默认模型；当前默认 V5 明确不支持 Vibe，因此这两个主线既有测试失败。本 PR 未修改 Vibe 行为或对应测试。

未执行真实生成，不消耗 Anlas。