### PR TITLE
fix(prompt): 将助手工具栏移出输入框

### DIFF
--- a/lib/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart
+++ b/lib/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart
@@ -27,6 +27,10 @@ class PromptAssistantOverlay extends ConsumerStatefulWidget {
   static double get contentBottomClearance =>
       PlatformCapabilities.current.hasTouchInput ? 68 : 56;
 
+  /// Width of the collapsed inline toolbar, including its horizontal padding.
+  static double get inlineCollapsedWidth =>
+      PlatformCapabilities.current.hasTouchInput ? 50 : 34;
+
   const PromptAssistantOverlay({
     super.key,
     required this.sessionId,
@@ -603,7 +607,7 @@ class _PromptAssistantOverlayState
           child: SingleChildScrollView(
             scrollDirection: Axis.horizontal,
             reverse: isExpanded,
-            clipBehavior: Clip.none,
+            clipBehavior: widget.floatOverEditor ? Clip.none : Clip.hardEdge,
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/lib/presentation/screens/generation/widgets/prompt_input.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_input.dart
@@ -2,8 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/constants/api_constants.dart';
+import '../../../../core/platform/platform_capabilities.dart';
 import '../../../../core/utils/localization_extension.dart';
+import '../../../prompt_assistant/providers/prompt_assistant_config_provider.dart';
 import '../../../prompt_assistant/providers/prompt_assistant_history_provider.dart';
+import '../../../prompt_assistant/providers/prompt_assistant_state_provider.dart';
 import '../../../prompt_assistant/widgets/prompt_assistant_overlay.dart';
 import '../../../providers/image_generation_provider.dart';
 import '../../../providers/pending_prompt_provider.dart';
@@ -20,6 +23,13 @@ import 'prompt_type_switch.dart';
 
 bool usesRichPromptTypeTooltip(TargetPlatform platform) =>
     shouldUseRichPromptTypeTooltip(platform);
+
+bool _isPromptAssistantVisible(WidgetRef ref) {
+  final config = ref.watch(promptAssistantConfigProvider);
+  return config.enabled &&
+      (!PlatformCapabilities.current.hasPrecisePointer ||
+          config.desktopOverlayEnabled);
+}
 
 class PromptInputWidget extends ConsumerStatefulWidget {
   const PromptInputWidget({
@@ -175,7 +185,7 @@ class _PromptInputWidgetState extends ConsumerState<PromptInputWidget> {
   }
 }
 
-class _FullPromptInput extends StatelessWidget {
+class _FullPromptInput extends ConsumerWidget {
   const _FullPromptInput({
     required this.controller,
     required this.commands,
@@ -187,17 +197,46 @@ class _FullPromptInput extends StatelessWidget {
   final PromptInputViewData viewData;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final negative = controller.isNegativeMode;
+    final assistantSessionId = negative
+        ? PromptHistorySessionIds.generationNegative
+        : PromptHistorySessionIds.generationPrompt;
+    final assistantVisible = _isPromptAssistantVisible(ref);
+    final assistantExpanded =
+        assistantVisible &&
+        ref.watch(
+          promptAssistantStateProvider.select(
+            (states) => states[assistantSessionId]?.expanded ?? false,
+          ),
+        );
     final editor = PromptInputEditor(
       controller: controller,
       commands: commands,
       viewData: viewData,
     );
     final footer = PromptInputFooter(
-      target: controller.isNegativeMode
+      target: negative
           ? PromptTokenCountTarget.negative
           : PromptTokenCountTarget.positive,
       topPadding: 6,
+      assistant: assistantVisible
+          ? PromptAssistantOverlay(
+              sessionId: assistantSessionId,
+              controller: negative
+                  ? controller.negativeController
+                  : controller.promptController,
+              onChanged: negative
+                  ? commands.updateNegativePrompt
+                  : commands.updatePrompt,
+              onOpenSettings: commands.openAssistantSettings,
+              floatOverEditor: false,
+            )
+          : null,
+      assistantExpanded: assistantExpanded,
+      assistantCollapsedWidth: assistantVisible
+          ? PromptAssistantOverlay.inlineCollapsedWidth
+          : 0,
     );
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -230,7 +269,7 @@ class _FullPromptInput extends StatelessWidget {
   }
 }
 
-class _CompactPromptInput extends StatelessWidget {
+class _CompactPromptInput extends ConsumerWidget {
   const _CompactPromptInput({
     required this.controller,
     required this.commands,
@@ -242,8 +281,9 @@ class _CompactPromptInput extends StatelessWidget {
   final PromptInputViewData viewData;
 
   @override
-  Widget build(BuildContext context) => LayoutBuilder(
+  Widget build(BuildContext context, WidgetRef ref) => LayoutBuilder(
     builder: (context, constraints) {
+      final assistantVisible = _isPromptAssistantVisible(ref);
       final showFooter = constraints.maxHeight >= 112;
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -264,13 +304,6 @@ class _CompactPromptInput extends StatelessWidget {
                 key: const ValueKey('generation_prompt_compact_actions'),
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  PromptAssistantOverlay(
-                    sessionId: PromptHistorySessionIds.generationPrompt,
-                    controller: controller.promptController,
-                    onOpenSettings: commands.openAssistantSettings,
-                    floatOverEditor: false,
-                    expandInPlace: false,
-                  ),
                   if (viewData.showMaximizeButton)
                     IconButton(
                       icon: const Icon(Icons.fullscreen),
@@ -285,6 +318,19 @@ class _CompactPromptInput extends StatelessWidget {
                     ),
                 ],
               ),
+              assistant: assistantVisible
+                  ? PromptAssistantOverlay(
+                      sessionId: PromptHistorySessionIds.generationPrompt,
+                      controller: controller.promptController,
+                      onChanged: commands.updatePrompt,
+                      onOpenSettings: commands.openAssistantSettings,
+                      floatOverEditor: false,
+                      expandInPlace: false,
+                    )
+                  : null,
+              assistantCollapsedWidth: assistantVisible
+                  ? PromptAssistantOverlay.inlineCollapsedWidth
+                  : 0,
             ),
         ],
       );

--- a/lib/presentation/screens/generation/widgets/prompt_input_editor.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_input_editor.dart
@@ -108,6 +108,7 @@ class PromptInputEditor extends ConsumerWidget {
       minLines: viewData.autoGrow ? 4 : null,
       expands: !viewData.autoGrow,
       fitContent: viewData.autoGrow,
+      enableAssistant: false,
       onComfyuiImport: negative ? null : commands.importComfyuiPrompt,
       onChanged: negative
           ? commands.updateNegativePrompt

--- a/lib/presentation/screens/generation/widgets/prompt_input_footer.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_input_footer.dart
@@ -16,11 +16,17 @@ class PromptInputFooter extends ConsumerWidget {
     required this.target,
     required this.topPadding,
     this.leading,
+    this.assistant,
+    this.assistantExpanded = false,
+    this.assistantCollapsedWidth = 0,
   });
 
   final PromptTokenCountTarget target;
   final double topPadding;
   final Widget? leading;
+  final Widget? assistant;
+  final bool assistantExpanded;
+  final double assistantCollapsedWidth;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -38,11 +44,16 @@ class PromptInputFooter extends ConsumerWidget {
         target == PromptTokenCountTarget.positive &&
         transparentBackground.supported;
 
+    final tokenCount = RepaintBoundary(
+      key: const ValueKey('generation_prompt_footer_count'),
+      child: PromptTokenCountAsyncBar(usage: tokenUsage),
+    );
+
     return Padding(
+      key: const ValueKey('generation_prompt_footer'),
       padding: EdgeInsets.only(top: topPadding),
       child: Row(
         children: [
-          if (leading != null) ...[leading!, const SizedBox(width: 4)],
           if (showTransparentBackground) ...[
             Tooltip(
               richMessage: WidgetSpan(
@@ -99,11 +110,31 @@ class PromptInputFooter extends ConsumerWidget {
             ),
             const SizedBox(width: 8),
           ],
-          Expanded(
-            child: RepaintBoundary(
-              child: PromptTokenCountAsyncBar(usage: tokenUsage),
+          if (leading != null) ...[leading!, const SizedBox(width: 4)],
+          if (assistant == null)
+            Expanded(child: tokenCount)
+          else
+            Expanded(
+              child: Stack(
+                alignment: Alignment.centerRight,
+                children: [
+                  Positioned.fill(
+                    right: assistantCollapsedWidth + 4,
+                    child: Offstage(
+                      offstage: assistantExpanded,
+                      child: tokenCount,
+                    ),
+                  ),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: KeyedSubtree(
+                      key: const ValueKey('generation_prompt_footer_assistant'),
+                      child: assistant!,
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/test/presentation/screens/generation/widgets/prompt_input_compact_test.dart
+++ b/test/presentation/screens/generation/widgets/prompt_input_compact_test.dart
@@ -77,11 +77,30 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(
-      find.byKey(const ValueKey('generation_transparent_background_toggle')),
-      findsOneWidget,
+    final input = find.byKey(const ValueKey('generation_prompt_compact_input'));
+    final transparent = find.byKey(
+      const ValueKey('generation_transparent_background_toggle'),
     );
+    final count = find.byKey(const ValueKey('generation_prompt_footer_count'));
+    final assistant = find.byKey(
+      const ValueKey('generation_prompt_footer_assistant'),
+    );
+
+    expect(transparent, findsOneWidget);
     expect(find.text('12 / 703'), findsOneWidget);
+    expect(assistant, findsOneWidget);
+    expect(
+      tester.getRect(transparent).top,
+      greaterThanOrEqualTo(tester.getRect(input).bottom),
+    );
+    expect(
+      tester.getRect(transparent).right,
+      lessThanOrEqualTo(tester.getRect(count).left),
+    );
+    expect(
+      tester.getRect(count).right,
+      lessThanOrEqualTo(tester.getRect(assistant).left),
+    );
     expect(tester.takeException(), isNull);
   });
 

--- a/test/presentation/screens/generation/widgets/prompt_input_test.dart
+++ b/test/presentation/screens/generation/widgets/prompt_input_test.dart
@@ -5,10 +5,12 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nai_launcher/core/platform/platform_capabilities.dart';
 import 'package:nai_launcher/core/services/prompt_token_counter_service.dart';
 import 'package:nai_launcher/core/storage/local_storage_service.dart';
 import 'package:nai_launcher/data/models/character/character_prompt.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/providers/prompt_assistant_history_provider.dart';
 import 'package:nai_launcher/presentation/prompt_assistant/providers/prompt_assistant_state_provider.dart';
 import 'package:nai_launcher/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart';
 import 'package:nai_launcher/presentation/providers/character_position_canvas_provider.dart';
@@ -487,6 +489,164 @@ void main() {
     expect(toggle, findsNothing);
   });
 
+  testWidgets('手机提示词助手在 footer 同栏展开且不侵占编辑区', (tester) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.android,
+    );
+    addTearDown(() => PlatformCapabilities.debugOverride = null);
+
+    final storage = _TestLocalStorageService(
+      defaultModel: 'nai-diffusion-5-curated',
+      lastPrompt: List.filled(24, 'long_prompt_tag').join(', '),
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localStorageServiceProvider.overrideWith((ref) => storage),
+          characterPromptNotifierProvider.overrideWith(
+            _TestCharacterPromptNotifier.new,
+          ),
+          promptTokenUsageProvider(
+            PromptTokenCountTarget.positive,
+          ).overrideWith(
+            (ref) async => const PromptTokenUsage(usedTokens: 259, limit: 1471),
+          ),
+          promptTokenUsageProvider(
+            PromptTokenCountTarget.negative,
+          ).overrideWith(
+            (ref) async => const PromptTokenUsage(usedTokens: 0, limit: 1471),
+          ),
+        ],
+        child: const MaterialApp(
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: Scaffold(
+            body: SizedBox(
+              width: 320,
+              height: 420,
+              child: PromptInputWidget(isMaximized: true),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final input = find.byKey(
+      const ValueKey('generation_prompt_positive_input'),
+    );
+    final transparent = find.byKey(
+      const ValueKey('generation_transparent_background_toggle'),
+    );
+    final count = find.byKey(const ValueKey('generation_prompt_footer_count'));
+    final assistant = find.byKey(
+      const ValueKey('generation_prompt_footer_assistant'),
+    );
+    final toolbar = find.byKey(
+      const ValueKey(
+        'prompt_assistant_toolbar_${PromptHistorySessionIds.generationPrompt}',
+      ),
+    );
+    final textField = tester.widget<TextField>(
+      find.descendant(of: input, matching: find.byType(TextField)).first,
+    );
+
+    expect(transparent, findsOneWidget);
+    expect(count, findsOneWidget);
+    expect(find.text('259 / 1471'), findsOneWidget);
+    expect(assistant, findsOneWidget);
+    expect(toolbar, findsOneWidget);
+    expect(textField.decoration?.contentPadding, const EdgeInsets.all(12));
+    expect(
+      tester.getRect(transparent).top,
+      greaterThanOrEqualTo(tester.getRect(input).bottom),
+    );
+    expect(
+      tester.getRect(count).top,
+      greaterThanOrEqualTo(tester.getRect(input).bottom),
+    );
+    expect(
+      tester.getRect(assistant).top,
+      greaterThanOrEqualTo(tester.getRect(input).bottom),
+    );
+    expect(
+      tester.getRect(transparent).right,
+      lessThanOrEqualTo(tester.getRect(count).left),
+    );
+    expect(
+      tester.getRect(count).right,
+      lessThanOrEqualTo(tester.getRect(assistant).left),
+    );
+    expect(tester.getSize(toolbar).width, greaterThanOrEqualTo(48));
+    expect(tester.getSize(toolbar).height, 48);
+
+    await tester.tap(
+      find.descendant(
+        of: assistant,
+        matching: find.byIcon(Icons.auto_awesome_rounded),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 160));
+
+    expect(count, findsNothing);
+    expect(find.text('259 / 1471'), findsNothing);
+    expect(assistant, findsOneWidget);
+    expect(
+      tester.getRect(assistant).top,
+      greaterThanOrEqualTo(tester.getRect(input).bottom),
+    );
+    expect(
+      tester.getCenter(transparent).dy,
+      closeTo(tester.getCenter(assistant).dy, 0.1),
+    );
+    expect(
+      tester.getRect(transparent).right,
+      lessThanOrEqualTo(tester.getRect(assistant).left),
+    );
+    for (final icon in [
+      Icons.translate,
+      Icons.auto_fix_high,
+      Icons.more_horiz,
+      Icons.keyboard_arrow_down_rounded,
+    ]) {
+      final action = find.widgetWithIcon(IconButton, icon);
+      expect(action, findsOneWidget);
+      expect(tester.getSize(action), const Size(48, 48));
+      await tester.ensureVisible(action);
+      await tester.pump();
+      expect(
+        tester.getRect(action).top,
+        greaterThanOrEqualTo(tester.getRect(input).bottom),
+      );
+      expect(
+        tester.getRect(action).left,
+        greaterThanOrEqualTo(tester.getRect(assistant).left),
+      );
+      expect(
+        tester.getRect(action).right,
+        lessThanOrEqualTo(tester.getRect(assistant).right),
+      );
+    }
+
+    await tester.tap(
+      find.descendant(
+        of: assistant,
+        matching: find.byIcon(Icons.keyboard_arrow_down_rounded),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 160));
+    expect(count, findsOneWidget);
+    expect(find.text('259 / 1471'), findsOneWidget);
+    expect(
+      tester.getRect(count).right,
+      lessThanOrEqualTo(tester.getRect(assistant).left),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('Ctrl+F 搜索选中命中且编辑提示词不重置光标', (tester) async {
     const prompt = 'alpha, beta, Alpha';
     debugDefaultTargetPlatformOverride = TargetPlatform.windows;
@@ -877,10 +1037,12 @@ class _TestLocalStorageService extends LocalStorageService {
   _TestLocalStorageService({
     this.enablePromptWeightScroll = true,
     this.defaultModel = 'nai-diffusion-4-5-full',
+    this.lastPrompt = '',
   });
 
   final bool enablePromptWeightScroll;
   final String defaultModel;
+  final String lastPrompt;
   bool? savedTransparentBackground;
 
   @override
@@ -902,7 +1064,7 @@ class _TestLocalStorageService extends LocalStorageService {
   bool getEnableCooccurrenceRecommendation() => false;
 
   @override
-  String getLastPrompt() => '';
+  String getLastPrompt() => lastPrompt;
 
   @override
   Future<void> setLastPrompt(String prompt) async {}


### PR DESCRIPTION
## 变更
- 将正向/负向提示词助手从编辑器内部移至输入框下方现有 footer，同栏复用透明背景与 token 计数空间
- 收起时保持 `[透明背景] ... [token 计数] [助手入口]`；展开时隐藏计数并由可横向滚动的完整工具栏占用右侧区域
- 同步覆盖 compact、手机最大化与 desktop/tablet auto-grow 布局，保留助手状态、动画和全部操作

## 验证
- `flutter test test/presentation/screens/generation/widgets/prompt_input_test.dart test/presentation/screens/generation/widgets/prompt_input_compact_test.dart`
- `flutter analyze lib/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart lib/presentation/screens/generation/widgets/prompt_input.dart lib/presentation/screens/generation/widgets/prompt_input_editor.dart lib/presentation/screens/generation/widgets/prompt_input_footer.dart test/presentation/screens/generation/widgets/prompt_input_test.dart test/presentation/screens/generation/widgets/prompt_input_compact_test.dart`
- `git diff --check`

## 已知基线
- 全仓 `flutter analyze` 仍有 1 条与本改动无关的既有 warning：`lib/presentation/screens/settings/widgets/cloud_sync_conflict_resolution_dialog.dart:297` 的 `unused_element`。
