### PR TITLE
fix(gallery): 修复长列表分页边界与查询切换

### DIFF
--- a/lib/data/datasources/remote/online_gallery/donmai_gallery_source_adapter.dart
+++ b/lib/data/datasources/remote/online_gallery/donmai_gallery_source_adapter.dart
@@ -105,12 +105,21 @@ class DonmaiGallerySourceAdapter implements GallerySourceAdapter {
         request.ratings,
         request.blacklistTags,
       );
-      final nextCursor = parsed.isEmpty ? null : 'b${parsed.last.id}';
+      Object? lastRawId;
+      for (final value in raw.reversed) {
+        if (value is Map && value['id'] != null) {
+          lastRawId = value['id'];
+          break;
+        }
+      }
+      final nextCursor = lastRawId == null ? null : 'b$lastRawId';
       return GalleryPage(
         items: filtered,
         cursor: request.cursor,
         nextCursor: nextCursor,
-        hasMore: raw.length >= request.pageSize && nextCursor != null,
+        // The endpoint may enforce a smaller page than requested and exposes no
+        // total. A non-empty ID-cursor page is therefore not proof of EOF.
+        hasMore: raw.isNotEmpty && nextCursor != null,
         rawItemCount: raw.length,
         rawPageIdentity: raw
             .map((value) => value is Map ? value['id'] : null)

--- a/lib/data/models/online_gallery/chunked_gallery_items.dart
+++ b/lib/data/models/online_gallery/chunked_gallery_items.dart
@@ -128,6 +128,50 @@ class ChunkedGalleryItems extends ListBase<GalleryItem> {
     );
   }
 
+  /// Inserts unseen rows at a real page boundary and combines duplicates.
+  ///
+  /// Normal pagination uses [appendPage]. This path intentionally rebuilds the
+  /// index because a sparse page jump can insert a response before a later
+  /// boundary and every following stable-key offset must move atomically.
+  ChunkedGalleryItems insertPage(
+    int index,
+    Iterable<GalleryItem> page, {
+    GalleryItem Function(GalleryItem current, GalleryItem incoming)?
+    mergeDuplicate,
+  }) {
+    RangeError.checkValueInInterval(index, 0, length, 'index');
+    if (index == length) {
+      return mergePage(page, mergeDuplicate: mergeDuplicate);
+    }
+
+    final rows = toList(growable: true);
+    final indices = <String, int>{
+      for (var rowIndex = 0; rowIndex < rows.length; rowIndex++)
+        rows[rowIndex].stableKey: rowIndex,
+    };
+    final inserted = <GalleryItem>[];
+    for (final item in page) {
+      final existingIndex = indices[item.stableKey];
+      if (existingIndex != null) {
+        final current = rows[existingIndex];
+        rows[existingIndex] = mergeDuplicate?.call(current, item) ?? current;
+        continue;
+      }
+      final pendingIndex = inserted.indexWhere(
+        (pending) => pending.stableKey == item.stableKey,
+      );
+      if (pendingIndex >= 0) {
+        final current = inserted[pendingIndex];
+        inserted[pendingIndex] = mergeDuplicate?.call(current, item) ?? current;
+      } else {
+        inserted.add(item);
+      }
+    }
+    if (inserted.isEmpty) return ChunkedGalleryItems.from(rows);
+    rows.insertAll(index, inserted);
+    return ChunkedGalleryItems.from(rows);
+  }
+
   /// Removes rows without copying chunks that contain no matching keys.
   ChunkedGalleryItems removeStableKeys(Set<String> stableKeys) {
     if (stableKeys.isEmpty ||

--- a/lib/presentation/providers/online_gallery_command_service.dart
+++ b/lib/presentation/providers/online_gallery_command_service.dart
@@ -129,13 +129,25 @@ class OnlineGalleryCommandService {
     await _loadIfMissing();
   }
 
-  Future<void> setSource(Object source) async {
+  Future<void> setSource(
+    Object source, {
+    String? draftQuery,
+    String? draftPrompt,
+  }) async {
     final sourceId = normalizeSource(source);
     if (sourceId == null || !sourceId.capabilities.supportsSearch) return;
-    if (state.sourceId == sourceId) return;
+    final normalizedQuery = (draftQuery ?? state.searchQuery).trim();
+    final normalizedPrompt = (draftPrompt ?? state.promptQuery).trim();
+    if (state.sourceId == sourceId &&
+        state.searchQuery == normalizedQuery &&
+        state.promptQuery == normalizedPrompt) {
+      return;
+    }
     _cancelCurrentRequest();
     state = state.copyWith(
       sourceId: sourceId,
+      searchQuery: normalizedQuery,
+      promptQuery: normalizedPrompt,
       popularSourceId: sourceId.capabilities.supportsRanking
           ? sourceId
           : state.popularSourceId,
@@ -149,17 +161,35 @@ class OnlineGalleryCommandService {
       clearDateRange: true,
       clearError: true,
     );
-    await _loadIfMissing();
+    if (!GalleryTagQueryParser.parse(normalizedQuery).isValid) {
+      state = state.copyWith(
+        errorCode: OnlineGalleryErrorCode.tooManySearchTags,
+      );
+      return;
+    }
+    await _loadPosts(refresh: true);
   }
 
-  Future<void> setPopularSource(Object source) async {
+  Future<void> setPopularSource(
+    Object source, {
+    String? draftQuery,
+    String? draftPrompt,
+  }) async {
     final sourceId = normalizeSource(source);
     if (sourceId == null || !sourceId.capabilities.supportsRanking) return;
-    if (state.popularSourceId == sourceId) return;
+    final normalizedQuery = (draftQuery ?? state.popularQuery).trim();
+    final normalizedPrompt = (draftPrompt ?? state.popularPromptQuery).trim();
+    if (state.popularSourceId == sourceId &&
+        state.popularQuery == normalizedQuery &&
+        state.popularPromptQuery == normalizedPrompt) {
+      return;
+    }
     _cancelCurrentRequest();
     state = state.copyWith(
       sourceId: sourceId,
       popularSourceId: sourceId,
+      popularQuery: normalizedQuery,
+      popularPromptQuery: normalizedPrompt,
       favoritesSourceId: sourceId.capabilities.supportsLocalFavorites
           ? sourceId
           : state.favoritesSourceId,
@@ -167,27 +197,40 @@ class OnlineGalleryCommandService {
       clearDateRange: true,
       clearError: true,
     );
-    if (state.viewMode == GalleryViewMode.popular) await _loadIfMissing();
+    if (!GalleryTagQueryParser.parse(normalizedQuery).isValid) {
+      state = state.copyWith(
+        errorCode: OnlineGalleryErrorCode.tooManySearchTags,
+      );
+      return;
+    }
+    if (state.viewMode == GalleryViewMode.popular) {
+      await _loadPosts(refresh: true);
+    }
   }
 
-  Future<void> setFavoritesSource(Object source) async {
+  Future<void> setFavoritesSource(Object source, {String? draftQuery}) async {
     final sourceId = normalizeSource(source);
     if (sourceId == null || !sourceId.capabilities.supportsLocalFavorites) {
       return;
     }
-    if (state.favoritesSourceId == sourceId) return;
+    final normalizedQuery = (draftQuery ?? state.favoriteSearchQuery).trim();
+    if (state.favoritesSourceId == sourceId &&
+        state.favoriteSearchQuery == normalizedQuery) {
+      return;
+    }
+    _cancelCurrentRequest();
     final generation = _continuationGeneration;
     if (sourceId == GallerySourceId.gelbooru) {
       await _ref.read(gelbooruAuthProvider.notifier).ensureInitialized();
       if (!_isCurrentContinuation(generation)) return;
     }
-    _cancelCurrentRequest();
     state = state.copyWith(
       sourceId: sourceId,
       popularSourceId: sourceId.capabilities.supportsRanking
           ? sourceId
           : state.popularSourceId,
       favoritesSourceId: sourceId,
+      favoriteSearchQuery: normalizedQuery,
       quickTagCloudFilterKey: sourceId == GallerySourceId.quickTagCloud
           ? _ref.read(quickTagCloudFilterProvider).stableKey
           : state.quickTagCloudFilterKey,
@@ -203,10 +246,6 @@ class OnlineGalleryCommandService {
 
   Future<void> searchFavorites(String query) async {
     final normalized = query.trim();
-    if (state.favoriteSearchQuery == normalized &&
-        state.viewMode == GalleryViewMode.favorites) {
-      return;
-    }
     _cancelCurrentRequest();
     state = state.copyWith(
       favoriteSearchQuery: normalized,
@@ -301,6 +340,52 @@ class OnlineGalleryCommandService {
       await _loadRandom(replace: true, restart: true);
     } else if (state.currentCache.posts.isEmpty) {
       await _loadPosts(refresh: true);
+    }
+  }
+
+  Future<void> refreshWithDraft({
+    required String query,
+    required String prompt,
+  }) async {
+    if (state.randomEnabled) {
+      final normalized = query.trim();
+      final parsed = GalleryTagQueryParser.parse(normalized);
+      _cancelCurrentRequest();
+      state = switch (state.viewMode) {
+        GalleryViewMode.search => state.copyWith(
+          searchQuery: normalized,
+          promptQuery: prompt.trim(),
+          clearError: true,
+        ),
+        GalleryViewMode.popular => state.copyWith(
+          popularQuery: normalized,
+          popularPromptQuery: prompt.trim(),
+          clearError: true,
+        ),
+        GalleryViewMode.favorites => state.copyWith(
+          favoriteSearchQuery: normalized,
+          clearError: true,
+        ),
+      };
+      if (state.viewMode != GalleryViewMode.favorites && !parsed.isValid) {
+        state = state.copyWith(
+          errorCode: OnlineGalleryErrorCode.tooManySearchTags,
+        );
+        return;
+      }
+      await _loadRandom(replace: true, restart: true);
+      return;
+    }
+    switch (state.viewMode) {
+      case GalleryViewMode.search:
+        await searchWithPrompt(query, prompt: prompt);
+        break;
+      case GalleryViewMode.popular:
+        await searchPopular(query: query, prompt: prompt);
+        break;
+      case GalleryViewMode.favorites:
+        await searchFavorites(query);
+        break;
     }
   }
 

--- a/lib/presentation/providers/online_gallery_pagination_service.dart
+++ b/lib/presentation/providers/online_gallery_pagination_service.dart
@@ -155,11 +155,15 @@ class OnlineGalleryPaginationService {
         if (!_isCurrent(generation, cacheKey)) return;
       }
       final artistHuntActive = state.isArtistHuntActive;
-      final baseItems = refresh
+      final resetsQuery = refresh || cache.pageBoundaries.isEmpty;
+      final baseItems = resetsQuery
           ? ChunkedGalleryItems()
           : cache.posts is ChunkedGalleryItems
           ? cache.posts as ChunkedGalleryItems
           : ChunkedGalleryItems.from(cache.posts);
+      final pageBoundaries = <GalleryPageBoundary>[
+        if (!resetsQuery) ...cache.pageBoundaries,
+      ];
       final huntKeys = artistHuntActive
           ? _artistHunt.deduplicationKeys(baseItems)
           : null;
@@ -176,6 +180,7 @@ class OnlineGalleryPaginationService {
       var pagesFetched = 0;
       var stalledCursor = false;
       var repeatedRawPage = false;
+      var duplicateResponsePage = false;
       var scanBudgetReached = false;
       var previousRawIdentity = refresh ? null : cache.lastRawPageIdentity;
       final visitedCursors = <String>{};
@@ -233,6 +238,20 @@ class OnlineGalleryPaginationService {
           previousRawIdentity = rawIdentity;
         }
         queryCandidateCount += page.items.length;
+        final predecessor = pageBoundaries
+            .where((boundary) => boundary.nextCursor == page.cursor)
+            .firstOrNull;
+        final boundaryPage = galleryCursorPage(
+          page.cursor,
+          fallback: predecessor?.page == null ? 1 : predecessor!.page + 1,
+        );
+        final laterBoundaryIndex = pageBoundaries.indexWhere(
+          (boundary) => boundary.page > boundaryPage,
+        );
+        final insertionIndex = laterBoundaryIndex < 0
+            ? merged.length
+            : pageBoundaries[laterBoundaryIndex].startIndex;
+        final itemCountBeforePage = merged.length;
         final tagFiltered = await _search.filterByPlan(
           candidates: page.items,
           plan: tagPlan,
@@ -267,7 +286,13 @@ class OnlineGalleryPaginationService {
               if (!_isCurrent(generation, cacheKey)) return;
               resolvedCount += resolvedDelta;
               failureCount += failureDelta;
-              if (items.isNotEmpty) merged = merged.appendPage(items);
+              if (items.isNotEmpty) {
+                final insertAt =
+                    insertionIndex + (merged.length - itemCountBeforePage);
+                merged = insertAt == merged.length
+                    ? merged.appendPage(items)
+                    : merged.insertPage(insertAt, items);
+              }
               state = state.updateCurrentCache(
                 cache.copyWith(
                   posts: merged,
@@ -290,9 +315,43 @@ class OnlineGalleryPaginationService {
           }
           visibleItems = resolution.items;
         } else {
-          merged = merged.appendPage(visibleItems);
+          merged = insertionIndex == merged.length
+              ? merged.appendPage(visibleItems)
+              : merged.insertPage(insertionIndex, visibleItems);
         }
-        matchedItemCount += visibleItems.length;
+        final uniqueItemCount = merged.length - itemCountBeforePage;
+        matchedItemCount += uniqueItemCount;
+        if (uniqueItemCount > 0 && laterBoundaryIndex >= 0) {
+          for (
+            var boundaryIndex = laterBoundaryIndex;
+            boundaryIndex < pageBoundaries.length;
+            boundaryIndex++
+          ) {
+            final boundary = pageBoundaries[boundaryIndex];
+            pageBoundaries[boundaryIndex] = GalleryPageBoundary(
+              page: boundary.page,
+              cursor: boundary.cursor,
+              startIndex: boundary.startIndex + uniqueItemCount,
+              endIndex: boundary.endIndex + uniqueItemCount,
+              rawItemCount: boundary.rawItemCount,
+              nextCursor: boundary.nextCursor,
+            );
+          }
+        }
+        final boundary = GalleryPageBoundary(
+          page: boundaryPage,
+          cursor: page.cursor,
+          startIndex: insertionIndex,
+          endIndex: insertionIndex + uniqueItemCount,
+          rawItemCount: page.rawItemCount,
+          nextCursor: page.nextCursor,
+        );
+        if (laterBoundaryIndex < 0) {
+          pageBoundaries.add(boundary);
+        } else {
+          pageBoundaries.insert(laterBoundaryIndex, boundary);
+        }
+        duplicateResponsePage = visibleItems.isNotEmpty && uniqueItemCount == 0;
         final nextCursor = page.nextCursor;
         final needsMore =
             (page.rawItemCount > 0 &&
@@ -303,6 +362,7 @@ class OnlineGalleryPaginationService {
             nextCursor != null &&
             visitedCursors.contains(nextCursor);
         final shouldContinue =
+            !duplicateResponsePage &&
             needsMore &&
             matchedItemCount < _pageSize &&
             page.hasMore &&
@@ -317,6 +377,7 @@ class OnlineGalleryPaginationService {
         state = state.updateCurrentCache(
           cache.copyWith(
             posts: merged,
+            pageBoundaries: pageBoundaries,
             nextCursor: nextCursor,
             hasMore: true,
             scrollOffset: refresh ? 0 : cache.scrollOffset,
@@ -331,27 +392,44 @@ class OnlineGalleryPaginationService {
         );
         if (queryRequestCount.isEven) await Future<void>.delayed(Duration.zero);
       }
-      final duplicatePage =
-          !refresh && matchedItemCount > 0 && merged.length == baseItems.length;
       final endedByDuplicate =
-          duplicatePage || stalledCursor || repeatedRawPage;
-      final initial =
-          !refresh && cache.posts.isEmpty && cache.page == 1 && cursor == '1';
-      final firstPage = refresh || initial
-          ? galleryCursorPage(cursor)
-          : cache.page + 1;
-      final parsedPage = galleryCursorPage(
-        page.cursor,
-        fallback: firstPage + pagesFetched - 1,
+          duplicateResponsePage || stalledCursor || repeatedRawPage;
+      final firstVisibleBoundary = pageBoundaries.firstWhere(
+        (boundary) => boundary.endIndex > boundary.startIndex,
+        orElse: () => pageBoundaries.first,
       );
+      final visiblePage = resetsQuery ? firstVisibleBoundary.page : cache.page;
+      final tailBoundary = pageBoundaries.last;
+      final responsePredecessor = pageBoundaries
+          .where((boundary) => boundary.nextCursor == page.cursor)
+          .firstOrNull;
+      final responsePage = galleryCursorPage(
+        page.cursor,
+        fallback: responsePredecessor == null
+            ? 1
+            : responsePredecessor.page + 1,
+      );
+      final loadedTail = tailBoundary.page <= responsePage;
+      final tailNextCursor = loadedTail && endedByDuplicate
+          ? null
+          : tailBoundary.nextCursor;
       final nextCache = ModeCache(
         posts: merged,
-        page: parsedPage,
-        nextCursor: endedByDuplicate ? null : page.nextCursor,
-        total: artistHuntActive ? null : page.total,
-        hasMore: !endedByDuplicate && page.hasMore && page.nextCursor != null,
+        page: visiblePage,
+        pageBoundaries: pageBoundaries,
+        nextCursor: tailNextCursor,
+        total: artistHuntActive
+            ? null
+            : loadedTail
+            ? page.total
+            : cache.total,
+        hasMore: loadedTail
+            ? !endedByDuplicate && page.hasMore && tailNextCursor != null
+            : cache.hasMore && tailNextCursor != null,
         scrollOffset: refresh ? 0 : cache.scrollOffset,
-        endedByDuplicatePage: endedByDuplicate,
+        endedByDuplicatePage: loadedTail
+            ? endedByDuplicate
+            : cache.endedByDuplicatePage,
         artistHuntCandidateCount: candidateCount,
         artistHuntResolvedCount: resolvedCount,
         artistHuntFailureCount: failureCount,
@@ -359,7 +437,9 @@ class OnlineGalleryPaginationService {
         queryCandidateCount: queryCandidateCount,
         queryFilterMicros: queryFilterMicros,
         queryDetailFailureCount: detailFailureCount,
-        lastRawPageIdentity: previousRawIdentity,
+        lastRawPageIdentity: loadedTail
+            ? previousRawIdentity
+            : cache.lastRawPageIdentity,
         queryScanPaused: scanBudgetReached,
       );
       final invalidGelbooru =

--- a/lib/presentation/providers/online_gallery_provider.dart
+++ b/lib/presentation/providers/online_gallery_provider.dart
@@ -64,6 +64,7 @@ export 'online_gallery_dependencies.dart'
         quickTagCloudGallerySourceAdapterProvider;
 export 'online_gallery_state.dart'
     show
+        GalleryPageBoundary,
         GallerySourceIdCapabilities,
         GalleryViewMode,
         ModeCache,
@@ -81,6 +82,18 @@ export 'online_gallery_state.dart'
 part 'online_gallery_provider.g.dart';
 
 const int onlineGalleryPageSize = 60;
+
+class GalleryPageJumpTarget {
+  const GalleryPageJumpTarget({
+    required this.page,
+    required this.itemIndex,
+    required this.stableKey,
+  });
+
+  final int page;
+  final int itemIndex;
+  final String stableKey;
+}
 
 @riverpod
 class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
@@ -111,6 +124,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   int _detailRequestScopeRevision = 0;
   bool _loadMoreClaimed = false;
   int _loadMoreClaimRevision = 0;
+  int _pageJumpRevision = 0;
   bool _backgroundNetworkPaused = false;
   int _explicitNetworkAccessCount = 0;
   bool _resumeInitialLoadAfterBackgroundPause = false;
@@ -286,6 +300,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   void _cancelCurrentRequest() {
     _loadCoordinator.cancel('Superseded by a gallery state change');
     _loadMoreClaimRevision++;
+    _pageJumpRevision++;
     _loadMoreClaimed = false;
     _detailRequestScopeRevision++;
     _detailCoordinator?.cancelQueuedVisible();
@@ -298,6 +313,14 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   bool _isCurrentRequest(OnlineGalleryRequestHandle request, String cacheKey) {
     return _loadCoordinator.isCurrent(request, cacheKey: cacheKey) &&
         state.currentCacheKey == cacheKey;
+  }
+
+  void updateVisibleItemIndex(int index) {
+    if (state.randomEnabled) return;
+    final cache = state.currentCache;
+    final visiblePage = cache.pageForItemIndex(index);
+    if (visiblePage == null || visiblePage == cache.page) return;
+    state = state.updateCurrentCache(cache.copyWith(page: visiblePage));
   }
 
   void saveScrollOffset(
@@ -316,13 +339,28 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
 
   Future<void> switchToFavorites() => _commands.switchToFavorites();
 
-  Future<void> setSource(Object source) => _commands.setSource(source);
+  Future<void> setSource(
+    Object source, {
+    String? draftQuery,
+    String? draftPrompt,
+  }) => _commands.setSource(
+    source,
+    draftQuery: draftQuery,
+    draftPrompt: draftPrompt,
+  );
 
-  Future<void> setPopularSource(Object source) =>
-      _commands.setPopularSource(source);
+  Future<void> setPopularSource(
+    Object source, {
+    String? draftQuery,
+    String? draftPrompt,
+  }) => _commands.setPopularSource(
+    source,
+    draftQuery: draftQuery,
+    draftPrompt: draftPrompt,
+  );
 
-  Future<void> setFavoritesSource(Object source) =>
-      _commands.setFavoritesSource(source);
+  Future<void> setFavoritesSource(Object source, {String? draftQuery}) =>
+      _commands.setFavoritesSource(source, draftQuery: draftQuery);
 
   Future<void> searchFavorites(String query) =>
       _commands.searchFavorites(query);
@@ -347,6 +385,11 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
 
   Future<void> setArtistHuntEnabled(bool enabled) =>
       _commands.setArtistHuntEnabled(enabled);
+
+  Future<void> refreshWithDraft({
+    required String query,
+    required String prompt,
+  }) => _commands.refreshWithDraft(query: query, prompt: prompt);
 
   Future<void> search(String query) => _commands.search(query);
 
@@ -846,14 +889,14 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     switch (state.viewMode) {
       case GalleryViewMode.search:
       case GalleryViewMode.popular:
-        await _loadAdapterPage(
-          refresh: refresh,
-          initialCursor: restoredPage == null ? null : '$restoredPage',
-        );
-        return;
+        await _loadAdapterPage(refresh: refresh);
+        break;
       case GalleryViewMode.favorites:
-        await _loadFavorites(refresh: refresh, targetPage: restoredPage);
-        return;
+        await _loadFavorites(refresh: refresh);
+        break;
+    }
+    if (restoredPage != null && restoredPage > 1) {
+      await goToPage(restoredPage);
     }
   }
 
@@ -897,18 +940,51 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
     await loadPosts();
   }
 
-  Future<void> goToPage(int page) async {
-    if (_networkRequestsPaused ||
-        page < 1 ||
-        state.isLoading ||
-        state.isLoadingMore) {
-      return;
+  Future<GalleryPageJumpTarget?> goToPage(int page) async {
+    if (_networkRequestsPaused || page < 1 || state.randomEnabled) return null;
+
+    _cancelCurrentRequest();
+    final jumpRevision = ++_pageJumpRevision;
+    var cache = state.currentCache;
+
+    // Legacy/restored caches can contain records without response boundaries.
+    // Rebuild from page 1 rather than manufacturing an index from pageSize.
+    if (cache.posts.isNotEmpty && cache.pageBoundaries.isEmpty) {
+      await loadPosts(refresh: true);
+      if (jumpRevision != _pageJumpRevision) return null;
+      cache = state.currentCache;
     }
-    if (state.viewMode == GalleryViewMode.favorites) {
-      await _loadFavorites(refresh: true, targetPage: page);
-      return;
+
+    if (cache.boundaryForPage(page) == null &&
+        page != cache.lastLoadedPage + 1) {
+      if (state.viewMode == GalleryViewMode.favorites) {
+        await _loadFavorites(refresh: false, targetPage: page);
+      } else {
+        await _loadAdapterPage(refresh: false, initialCursor: '$page');
+      }
+      if (jumpRevision != _pageJumpRevision) return null;
+      cache = state.currentCache;
     }
-    await _loadAdapterPage(refresh: true, initialCursor: '$page');
+
+    while (cache.boundaryForPage(page) == null &&
+        cache.lastLoadedPage < page &&
+        cache.hasMore) {
+      await loadPosts();
+      if (jumpRevision != _pageJumpRevision) return null;
+      cache = state.currentCache;
+    }
+
+    final boundary = cache.boundaryForPage(page);
+    if (boundary == null || boundary.startIndex >= cache.posts.length) {
+      return null;
+    }
+    final item = cache.posts[boundary.startIndex];
+    state = state.updateCurrentCache(cache.copyWith(page: page));
+    return GalleryPageJumpTarget(
+      page: page,
+      itemIndex: boundary.startIndex,
+      stableKey: item.stableKey,
+    );
   }
 
   Future<void> _loadAdapterPage({
@@ -934,25 +1010,59 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
   Future<void> _loadFavorites({required bool refresh, int? targetPage}) async {
     final sourceId = state.favoritesSourceId;
     final previousCache = state.currentCache;
-    final pageNumber = targetPage ?? (refresh ? 1 : previousCache.page + 1);
+    final pageNumber =
+        targetPage ?? (refresh ? 1 : previousCache.lastLoadedPage + 1);
     final generation = _beginRequest();
     final cacheKey = state.currentCacheKey;
-    final resetBranches = refresh || targetPage != null;
+    final resetBranches = refresh;
     final isAppend = !resetBranches && previousCache.posts.isNotEmpty;
     var cache = resetBranches
         ? ModeCache(
             posts: previousCache.posts,
-            page: pageNumber,
-            localFavoritesOffset: (pageNumber - 1) * _pageSize,
-            remoteFavoritesPage: pageNumber,
+            page: 1,
+            localFavoritesOffset: 0,
+            remoteFavoritesPage: 1,
             localFavoriteItemKeys: previousCache.localFavoriteItemKeys,
             remoteFavoriteItemKeys: previousCache.remoteFavoriteItemKeys,
-            scrollOffset: refresh ? 0 : previousCache.scrollOffset,
+          )
+        : targetPage != null
+        ? previousCache.copyWith(
+            localFavoritesOffset: (targetPage - 1) * _pageSize,
+            remoteFavoritesPage: targetPage,
+            localFavoritesHasMore: true,
+            remoteFavoritesHasMore: true,
           )
         : previousCache;
     var posts = cache.posts is ChunkedGalleryItems
         ? cache.posts as ChunkedGalleryItems
         : ChunkedGalleryItems.from(cache.posts);
+    final laterBoundaryIndex = resetBranches
+        ? -1
+        : previousCache.pageBoundaries.indexWhere(
+            (boundary) => boundary.page > pageNumber,
+          );
+    final pageStartIndex = resetBranches
+        ? 0
+        : laterBoundaryIndex < 0
+        ? posts.length
+        : previousCache.pageBoundaries[laterBoundaryIndex].startIndex;
+    final itemCountBeforePage = posts.length;
+    void mergePageItems(Iterable<GalleryItem> items) {
+      if (resetBranches) {
+        posts = posts.mergePage(items, mergeDuplicate: _favorites.mergeItem);
+        return;
+      }
+      final insertAt = pageStartIndex + (posts.length - itemCountBeforePage);
+      posts = insertAt == posts.length
+          ? posts.mergePage(items, mergeDuplicate: _favorites.mergeItem)
+          : posts.insertPage(
+              insertAt,
+              items,
+              mergeDuplicate: _favorites.mergeItem,
+            );
+    }
+
+    var rawItemCount = 0;
     state = state.copyWith(
       isLoading: !isAppend,
       isLoadingMore: isAppend,
@@ -1001,6 +1111,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
               limit: _pageSize,
             ),
           );
+          rawItemCount += localPage.records.length;
           final loadedLocalItemKeys = localPage.items
               .map(onlineGalleryPostKey)
               .toSet();
@@ -1013,10 +1124,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
               retainedByOtherBranch: cache.remoteFavoriteItemKeys,
             );
           }
-          posts = posts.mergePage(
-            localPage.items,
-            mergeDuplicate: _favorites.mergeItem,
-          );
+          mergePageItems(localPage.items);
           final localItemKeys = resetBranches
               ? loadedLocalItemKeys
               : {
@@ -1066,6 +1174,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
             );
           }
           if (!_isCurrentRequest(generation, cacheKey)) return;
+          rawItemCount += remotePage.rawCount;
           final matching = _query
               .filterLocal(
                 items: remotePage.items,
@@ -1101,10 +1210,7 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
             );
             _remoteFavoriteKeys.removeAll(cache.remoteFavoriteItemKeys);
           }
-          posts = posts.mergePage(
-            remoteItems,
-            mergeDuplicate: _favorites.mergeItem,
-          );
+          mergePageItems(remoteItems);
           final remoteItemKeys = resetBranches
               ? loadedRemoteItemKeys
               : {
@@ -1194,12 +1300,71 @@ class OnlineGalleryNotifier extends _$OnlineGalleryNotifier {
           !cache.remoteFavoritesHasMore;
       final hasMore =
           cache.localFavoritesHasMore || cache.remoteFavoritesHasMore;
+      final insertedItemCount = resetBranches
+          ? posts.length
+          : posts.length - itemCountBeforePage;
+      final boundaries = <GalleryPageBoundary>[
+        if (!refresh) ...previousCache.pageBoundaries,
+      ];
+      if (!refresh && insertedItemCount > 0 && laterBoundaryIndex >= 0) {
+        for (
+          var boundaryIndex = laterBoundaryIndex;
+          boundaryIndex < boundaries.length;
+          boundaryIndex++
+        ) {
+          final boundary = boundaries[boundaryIndex];
+          boundaries[boundaryIndex] = GalleryPageBoundary(
+            page: boundary.page,
+            cursor: boundary.cursor,
+            startIndex: boundary.startIndex + insertedItemCount,
+            endIndex: boundary.endIndex + insertedItemCount,
+            rawItemCount: boundary.rawItemCount,
+            nextCursor: boundary.nextCursor,
+          );
+        }
+      }
+      final pageBoundary = GalleryPageBoundary(
+        page: pageNumber,
+        cursor: '$pageNumber',
+        startIndex: pageStartIndex,
+        endIndex: pageStartIndex + insertedItemCount,
+        rawItemCount: rawItemCount,
+        nextCursor: hasMore ? '${pageNumber + 1}' : null,
+      );
+      if (refresh || laterBoundaryIndex < 0) {
+        boundaries.add(pageBoundary);
+      } else {
+        boundaries.insert(laterBoundaryIndex, pageBoundary);
+      }
+      final loadedTail = boundaries.last.page == pageNumber;
+      final tailHasMore = loadedTail ? hasMore : previousCache.hasMore;
+      final tailNextCursor = loadedTail
+          ? hasMore
+                ? '${pageNumber + 1}'
+                : null
+          : boundaries.last.nextCursor;
       cache = cache.copyWith(
         posts: posts,
-        page: pageNumber,
-        nextCursor: hasMore ? '${pageNumber + 1}' : null,
-        hasMore: hasMore,
-        endedByDuplicatePage: duplicatePage,
+        page: refresh ? pageNumber : previousCache.page,
+        pageBoundaries: boundaries,
+        nextCursor: tailNextCursor,
+        clearNextCursor: tailNextCursor == null,
+        hasMore: tailHasMore && tailNextCursor != null,
+        endedByDuplicatePage: loadedTail
+            ? duplicatePage
+            : previousCache.endedByDuplicatePage,
+        localFavoritesOffset: loadedTail
+            ? cache.localFavoritesOffset
+            : previousCache.localFavoritesOffset,
+        remoteFavoritesPage: loadedTail
+            ? cache.remoteFavoritesPage
+            : previousCache.remoteFavoritesPage,
+        localFavoritesHasMore: loadedTail
+            ? cache.localFavoritesHasMore
+            : previousCache.localFavoritesHasMore,
+        remoteFavoritesHasMore: loadedTail
+            ? cache.remoteFavoritesHasMore
+            : previousCache.remoteFavoritesHasMore,
         appendErrorCode: allAvailableBranchesFailed && isAppend
             ? _errorCode(remoteError ?? localError)
             : null,

--- a/lib/presentation/providers/online_gallery_state.dart
+++ b/lib/presentation/providers/online_gallery_state.dart
@@ -73,6 +73,28 @@ enum OnlineGalleryNotice {
 
 String onlineGalleryPostKey(GalleryItem item) => item.stableKey;
 
+/// Maps one upstream response to the exact records it contributed after
+/// filtering and stable-key deduplication.
+class GalleryPageBoundary {
+  const GalleryPageBoundary({
+    required this.page,
+    required this.cursor,
+    required this.startIndex,
+    required this.endIndex,
+    required this.rawItemCount,
+    this.nextCursor,
+  });
+
+  final int page;
+  final String cursor;
+  final int startIndex;
+  final int endIndex;
+  final int rawItemCount;
+  final String? nextCursor;
+
+  bool containsItem(int index) => startIndex <= index && index < endIndex;
+}
+
 class RandomGallerySession {
   const RandomGallerySession({
     this.scopeKey = '',
@@ -123,6 +145,7 @@ class ModeCache {
   const ModeCache({
     this.posts = const [],
     this.page = 1,
+    this.pageBoundaries = const [],
     this.nextCursor = '1',
     this.hasMore = true,
     this.total,
@@ -151,8 +174,37 @@ class ModeCache {
   });
 
   final List<GalleryItem> posts;
+
+  /// Page containing the first visible record, not the last fetched page.
   final int page;
+  final List<GalleryPageBoundary> pageBoundaries;
   final String? nextCursor;
+
+  int get lastLoadedPage => pageBoundaries.isEmpty
+      ? (posts.isEmpty ? 0 : page)
+      : pageBoundaries.last.page;
+
+  GalleryPageBoundary? boundaryForPage(int targetPage) {
+    for (final boundary in pageBoundaries) {
+      if (boundary.page == targetPage &&
+          boundary.endIndex > boundary.startIndex) {
+        return boundary;
+      }
+    }
+    return null;
+  }
+
+  int? pageForItemIndex(int index) {
+    for (final boundary in pageBoundaries.reversed) {
+      if (boundary.containsItem(index)) return boundary.page;
+    }
+    return null;
+  }
+
+  bool isPageBoundaryStart(int index) => pageBoundaries.any(
+    (boundary) =>
+        boundary.startIndex == index && boundary.endIndex > boundary.startIndex,
+  );
   final bool hasMore;
   final int? total;
   final double scrollOffset;
@@ -184,7 +236,9 @@ class ModeCache {
   ModeCache copyWith({
     List<GalleryItem>? posts,
     int? page,
+    List<GalleryPageBoundary>? pageBoundaries,
     String? nextCursor,
+    bool clearNextCursor = false,
     bool? hasMore,
     int? total,
     double? scrollOffset,
@@ -217,7 +271,8 @@ class ModeCache {
     return ModeCache(
       posts: posts ?? this.posts,
       page: page ?? this.page,
-      nextCursor: nextCursor ?? this.nextCursor,
+      pageBoundaries: List.unmodifiable(pageBoundaries ?? this.pageBoundaries),
+      nextCursor: clearNextCursor ? null : (nextCursor ?? this.nextCursor),
       hasMore: hasMore ?? this.hasMore,
       total: total ?? this.total,
       scrollOffset: scrollOffset ?? this.scrollOffset,
@@ -518,7 +573,6 @@ class OnlineGalleryState {
     final updated = LinkedHashMap<String, ModeCache>.of(caches)
       ..remove(currentCacheKey)
       ..[currentCacheKey] = cache;
-    _trimCaches(updated, currentCacheKey);
     switch (viewMode) {
       case GalleryViewMode.search:
         return copyWith(caches: updated, searchCache: cache);
@@ -538,22 +592,7 @@ class OnlineGalleryState {
     final updated = LinkedHashMap<String, ModeCache>.of(caches)
       ..remove(key)
       ..[key] = cache;
-    _trimCaches(updated, currentCacheKey);
     return copyWith(caches: updated);
-  }
-
-  static void _trimCaches(
-    LinkedHashMap<String, ModeCache> caches,
-    String protectedKey,
-  ) {
-    while (caches.length > 12) {
-      final oldestEvictable = caches.keys.cast<String?>().firstWhere(
-        (key) => key != protectedKey,
-        orElse: () => null,
-      );
-      if (oldestEvictable == null) return;
-      caches.remove(oldestEvictable);
-    }
   }
 
   String _authScopeFor(GallerySourceId sourceId) => switch (sourceId) {

--- a/lib/presentation/screens/online_gallery/online_gallery_content.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_content.dart
@@ -91,6 +91,18 @@ class _OnlineGalleryContentPresenter {
     return _buildPageContent(theme, state);
   }
 
+  Future<void> _refreshFromVisibleDraft(OnlineGalleryState state) {
+    final query = switch (state.viewMode) {
+      GalleryViewMode.search => _controller.searchController.text,
+      GalleryViewMode.popular => _controller.popularSearchController.text,
+      GalleryViewMode.favorites => _controller.favoriteSearchController.text,
+    };
+    final prompt = state.viewMode == GalleryViewMode.popular
+        ? _controller.popularPromptSearchController.text
+        : _controller.promptSearchController.text;
+    return _galleryNotifier.refreshWithDraft(query: query, prompt: prompt);
+  }
+
   /// 构建错误状态
   Widget _buildErrorState(ThemeData theme, OnlineGalleryState state) {
     final message = state.error ?? _localizedError(state.errorCode);
@@ -117,7 +129,7 @@ class _OnlineGalleryContentPresenter {
           FilledButton.icon(
             onPressed: needsGelbooruCredentials
                 ? () => _showGelbooruCredentialsDialog(context)
-                : _galleryNotifier.refresh,
+                : () => _refreshFromVisibleDraft(state),
             icon: Icon(
               needsGelbooruCredentials ? Icons.key_outlined : Icons.refresh,
               size: 18,
@@ -244,7 +256,7 @@ class _OnlineGalleryContentPresenter {
             ),
             const SizedBox(height: 8),
             TextButton.icon(
-              onPressed: _galleryNotifier.refresh,
+              onPressed: () => _refreshFromVisibleDraft(state),
               icon: const Icon(Icons.refresh, size: 18),
               label: Text(context.l10n.common_retry),
             ),
@@ -261,7 +273,7 @@ class _OnlineGalleryContentPresenter {
             ),
             const SizedBox(height: 8),
             TextButton.icon(
-              onPressed: _galleryNotifier.refresh,
+              onPressed: () => _refreshFromVisibleDraft(state),
               icon: const Icon(Icons.refresh, size: 18),
               label: Text(context.l10n.common_retry),
             ),
@@ -302,7 +314,11 @@ class _OnlineGalleryContentPresenter {
       itemWidth: itemWidth,
       columnCount: columnCount,
       scrolling: _controller.scrolling,
-      anchorKey: post.stableKey == _controller.pendingAnchorStableKey
+      anchorKey:
+          (state.randomEnabled ? state.randomSession.cache : state.currentCache)
+              .isPageBoundaryStart(index)
+          ? _controller.pageAnchorKey(post.stableKey)
+          : post.stableKey == _controller.pendingAnchorStableKey
           ? _controller.anchorRestoreKey
           : null,
       onVisibilityChanged: _scrollCoordinator.handleCardVisibility,
@@ -553,7 +569,7 @@ class _OnlineGalleryContentPresenter {
     if (activeCache.queryDetailFailureCount > 0) {
       return Center(
         child: TextButton.icon(
-          onPressed: _galleryNotifier.refresh,
+          onPressed: () => _refreshFromVisibleDraft(state),
           icon: Icon(Icons.refresh, color: theme.colorScheme.error),
           label: Text(
             context.l10n.onlineGallery_tagDetailsIncomplete,
@@ -670,7 +686,7 @@ class _OnlineGalleryContentPresenter {
                   TextButton(
                     onPressed: state.isLoading
                         ? null
-                        : _galleryNotifier.refresh,
+                        : () => _refreshFromVisibleDraft(state),
                     child: Text(context.l10n.common_retry),
                   ),
                 ],

--- a/lib/presentation/screens/online_gallery/online_gallery_grid.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_grid.dart
@@ -5,6 +5,7 @@ import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../../core/cache/online_gallery_preload_policy.dart';
+import '../../../data/models/online_gallery/chunked_gallery_items.dart';
 import '../../providers/online_gallery_provider.dart';
 import '../../widgets/online_gallery/online_gallery_image_placeholder.dart';
 import 'online_gallery_screen_controller.dart';
@@ -74,6 +75,22 @@ class OnlineGalleryGrid extends StatelessWidget {
             ? 'random:${state.randomSession.scopeKey}'
             : 'normal';
         final placeholderCount = _placeholderCount();
+        final masonryChildCount = state.posts.length + placeholderCount;
+        int? findPostIndex(Key key) {
+          if (key is! ValueKey<String>) return null;
+          const prefix = 'grid-item:';
+          if (!key.value.startsWith(prefix)) return null;
+          final stableKey = key.value.substring(prefix.length);
+          final posts = state.posts;
+          if (posts is ChunkedGalleryItems) {
+            return posts.indexOfStableKey(stableKey);
+          }
+          for (var index = 0; index < posts.length; index++) {
+            if (posts[index].stableKey == stableKey) return index;
+          }
+          return null;
+        }
+
         return CustomScrollView(
           key: PageStorageKey<String>(
             'online_gallery_$storageScope:${state.currentCacheKey}',
@@ -88,43 +105,37 @@ class OnlineGalleryGrid extends StatelessWidget {
                 12,
                 12,
                 12,
-                state.posts.isEmpty ? 0 : 6,
+                masonryChildCount == 0 ? 0 : 6,
               ),
-              sliver: SliverMasonryGrid.count(
-                crossAxisCount: columnCount,
+              sliver: SliverMasonryGrid(
+                gridDelegate: SliverSimpleGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: columnCount,
+                ),
                 mainAxisSpacing: spacing,
                 crossAxisSpacing: spacing,
-                childCount: state.posts.length,
-                itemBuilder: (context, index) =>
-                    itemBuilder(context, index, itemWidth, columnCount),
-              ),
-            ),
-            if (placeholderCount > 0)
-              SliverPadding(
-                padding: EdgeInsets.fromLTRB(
-                  12,
-                  state.posts.isEmpty ? 12 : 0,
-                  12,
-                  0,
-                ),
-                sliver: SliverGrid(
-                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: columnCount,
-                    mainAxisSpacing: spacing,
-                    crossAxisSpacing: spacing,
-                  ),
-                  delegate: SliverChildBuilderDelegate(
-                    (context, placeholderIndex) => OnlineGalleryPendingCard(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) {
+                    if (index < state.posts.length) {
+                      return itemBuilder(
+                        context,
+                        index,
+                        itemWidth,
+                        columnCount,
+                      );
+                    }
+                    return OnlineGalleryPendingCard(
                       key: ValueKey(
                         'online-gallery-pending:'
-                        '${state.currentCacheKey}:$placeholderIndex',
+                        '${state.currentCacheKey}:$index',
                       ),
                       itemWidth: itemWidth,
-                    ),
-                    childCount: placeholderCount,
-                  ),
+                    );
+                  },
+                  childCount: masonryChildCount,
+                  findChildIndexCallback: findPostIndex,
                 ),
               ),
+            ),
             SliverPadding(
               padding: const EdgeInsets.fromLTRB(12, 6, 12, 12),
               sliver: SliverList(

--- a/lib/presentation/screens/online_gallery/online_gallery_pagination.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_pagination.dart
@@ -12,11 +12,13 @@ class OnlineGalleryPagination extends StatelessWidget {
     required this.state,
     required this.controller,
     required this.notifier,
+    required this.onGoToPage,
   });
 
   final OnlineGalleryState state;
   final OnlineGalleryScreenController controller;
   final OnlineGalleryNotifier notifier;
+  final Future<void> Function(int page) onGoToPage;
 
   @override
   Widget build(BuildContext context) {
@@ -81,9 +83,7 @@ class OnlineGalleryPagination extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           IconButton(
-            onPressed: state.page > 1 && !state.isLoading
-                ? () => notifier.goToPage(state.page - 1)
-                : null,
+            onPressed: state.page > 1 ? () => onGoToPage(state.page - 1) : null,
             icon: const Icon(Icons.chevron_left, size: 24),
             tooltip: context.l10n.onlineGallery_previousPage,
           ),
@@ -93,8 +93,10 @@ class OnlineGalleryPagination extends StatelessWidget {
               : _buildPageDisplay(context, theme),
           SizedBox(width: isCompact ? 4 : 8),
           IconButton(
-            onPressed: state.hasMore && !state.isLoading
-                ? () => notifier.goToPage(state.page + 1)
+            onPressed:
+                (state.currentCache.boundaryForPage(state.page + 1) != null ||
+                    state.hasMore)
+                ? () => onGoToPage(state.page + 1)
                 : null,
             icon: const Icon(Icons.chevron_right, size: 24),
             tooltip: context.l10n.onlineGallery_nextPage,
@@ -140,9 +142,7 @@ class OnlineGalleryPagination extends StatelessWidget {
 
   Widget _buildPageDisplay(BuildContext context, ThemeData theme) {
     return InkWell(
-      onTap: !state.isLoading
-          ? () => controller.beginPageEditing(state.page)
-          : null,
+      onTap: () => controller.beginPageEditing(state.page),
       borderRadius: BorderRadius.circular(16),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
@@ -150,33 +150,24 @@ class OnlineGalleryPagination extends StatelessWidget {
           color: theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
           borderRadius: BorderRadius.circular(16),
         ),
-        child: state.isLoading && state.posts.isNotEmpty
-            ? SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: theme.colorScheme.primary,
-                ),
-              )
-            : Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    context.l10n.onlineGallery_pageN(state.page.toString()),
-                    style: theme.textTheme.labelLarge?.copyWith(
-                      color: theme.colorScheme.onSurface,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const SizedBox(width: 4),
-                  Icon(
-                    Icons.edit,
-                    size: 12,
-                    color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
-                  ),
-                ],
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              context.l10n.onlineGallery_pageN(state.page.toString()),
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.onSurface,
+                fontWeight: FontWeight.w500,
               ),
+            ),
+            const SizedBox(width: 4),
+            Icon(
+              Icons.edit,
+              size: 12,
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -206,7 +197,7 @@ class OnlineGalleryPagination extends StatelessWidget {
         ],
         onSubmitted: (_) {
           final page = controller.finishPageEditing();
-          if (page != null && page != state.page) notifier.goToPage(page);
+          if (page != null && page != state.page) onGoToPage(page);
         },
       ),
     );

--- a/lib/presentation/screens/online_gallery/online_gallery_screen.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen.dart
@@ -42,6 +42,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
   late final OnlineGalleryScreenCommands _commands;
   late final ProviderSubscription<OnlineGalleryState> _gallerySubscription;
   bool _appForeground = true;
+  int _pageJumpRevision = 0;
 
   @override
   bool get wantKeepAlive => true;
@@ -178,6 +179,27 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
       state == AppLifecycleState.resumed ||
       state == AppLifecycleState.inactive;
 
+  Future<void> _goToPage(int page) async {
+    final revision = ++_pageJumpRevision;
+    final cacheKey = ref.read(onlineGalleryNotifierProvider).currentCacheKey;
+    _scrollCoordinator.beginPageJump();
+    try {
+      final target = await _galleryNotifier.goToPage(page);
+      bool isCurrent() {
+        return mounted &&
+            revision == _pageJumpRevision &&
+            ref.read(onlineGalleryNotifierProvider).currentCacheKey == cacheKey;
+      }
+
+      if (target == null || !isCurrent()) return;
+      await _scrollCoordinator.jumpToPageTarget(target, isCurrent: isCurrent);
+    } finally {
+      if (mounted && revision == _pageJumpRevision) {
+        _scrollCoordinator.endPageJump();
+      }
+    }
+  }
+
   void _handleGalleryStateChanged(OnlineGalleryState state) {
     final browsingContextChanged =
         (_controller.lastViewMode != null &&
@@ -198,6 +220,11 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
         state.posts.isNotEmpty &&
         !state.isLoading;
     if (browsingContextChanged || randomDrawChanged || initialPositionReady) {
+      if (browsingContextChanged) {
+        _pageJumpRevision++;
+        _scrollCoordinator.endPageJump();
+        _controller.synchronizeQueries(state);
+      }
       _controller.hoverController.dismiss();
       _controller.visibleItems.clear();
       _controller.prefetchCoordinator.rotateGeneration();
@@ -218,6 +245,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
 
   @override
   void dispose() {
+    _pageJumpRevision++;
     WidgetsBinding.instance.removeObserver(this);
     CriticalNetworkActivityCoordinator.instance.removeListener(
       _handleCriticalNetworkActivity,
@@ -340,6 +368,7 @@ class _OnlineGalleryScreenState extends ConsumerState<OnlineGalleryScreen>
               state: state,
               controller: _controller,
               notifier: _galleryNotifier,
+              onGoToPage: _goToPage,
             ),
           ],
         ),

--- a/lib/presentation/screens/online_gallery/online_gallery_screen_controller.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen_controller.dart
@@ -33,6 +33,7 @@ class OnlineGalleryScreenController extends ChangeNotifier {
   final anchorRestoreKey = GlobalKey();
   final primarySearchRevealKey = GlobalKey();
   final scrolling = ValueNotifier<bool>(false);
+  final Map<String, GlobalKey> _pageAnchorKeys = <String, GlobalKey>{};
 
   final Map<
     int,
@@ -60,6 +61,11 @@ class OnlineGalleryScreenController extends ChangeNotifier {
   double? _lookaheadItemWidth;
   int? _lookaheadColumnCount;
   bool get isScrolling => scrolling.value;
+  double? get currentItemWidth => _lookaheadItemWidth;
+  int? get currentColumnCount => _lookaheadColumnCount;
+  GlobalKey pageAnchorKey(String stableKey) =>
+      _pageAnchorKeys.putIfAbsent(stableKey, () => GlobalKey());
+
   bool isEditingPage = false;
   GalleryViewMode? lastViewMode;
   GallerySourceId? lastFavoritesSource;
@@ -188,6 +194,7 @@ class OnlineGalleryScreenController extends ChangeNotifier {
     pageController.dispose();
     pageFocusNode.dispose();
     scrolling.dispose();
+    _pageAnchorKeys.clear();
     super.dispose();
   }
 }

--- a/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
@@ -26,6 +26,9 @@ class OnlineGalleryScrollPrefetchCoordinator {
   final WidgetRef ref;
   final OnlineGalleryScreenController controller;
   final OnlineGalleryNotifier notifier;
+  bool _visiblePageUpdateScheduled = false;
+  bool _pageJumpInProgress = false;
+  int _visiblePageUpdateRevision = 0;
 
   OnlineGalleryState readState() => ref.read(onlineGalleryNotifierProvider);
   bool isMounted() => context.mounted;
@@ -164,6 +167,89 @@ class OnlineGalleryScrollPrefetchCoordinator {
     });
   }
 
+  void beginPageJump() {
+    _pageJumpInProgress = true;
+    _visiblePageUpdateRevision++;
+    controller.visibleItems.clear();
+  }
+
+  void endPageJump() {
+    final wasInProgress = _pageJumpInProgress;
+    _pageJumpInProgress = false;
+    _visiblePageUpdateRevision++;
+    if (wasInProgress) {
+      _scheduleVisiblePageUpdate();
+      if (controller.visibleItems.isNotEmpty) scheduleVisiblePrefetch();
+    }
+  }
+
+  Future<void> jumpToPageTarget(
+    GalleryPageJumpTarget target, {
+    required bool Function() isCurrent,
+  }) async {
+    if (!isCurrent() || !controller.scrollController.hasClients) return;
+    final state = readState();
+    final cache = state.currentCache;
+    if (target.itemIndex >= cache.posts.length ||
+        cache.posts[target.itemIndex].stableKey != target.stableKey) {
+      return;
+    }
+
+    final viewportWidth =
+        context.size?.width ?? MediaQuery.sizeOf(context).width;
+    const horizontalPadding = 24.0;
+    const spacing = 6.0;
+    final availableWidth = (viewportWidth - horizontalPadding).clamp(
+      0.0,
+      double.infinity,
+    );
+    final columnCount =
+        controller.currentColumnCount ??
+        ((availableWidth + spacing) / (160 + spacing)).floor().clamp(1, 8);
+    final itemWidth =
+        controller.currentItemWidth ??
+        (availableWidth - (columnCount - 1) * spacing) / columnCount;
+    final columnEnds = List<double>.filled(columnCount, 12);
+    for (var index = 0; index < target.itemIndex; index++) {
+      var column = 0;
+      for (var candidate = 1; candidate < columnEnds.length; candidate++) {
+        if (columnEnds[candidate] < columnEnds[column]) column = candidate;
+      }
+      final item = cache.posts[index];
+      final ratio = item.width > 0 && item.height > 0
+          ? item.width / item.height
+          : 1.0;
+      final height = (itemWidth / ratio).clamp(80.0, itemWidth * 2.5);
+      columnEnds[column] += height + spacing;
+    }
+    final estimatedOffset = columnEnds.reduce(
+      (left, right) => left < right ? left : right,
+    );
+    final position = controller.scrollController.position;
+    controller.scrollController.jumpTo(
+      estimatedOffset.clamp(position.minScrollExtent, position.maxScrollExtent),
+    );
+
+    await WidgetsBinding.instance.endOfFrame;
+    if (!isMounted() || !isCurrent()) return;
+    final latestCache = readState().currentCache;
+    if (target.itemIndex >= latestCache.posts.length ||
+        latestCache.posts[target.itemIndex].stableKey != target.stableKey) {
+      return;
+    }
+    final anchorContext = controller
+        .pageAnchorKey(target.stableKey)
+        .currentContext;
+    if (anchorContext == null || !anchorContext.mounted || !isCurrent()) {
+      return;
+    }
+    await Scrollable.ensureVisible(
+      anchorContext,
+      alignment: 0,
+      duration: Duration.zero,
+    );
+  }
+
   void handleCardVisibility(
     int index,
     GalleryItem item,
@@ -182,6 +268,7 @@ class OnlineGalleryScrollPrefetchCoordinator {
           controller.prefetchCoordinator.cancelPending(request);
         }
       }
+      _scheduleVisiblePageUpdate();
       return;
     }
     final thumbnailRequest = !item.mediaCapability.canPrefetchPreview
@@ -199,6 +286,7 @@ class OnlineGalleryScrollPrefetchCoordinator {
       visibleTop: visibleTop,
       thumbnailRequest: thumbnailRequest,
     );
+    _scheduleVisiblePageUpdate();
     if (controller.scrollController.hasClients) {
       final position = controller.scrollController.position;
       if (controller.updateLookaheadMetrics(
@@ -231,6 +319,26 @@ class OnlineGalleryScrollPrefetchCoordinator {
         },
       );
     }
+  }
+
+  void _scheduleVisiblePageUpdate() {
+    if (_visiblePageUpdateScheduled || _pageJumpInProgress) return;
+    _visiblePageUpdateScheduled = true;
+    final revision = _visiblePageUpdateRevision;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _visiblePageUpdateScheduled = false;
+      if (!isMounted() ||
+          _pageJumpInProgress ||
+          revision != _visiblePageUpdateRevision ||
+          controller.visibleItems.isEmpty) {
+        return;
+      }
+      notifier.updateVisibleItemIndex(
+        controller.visibleItems.keys.reduce(
+          (left, right) => left < right ? left : right,
+        ),
+      );
+    });
   }
 
   void scheduleVisiblePrefetch() {

--- a/lib/presentation/screens/online_gallery/widgets/online_gallery_toolbar/online_gallery_toolbar_feature.dart
+++ b/lib/presentation/screens/online_gallery/widgets/online_gallery_toolbar/online_gallery_toolbar_feature.dart
@@ -625,24 +625,15 @@ class _OnlineGalleryToolbarPresenter {
         ref.invalidate(quickTagCloudCodexProvider(query.codexId));
       }
     }
-    if (activeSource == GallerySourceId.aiTag &&
-        state.viewMode == GalleryViewMode.search) {
-      unawaited(
-        _galleryNotifier.searchWithPrompt(
-          _controller.searchController.text,
-          prompt: _controller.promptSearchController.text,
-        ),
-      );
-    } else if (activeSource == GallerySourceId.aiTag && isPopular) {
-      unawaited(
-        _galleryNotifier.searchPopular(
-          query: _controller.popularSearchController.text,
-          prompt: _controller.popularPromptSearchController.text,
-        ),
-      );
-    } else {
-      unawaited(_galleryNotifier.refresh());
-    }
+    final query = switch (state.viewMode) {
+      GalleryViewMode.search => _controller.searchController.text,
+      GalleryViewMode.popular => _controller.popularSearchController.text,
+      GalleryViewMode.favorites => _controller.favoriteSearchController.text,
+    };
+    final prompt = isPopular
+        ? _controller.popularPromptSearchController.text
+        : _controller.promptSearchController.text;
+    unawaited(_galleryNotifier.refreshWithDraft(query: query, prompt: prompt));
     if (state.randomEnabled && _controller.scrollController.hasClients) {
       _controller.scrollController.jumpTo(0);
     }

--- a/lib/presentation/screens/online_gallery/widgets/online_gallery_toolbar/online_gallery_toolbar_source_controls.dart
+++ b/lib/presentation/screens/online_gallery/widgets/online_gallery_toolbar/online_gallery_toolbar_source_controls.dart
@@ -171,7 +171,11 @@ class OnlineGalleryToolbarSourceControls {
         expandLabel: expandLabel,
         onChanged: (source) {
           bindings.commands.saveScrollOffset();
-          _galleryNotifier.setSource(source);
+          _galleryNotifier.setSource(
+            source,
+            draftQuery: _controller.searchController.text,
+            draftPrompt: _controller.promptSearchController.text,
+          );
         },
       ),
       GalleryViewMode.popular => OnlineGallerySourceDropdown(
@@ -186,7 +190,11 @@ class OnlineGalleryToolbarSourceControls {
         expandLabel: expandLabel,
         onChanged: (source) {
           bindings.commands.saveScrollOffset();
-          _galleryNotifier.setPopularSource(source);
+          _galleryNotifier.setPopularSource(
+            source,
+            draftQuery: _controller.popularSearchController.text,
+            draftPrompt: _controller.popularPromptSearchController.text,
+          );
         },
       ),
       GalleryViewMode.favorites => OnlineGallerySourceDropdown(
@@ -204,7 +212,10 @@ class OnlineGalleryToolbarSourceControls {
         expandLabel: expandLabel,
         onChanged: (source) {
           bindings.commands.saveScrollOffset();
-          _galleryNotifier.setFavoritesSource(source);
+          _galleryNotifier.setFavoritesSource(
+            source,
+            draftQuery: _controller.favoriteSearchController.text,
+          );
         },
       ),
     };
@@ -490,7 +501,12 @@ class OnlineGalleryToolbarSourceControls {
           Text(message),
           IconButton(
             tooltip: context.l10n.common_retry,
-            onPressed: state.isLoading ? null : _galleryNotifier.refresh,
+            onPressed: state.isLoading
+                ? null
+                : () => _galleryNotifier.refreshWithDraft(
+                    query: _controller.favoriteSearchController.text,
+                    prompt: '',
+                  ),
             icon: const Icon(Icons.refresh_rounded, size: 17),
             visualDensity: PlatformCapabilities.current.isMobile
                 ? VisualDensity.standard

--- a/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
+++ b/test/data/datasources/remote/online_gallery/gallery_source_adapter_test.dart
@@ -51,6 +51,57 @@ void main() {
       },
     );
 
+    test(
+      'keeps a short Safebooru response pageable and sends an empty query',
+      () async {
+        final http = _RecordingHttpAdapter((request) {
+          expect(request.uri.host, 'safebooru.donmai.us');
+          expect(request.queryParameters['tags'], '');
+          expect(request.queryParameters['limit'], 60);
+          expect(request.queryParameters['page'], '1');
+          return [for (var id = 100; id > 80; id--) _donmaiPost(id)];
+        });
+        final adapter = DonmaiGallerySourceAdapter(
+          sourceId: GallerySourceId.safebooru,
+          dio: Dio()..httpClientAdapter = http,
+        );
+
+        final page = await adapter.search(
+          const GallerySearchRequest(cursor: '1', pageSize: 60, query: ''),
+        );
+
+        expect(page.rawItemCount, 20);
+        expect(page.hasMore, isTrue);
+        expect(page.nextCursor, 'b81');
+      },
+    );
+
+    test(
+      'advances from the last raw ID when trailing media is unusable',
+      () async {
+        final unusable = <String, dynamic>{
+          ..._donmaiPost(80),
+          'file_url': null,
+          'large_file_url': null,
+          'preview_file_url': null,
+        };
+        final http = _RecordingHttpAdapter((_) => [_donmaiPost(81), unusable]);
+        final adapter = DonmaiGallerySourceAdapter(
+          sourceId: GallerySourceId.safebooru,
+          dio: Dio()..httpClientAdapter = http,
+        );
+
+        final page = await adapter.search(
+          const GallerySearchRequest(cursor: '1', pageSize: 60),
+        );
+
+        expect(page.items.map((item) => item.id), [81]);
+        expect(page.rawItemCount, 2);
+        expect(page.nextCursor, 'b80');
+        expect(page.hasMore, isTrue);
+      },
+    );
+
     test('sends real scale, date, and page to Safebooru ranking', () async {
       final http = _RecordingHttpAdapter((request) {
         expect(request.uri.host, 'safebooru.donmai.us');

--- a/test/presentation/providers/online_gallery_cache_test.dart
+++ b/test/presentation/providers/online_gallery_cache_test.dart
@@ -4,7 +4,7 @@ import 'package:nai_launcher/data/models/online_gallery/gallery_source.dart';
 import 'package:nai_launcher/presentation/providers/online_gallery_provider.dart';
 
 void main() {
-  test('ordinary query cache retains at most 12 most-recent queries', () {
+  test('ordinary query cache never evicts loaded business records', () {
     var state = const OnlineGalleryState();
 
     for (var index = 0; index < 14; index++) {
@@ -14,16 +14,16 @@ void main() {
       );
     }
 
-    expect(state.caches, hasLength(12));
+    expect(state.caches, hasLength(14));
     expect(state.currentCache.posts.single.id, 13);
     expect(state.currentCache.page, 14);
     expect(
       state.caches.values.expand((cache) => cache.posts).map((item) => item.id),
-      isNot(contains(0)),
+      containsAll(<int>[0, 13]),
     );
   });
 
-  test('background cache updates never evict the active query', () {
+  test('background cache updates retain every query cache', () {
     const base = OnlineGalleryState(searchQuery: 'keep-me');
     final caches = <String, ModeCache>{
       base.currentCacheKey: const ModeCache(page: 9),
@@ -38,7 +38,7 @@ void main() {
           const ModeCache(page: 2),
         );
 
-    expect(state.caches, hasLength(12));
+    expect(state.caches, hasLength(13));
     expect(state.caches, contains(base.currentCacheKey));
     expect(state.currentCache.page, 9);
   });

--- a/test/presentation/providers/online_gallery_gelbooru_auth_test.dart
+++ b/test/presentation/providers/online_gallery_gelbooru_auth_test.dart
@@ -784,6 +784,43 @@ void main() {
     expect(gelbooruApi.favoritePids, [0, 1]);
   });
 
+  test('sparse favorite jumps preserve real page order', () async {
+    final hiveDirectory = await Directory.systemTemp.createTemp(
+      'online-gallery-favorites-sparse-pages-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox<dynamic>(StorageKeys.settingsBox);
+    await Hive.openBox<dynamic>(StorageKeys.localFavoritesBox);
+    addTearDown(() async {
+      await Hive.close();
+      await hiveDirectory.delete(recursive: true);
+    });
+
+    final gelbooruApi = _FakeGelbooruApiService(
+      favoritesByPid: {
+        0: GelbooruPostPage(posts: [_gelbooruPost(1)], rawCount: 1),
+        6: GelbooruPostPage(posts: [_gelbooruPost(7)], rawCount: 1),
+        2: GelbooruPostPage(posts: [_gelbooruPost(3)], rawCount: 1),
+      },
+    );
+    final container = createContainer(
+      storedCredentials: stored(credentials),
+      gelbooruApi: gelbooruApi,
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.setFavoritesSource(GallerySourceId.gelbooru);
+    await notifier.switchToFavorites();
+    await notifier.goToPage(7);
+    await notifier.goToPage(3);
+
+    final cache = container.read(onlineGalleryNotifierProvider).currentCache;
+    expect(gelbooruApi.favoritePids, [0, 6, 2]);
+    expect(cache.posts.map((item) => item.id), [1, 3, 7]);
+    expect(cache.pageBoundaries.map((boundary) => boundary.page), [1, 3, 7]);
+  });
+
   test('favorite caches retain independent scroll and pagination state', () {
     final danbooruCache = ModeCache(
       posts: [_danbooruPost(1)],
@@ -840,11 +877,14 @@ void main() {
 
   test('Gelbooru page navigation uses zero-based DAPI pid', () async {
     final gelbooruApi = _FakeGelbooruApiService(
-      searchResult: GelbooruPostPage(posts: [_gelbooruPost(505)], rawCount: 40),
-      favoritesResult: GelbooruPostPage(
-        posts: [_gelbooruPost(506)],
-        rawCount: 40,
-      ),
+      searchByPid: {
+        0: GelbooruPostPage(posts: [_gelbooruPost(505)], rawCount: 40),
+        3: GelbooruPostPage(posts: [_gelbooruPost(507)], rawCount: 40),
+      },
+      favoritesByPid: {
+        0: GelbooruPostPage(posts: [_gelbooruPost(506)], rawCount: 40),
+        2: GelbooruPostPage(posts: [_gelbooruPost(508)], rawCount: 40),
+      },
     );
     final container = createContainer(
       storedCredentials: stored(credentials),
@@ -922,6 +962,7 @@ class _FakeDanbooruCredentialVerifier extends DanbooruCredentialVerifier {
 class _FakeGelbooruApiService extends GelbooruApiService {
   _FakeGelbooruApiService({
     this.searchResult = const GelbooruPostPage(posts: [], rawCount: 0),
+    this.searchByPid,
     this.favoritesResult = const GelbooruPostPage(posts: [], rawCount: 0),
     this.favoritesByPid,
     this.favoritesLoader,
@@ -929,6 +970,7 @@ class _FakeGelbooruApiService extends GelbooruApiService {
   }) : super(Dio());
 
   final GelbooruPostPage searchResult;
+  final Map<int, GelbooruPostPage>? searchByPid;
   final GelbooruPostPage favoritesResult;
   final Map<int, GelbooruPostPage>? favoritesByPid;
   final Future<GelbooruPostPage> Function(int pid)? favoritesLoader;
@@ -950,7 +992,7 @@ class _FakeGelbooruApiService extends GelbooruApiService {
     searchCalls++;
     searchPids.add(pid);
     if (searchError != null) throw searchError!;
-    return searchResult;
+    return searchByPid?[pid] ?? searchResult;
   }
 
   @override

--- a/test/presentation/providers/online_gallery_pagination_test.dart
+++ b/test/presentation/providers/online_gallery_pagination_test.dart
@@ -41,7 +41,8 @@ void main() {
       expect(adapter.searchCursors, ['1', '2']);
       expect(adapter.searchPageSizes, [60, 60]);
       expect(state.posts.map((item) => item.id), [1, 2, 3]);
-      expect(state.page, 2);
+      expect(state.page, 1);
+      expect(state.currentCache.boundaryForPage(2)?.startIndex, 2);
       expect(state.currentCache.nextCursor, '3');
       expect(state.isLoadingMore, isFalse);
     },
@@ -146,7 +147,7 @@ void main() {
         () => container.read(onlineGalleryNotifierProvider).posts.length == 2,
       );
       expect(adapter.searchCursors, ['1', '2', '2']);
-      expect(container.read(onlineGalleryNotifierProvider).page, 2);
+      expect(container.read(onlineGalleryNotifierProvider).page, 1);
     },
   );
 
@@ -294,7 +295,7 @@ void main() {
   );
 
   test(
-    'jumping to a page requests that page and replaces the visible page',
+    'jumping to an unloaded page requests its real boundary and preserves records',
     () async {
       final adapter = _FakeGalleryAdapter(
         GallerySourceId.danbooru,
@@ -311,39 +312,386 @@ void main() {
 
       final state = container.read(onlineGalleryNotifierProvider);
       expect(adapter.searchCursors, ['1', '5']);
-      expect(state.posts.single.id, 5);
+      expect(state.posts.map((item) => item.id), [1, 5]);
+      expect(state.currentCache.boundaryForPage(5)?.startIndex, 1);
       expect(state.page, 5);
     },
   );
 
+  test('sparse unloaded jumps insert records by real page order', () async {
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async {
+        final page = int.parse(request.cursor);
+        return _page(request.cursor, [_item(page)], nextCursor: '${page + 1}');
+      },
+    );
+    final container = _container(danbooru: adapter);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.loadPosts();
+    await notifier.goToPage(7);
+    await notifier.goToPage(3);
+
+    final cache = container.read(onlineGalleryNotifierProvider).currentCache;
+    expect(adapter.searchCursors, ['1', '7', '3']);
+    expect(cache.posts.map((item) => item.id), [1, 3, 7]);
+    expect(cache.pageBoundaries.map((boundary) => boundary.page), [1, 3, 7]);
+    expect(cache.pageBoundaries.map((boundary) => boundary.startIndex), [
+      0,
+      1,
+      2,
+    ]);
+    expect(cache.nextCursor, '8');
+  });
+
   test(
-    'source caches are isolated and restored without a repeated request',
+    'twenty-one response boundaries preserve every ordered record',
+    () async {
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async {
+          final page = int.parse(request.cursor);
+          final firstId = page == 1 ? 1 : page * 2 - 2;
+          return _page(request.cursor, [
+            _item(firstId),
+            _item(page * 2 - 1),
+            _item(page * 2),
+          ], nextCursor: page < 21 ? '${page + 1}' : null);
+        },
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.loadPosts();
+      for (var page = 2; page <= 21; page++) {
+        await notifier.loadMore();
+      }
+
+      var state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.searchCursors, [
+        for (var page = 1; page <= 21; page++) '$page',
+      ]);
+      expect(state.posts.map((item) => item.id), [
+        for (var id = 1; id <= 42; id++) id,
+      ]);
+      expect(state.currentCache.pageBoundaries, hasLength(21));
+      expect(state.currentCache.boundaryForPage(21)?.startIndex, 40);
+
+      notifier.clearDetailCache();
+      expect(
+        container.read(onlineGalleryNotifierProvider).posts,
+        hasLength(42),
+      );
+
+      notifier.updateVisibleItemIndex(40);
+      expect(container.read(onlineGalleryNotifierProvider).page, 21);
+      notifier.updateVisibleItemIndex(0);
+      state = container.read(onlineGalleryNotifierProvider);
+      expect(state.page, 1);
+      expect(state.posts, hasLength(42));
+    },
+  );
+
+  test('query cache retention never evicts loaded business records', () {
+    var state = const OnlineGalleryState();
+    for (var queryIndex = 0; queryIndex < 20; queryIndex++) {
+      state = state.copyWith(searchQuery: 'query$queryIndex');
+      state = state.updateCurrentCache(
+        ModeCache(
+          posts: [_item(queryIndex)],
+          pageBoundaries: [
+            const GalleryPageBoundary(
+              page: 1,
+              cursor: '1',
+              startIndex: 0,
+              endIndex: 1,
+              rawItemCount: 1,
+              nextCursor: null,
+            ),
+          ],
+          hasMore: false,
+          nextCursor: null,
+        ),
+      );
+    }
+
+    expect(state.caches, hasLength(20));
+    final restored = state.copyWith(searchQuery: 'query0').currentCache;
+    expect(restored.posts.single.id, 0);
+    expect(restored.boundaryForPage(1)?.startIndex, 0);
+  });
+
+  test(
+    'a loaded jump resolves its stable boundary without requesting',
+    () async {
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async {
+          final page = int.parse(request.cursor);
+          return _page(request.cursor, [
+            _item(page * 10),
+            _item(page * 10 + 1),
+          ], nextCursor: page < 7 ? '${page + 1}' : null);
+        },
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+      await notifier.loadPosts();
+      for (var page = 2; page <= 7; page++) {
+        await notifier.loadMore();
+      }
+      final requestsBeforeJump = adapter.searchCursors.length;
+
+      final target = await notifier.goToPage(4);
+
+      expect(adapter.searchCursors, hasLength(requestsBeforeJump));
+      expect(target?.page, 4);
+      expect(target?.itemIndex, 6);
+      expect(
+        target?.stableKey,
+        container.read(onlineGalleryNotifierProvider).posts[6].stableKey,
+      );
+    },
+  );
+
+  test('a newer page jump cancels and replaces an unloaded jump', () async {
+    final firstPageTwoStarted = Completer<void>();
+    var pageTwoCalls = 0;
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, cancelToken) async {
+        if (request.cursor == '1') {
+          return _page('1', [_item(1)], nextCursor: '2');
+        }
+        if (request.cursor == '5' && pageTwoCalls++ == 0) {
+          firstPageTwoStarted.complete();
+          throw await cancelToken!.whenCancel;
+        }
+        final page = int.parse(request.cursor);
+        return _page(request.cursor, [
+          _item(page),
+        ], nextCursor: page < 5 ? '${page + 1}' : null);
+      },
+    );
+    final container = _container(danbooru: adapter);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+    await notifier.loadPosts();
+
+    final staleJump = notifier.goToPage(5);
+    await firstPageTwoStarted.future;
+    final currentJump = notifier.goToPage(3);
+
+    expect(await staleJump, isNull);
+    final target = await currentJump;
+    expect(target?.page, 3);
+    expect(container.read(onlineGalleryNotifierProvider).page, 3);
+    expect(
+      container
+          .read(onlineGalleryNotifierProvider)
+          .posts
+          .map((item) => item.id),
+      [1, 3],
+    );
+  });
+
+  test('source switches start a fresh generation at page 1', () async {
+    final danbooru = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async =>
+          _page(request.cursor, [_item(11)], nextCursor: null),
+    );
+    final safebooru = _FakeGalleryAdapter(
+      GallerySourceId.safebooru,
+      onSearch: (request, _) async => _page(request.cursor, [
+        _item(22, source: GallerySourceId.safebooru),
+      ], nextCursor: null),
+    );
+    final container = _container(danbooru: danbooru, safebooru: safebooru);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.loadPosts();
+    await notifier.setSource(GallerySourceId.safebooru);
+    expect(container.read(onlineGalleryNotifierProvider).posts.single.id, 22);
+    await notifier.setSource(GallerySourceId.danbooru);
+
+    expect(container.read(onlineGalleryNotifierProvider).posts.single.id, 11);
+    expect(danbooru.searchCursors, ['1', '1']);
+    expect(safebooru.searchCursors, ['1']);
+  });
+
+  test(
+    'refresh commits an empty visible draft before requesting page 1',
+    () async {
+      final adapter = _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async => _page(request.cursor, [
+          _item(request.query.isEmpty ? 2 : 1, tags: [request.query]),
+        ], nextCursor: null),
+      );
+      final container = _container(danbooru: adapter);
+      addTearDown(container.dispose);
+      final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+      await notifier.search('foo');
+      await notifier.refreshWithDraft(query: '', prompt: '');
+      await notifier.search('x');
+      await notifier.refreshWithDraft(query: '', prompt: '');
+
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(adapter.searchQueries, ['foo', '', 'x', '']);
+      expect(adapter.searchCursors, ['1', '1', '1', '1']);
+      expect(state.searchQuery, '');
+      expect(state.page, 1);
+      expect(state.posts.single.id, 2);
+    },
+  );
+
+  test('late tagged results cannot overwrite an empty draft refresh', () async {
+    final taggedStarted = Completer<void>();
+    final taggedResult = Completer<GalleryPage>();
+    final adapter = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async {
+        if (request.query == 'foo') {
+          taggedStarted.complete();
+          return taggedResult.future;
+        }
+        return _page(request.cursor, [
+          _item(2, tags: const ['empty']),
+        ], nextCursor: null);
+      },
+    );
+    final container = _container(danbooru: adapter);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    final taggedSearch = notifier.search('foo');
+    await taggedStarted.future;
+    await notifier.refreshWithDraft(query: '', prompt: '');
+    taggedResult.complete(
+      _page('1', [
+        _item(1, tags: const ['foo']),
+      ], nextCursor: null),
+    );
+    await taggedSearch;
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(state.searchQuery, '');
+    expect(state.posts.single.id, 2);
+  });
+
+  test(
+    'Safebooru source switch and refresh both use the empty draft',
     () async {
       final danbooru = _FakeGalleryAdapter(
         GallerySourceId.danbooru,
         onSearch: (request, _) async =>
-            _page(request.cursor, [_item(11)], nextCursor: null),
+            _page(request.cursor, [_item(1)], nextCursor: null),
       );
       final safebooru = _FakeGalleryAdapter(
         GallerySourceId.safebooru,
         onSearch: (request, _) async => _page(request.cursor, [
-          _item(22, source: GallerySourceId.safebooru),
+          _item(20, source: GallerySourceId.safebooru, tags: const ['safe']),
         ], nextCursor: null),
       );
       final container = _container(danbooru: danbooru, safebooru: safebooru);
       addTearDown(container.dispose);
       final notifier = container.read(onlineGalleryNotifierProvider.notifier);
 
-      await notifier.loadPosts();
-      await notifier.setSource(GallerySourceId.safebooru);
-      expect(container.read(onlineGalleryNotifierProvider).posts.single.id, 22);
-      await notifier.setSource(GallerySourceId.danbooru);
+      await notifier.search('foo');
+      await notifier.setSource(
+        GallerySourceId.safebooru,
+        draftQuery: '',
+        draftPrompt: '',
+      );
+      await notifier.refreshWithDraft(query: '', prompt: '');
 
-      expect(container.read(onlineGalleryNotifierProvider).posts.single.id, 11);
-      expect(danbooru.searchCursors, ['1']);
-      expect(safebooru.searchCursors, ['1']);
+      final state = container.read(onlineGalleryNotifierProvider);
+      expect(safebooru.searchQueries, ['', '']);
+      expect(safebooru.searchCursors, ['1', '1']);
+      expect(state.searchQuery, '');
+      expect(state.page, 1);
+      expect(state.posts.single.sourceId, GallerySourceId.safebooru);
     },
   );
+
+  test('popular source switch commits the visible empty draft', () async {
+    final danbooru = _FakeGalleryAdapter(
+      GallerySourceId.danbooru,
+      onSearch: (request, _) async =>
+          _page(request.cursor, [_item(1)], nextCursor: null),
+    );
+    final safebooru = _FakeGalleryAdapter(
+      GallerySourceId.safebooru,
+      onSearch: (request, _) async => _page(request.cursor, [
+        _item(2, source: GallerySourceId.safebooru),
+      ], nextCursor: null),
+    );
+    final container = _container(danbooru: danbooru, safebooru: safebooru);
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.switchToPopular();
+    await notifier.searchPopular(query: 'foo', prompt: 'old prompt');
+    await notifier.setPopularSource(
+      GallerySourceId.safebooru,
+      draftQuery: '',
+      draftPrompt: '',
+    );
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(safebooru.searchQueries, ['']);
+    expect(state.popularQuery, '');
+    expect(state.popularPromptQuery, '');
+    expect(state.page, 1);
+    expect(state.posts.single.sourceId, GallerySourceId.safebooru);
+  });
+
+  test('Safebooru twenty-item responses continue across pages', () async {
+    final safebooru = _FakeGalleryAdapter(
+      GallerySourceId.safebooru,
+      onSearch: (request, _) async {
+        final page = int.parse(request.cursor);
+        return _page(
+          request.cursor,
+          [
+            for (var index = 0; index < 20; index++)
+              _item(
+                (page - 1) * 20 + index + 1,
+                source: GallerySourceId.safebooru,
+              ),
+          ],
+          nextCursor: '${page + 1}',
+          rawItemCount: 20,
+        );
+      },
+    );
+    final container = _container(
+      danbooru: _FakeGalleryAdapter(
+        GallerySourceId.danbooru,
+        onSearch: (request, _) async =>
+            _page(request.cursor, const [], nextCursor: null),
+      ),
+      safebooru: safebooru,
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(onlineGalleryNotifierProvider.notifier);
+
+    await notifier.setSource(GallerySourceId.safebooru, draftQuery: '');
+    await notifier.loadMore();
+
+    final state = container.read(onlineGalleryNotifierProvider);
+    expect(safebooru.searchCursors, ['1', '2']);
+    expect(state.posts, hasLength(40));
+    expect(state.hasMore, isTrue);
+    expect(state.currentCache.boundaryForPage(2)?.startIndex, 20);
+  });
 
   test(
     'switching to a cached source clears loading from the cancelled request',
@@ -374,8 +722,7 @@ void main() {
 
       await notifier.loadPosts();
       await notifier.setSource(GallerySourceId.safebooru);
-      await notifier.setSource(GallerySourceId.danbooru);
-      final refresh = notifier.refresh();
+      final pendingSwitch = notifier.setSource(GallerySourceId.danbooru);
       await Future<void>.delayed(Duration.zero);
       expect(container.read(onlineGalleryNotifierProvider).isLoading, isTrue);
 
@@ -386,7 +733,7 @@ void main() {
       expect(state.isLoading, isFalse);
       expect(state.isLoadingMore, isFalse);
       pendingRefresh.complete(_page('1', [_item(99)], nextCursor: null));
-      await refresh;
+      await pendingSwitch;
       state = container.read(onlineGalleryNotifierProvider);
       expect(state.posts.single.id, 22);
       expect(state.isLoading, isFalse);
@@ -428,7 +775,8 @@ void main() {
     state = container.read(onlineGalleryNotifierProvider);
     expect(adapter.searchCursors, ['1', 'b900', 'b800']);
     expect(state.posts.map((item) => item.id), [2, 3]);
-    expect(state.page, 3);
+    expect(state.page, 2);
+    expect(state.currentCache.boundaryForPage(3)?.startIndex, 1);
     expect(state.currentCache.nextCursor, 'b700');
   });
 
@@ -1502,7 +1850,14 @@ class _FakeGalleryAdapter implements GallerySourceAdapter {
     CancelToken? cancelToken,
   }) {
     return search(
-      GallerySearchRequest(cursor: request.cursor, pageSize: request.pageSize),
+      GallerySearchRequest(
+        cursor: request.cursor,
+        pageSize: request.pageSize,
+        query: request.query,
+        prompt: request.prompt,
+        ratings: request.ratings,
+        blacklistTags: request.blacklistTags,
+      ),
       cancelToken: cancelToken,
     );
   }

--- a/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
@@ -268,7 +268,7 @@ void main() {
     expect(find.byType(OnlineGalleryPendingCard), findsWidgets);
     expect(
       find.descendant(
-        of: find.byType(SliverGrid),
+        of: find.byType(SliverMasonryGrid),
         matching: find.byType(OnlineGalleryPendingCard),
       ),
       findsWidgets,
@@ -316,6 +316,85 @@ void main() {
     expect(find.byType(OnlineGalleryPendingCard), findsNothing);
     expect(find.byKey(const ValueKey('completed-0')), findsOneWidget);
   });
+
+  testWidgets(
+    'keeps twenty-one loaded pages reachable after append placeholders change',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(840, 700);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+      final controller = OnlineGalleryScreenController(
+        prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
+          preloader: (_) =>
+              GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
+        ),
+      );
+      addTearDown(controller.dispose);
+      final initialItems = List.generate(
+        21 * 60,
+        (index) => GalleryItem(
+          id: index,
+          workId: 'post-$index',
+          sourceId: GallerySourceId.danbooru,
+          width: 1,
+          height: 1,
+        ),
+      );
+
+      Widget subject(List<GalleryItem> items, {bool loadingMore = false}) {
+        return MaterialApp(
+          home: Scaffold(
+            body: OnlineGalleryGrid(
+              state: OnlineGalleryState(
+                isLoadingMore: loadingMore,
+                searchCache: ModeCache(posts: items, hasMore: loadingMore),
+              ),
+              controller: controller,
+              itemBuilder: (context, index, itemWidth, columnCount) =>
+                  SizedBox(key: ValueKey('post-$index'), height: 100),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(subject(initialItems));
+      controller.scrollController.jumpTo(
+        controller.scrollController.position.maxScrollExtent,
+      );
+      await tester.pump();
+      final bottomOffset = controller.scrollController.offset;
+      expect(bottomOffset, greaterThan(1000));
+
+      await tester.pumpWidget(subject(initialItems, loadingMore: true));
+      await tester.pump();
+      expect(controller.scrollController.offset, greaterThan(1000));
+
+      final appendedItems = [
+        ...initialItems,
+        for (
+          var index = initialItems.length;
+          index < initialItems.length + 60;
+          index++
+        )
+          GalleryItem(
+            id: index,
+            workId: 'post-$index',
+            sourceId: GallerySourceId.danbooru,
+            width: 1,
+            height: 1,
+          ),
+      ];
+      await tester.pumpWidget(subject(appendedItems));
+      await tester.pump();
+      expect(controller.scrollController.offset, greaterThan(1000));
+
+      controller.scrollController.jumpTo(0);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('post-0')), findsOneWidget);
+      expect(appendedItems, hasLength(1320));
+    },
+  );
 
   testWidgets(
     'derives column count from grid width rather than viewport height',

--- a/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
@@ -890,7 +890,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('page replacement renders the second page URL with stable keys', (
+  testWidgets('page jump preserves the first page and targets stable keys', (
     tester,
   ) async {
     await _setViewSize(tester, 1200);
@@ -921,6 +921,11 @@ void main() {
     await tester.tap(find.byIcon(Icons.chevron_right));
     await tester.pump();
 
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(OnlineGalleryScreen)),
+    );
+    expect(container.read(onlineGalleryNotifierProvider).page, 2);
+
     final detector = tester.widget<VisibilityDetector>(
       find.byKey(const ValueKey('gallery-visibility:danbooru:402')),
     );
@@ -933,19 +938,13 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.byKey(const ValueKey('danbooru:401')), findsNothing);
+    expect(find.byKey(const ValueKey('danbooru:401')), findsOneWidget);
     expect(find.byKey(const ValueKey('danbooru:402')), findsOneWidget);
-    expect(
-      tester
-          .widget<DanbooruPostCard>(find.byType(DanbooruPostCard))
-          .post
-          .previewUrl,
-      contains('page-2'),
+    final secondPageCard = tester.widget<DanbooruPostCard>(
+      find.byKey(const ValueKey('danbooru:402')),
     );
-    expect(
-      tester.widget<DanbooruPostCard>(find.byType(DanbooruPostCard)).post.id,
-      402,
-    );
+    expect(secondPageCard.post.previewUrl, contains('page-2'));
+    expect(secondPageCard.post.id, 402);
   });
 
   testWidgets('favorites source selector switches back to Danbooru', (
@@ -1601,7 +1600,11 @@ class _QuickTagCloudGalleryNotifier extends OnlineGalleryNotifier {
   }
 
   @override
-  Future<void> setSource(Object source) async {
+  Future<void> setSource(
+    Object source, {
+    String? draftQuery,
+    String? draftPrompt,
+  }) async {
     selectedSource = source as GallerySourceId;
   }
 }
@@ -1898,14 +1901,36 @@ class _PagedGalleryNotifier extends OnlineGalleryNotifier {
   Future<void> loadMore() async {}
 
   @override
-  Future<void> goToPage(int page) async {
+  Future<GalleryPageJumpTarget?> goToPage(int page) async {
     state = const OnlineGalleryState(
       searchCache: ModeCache(
-        posts: [_pageTwoPost],
+        posts: [_pageOnePost, _pageTwoPost],
         page: 2,
         nextCursor: null,
         hasMore: false,
+        pageBoundaries: [
+          GalleryPageBoundary(
+            page: 1,
+            cursor: '1',
+            startIndex: 0,
+            endIndex: 1,
+            rawItemCount: 1,
+            nextCursor: '2',
+          ),
+          GalleryPageBoundary(
+            page: 2,
+            cursor: '2',
+            startIndex: 1,
+            endIndex: 2,
+            rawItemCount: 1,
+          ),
+        ],
       ),
+    );
+    return const GalleryPageJumpTarget(
+      page: 2,
+      itemIndex: 1,
+      stableKey: 'danbooru:402',
     );
   }
 }


### PR DESCRIPTION
## 用户可见变化
- 修复在线画廊连续加载约 21 页后向上滚动时中间记录消失、滚动范围错乱及页码跳转落错页
- 页码跳转改为使用真实 page/cursor 边界；支持已加载、未加载及快速连续替换目标，不再按去重后的扁平列表乘固定 pageSize
- 来源切换、清空搜索与刷新统一提交当前输入框 draft；空字符串不再回退到旧 query，迟到的旧请求不会污染新来源
- Safebooru 短页不再被误判为加载结束；使用真实 cursor 并在空页或重复页时结束
- 保留所有已加载业务记录和边界，只维持现有媒体层缓存策略

## 实现要点
- 记录每个真实请求页的 cursor、前后继 cursor 与稳定 start/end 边界
- Masonry grid 恢复单一连续虚拟化 delegate，并提供 stable-key index 映射
- 可见页由真实首可见 item boundary 推导，响应式列数变化后重新定位稳定锚点
- query/source 变更旋转 request generation，并取消或拒绝旧响应

## 验证
- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1（303 tests passed）
- git diff --check
- 针对性 provider、adapter、grid、source auth 测试均通过
- lutter analyze：仅报告既有且与本 PR 无关的 lib/core/agent/context_usage.dart:70 warning；本 PR 修改文件单独 analyze 无问题

## 说明
- 未修改 CHANGELOG.md
- 未启动 Windows/Android runtime runner