### PR TITLE
feat(agent): 补全生成图片工具链

### DIFF
--- a/lib/core/agent/permissions/agent_permission.dart
+++ b/lib/core/agent/permissions/agent_permission.dart
@@ -15,6 +15,7 @@ enum AgentPermissionDomain {
   skills,
   web,
   file,
+  externalActions,
 }
 
 /// Access granted to tools in one [AgentPermissionDomain].

--- a/lib/core/agent/permissions/tool_permission_catalog.dart
+++ b/lib/core/agent/permissions/tool_permission_catalog.dart
@@ -44,10 +44,13 @@ class AgentToolPermissionCatalog {
       descriptor.operation,
     );
     if (ordinaryDecision == AgentPermissionDecision.block ||
-        !descriptor.mayConsumeAnlas ||
-        (estimatedAnlas != null && estimatedAnlas <= 0)) {
+        !descriptor.mayConsumeAnlas) {
       return ordinaryDecision;
     }
+    if (estimatedAnlas != null && estimatedAnlas < 0) {
+      return AgentPermissionDecision.block;
+    }
+    if (estimatedAnlas == 0) return ordinaryDecision;
     return AgentPermissionDecision.confirmCharge;
   }
 
@@ -165,7 +168,12 @@ AgentToolPermissionDescriptor describeAgentToolPermission(String toolName) {
 
   final domain = switch (toolName) {
     'get_application_context' ||
-    'navigate_application' => AgentPermissionDomain.appNavigation,
+    'navigate_application' ||
+    'select_generated_image' => AgentPermissionDomain.appNavigation,
+    'set_generated_image_favorite' => AgentPermissionDomain.localGallery,
+    'save_generated_image' => AgentPermissionDomain.file,
+    'copy_generated_image_to_clipboard' ||
+    'send_generated_image_to_krita' => AgentPermissionDomain.externalActions,
     String()
         when toolName.contains('fixed_tag') ||
             toolName.contains('tag_library') =>
@@ -225,15 +233,19 @@ AgentToolPermissionDescriptor describeAgentToolPermission(String toolName) {
       toolName.startsWith('remove_') ||
       toolName.startsWith('clear_') ||
       toolName.startsWith('cancel_');
-  final operation = isDelete
-      ? AgentPermissionOperation.delete
-      : isRead
-      ? AgentPermissionOperation.read
-      : toolName.startsWith('create_') || toolName.startsWith('prepare_')
-      ? AgentPermissionOperation.create
-      : toolName == 'navigate_application'
-      ? AgentPermissionOperation.execute
-      : AgentPermissionOperation.update;
+  final operation = switch (toolName) {
+    'save_generated_image' => AgentPermissionOperation.create,
+    'navigate_application' ||
+    'select_generated_image' ||
+    'open_generation_image_workflow' ||
+    'copy_generated_image_to_clipboard' ||
+    'send_generated_image_to_krita' => AgentPermissionOperation.execute,
+    _ when isDelete => AgentPermissionOperation.delete,
+    _ when isRead => AgentPermissionOperation.read,
+    _ when toolName.startsWith('create_') || toolName.startsWith('prepare_') =>
+      AgentPermissionOperation.create,
+    _ => AgentPermissionOperation.update,
+  };
   return AgentToolPermissionDescriptor(
     toolName: toolName,
     domain: domain,

--- a/lib/core/agent/validate_tool_arguments.dart
+++ b/lib/core/agent/validate_tool_arguments.dart
@@ -1,7 +1,8 @@
 import 'agent_types.dart';
 
 /// 工具参数校验
-/// 子集实现：type/properties/required/enum/items/minimum/maximum。校验失败抛出
+/// 子集实现：type/properties/required/additionalProperties/enum/items/
+/// minimum/maximum。校验失败抛出
 /// [FormatException]，由 loop 捕获并转为错误工具结果让模型重试。
 Map<String, dynamic> validateToolArguments(
   AgentTool tool,
@@ -47,6 +48,16 @@ void _validateAgainstSchema(
       }
     }
     final properties = schema['properties'];
+    if (schema['additionalProperties'] == false) {
+      final allowed = properties is Map<String, dynamic>
+          ? properties.keys.toSet()
+          : const <String>{};
+      for (final key in value.keys) {
+        if (!allowed.contains(key)) {
+          throw FormatException('$path: unknown property "$key"');
+        }
+      }
+    }
     if (properties is Map<String, dynamic>) {
       for (final entry in properties.entries) {
         if (value.containsKey(entry.key) &&

--- a/lib/presentation/agent_chat/providers/agent_chat_notifier.dart
+++ b/lib/presentation/agent_chat/providers/agent_chat_notifier.dart
@@ -245,6 +245,8 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
       generationRuntime: _generationPreparationRuntime,
       queueRuntime: _queueControlRuntime,
       manualInpaintToolbox: _manualInpaintToolbox,
+      activeSessionId: () => state.activeSessionId,
+      isMounted: () => mounted,
     );
     _sessionControllerValue = AgentChatSessionController(
       repository: sessionRepository,

--- a/lib/presentation/agent_chat/services/agent_resource_resolver.dart
+++ b/lib/presentation/agent_chat/services/agent_resource_resolver.dart
@@ -17,6 +17,7 @@ import '../../providers/online_gallery_provider.dart';
 import '../../providers/precise_ref_library_provider.dart';
 import '../../providers/tag_library_page_provider.dart';
 import '../../providers/vibe_library_provider.dart';
+import 'generation_image_resource.dart';
 
 final class ResolvedAgentResource {
   const ResolvedAgentResource({
@@ -64,6 +65,17 @@ class AgentResourceResolver {
     );
   }
 
+  Future<void> validateForDisplay(AgentChatResourceReference reference) async {
+    if (reference.kind != AgentChatResourceKind.generatedImage) return;
+    await _ref
+        .read(imageGenerationNotifierProvider.notifier)
+        .ensureGenerationHistoryRestored();
+    requireAvailableGenerationImage(
+      _ref.read(imageGenerationNotifierProvider),
+      generationImageResourceReference(reference.resourceId),
+    );
+  }
+
   Future<ResolvedAgentResource?> resolve(
     AgentChatResourceReference reference,
   ) async {
@@ -100,10 +112,13 @@ class AgentResourceResolver {
             !record.isDeleted &&
             await File(record.filePath).exists();
       case AgentChatResourceKind.generatedImage:
-        return _ref
-                .read(imageGenerationNotifierProvider)
-                .findImageById(reference.resourceId) !=
-            null;
+        await _ref
+            .read(imageGenerationNotifierProvider.notifier)
+            .ensureGenerationHistoryRestored();
+        final image = _ref
+            .read(imageGenerationNotifierProvider)
+            .findImageById(reference.resourceId);
+        return image != null && !image.isFailedStreamSnapshot;
       case AgentChatResourceKind.onlineGalleryMedia:
         return _onlineExists(reference);
       case AgentChatResourceKind.inpaintDraft:
@@ -251,15 +266,18 @@ class AgentResourceResolver {
     );
   }
 
-  ResolvedAgentResource? _resolveGenerated(
+  Future<ResolvedAgentResource?> _resolveGenerated(
     AgentChatResourceReference reference,
-  ) {
+  ) async {
+    await _ref
+        .read(imageGenerationNotifierProvider.notifier)
+        .ensureGenerationHistoryRestored();
     final image = _ref
         .read(imageGenerationNotifierProvider)
         .findImageById(reference.resourceId);
-    if (image == null) return null;
+    if (image == null || image.isFailedStreamSnapshot) return null;
     return ResolvedAgentResource(
-      reference: reference,
+      reference: generationImageResourceReference(image.id),
       label: reference.display['label'] ?? 'Generated image',
       bytes: image.bytes,
       filePath: image.filePath,

--- a/lib/presentation/agent_chat/services/agent_system_prompt.dart
+++ b/lib/presentation/agent_chat/services/agent_system_prompt.dart
@@ -62,6 +62,13 @@ String buildAgentSystemPrompt({
         'and stable resource_ref. Never derive a filename or extension from a '
         'resource_ref/resourceId; use the returned path with read, or pass the '
         'resource_ref to preview_generated_image.',
+    '- Reuse that exact generated-image resource_ref for selection, favorites, '
+        'tag-library thumbnails, saving, clipboard, Krita, and '
+        'open_generation_image_workflow. Never substitute an index or raw path.',
+    '- open_generation_image_workflow only prepares or opens edit, inpaint, '
+        'variations, director, enhance, or upscale in the real application. It '
+        'never submits or spends Anlas; report its next_step and let the user '
+        'edit/review before any separately confirmed paid submission.',
     '- Image retrieval tools such as get_recent_images and gallery searches '
         'return metadata and stable resource_ref objects; they do not display '
         'their media automatically. Always pass the required get_recent_images '

--- a/lib/presentation/agent_chat/services/agent_tool_registry_builder.dart
+++ b/lib/presentation/agent_chat/services/agent_tool_registry_builder.dart
@@ -1,19 +1,30 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/agent/agent.dart';
+import '../../../core/agent/harness/env/dart_io_execution_env.dart';
 import '../../../core/agent/harness/harness_types.dart';
 import '../../../core/agent/harness/skills.dart';
 import '../../../core/agent/permissions/permissions.dart';
 import '../../agent_settings/providers/agent_settings_provider.dart';
 import '../../prompt_assistant/models/prompt_assistant_models.dart';
 import '../../prompt_assistant/providers/web_access_provider.dart';
+import '../../providers/krita/krita_bridge_notifier.dart';
+import '../../router/app_router_config.dart';
+import '../../router/app_routes.dart';
 import 'agent_resource_resolver.dart';
 import 'application_toolbox.dart';
 import 'display_images_toolbox.dart';
 import 'execution_toolbox.dart';
 import 'gallery_toolbox.dart';
+import 'generation_image_favorite_toolbox.dart';
+import 'generation_image_workflow_launcher_adapter.dart';
+import 'generation_image_workflow_service.dart';
+import 'generation_image_workflow_toolbox.dart';
 import 'generation_preparation_runtime.dart';
+import 'generation_resource_toolbox.dart';
 import 'generation_toolbox.dart';
+import 'image_resource_action_service.dart';
+import 'image_resource_action_toolbox.dart';
 import 'manual_inpaint_toolbox.dart';
 import 'prompt_toolbox.dart';
 import 'queue_toolbox.dart';
@@ -44,6 +55,8 @@ class AgentToolRegistryBuilder {
     required GenerationPreparationRuntime generationRuntime,
     required QueueControlRuntime queueRuntime,
     required ManualInpaintToolbox manualInpaintToolbox,
+    required String Function() activeSessionId,
+    required bool Function() isMounted,
   }) : _ref = ref,
        _workspaceDir = workspaceDir,
        _skills = skills,
@@ -51,7 +64,9 @@ class AgentToolRegistryBuilder {
        _reloadSkills = reloadSkills,
        _generationRuntime = generationRuntime,
        _queueRuntime = queueRuntime,
-       _manualInpaintToolbox = manualInpaintToolbox;
+       _manualInpaintToolbox = manualInpaintToolbox,
+       _activeSessionId = activeSessionId,
+       _isMounted = isMounted;
 
   final Ref _ref;
   final String _workspaceDir;
@@ -61,6 +76,8 @@ class AgentToolRegistryBuilder {
   final GenerationPreparationRuntime _generationRuntime;
   final QueueControlRuntime _queueRuntime;
   final ManualInpaintToolbox _manualInpaintToolbox;
+  final String Function() _activeSessionId;
+  final bool Function() _isMounted;
 
   AgentToolRegistry build({
     required bool fullAccess,
@@ -80,6 +97,49 @@ class AgentToolRegistryBuilder {
       loadInpaintDraftImage: _manualInpaintToolbox.loadDraftImage,
     );
     _manualInpaintToolbox.configureResourceResolver(resourceResolver);
+    final workflowService = GenerationImageWorkflowService(
+      loadResource: generationWorkflowResourceLoader(_ref),
+      activeSessionId: _activeSessionId,
+      isMounted: _isMounted,
+      launcher: ApplicationGenerationImageWorkflowLauncher(
+        ref: _ref,
+        navigator: () => _ref
+            .read(appRouterProvider)
+            .routerDelegate
+            .navigatorKey
+            .currentState,
+        openGeneration: () async =>
+            _ref.read(appRouterProvider).go(AppRoutes.generation),
+        manualInpaintToolbox: _manualInpaintToolbox,
+      ),
+    );
+    final imageActionService = ImageResourceActionService(
+      resolve: (reference) async {
+        await resourceResolver.validateForDisplay(reference);
+        final resolved = await resourceResolver.resolve(reference);
+        final bytes = resolved?.bytes;
+        return resolved == null || bytes == null
+            ? null
+            : ResolvedImageResourceActionSource(
+                label: resolved.label,
+                bytes: bytes,
+              );
+      },
+      env: DartIoExecutionEnv(
+        workingDirectory: _workspaceDir,
+        allowOutsideWorkingDirectory: fullAccess,
+      ),
+      readKritaBridgeState: () {
+        final state = _ref.read(kritaBridgeNotifierProvider);
+        return ImageResourceKritaBridgeState(
+          configured: state.enabled,
+          connected: state.status == KritaBridgeStatus.connected,
+        );
+      },
+      sendToKrita: (bytes, {required name}) => _ref
+          .read(kritaBridgeNotifierProvider.notifier)
+          .sendImageToKrita(bytes, name: name),
+    );
     final tools = <AgentTool>[
       ...PromptToolbox(
         _ref,
@@ -104,10 +164,15 @@ class AgentToolRegistryBuilder {
       ...ApplicationToolbox(
         _ref,
         loadDrafts: _manualInpaintToolbox.listDraftSummaries,
+        resourceResolver: resourceResolver,
       ).tools(),
       ...GalleryToolbox(_ref).tools(),
       ...ReferenceLibraryToolbox(_ref, resourceResolver).tools(),
       ...DisplayImagesToolbox(resourceResolver).tools(),
+      ...GenerationResourceToolbox(_ref).tools(),
+      ...GenerationImageWorkflowToolbox(workflowService).tools(),
+      ...GenerationImageFavoriteToolbox(_ref).tools(),
+      ...ImageResourceActionToolbox(imageActionService).tools(),
       if (webAccessEnabled)
         ...WebAccessToolbox(
           config: _ref

--- a/lib/presentation/agent_chat/services/application_toolbox.dart
+++ b/lib/presentation/agent_chat/services/application_toolbox.dart
@@ -1,20 +1,22 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/agent/agent_types.dart';
+import 'agent_resource_resolver.dart';
 import 'application_context_toolbox.dart';
 import 'fixed_tags_toolbox.dart';
 import 'tag_library_toolbox.dart';
 
 /// Backward-compatible registration facade for application-owned tools.
 class ApplicationToolbox {
-  ApplicationToolbox(this._ref, {this.loadDrafts});
+  ApplicationToolbox(this._ref, {this.loadDrafts, this.resourceResolver});
 
   final Ref _ref;
   final AgentDraftSnapshotLoader? loadDrafts;
+  final AgentResourceResolver? resourceResolver;
 
   List<AgentTool> tools() => [
     ...ApplicationContextToolbox(_ref, loadDrafts: loadDrafts).tools(),
-    ...TagLibraryToolbox(_ref).tools(),
+    ...TagLibraryToolbox(_ref, resourceResolver: resourceResolver).tools(),
     ...FixedTagsToolbox(_ref).tools(),
   ];
 }

--- a/lib/presentation/agent_chat/services/display_images_toolbox.dart
+++ b/lib/presentation/agent_chat/services/display_images_toolbox.dart
@@ -7,21 +7,31 @@ import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
 import '../../../core/utils/display_thumbnail_utils.dart';
 import 'agent_resource_resolver.dart';
 import 'defined_agent_tool.dart';
+import 'generation_image_resource.dart';
 
 typedef DisplayImageResourceResolver =
     Future<ResolvedAgentResource?> Function(
       AgentChatResourceReference reference,
     );
+typedef DisplayImageResourceValidator =
+    Future<void> Function(AgentChatResourceReference reference);
 
 /// Resolves stable application-owned image references into bounded previews.
 class DisplayImagesService {
-  DisplayImagesService({required DisplayImageResourceResolver resolve})
-    : _resolve = resolve;
+  DisplayImagesService({
+    required DisplayImageResourceResolver resolve,
+    DisplayImageResourceValidator? validate,
+  }) : _resolve = resolve,
+       _validate = validate;
 
   factory DisplayImagesService.fromResolver(AgentResourceResolver resolver) =>
-      DisplayImagesService(resolve: resolver.resolve);
+      DisplayImagesService(
+        resolve: resolver.resolve,
+        validate: resolver.validateForDisplay,
+      );
 
   final DisplayImageResourceResolver _resolve;
+  final DisplayImageResourceValidator? _validate;
 
   Future<AgentToolResult> display(Map<String, dynamic> args) async {
     final values = args['resource_refs'];
@@ -67,7 +77,10 @@ class DisplayImagesService {
     for (var index = 0; index < references.length; index++) {
       final ResolvedAgentResource? resolved;
       try {
+        await _validate?.call(references[index]);
         resolved = await _resolve(references[index]);
+      } on GenerationImageResourceException catch (error) {
+        return agentToolError(error.code, error.message);
       } on Exception {
         return agentToolError(
           'resource_resolution_failed',
@@ -98,7 +111,7 @@ class DisplayImagesService {
         );
       }
       previews.add((
-        reference: references[index],
+        reference: resolved.reference,
         label: resolved.label,
         mime: mime,
         data: base64Encode(thumbnail),

--- a/lib/presentation/agent_chat/services/generation_history_service.dart
+++ b/lib/presentation/agent_chat/services/generation_history_service.dart
@@ -10,6 +10,7 @@ import '../../../core/utils/display_thumbnail_utils.dart';
 import '../../providers/image_generation_provider.dart';
 import 'agent_resource_resolver.dart';
 import 'defined_agent_tool.dart';
+import 'generation_image_resource.dart';
 import 'generation_tool_results.dart';
 import 'generation_workspace_path_resolver.dart';
 
@@ -40,9 +41,13 @@ class GenerationHistoryService {
         'Parameter "limit" must be between 1 and $_maxRecentImageLimit.',
       );
     }
+    await _ref
+        .read(imageGenerationNotifierProvider.notifier)
+        .ensureGenerationHistoryRestored();
     final history = _ref.read(imageGenerationNotifierProvider).history;
     final report = <Map<String, dynamic>>[];
     for (final image in history) {
+      if (image.isFailedStreamSnapshot) continue;
       final filePath = image.filePath;
       if (filePath == null || !await File(filePath).exists()) continue;
       final readablePath = _pathResolver.readableRelativePath(filePath);
@@ -69,23 +74,37 @@ class GenerationHistoryService {
   Future<AgentToolResult> previewGeneratedImage(
     Map<String, dynamic> args,
   ) async {
-    AgentChatResourceReference reference;
+    await _ref
+        .read(imageGenerationNotifierProvider.notifier)
+        .ensureGenerationHistoryRestored();
+    final AgentChatResourceReference reference;
     try {
-      reference = _resourceResolver.decode(args['resource_ref']);
-    } on FormatException catch (error) {
-      return agentToolError('invalid_resource_ref', '$error');
-    }
-    if (reference.kind != AgentChatResourceKind.generatedImage) {
+      reference = parseGenerationImageResource(args);
+      requireAvailableGenerationImage(
+        _ref.read(imageGenerationNotifierProvider),
+        reference,
+      );
+    } on GenerationImageResourceException catch (error) {
       return agentToolError(
-        'wrong_resource_kind',
-        'resource_ref must identify a generated image.',
+        error.code,
+        'preview_generated_image: ${error.message}',
       );
     }
-    final resolved = await _resourceResolver.resolve(reference);
+    final ResolvedAgentResource? resolved;
+    try {
+      resolved = await _resourceResolver.resolve(reference);
+    } on Object catch (error) {
+      return agentToolError(
+        'resource_resolution_failed',
+        'preview_generated_image: generated image ${reference.resourceId} '
+            'failed during resource resolution (${error.runtimeType}).',
+      );
+    }
     if (resolved?.bytes == null) {
       return agentToolError(
         'resource_unavailable',
-        'Generated image is unavailable.',
+        'preview_generated_image: generated image ${reference.resourceId} '
+            'has no available bytes.',
       );
     }
     final thumbnail = await DisplayThumbnailUtils.normalize(resolved!.bytes!);
@@ -95,7 +114,8 @@ class GenerationHistoryService {
     if (thumbnail == null || mime == null) {
       return agentToolError(
         'preview_invalid',
-        'Generated image preview is invalid.',
+        'preview_generated_image: generated image ${reference.resourceId} '
+            'could not be normalized for preview.',
       );
     }
     final details = <String, dynamic>{
@@ -119,10 +139,5 @@ class GenerationHistoryService {
   }
 
   AgentChatResourceReference generatedImageReference(String imageId) =>
-      AgentChatResourceReference(
-        kind: AgentChatResourceKind.generatedImage,
-        source: 'generation_history',
-        resourceId: imageId,
-        display: {'title': imageId},
-      );
+      generationImageResourceReference(imageId);
 }

--- a/lib/presentation/agent_chat/services/generation_image_favorite_toolbox.dart
+++ b/lib/presentation/agent_chat/services/generation_image_favorite_toolbox.dart
@@ -1,0 +1,224 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/agent/agent_types.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
+import '../../../core/database/database_providers.dart';
+import '../../providers/image_generation_provider.dart';
+import '../../providers/local_gallery_provider.dart';
+import 'defined_agent_tool.dart';
+import 'generation_image_resource.dart';
+import 'toolbox_json.dart';
+
+typedef GeneratedImageFavoriteResolver = GeneratedImage? Function(String id);
+typedef LocalGalleryFavoriteReader =
+    Future<LocalGalleryFavoriteRecord?> Function(String path);
+typedef LocalGalleryFavoriteWriter =
+    Future<bool> Function(String path, bool favorite);
+
+class LocalGalleryFavoriteRecord {
+  const LocalGalleryFavoriteRecord({required this.id, required this.favorite});
+
+  final int id;
+  final bool favorite;
+}
+
+/// Mutates the favorite state owned by the indexed local gallery.
+///
+/// A generated image without an existing persistent gallery record is rejected;
+/// this toolbox never creates a parallel favorite state for generation history.
+class GenerationImageFavoriteToolbox {
+  GenerationImageFavoriteToolbox(
+    Ref ref, {
+    GeneratedImageFavoriteResolver? resolveImage,
+    LocalGalleryFavoriteReader? readFavorite,
+    LocalGalleryFavoriteWriter? writeFavorite,
+  }) : _ref = ref,
+       _resolveImage =
+           resolveImage ??
+           ((id) =>
+               ref.read(imageGenerationNotifierProvider).findImageById(id)),
+       _readFavorite = readFavorite,
+       _writeFavorite = writeFavorite;
+
+  GenerationImageFavoriteToolbox.forTesting({
+    required GeneratedImageFavoriteResolver resolveImage,
+    required LocalGalleryFavoriteReader readFavorite,
+    required LocalGalleryFavoriteWriter writeFavorite,
+  }) : _ref = null,
+       _resolveImage = resolveImage,
+       _readFavorite = readFavorite,
+       _writeFavorite = writeFavorite;
+
+  final Ref? _ref;
+  final GeneratedImageFavoriteResolver _resolveImage;
+  final LocalGalleryFavoriteReader? _readFavorite;
+  final LocalGalleryFavoriteWriter? _writeFavorite;
+
+  List<AgentTool> tools() => [_setFavorite()];
+
+  DefinedAgentTool _setFavorite() => DefinedAgentTool(
+    name: 'set_generated_image_favorite',
+    label: 'Set Generated Image Favorite',
+    description:
+        'Favorite or unfavorite a generated image through its existing indexed '
+        'local-gallery record. Pass the stable generated-image resource_ref; '
+        'unsaved or unindexed history images are rejected.',
+    parameters: toolboxObject(
+      properties: {
+        'resource_ref': {'type': 'object'},
+        'favorite': {'type': 'boolean'},
+      },
+      required: const ['resource_ref', 'favorite'],
+    ),
+    executionModeOverride: ToolExecutionMode.sequential,
+    executeFn: (_, params) => setFavorite(params),
+  );
+
+  Future<AgentToolResult> setFavorite(Map<String, dynamic> params) async {
+    final AgentChatResourceReference reference;
+    try {
+      reference = parseGenerationImageResource(params);
+    } on GenerationImageResourceException catch (error) {
+      return agentToolError(
+        error.code,
+        'set_generated_image_favorite: ${error.message}',
+      );
+    }
+    final ref = _ref;
+    if (ref != null) {
+      await ref
+          .read(imageGenerationNotifierProvider.notifier)
+          .ensureGenerationHistoryRestored();
+    }
+    final image = _resolveImage(reference.resourceId);
+    if (image == null) {
+      return agentToolError(
+        'stale_image_resource',
+        'set_generated_image_favorite: generated image '
+            '${reference.resourceId} is no longer available.',
+      );
+    }
+    if (!image.canFavorite) {
+      return agentToolError(
+        'failed_stream_snapshot',
+        'set_generated_image_favorite: generated image '
+            '${reference.resourceId} is a failed stream snapshot.',
+      );
+    }
+    final path = image.filePath;
+    if (path == null || path.isEmpty || !await File(path).exists()) {
+      return agentToolError(
+        'local_record_required',
+        'set_generated_image_favorite: generated image '
+            '${reference.resourceId} has no available persisted local file.',
+      );
+    }
+
+    final LocalGalleryFavoriteRecord? record;
+    try {
+      record = await (_readFavorite ?? _readIndexedFavorite)(path);
+    } on Object catch (error) {
+      return agentToolError(
+        'favorite_read_failed',
+        'set_generated_image_favorite: generated image '
+            '${reference.resourceId} failed while reading its indexed '
+            'local-gallery record (${error.runtimeType}).',
+      );
+    }
+    if (record == null) {
+      return agentToolError(
+        'local_record_required',
+        'set_generated_image_favorite: generated image '
+            '${reference.resourceId} has no indexed local-gallery record.',
+      );
+    }
+    final currentImage = _resolveImage(reference.resourceId);
+    if (currentImage == null) {
+      return agentToolError(
+        'stale_image_resource',
+        'set_generated_image_favorite: generated image '
+            '${reference.resourceId} became unavailable before mutation.',
+      );
+    }
+    if (!currentImage.canFavorite) {
+      return agentToolError(
+        'failed_stream_snapshot',
+        'set_generated_image_favorite: generated image '
+            '${reference.resourceId} became a failed stream snapshot before '
+            'mutation.',
+      );
+    }
+    if (currentImage.filePath != path || !await File(path).exists()) {
+      return agentToolError(
+        'stale_image_resource',
+        'set_generated_image_favorite: generated image '
+            '${reference.resourceId} changed before mutation.',
+      );
+    }
+
+    final requested = params['favorite'] as bool;
+    var favorite = record.favorite;
+    if (favorite != requested) {
+      try {
+        favorite = await (_writeFavorite ?? _writeIndexedFavorite)(
+          path,
+          requested,
+        );
+      } on Object catch (error) {
+        return agentToolError(
+          'favorite_update_failed',
+          'set_generated_image_favorite: generated image '
+              '${reference.resourceId} failed while persisting local-gallery '
+              'favorite state (${error.runtimeType}).',
+        );
+      }
+      if (favorite != requested) {
+        return agentToolError(
+          'favorite_update_failed',
+          'set_generated_image_favorite: generated image '
+              '${reference.resourceId} local-gallery favorite state did not persist.',
+        );
+      }
+    }
+    return agentToolJsonResult({
+      'ok': true,
+      'image_id': reference.resourceId,
+      'local_gallery_image_id': record.id,
+      'favorite': favorite,
+      'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(reference),
+      'local_gallery_resource_ref':
+          AgentChatResourceReferenceCodec.encodeJsonMap(
+            AgentChatResourceReference(
+              kind: AgentChatResourceKind.localGalleryImage,
+              source: 'local_gallery',
+              resourceId: '${record.id}',
+            ),
+          ),
+    });
+  }
+
+  Future<LocalGalleryFavoriteRecord?> _readIndexedFavorite(String path) async {
+    final source = (await _ref!.read(
+      databaseManagerProvider.future,
+    )).galleryDataSource;
+    if (source == null) return null;
+    final id = await source.getImageIdByPath(path);
+    if (id == null) return null;
+    final record = await source.getImageById(id);
+    if (record == null || record.isDeleted) return null;
+    return LocalGalleryFavoriteRecord(
+      id: id,
+      favorite: await source.isFavorite(id),
+    );
+  }
+
+  Future<bool> _writeIndexedFavorite(String path, bool favorite) async {
+    final notifier = _ref!.read(localGalleryNotifierProvider.notifier);
+    final current = await notifier.isFavorite(path);
+    if (current != favorite) await notifier.toggleFavorite(path);
+    return notifier.isFavorite(path);
+  }
+}

--- a/lib/presentation/agent_chat/services/generation_image_resource.dart
+++ b/lib/presentation/agent_chat/services/generation_image_resource.dart
@@ -1,0 +1,94 @@
+import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
+import '../../providers/image_generation_provider.dart';
+
+const String generationImageResourceSource = 'generation_history';
+
+AgentChatResourceReference generationImageResourceReference(String imageId) {
+  return AgentChatResourceReference(
+    kind: AgentChatResourceKind.generatedImage,
+    source: generationImageResourceSource,
+    resourceId: imageId,
+    display: {'title': imageId},
+  );
+}
+
+final class GenerationImageResourceException implements Exception {
+  const GenerationImageResourceException(this.code, this.message);
+
+  final String code;
+  final String message;
+}
+
+/// Parses only stable generation identities. A resource reference takes
+/// precedence over the compatibility image_id when both are supplied.
+AgentChatResourceReference parseGenerationImageResource(
+  Map<String, dynamic> args,
+) {
+  if (args.containsKey('resource_ref')) {
+    final value = args['resource_ref'];
+    if (value is! Map) {
+      throw const GenerationImageResourceException(
+        'invalid_resource_ref',
+        'resource_ref must be a stable resource reference object.',
+      );
+    }
+
+    final AgentChatResourceReference reference;
+    try {
+      reference = AgentChatResourceReferenceCodec.decodeJsonMap(
+        Map<String, dynamic>.from(value),
+      );
+    } on FormatException catch (error) {
+      throw GenerationImageResourceException(
+        'invalid_resource_ref',
+        'resource_ref is invalid: ${error.message}',
+      );
+    }
+    if (reference.kind != AgentChatResourceKind.generatedImage) {
+      throw const GenerationImageResourceException(
+        'wrong_resource_kind',
+        'resource_ref must identify a generated image.',
+      );
+    }
+    final imageId = reference.resourceId.trim();
+    if (imageId.isEmpty) {
+      throw const GenerationImageResourceException(
+        'invalid_resource_ref',
+        'resource_ref must contain a non-empty generated image ID.',
+      );
+    }
+    return generationImageResourceReference(imageId);
+  }
+
+  final imageId = args['image_id'];
+  if (imageId is! String || imageId.trim().isEmpty) {
+    throw const GenerationImageResourceException(
+      'missing_image_resource',
+      'Provide resource_ref or a stable image_id.',
+    );
+  }
+  return generationImageResourceReference(imageId.trim());
+}
+
+GeneratedImage requireAvailableGenerationImage(
+  ImageGenerationState state,
+  AgentChatResourceReference reference,
+) {
+  final image = state.findImageById(reference.resourceId);
+  if (image == null) {
+    throw GenerationImageResourceException(
+      'stale_image_resource',
+      'Generated image ${reference.resourceId} no longer exists in '
+          'currentImages, history, or displayImages.',
+    );
+  }
+  if (image.isFailedStreamSnapshot) {
+    throw GenerationImageResourceException(
+      'failed_stream_snapshot',
+      'Generated image ${reference.resourceId} is a failed stream snapshot '
+          'and cannot be used.',
+    );
+  }
+  return image;
+}

--- a/lib/presentation/agent_chat/services/generation_image_workflow_launcher_adapter.dart
+++ b/lib/presentation/agent_chat/services/generation_image_workflow_launcher_adapter.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/utils/app_logger.dart';
+import '../../providers/image_generation_provider.dart';
+import '../../services/image_workflow_launcher.dart';
+import '../../widgets/image_editor/image_editor_types.dart';
+import 'generation_image_workflow_service.dart';
+import 'manual_inpaint_toolbox.dart';
+
+/// Production adapter over the same launchers used by image preview actions.
+/// It only needs the Ref available to the registry builder plus the root
+/// navigator owned by the application shell.
+final class ApplicationGenerationImageWorkflowLauncher
+    implements GenerationImageWorkflowLauncherAdapter {
+  ApplicationGenerationImageWorkflowLauncher({
+    required Ref ref,
+    required NavigatorState? Function() navigator,
+    required Future<void> Function() openGeneration,
+    required ManualInpaintToolbox manualInpaintToolbox,
+  }) : _ref = ref,
+       _navigator = navigator,
+       _openGeneration = openGeneration,
+       _manualInpaintToolbox = manualInpaintToolbox;
+
+  final Ref _ref;
+  final NavigatorState? Function() _navigator;
+  final Future<void> Function() _openGeneration;
+  final ManualInpaintToolbox _manualInpaintToolbox;
+
+  BuildContext _rootContext() {
+    final context = _navigator()?.context;
+    if (context == null || !context.mounted) {
+      throw StateError('Root navigator context is unavailable.');
+    }
+    return context;
+  }
+
+  @override
+  Future<Map<String, dynamic>> open(
+    GenerationImageWorkflowMode mode,
+    AgentChatResourceReference reference,
+    Uint8List imageBytes, {
+    required bool Function() isCurrent,
+  }) async {
+    switch (mode) {
+      case GenerationImageWorkflowMode.edit:
+        await _launchUi(
+          ImageWorkflowLauncher.openEditorFromRef(
+            _rootContext(),
+            _ref,
+            imageBytes,
+            mode: ImageEditorMode.edit,
+            isCurrent: isCurrent,
+          ).then((applied) async {
+            if (applied && isCurrent()) await _openGeneration();
+          }),
+          mode,
+          reference,
+        );
+        return const {'started': true, 'awaiting_user': true};
+      case GenerationImageWorkflowMode.inpaint:
+        final result = await _manualInpaintToolbox.createDraftFromResource(
+          reference,
+        );
+        if (result.isError) {
+          throw StateError(
+            result.details['message']?.toString() ??
+                'Unable to open inpaint draft.',
+          );
+        }
+        return {'draft': result.details['draft']};
+      case GenerationImageWorkflowMode.variations:
+        await ImageWorkflowLauncher.prepareVariationsFromRef(
+          _rootContext(),
+          _ref,
+          imageBytes,
+          isCurrent: isCurrent,
+        );
+        if (!isCurrent()) return const {};
+        await _openGeneration();
+        return const {};
+      case GenerationImageWorkflowMode.director:
+        await _launchUi(
+          ImageWorkflowLauncher.openDirectorToolsFromRef(
+            _rootContext(),
+            _ref,
+            imageBytes,
+            isCurrent: isCurrent,
+          ).then((applied) async {
+            if (applied && isCurrent()) await _openGeneration();
+          }),
+          mode,
+          reference,
+        );
+        return const {'started': true, 'awaiting_user': true};
+      case GenerationImageWorkflowMode.enhance:
+        ImageWorkflowLauncher.openEnhanceFromRef(_ref, imageBytes);
+        await _openGeneration();
+        return const {};
+      case GenerationImageWorkflowMode.upscale:
+        ImageWorkflowLauncher.openUpscaleFromRef(_ref, imageBytes);
+        await _openGeneration();
+        return const {};
+    }
+  }
+
+  Future<void> _launchUi(
+    Future<void> future,
+    GenerationImageWorkflowMode mode,
+    AgentChatResourceReference reference,
+  ) async {
+    Object? startupError;
+    StackTrace? startupStackTrace;
+    var observingStartup = true;
+    unawaited(
+      future.catchError((Object error, StackTrace stackTrace) {
+        if (observingStartup) {
+          startupError = error;
+          startupStackTrace = stackTrace;
+          return;
+        }
+        AppLogger.e(
+          'Agent image workflow UI failed: mode=${mode.name}, '
+              'resourceId=${reference.resourceId}',
+          error,
+          stackTrace,
+          'AgentImageWorkflow',
+        );
+      }),
+    );
+    await Future<void>.delayed(Duration.zero);
+    observingStartup = false;
+    if (startupError case final error?) {
+      Error.throwWithStackTrace(error, startupStackTrace ?? StackTrace.current);
+    }
+  }
+}
+
+GenerationWorkflowResourceLoader generationWorkflowResourceLoader(Ref ref) {
+  return (reference) async {
+    await ref
+        .read(imageGenerationNotifierProvider.notifier)
+        .ensureGenerationHistoryRestored();
+    final generation = ref.read(imageGenerationNotifierProvider);
+    final image = generation.findImageById(reference.resourceId);
+    if (image == null) {
+      return const GenerationWorkflowResourceSnapshot(
+        status: GenerationWorkflowResourceStatus.missing,
+      );
+    }
+    if (!image.canUseAsGenerationInput) {
+      return const GenerationWorkflowResourceSnapshot(
+        status: GenerationWorkflowResourceStatus.failedSnapshot,
+      );
+    }
+    return GenerationWorkflowResourceSnapshot(
+      status: GenerationWorkflowResourceStatus.ready,
+      bytes: image.bytes,
+    );
+  };
+}

--- a/lib/presentation/agent_chat/services/generation_image_workflow_service.dart
+++ b/lib/presentation/agent_chat/services/generation_image_workflow_service.dart
@@ -1,0 +1,202 @@
+import 'dart:typed_data';
+
+import '../../../core/agent/agent_types.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
+import 'defined_agent_tool.dart';
+import 'generation_image_resource.dart';
+
+enum GenerationImageWorkflowMode {
+  edit,
+  inpaint,
+  variations,
+  director,
+  enhance,
+  upscale;
+
+  static GenerationImageWorkflowMode? parse(Object? value) {
+    if (value is! String) return null;
+    for (final mode in values) {
+      if (mode.name == value) return mode;
+    }
+    return null;
+  }
+}
+
+enum GenerationWorkflowResourceStatus {
+  ready,
+  missing,
+  generating,
+  failedSnapshot,
+}
+
+final class GenerationWorkflowResourceSnapshot {
+  const GenerationWorkflowResourceSnapshot({required this.status, this.bytes});
+
+  final GenerationWorkflowResourceStatus status;
+  final Uint8List? bytes;
+}
+
+typedef GenerationWorkflowResourceLoader =
+    Future<GenerationWorkflowResourceSnapshot> Function(
+      AgentChatResourceReference reference,
+    );
+
+abstract interface class GenerationImageWorkflowLauncherAdapter {
+  Future<Map<String, dynamic>> open(
+    GenerationImageWorkflowMode mode,
+    AgentChatResourceReference reference,
+    Uint8List imageBytes, {
+    required bool Function() isCurrent,
+  });
+}
+
+/// Resolves one stable generation image and prepares the selected real UI
+/// workflow. It never invokes a generation submitter.
+final class GenerationImageWorkflowService {
+  GenerationImageWorkflowService({
+    required GenerationWorkflowResourceLoader loadResource,
+    required GenerationImageWorkflowLauncherAdapter launcher,
+    String Function()? activeSessionId,
+    bool Function()? isMounted,
+  }) : _loadResource = loadResource,
+       _launcher = launcher,
+       _activeSessionId = activeSessionId,
+       _isMounted = isMounted;
+
+  final GenerationWorkflowResourceLoader _loadResource;
+  final GenerationImageWorkflowLauncherAdapter _launcher;
+  final String Function()? _activeSessionId;
+  final bool Function()? _isMounted;
+  int _resourceSwitchEpoch = 0;
+
+  Future<AgentToolResult> open(Map<String, dynamic> args) async {
+    final mode = GenerationImageWorkflowMode.parse(args['mode']);
+    if (mode == null) {
+      return agentToolError(
+        'invalid_mode',
+        'mode must be edit, inpaint, variations, director, enhance, or upscale.',
+      );
+    }
+
+    final AgentChatResourceReference reference;
+    try {
+      reference = parseGenerationImageResource(args);
+    } on GenerationImageResourceException catch (error) {
+      return agentToolError(
+        error.code,
+        'open_generation_image_workflow: ${error.message}',
+      );
+    }
+
+    final epoch = ++_resourceSwitchEpoch;
+    final sessionId = _activeSessionId?.call();
+    bool isCurrent() =>
+        epoch == _resourceSwitchEpoch &&
+        (_isMounted?.call() ?? true) &&
+        _activeSessionId?.call() == sessionId;
+
+    final GenerationWorkflowResourceSnapshot snapshot;
+    try {
+      snapshot = await _loadResource(reference);
+    } on Object catch (error) {
+      if (!isCurrent()) return _switchedError(reference);
+      return agentToolError(
+        'resource_resolution_failed',
+        'open_generation_image_workflow: generated image '
+            '${reference.resourceId} failed during resource resolution '
+            '(${error.runtimeType}).',
+      );
+    }
+    if (!isCurrent()) {
+      return _switchedError(reference);
+    }
+
+    switch (snapshot.status) {
+      case GenerationWorkflowResourceStatus.missing:
+        return agentToolError(
+          'resource_unavailable',
+          'open_generation_image_workflow: generated image '
+              '${reference.resourceId} is unavailable.',
+        );
+      case GenerationWorkflowResourceStatus.generating:
+        return agentToolError(
+          'resource_generating',
+          'open_generation_image_workflow: generated image '
+              '${reference.resourceId} is not complete yet.',
+        );
+      case GenerationWorkflowResourceStatus.failedSnapshot:
+        return agentToolError(
+          'failed_stream_snapshot',
+          'open_generation_image_workflow: generated image '
+              '${reference.resourceId} is a failed stream snapshot.',
+        );
+      case GenerationWorkflowResourceStatus.ready:
+        break;
+    }
+
+    final bytes = snapshot.bytes;
+    if (bytes == null || bytes.isEmpty) {
+      return agentToolError(
+        'resource_unavailable',
+        'open_generation_image_workflow: generated image '
+            '${reference.resourceId} has no available bytes.',
+      );
+    }
+
+    final Map<String, dynamic> launchDetails;
+    try {
+      launchDetails = await _launcher.open(
+        mode,
+        reference,
+        bytes,
+        isCurrent: isCurrent,
+      );
+    } on Object catch (error) {
+      if (!isCurrent()) {
+        return _switchedError(reference);
+      }
+      return agentToolError(
+        'workflow_open_failed',
+        'open_generation_image_workflow: mode=${mode.name}, generated image '
+            '${reference.resourceId} failed while opening the real workflow '
+            'UI (${error.runtimeType}).',
+      );
+    }
+    if (!isCurrent()) {
+      return _switchedError(reference);
+    }
+    return agentToolJsonResult({
+      'ok': true,
+      'mode': mode.name,
+      'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(reference),
+      'submitted': false,
+      ...launchDetails,
+      'next_step': _nextStep(mode),
+    });
+  }
+}
+
+AgentToolResult _switchedError(AgentChatResourceReference reference) {
+  return agentToolError(
+    'resource_switched',
+    'open_generation_image_workflow: generated image '
+        '${reference.resourceId} is no longer current because the image '
+        'request or Agent session changed.',
+  );
+}
+
+String _nextStep(GenerationImageWorkflowMode mode) => switch (mode) {
+  GenerationImageWorkflowMode.edit =>
+    'Complete edits in the image editor, then review generation settings.',
+  GenerationImageWorkflowMode.inpaint =>
+    'Draw and confirm the manual inpaint mask, then explicitly submit the draft when ready.',
+  GenerationImageWorkflowMode.variations =>
+    'Review the prepared variation settings on Generation, then start manually.',
+  GenerationImageWorkflowMode.director =>
+    'Complete Director Tools, then review the resulting generation input.',
+  GenerationImageWorkflowMode.enhance =>
+    'Review the prepared Enhance workflow on Generation, then start manually.',
+  GenerationImageWorkflowMode.upscale =>
+    'Review the prepared Upscale workflow on Generation, then start manually.',
+};

--- a/lib/presentation/agent_chat/services/generation_image_workflow_toolbox.dart
+++ b/lib/presentation/agent_chat/services/generation_image_workflow_toolbox.dart
@@ -1,0 +1,42 @@
+import '../../../core/agent/agent_types.dart';
+import 'defined_agent_tool.dart';
+import 'generation_image_workflow_service.dart';
+
+final class GenerationImageWorkflowToolbox {
+  const GenerationImageWorkflowToolbox(this.service);
+
+  final GenerationImageWorkflowService service;
+
+  List<AgentTool> tools() => [
+    DefinedAgentTool(
+      name: 'open_generation_image_workflow',
+      label: 'Open Generation Image Workflow',
+      description:
+          'Prepare or open one real application image workflow for a generated '
+          'image. This tool only opens UI or prepares controller state; it never '
+          'starts generation or spends Anlas. The user must review and explicitly '
+          'start any paid operation.',
+      parameters: const {
+        'type': 'object',
+        'properties': {
+          'resource_ref': {'type': 'object'},
+          'mode': {
+            'type': 'string',
+            'enum': [
+              'edit',
+              'inpaint',
+              'variations',
+              'director',
+              'enhance',
+              'upscale',
+            ],
+          },
+        },
+        'required': ['resource_ref', 'mode'],
+        'additionalProperties': false,
+      },
+      executionModeOverride: ToolExecutionMode.sequential,
+      executeFn: (_, args) => service.open(args),
+    ),
+  ];
+}

--- a/lib/presentation/agent_chat/services/generation_resource_toolbox.dart
+++ b/lib/presentation/agent_chat/services/generation_resource_toolbox.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/agent/agent_types.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
+import '../../providers/generation/preview_selection_provider.dart';
+import '../../providers/image_generation_provider.dart';
+import '../../router/app_router_config.dart';
+import '../../router/app_routes.dart';
+import 'defined_agent_tool.dart';
+import 'generation_image_resource.dart';
+
+class GenerationResourceService {
+  GenerationResourceService({
+    required ImageGenerationState Function() readState,
+    required void Function(String imageId) select,
+    required void Function() navigateToGeneration,
+    Future<void> Function(AgentChatResourceReference reference)? beforeMutation,
+  }) : _readState = readState,
+       _select = select,
+       _navigateToGeneration = navigateToGeneration,
+       _beforeMutation = beforeMutation ?? _noDelay;
+
+  factory GenerationResourceService.fromRef(Ref ref) {
+    return GenerationResourceService(
+      readState: () => ref.read(imageGenerationNotifierProvider),
+      select: (imageId) =>
+          ref.read(generationPreviewSelectionProvider.notifier).select(imageId),
+      navigateToGeneration: () =>
+          ref.read(appRouterProvider).go(AppRoutes.generation),
+      beforeMutation: (_) => ref
+          .read(imageGenerationNotifierProvider.notifier)
+          .ensureGenerationHistoryRestored(),
+    );
+  }
+
+  final ImageGenerationState Function() _readState;
+  final void Function(String imageId) _select;
+  final void Function() _navigateToGeneration;
+  final Future<void> Function(AgentChatResourceReference reference)
+  _beforeMutation;
+
+  static Future<void> _noDelay(AgentChatResourceReference _) async {}
+
+  Future<AgentToolResult> selectGeneratedImage(
+    Map<String, dynamic> args,
+  ) async {
+    final navigate = args['navigate'];
+    if (navigate != null && navigate is! bool) {
+      return agentToolError(
+        'invalid_navigation',
+        'navigate must be a boolean when provided.',
+      );
+    }
+
+    final AgentChatResourceReference reference;
+    try {
+      reference = parseGenerationImageResource(args);
+    } on GenerationImageResourceException catch (error) {
+      return agentToolError(
+        error.code,
+        'select_generated_image: ${error.message}',
+      );
+    }
+    try {
+      await _beforeMutation(reference);
+      // Resolve persisted history first, then re-read the authoritative owner.
+      requireAvailableGenerationImage(_readState(), reference);
+    } on GenerationImageResourceException catch (error) {
+      return agentToolError(
+        error.code,
+        'select_generated_image: ${error.message}',
+      );
+    } on Object catch (error) {
+      return agentToolError(
+        'resource_resolution_failed',
+        'select_generated_image: generated image ${reference.resourceId} '
+            'failed during history resolution (${error.runtimeType}).',
+      );
+    }
+
+    _select(reference.resourceId);
+    if (navigate == null || navigate == true) {
+      _navigateToGeneration();
+    }
+
+    return agentToolJsonResult({
+      'ok': true,
+      'selected': true,
+      'navigated': navigate == null || navigate == true,
+      'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(reference),
+    });
+  }
+}
+
+/// Mutation toolbox for selecting a state-owned generated image preview.
+class GenerationResourceToolbox {
+  GenerationResourceToolbox(Ref ref)
+    : service = GenerationResourceService.fromRef(ref);
+
+  GenerationResourceToolbox.withService(this.service);
+
+  final GenerationResourceService service;
+
+  List<AgentTool> tools() => [
+    DefinedAgentTool(
+      name: 'select_generated_image',
+      label: 'Select Generated Image',
+      description:
+          'Select a generated image by stable resource_ref (preferred) or '
+          'stable image_id. List indexes and file paths are not accepted. '
+          'Optionally navigate to the generation page.',
+      parameters: const {
+        'type': 'object',
+        'properties': {
+          'resource_ref': {'type': 'object'},
+          'image_id': {'type': 'string'},
+          'navigate': {
+            'type': 'boolean',
+            'description':
+                'Navigate to generation after selecting; defaults to true.',
+          },
+        },
+        'required': <String>[],
+        'additionalProperties': false,
+      },
+      // Selection and navigation mutate application UI state and must not run
+      // concurrently with sibling tool calls.
+      executionModeOverride: ToolExecutionMode.sequential,
+      executeFn: (_, args) => service.selectGeneratedImage(args),
+    ),
+  ];
+}

--- a/lib/presentation/agent_chat/services/generation_tool_definitions.dart
+++ b/lib/presentation/agent_chat/services/generation_tool_definitions.dart
@@ -363,14 +363,17 @@ class GenerationToolDefinitions {
         name: 'preview_generated_image',
         label: 'Preview Generated Image',
         description:
-            'Resolve one generated-image resource reference and return a '
-            'bounded preview without exposing its saved file path.',
+            'Resolve one generated image by stable resource_ref (preferred) '
+            'or stable image_id and return a bounded preview without exposing '
+            'its saved file path. List indexes and paths are not accepted.',
         parameters: const {
           'type': 'object',
           'properties': {
             'resource_ref': {'type': 'object'},
+            'image_id': {'type': 'string'},
           },
-          'required': ['resource_ref'],
+          'required': <String>[],
+          'additionalProperties': false,
         },
         executeFn: (_, params) => _history.previewGeneratedImage(params),
       ),

--- a/lib/presentation/agent_chat/services/image_resource_action_service.dart
+++ b/lib/presentation/agent_chat/services/image_resource_action_service.dart
@@ -1,0 +1,442 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path/path.dart' as p;
+
+import '../../../core/agent/agent_types.dart';
+import '../../../core/agent/harness/harness_types.dart';
+import '../../../core/agent/harness/tools/image.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
+import '../../../core/krita/krita_outbound_image.dart';
+import '../../../core/platform/platform_capabilities.dart';
+import '../../utils/clipboard_image.dart';
+import 'defined_agent_tool.dart';
+import 'generation_image_resource.dart';
+
+final class ResolvedImageResourceActionSource {
+  const ResolvedImageResourceActionSource({
+    required this.label,
+    required this.bytes,
+  });
+
+  final String label;
+  final Uint8List bytes;
+}
+
+/// Injectable boundary for image clipboard writes.
+typedef ImageResourceActionResolver =
+    Future<ResolvedImageResourceActionSource?> Function(
+      AgentChatResourceReference reference,
+    );
+typedef ResourceImageClipboardWriter = Future<void> Function(Uint8List bytes);
+typedef ResourceImageKritaSender =
+    FutureOr<bool> Function(Uint8List bytes, {required String name});
+typedef ResourceImageExclusiveWriter =
+    Future<void> Function(String path, Uint8List bytes, String canonicalParent);
+
+final class ImageResourceKritaBridgeState {
+  const ImageResourceKritaBridgeState({
+    required this.configured,
+    required this.connected,
+  });
+
+  final bool configured;
+  final bool connected;
+}
+
+/// Executes explicit external actions for generated-image resource references.
+///
+/// Stable references are resolved through the application owner. File targets
+/// are checked by the same [ExecutionEnv] boundary used by workspace/full-access
+/// tools, and the default writer creates files exclusively to avoid overwrites.
+final class ImageResourceActionService {
+  ImageResourceActionService({
+    required ImageResourceActionResolver resolve,
+    required ExecutionEnv env,
+    ResourceImageClipboardWriter clipboardWriter =
+        writeImageBytesToClipboardAsPng,
+    bool Function()? supportsKritaBridge,
+    ImageResourceKritaBridgeState Function()? readKritaBridgeState,
+    ResourceImageKritaSender? sendToKrita,
+    ResourceImageExclusiveWriter? exclusiveWriter,
+  }) : _resolve = resolve,
+       _env = env,
+       _clipboardWriter = clipboardWriter,
+       _supportsKritaBridge =
+           supportsKritaBridge ??
+           (() => PlatformCapabilities.current.supportsKritaBridge),
+       _readKritaBridgeState = readKritaBridgeState,
+       _sendToKrita = sendToKrita,
+       _exclusiveWriter = exclusiveWriter ?? _writeExclusive;
+
+  final ImageResourceActionResolver _resolve;
+  final ExecutionEnv _env;
+  final ResourceImageClipboardWriter _clipboardWriter;
+  final bool Function() _supportsKritaBridge;
+  final ImageResourceKritaBridgeState Function()? _readKritaBridgeState;
+  final ResourceImageKritaSender? _sendToKrita;
+  final ResourceImageExclusiveWriter _exclusiveWriter;
+
+  Future<AgentToolResult> save(Map<String, dynamic> args) async {
+    final loaded = await _loadGeneratedImage(
+      args,
+      action: 'save_generated_image',
+    );
+    if (loaded.error case final error?) return error;
+
+    final requestedPath = args['destination_path'];
+    if (requestedPath is! String || requestedPath.trim().isEmpty) {
+      return agentToolError(
+        'invalid_destination',
+        'destination_path must be a non-empty explicit file target.',
+      );
+    }
+    final normalizedRequest = requestedPath.trim();
+    if (p.basename(normalizedRequest).isEmpty ||
+        p.basename(normalizedRequest) == '.' ||
+        p.basename(normalizedRequest) == '..') {
+      return agentToolError(
+        'invalid_destination',
+        'destination_path must identify a file, not a directory.',
+      );
+    }
+
+    final absoluteResult = await _env.absolutePath(normalizedRequest);
+    if (absoluteResult case HarnessErr<String, FileError>()) {
+      return agentToolError(
+        'unsafe_destination',
+        'The requested destination is outside the permitted file scope.',
+      );
+    }
+    final absolutePath = (absoluteResult as HarnessOk<String, FileError>).value;
+    final extensionError = _validateTargetExtension(
+      absolutePath,
+      loaded.mimeType!,
+    );
+    if (extensionError != null) return extensionError;
+
+    final parentResult = await _env.createDir(p.dirname(absolutePath));
+    if (parentResult case HarnessErr<void, FileError>()) {
+      return agentToolError(
+        'destination_unavailable',
+        'The destination directory could not be created.',
+      );
+    }
+
+    final String writePath;
+    final String canonicalParent;
+    try {
+      canonicalParent = await Directory(
+        p.dirname(absolutePath),
+      ).resolveSymbolicLinks();
+      final canonicalTarget = p.join(canonicalParent, p.basename(absolutePath));
+      final canonicalResult = await _env.absolutePath(
+        p.relative(canonicalTarget, from: _env.cwd),
+      );
+      if (canonicalResult case HarnessErr<String, FileError>()) {
+        return agentToolError(
+          'unsafe_destination',
+          'The requested destination changed outside the permitted file scope.',
+        );
+      }
+      writePath = (canonicalResult as HarnessOk<String, FileError>).value;
+    } on FileSystemException {
+      return agentToolError(
+        'destination_unavailable',
+        'The destination directory could not be resolved safely.',
+      );
+    }
+
+    final existsResult = await _env.exists(writePath);
+    if (existsResult case HarnessErr<bool, FileError>()) {
+      return agentToolError(
+        'destination_check_failed',
+        'The destination could not be checked safely.',
+      );
+    }
+    if ((existsResult as HarnessOk<bool, FileError>).value) {
+      return agentToolError(
+        'destination_exists',
+        'The destination already exists; image resources are never overwritten.',
+      );
+    }
+
+    try {
+      await _exclusiveWriter(writePath, loaded.bytes!, canonicalParent);
+    } on _UnsafeDestinationChanged {
+      return agentToolError(
+        'unsafe_destination',
+        'The requested destination changed outside the permitted file scope.',
+      );
+    } on FileSystemException {
+      if (await File(writePath).exists()) {
+        return agentToolError(
+          'destination_exists',
+          'The destination already exists; image resources are never overwritten.',
+        );
+      }
+      return agentToolError(
+        'save_failed',
+        'save_generated_image: generated image '
+            '${loaded.reference!.resourceId} failed during exclusive file '
+            'write.',
+      );
+    } on Object catch (error) {
+      return agentToolError(
+        'save_failed',
+        'save_generated_image: generated image '
+            '${loaded.reference!.resourceId} failed during exclusive file '
+            'write (${error.runtimeType}).',
+      );
+    }
+
+    final destination = _safeDestinationDescription(absolutePath);
+    return agentToolJsonResult({
+      'ok': true,
+      'action': 'saved',
+      'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(
+        loaded.reference!,
+      ),
+      ...destination,
+    });
+  }
+
+  Future<AgentToolResult> copy(Map<String, dynamic> args) async {
+    final loaded = await _loadGeneratedImage(
+      args,
+      action: 'copy_generated_image_to_clipboard',
+    );
+    if (loaded.error case final error?) return error;
+    try {
+      await _clipboardWriter(loaded.bytes!);
+    } on Object catch (error) {
+      return agentToolError(
+        'clipboard_write_failed',
+        'copy_generated_image_to_clipboard: generated image '
+            '${loaded.reference!.resourceId} failed during clipboard write '
+            '(${error.runtimeType}).',
+      );
+    }
+    return agentToolJsonResult({
+      'ok': true,
+      'action': 'copied_to_clipboard',
+      'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(
+        loaded.reference!,
+      ),
+    });
+  }
+
+  Future<AgentToolResult> sendKrita(Map<String, dynamic> args) async {
+    if (!_supportsKritaBridge()) {
+      return agentToolError(
+        'krita_unsupported',
+        'send_generated_image_to_krita: Krita Bridge is not supported on '
+            'this platform.',
+      );
+    }
+    final stateReader = _readKritaBridgeState;
+    final sender = _sendToKrita;
+    if (stateReader == null || sender == null) {
+      return agentToolError(
+        'krita_not_configured',
+        'send_generated_image_to_krita: Krita Bridge is not configured for '
+            'Agent image actions.',
+      );
+    }
+    final state = stateReader();
+    if (!state.configured) {
+      return agentToolError(
+        'krita_not_configured',
+        'send_generated_image_to_krita: Krita Bridge is disabled or not '
+            'configured.',
+      );
+    }
+    if (!state.connected) {
+      return agentToolError(
+        'krita_not_connected',
+        'send_generated_image_to_krita: Krita Bridge has no authenticated '
+            'client connection.',
+      );
+    }
+
+    final loaded = await _loadGeneratedImage(
+      args,
+      action: 'send_generated_image_to_krita',
+    );
+    if (loaded.error case final error?) return error;
+    final KritaOutboundImage outbound;
+    try {
+      outbound = KritaOutboundImage.prepare(loaded.bytes!, name: loaded.label!);
+    } on Object {
+      return agentToolError(
+        'krita_unsupported_image',
+        'send_generated_image_to_krita: generated image '
+            '${loaded.reference!.resourceId} format could not be prepared for '
+            'Krita.',
+      );
+    }
+    try {
+      final sent = await sender(outbound.bytes, name: outbound.name);
+      if (!sent) {
+        return agentToolError(
+          'krita_send_failed',
+          'send_generated_image_to_krita: generated image '
+              '${loaded.reference!.resourceId} was rejected by Krita Bridge.',
+        );
+      }
+    } on Object catch (error) {
+      return agentToolError(
+        'krita_send_failed',
+        'send_generated_image_to_krita: generated image '
+            '${loaded.reference!.resourceId} failed during Krita Bridge send '
+            '(${error.runtimeType}).',
+      );
+    }
+    return agentToolJsonResult({
+      'ok': true,
+      'action': 'sent_to_krita',
+      'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(
+        loaded.reference!,
+      ),
+      'name': outbound.name,
+    });
+  }
+
+  Future<_LoadedImage> _loadGeneratedImage(
+    Map<String, dynamic> args, {
+    required String action,
+  }) async {
+    final AgentChatResourceReference reference;
+    try {
+      reference = parseGenerationImageResource(args);
+    } on GenerationImageResourceException catch (error) {
+      return _LoadedImage.error(
+        agentToolError(error.code, '$action: ${error.message}'),
+      );
+    }
+
+    final ResolvedImageResourceActionSource? resolved;
+    try {
+      resolved = await _resolve(reference);
+    } on GenerationImageResourceException catch (error) {
+      return _LoadedImage.error(
+        agentToolError(error.code, '$action: ${error.message}'),
+      );
+    } on Object catch (error) {
+      return _LoadedImage.error(
+        agentToolError(
+          'resource_resolution_failed',
+          '$action: generated image ${reference.resourceId} failed during '
+              'resource resolution (${error.runtimeType}).',
+        ),
+      );
+    }
+    final bytes = resolved?.bytes;
+    final mimeType = bytes == null ? null : detectSupportedImageMimeType(bytes);
+    if (resolved == null || bytes == null || mimeType == null) {
+      return _LoadedImage.error(
+        agentToolError(
+          'resource_unavailable',
+          '$action: generated image ${reference.resourceId} is unavailable or unsupported.',
+        ),
+      );
+    }
+    return _LoadedImage(
+      reference: reference,
+      bytes: bytes,
+      mimeType: mimeType,
+      label: resolved.label,
+    );
+  }
+
+  AgentToolResult? _validateTargetExtension(String path, String mimeType) {
+    final extension = p.extension(path).toLowerCase();
+    final expected = switch (mimeType) {
+      'image/jpeg' => const {'.jpg', '.jpeg'},
+      'image/png' => const {'.png'},
+      'image/gif' => const {'.gif'},
+      'image/webp' => const {'.webp'},
+      'image/bmp' => const {'.bmp'},
+      _ => const <String>{},
+    };
+    if (!expected.contains(extension)) {
+      return agentToolError(
+        'invalid_destination_extension',
+        'destination_path must use an extension matching the image format.',
+      );
+    }
+    return null;
+  }
+
+  Map<String, dynamic> _safeDestinationDescription(String absolutePath) {
+    final root = p.normalize(_env.cwd);
+    final target = p.normalize(absolutePath);
+    final relative = p.relative(target, from: root);
+    final inside =
+        relative != '..' &&
+        !p.isAbsolute(relative) &&
+        !relative.startsWith('..${p.separator}');
+    return inside
+        ? {
+            'destination_path': relative.replaceAll(p.separator, '/'),
+            'destination_scope': 'workspace',
+          }
+        : {'file_name': p.basename(target), 'destination_scope': 'external'};
+  }
+
+  static Future<void> _writeExclusive(
+    String path,
+    Uint8List bytes,
+    String canonicalParent,
+  ) async {
+    final file = File(path);
+    RandomAccessFile? output;
+    String? openedPath;
+    try {
+      await file.create(exclusive: true);
+      output = await file.open(mode: FileMode.writeOnly);
+      openedPath = await file.resolveSymbolicLinks();
+      if (!p.equals(p.dirname(openedPath), canonicalParent)) {
+        throw const _UnsafeDestinationChanged();
+      }
+      await output.writeFrom(bytes);
+      await output.flush();
+    } on Object {
+      await output?.close();
+      output = null;
+      if (openedPath != null) {
+        try {
+          await File(openedPath).delete();
+        } on Object {
+          // Preserve the original write or boundary failure.
+        }
+      }
+      rethrow;
+    } finally {
+      await output?.close();
+    }
+  }
+}
+
+final class _UnsafeDestinationChanged implements Exception {
+  const _UnsafeDestinationChanged();
+}
+
+final class _LoadedImage {
+  const _LoadedImage({this.reference, this.bytes, this.mimeType, this.label})
+    : error = null;
+
+  const _LoadedImage.error(AgentToolResult this.error)
+    : reference = null,
+      bytes = null,
+      mimeType = null,
+      label = null;
+
+  final AgentChatResourceReference? reference;
+  final Uint8List? bytes;
+  final String? mimeType;
+  final String? label;
+  final AgentToolResult? error;
+}

--- a/lib/presentation/agent_chat/services/image_resource_action_toolbox.dart
+++ b/lib/presentation/agent_chat/services/image_resource_action_toolbox.dart
@@ -1,0 +1,70 @@
+import '../../../core/agent/agent_types.dart';
+import 'defined_agent_tool.dart';
+import 'image_resource_action_service.dart';
+import 'toolbox_json.dart';
+
+/// Mutation/external-action tools for stable generated-image references.
+///
+/// Registration and permission policy intentionally remain outside this
+/// toolbox so the application registry can grant each action explicitly.
+final class ImageResourceActionToolbox {
+  ImageResourceActionToolbox(this.service);
+
+  final ImageResourceActionService service;
+
+  List<AgentTool> tools() => [
+    DefinedAgentTool(
+      name: 'save_generated_image',
+      label: 'Save Generated Image',
+      description:
+          'Save a generated image resource to one explicit safe file target. '
+          'Pass the stable generated-image resource_ref first and a complete '
+          'destination_path. The target must be within the configured file '
+          'scope, have a matching image extension, and must not already exist.',
+      parameters: toolboxObject(
+        properties: {
+          'resource_ref': {'type': 'object'},
+          'destination_path': {
+            'type': 'string',
+            'description':
+                'Explicit workspace-relative or permitted absolute file target.',
+          },
+        },
+        required: const ['resource_ref', 'destination_path'],
+      ),
+      executionModeOverride: ToolExecutionMode.sequential,
+      executeFn: (_, args) => service.save(args),
+    ),
+    DefinedAgentTool(
+      name: 'copy_generated_image_to_clipboard',
+      label: 'Copy Generated Image to Clipboard',
+      description:
+          'Copy a stable generated-image resource_ref to the system image '
+          'clipboard. This performs an external mutation.',
+      parameters: toolboxObject(
+        properties: {
+          'resource_ref': {'type': 'object'},
+        },
+        required: const ['resource_ref'],
+      ),
+      executionModeOverride: ToolExecutionMode.sequential,
+      executeFn: (_, args) => service.copy(args),
+    ),
+    DefinedAgentTool(
+      name: 'send_generated_image_to_krita',
+      label: 'Send Generated Image to Krita',
+      description:
+          'Send a stable generated-image resource_ref through the configured '
+          'Krita Bridge. Platform support, bridge configuration, and an '
+          'authenticated client connection are required.',
+      parameters: toolboxObject(
+        properties: {
+          'resource_ref': {'type': 'object'},
+        },
+        required: const ['resource_ref'],
+      ),
+      executionModeOverride: ToolExecutionMode.sequential,
+      executeFn: (_, args) => service.sendKrita(args),
+    ),
+  ];
+}

--- a/lib/presentation/agent_chat/services/manual_inpaint_toolbox.dart
+++ b/lib/presentation/agent_chat/services/manual_inpaint_toolbox.dart
@@ -154,6 +154,18 @@ class ManualInpaintToolbox {
     for (final draft in await _repository.list()) manualInpaintDraftJson(draft),
   ];
 
+  /// Opens the same persisted manual draft flow used by the Agent inpaint
+  /// tools, without submitting it.
+  Future<AgentToolResult> createDraftFromResource(
+    AgentChatResourceReference reference,
+  ) {
+    final prompt = _ref.read(generationParamsNotifierProvider).prompt.trim();
+    return _create({
+      'source_ref': AgentChatResourceReferenceCodec.encodeJsonMap(reference),
+      'prompt': prompt.isEmpty ? 'Edit the selected area' : prompt,
+    }, expectedSessionId: _activeSessionId?.call());
+  }
+
   Future<Uint8List?> loadDraftImage(
     String draftId, {
     required bool mask,
@@ -220,7 +232,12 @@ class ManualInpaintToolbox {
     }
   }
 
-  Future<AgentToolResult> _create(Map<String, dynamic> args) async {
+  Future<AgentToolResult> _create(
+    Map<String, dynamic> args, {
+    String? expectedSessionId,
+  }) async {
+    final sessionId = expectedSessionId ?? _activeSessionId?.call();
+    bool isCurrentSession() => _activeSessionId?.call() == sessionId;
     final prompt = (args['prompt'] as String?)?.trim() ?? '';
     if (prompt.isEmpty) {
       return agentToolError('invalid_prompt', 'prompt must not be empty.');
@@ -245,6 +262,12 @@ class ManualInpaintToolbox {
           return agentToolError(
             'resource_unavailable',
             'Source image resource is unavailable.',
+          );
+        }
+        if (!isCurrentSession()) {
+          return agentToolError(
+            'session_switched',
+            'The Agent session changed before the inpaint draft was prepared.',
           );
         }
         source = resolved;
@@ -288,8 +311,23 @@ class ManualInpaintToolbox {
         ),
       );
       createdDraftId = prepared.id;
-      _draftSessionIds[prepared.id] = _activeSessionId?.call() ?? '';
+      if (!isCurrentSession()) {
+        await _repository.cancel(prepared.id);
+        return agentToolError(
+          'session_switched',
+          'The Agent session changed before the inpaint editor was opened.',
+        );
+      }
+      _draftSessionIds[prepared.id] = sessionId ?? '';
       final editing = await _repository.beginEditing(prepared.id);
+      if (!isCurrentSession()) {
+        await _repository.cancel(editing.id);
+        _draftSessionIds.remove(editing.id);
+        return agentToolError(
+          'session_switched',
+          'The Agent session changed before the inpaint editor was opened.',
+        );
+      }
       final session = (_editorLauncher ?? _openEditor)(
         editing.id,
         source,
@@ -384,6 +422,13 @@ class ManualInpaintToolbox {
         return agentToolError(
           'not_ready',
           'Draft status is ${draft.status.name}; ready is required.',
+        );
+      }
+      if (draft.estimatedAnlas < 0) {
+        return agentToolError(
+          'invalid_cost_estimate',
+          'The inpaint draft does not have a valid Anlas estimate and cannot '
+              'be submitted.',
         );
       }
       final source = await _repository.readSource(id);

--- a/lib/presentation/agent_chat/services/tag_library_toolbox.dart
+++ b/lib/presentation/agent_chat/services/tag_library_toolbox.dart
@@ -1,22 +1,59 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/agent/agent_types.dart';
 import '../../../core/agent/harness/tools/image.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
+import '../../../core/utils/app_logger.dart';
 import '../../../core/utils/display_thumbnail_utils.dart';
 import '../../../data/models/tag_library/tag_library_category.dart';
 import '../../../data/models/tag_library/tag_library_entry.dart';
+import '../../../data/services/tag_library_portable_thumbnail_store.dart';
 import '../../providers/tag_library_page_provider.dart';
+import 'agent_resource_resolver.dart';
 import 'defined_agent_tool.dart';
+import 'generation_image_resource.dart';
 import 'toolbox_json.dart';
+
+typedef TagLibraryImageResourceLoader =
+    Future<ResolvedAgentResource?> Function(
+      AgentChatResourceReference reference,
+    );
 
 /// Production tools for the reusable tag library and its category tree.
 class TagLibraryToolbox {
-  TagLibraryToolbox(this._ref);
+  TagLibraryToolbox(
+    Ref ref, {
+    AgentResourceResolver? resourceResolver,
+    TagLibraryImageResourceLoader? resourceLoader,
+    TagLibraryPortableThumbnailStore thumbnailStore =
+        const TagLibraryPortableThumbnailStore(),
+  }) : assert(
+         resourceResolver == null || resourceLoader == null,
+         'Provide either resourceResolver or resourceLoader',
+       ),
+       _ref = ref,
+       _resourceLoader =
+           resourceLoader ??
+           _validatedResourceLoader(
+             resourceResolver ?? AgentResourceResolver(ref),
+           ),
+       _thumbnailStore = thumbnailStore;
 
   final Ref _ref;
+  final TagLibraryImageResourceLoader _resourceLoader;
+  final TagLibraryPortableThumbnailStore _thumbnailStore;
+
+  static TagLibraryImageResourceLoader _validatedResourceLoader(
+    AgentResourceResolver resolver,
+  ) => (reference) async {
+    await resolver.validateForDisplay(reference);
+    return resolver.resolve(reference);
+  };
 
   List<AgentTool> tools() => [
     _listEntries(),
@@ -51,8 +88,11 @@ class TagLibraryToolbox {
       final query = (params['query'] as String? ?? '').trim().toLowerCase();
       final categoryId = params['category_id'] as String?;
       final favoriteOnly = params['favorite_only'] as bool? ?? false;
-      final offset = (params['offset'] as int? ?? 0).clamp(0, 1 << 30);
-      final limit = (params['limit'] as int? ?? 50).clamp(1, 200);
+      final offset = ((params['offset'] as num?)?.toInt() ?? 0).clamp(
+        0,
+        1 << 30,
+      );
+      final limit = ((params['limit'] as num?)?.toInt() ?? 50).clamp(1, 200);
       final matching = state.entries
           .where((entry) {
             return (query.isEmpty ||
@@ -143,27 +183,196 @@ class TagLibraryToolbox {
   DefinedAgentTool _createEntry() => DefinedAgentTool(
     name: 'create_tag_library_entry',
     label: 'Create Tag Library Entry',
-    description: 'Create a persisted reusable prompt entry.',
+    description:
+        'Create a persisted reusable prompt entry. An optional generated-image '
+        'thumbnail must be supplied as thumbnail.resource_ref.',
     parameters: toolboxObject(
-      properties: _entryMutationProperties,
+      properties: {
+        ..._entryMutationProperties,
+        'thumbnail': {
+          'type': 'object',
+          'description':
+              'Optional thumbnail source. resource_ref is required and must '
+              'identify an available generated image.',
+          'properties': {
+            'resource_ref': {
+              'type': 'object',
+              'description': 'Stable generated-image resource reference.',
+            },
+          },
+          'required': ['resource_ref'],
+          'additionalProperties': false,
+        },
+      },
       required: const ['name', 'content'],
     ),
     executeFn: (_, params) async {
       final categoryError = _validateCategory(params['category_id'] as String?);
       if (categoryError != null) return categoryError;
-      final entry = await _ref
-          .read(tagLibraryPageNotifierProvider.notifier)
-          .addEntry(
-            name: params['name'] as String,
-            content: params['content'] as String,
-            tags: toolboxStrings(params['tags']),
-            categoryId: params['category_id'] as String?,
-            isFavorite: params['favorite'] as bool? ?? false,
-            failOnPersistenceError: true,
-          );
-      return agentToolJsonResult({'ok': true, 'entry': _entryJson(entry)});
+      final thumbnail = params['thumbnail'];
+      if (thumbnail == null) return _createEntryWithoutThumbnail(params);
+      if (thumbnail is! Map || !thumbnail.containsKey('resource_ref')) {
+        return agentToolError(
+          'invalid_resource_ref',
+          'thumbnail.resource_ref is required.',
+        );
+      }
+
+      final AgentChatResourceReference reference;
+      try {
+        final value = thumbnail['resource_ref'];
+        if (value is! Map) {
+          throw const FormatException('resource_ref must be an object');
+        }
+        reference = AgentChatResourceReferenceCodec.decodeJsonMap(
+          Map<String, dynamic>.from(value),
+        );
+      } on FormatException catch (error) {
+        return agentToolError(
+          'invalid_resource_ref',
+          'thumbnail.resource_ref is invalid: ${error.message}',
+        );
+      }
+      if (reference.kind != AgentChatResourceKind.generatedImage) {
+        return agentToolError(
+          'wrong_resource_kind',
+          'thumbnail.resource_ref must identify a generated image.',
+        );
+      }
+      final ResolvedAgentResource? resolved;
+      try {
+        resolved = await _resourceLoader(reference);
+      } on GenerationImageResourceException catch (error) {
+        return agentToolError(
+          error.code,
+          'create_tag_library_entry: ${error.message}',
+        );
+      } on Object catch (error) {
+        return agentToolError(
+          'resource_resolution_failed',
+          'create_tag_library_entry: generated image '
+              '${reference.resourceId} failed during thumbnail resource '
+              'resolution (${error.runtimeType}).',
+        );
+      }
+      final bytes = resolved?.bytes;
+      if (resolved == null || bytes == null || bytes.isEmpty) {
+        return agentToolError(
+          'resource_unavailable',
+          'create_tag_library_entry: generated image '
+              '${reference.resourceId} is unavailable.',
+        );
+      }
+      final extension = _thumbnailExtension(bytes);
+      if (extension == null) {
+        return agentToolError(
+          'unsupported_thumbnail',
+          'create_tag_library_entry: generated image '
+              '${reference.resourceId} is not a supported thumbnail format.',
+        );
+      }
+      return _createEntryWithThumbnail(params, reference, bytes, extension);
     },
   );
+
+  Future<AgentToolResult> _createEntryWithoutThumbnail(
+    Map<String, dynamic> params,
+  ) async {
+    final entry = await _addEntry(params);
+    return agentToolJsonResult({'ok': true, 'entry': _entryJson(entry)});
+  }
+
+  Future<AgentToolResult> _createEntryWithThumbnail(
+    Map<String, dynamic> params,
+    AgentChatResourceReference reference,
+    Uint8List bytes,
+    String extension,
+  ) async {
+    final notifier = _ref.read(tagLibraryPageNotifierProvider.notifier);
+    TagLibraryEntry? entry;
+    PortableThumbnailMutation? mutation;
+    var step = 'create_entry';
+    try {
+      entry = await _addEntry(params);
+      step = 'stage_thumbnail';
+      mutation = await _thumbnailStore.stage(
+        entry.id,
+        extension: extension,
+        bytes: Stream<List<int>>.value(bytes),
+      );
+      final persisted = entry.copyWith(
+        thumbnail: mutation.path,
+        updatedAt: DateTime.now(),
+      );
+      step = 'persist_thumbnail_link';
+      await notifier.updateEntry(persisted, failOnPersistenceError: true);
+      step = 'commit_thumbnail';
+      await mutation.commit();
+      return agentToolJsonResult({'ok': true, 'entry': _entryJson(persisted)});
+    } on Object catch (error, stackTrace) {
+      AppLogger.e(
+        'Agent tag-library thumbnail failed: entryId=${entry?.id}, step=$step',
+        error,
+        stackTrace,
+        'AgentTagLibrary',
+      );
+      final cleanupFailures = <String>[];
+      var entryRollbackFailed = false;
+      if (entry != null) {
+        try {
+          await notifier.deleteEntry(entry.id, failOnPersistenceError: true);
+        } on Object catch (deleteError, deleteStackTrace) {
+          AppLogger.e(
+            'Agent tag-library entry rollback failed: entryId=${entry.id}',
+            deleteError,
+            deleteStackTrace,
+            'AgentTagLibrary',
+          );
+          entryRollbackFailed = true;
+          cleanupFailures.add('entry rollback: ${_safeFailure(deleteError)}');
+        }
+      }
+      // A commit-stage failure may leave persistence pointing at the target.
+      // Keep that target if entry rollback also failed, rather than creating a
+      // broken persisted thumbnail reference.
+      if (!(entryRollbackFailed && step == 'commit_thumbnail')) {
+        try {
+          await mutation?.rollback();
+        } on Object catch (rollbackError, rollbackStackTrace) {
+          AppLogger.e(
+            'Agent tag-library thumbnail rollback failed: entryId=${entry?.id}',
+            rollbackError,
+            rollbackStackTrace,
+            'AgentTagLibrary',
+          );
+          cleanupFailures.add(
+            'thumbnail rollback: ${_safeFailure(rollbackError)}',
+          );
+        }
+      }
+      final cleanup = cleanupFailures.isEmpty
+          ? ''
+          : ' Cleanup also failed (${cleanupFailures.join('; ')}).';
+      return agentToolError(
+        cleanupFailures.isEmpty ? 'write_failed' : 'rollback_failed',
+        'create_tag_library_entry: generated image ${reference.resourceId} '
+        'thumbnail failed at $step (${_safeFailure(error)}).$cleanup',
+      );
+    }
+  }
+
+  String _safeFailure(Object error) => error.runtimeType.toString();
+
+  Future<TagLibraryEntry> _addEntry(Map<String, dynamic> params) => _ref
+      .read(tagLibraryPageNotifierProvider.notifier)
+      .addEntry(
+        name: params['name'] as String,
+        content: params['content'] as String,
+        tags: toolboxStrings(params['tags']),
+        categoryId: params['category_id'] as String?,
+        isFavorite: params['favorite'] as bool? ?? false,
+        failOnPersistenceError: true,
+      );
 
   DefinedAgentTool _updateEntry() => DefinedAgentTool(
     name: 'update_tag_library_entry',
@@ -374,6 +583,16 @@ const _idSchema = <String, dynamic>{
   },
   'required': ['entry_id'],
 };
+
+String? _thumbnailExtension(Uint8List bytes) =>
+    switch (detectSupportedImageMimeType(bytes)) {
+      'image/png' => '.png',
+      'image/jpeg' => '.jpg',
+      'image/webp' => '.webp',
+      'image/gif' => '.gif',
+      'image/bmp' => '.bmp',
+      _ => null,
+    };
 
 const _entryMutationProperties = <String, dynamic>{
   'name': {'type': 'string'},

--- a/lib/presentation/providers/tag_library_page_provider.dart
+++ b/lib/presentation/providers/tag_library_page_provider.dart
@@ -364,11 +364,22 @@ class TagLibraryPageNotifier extends _$TagLibraryPageNotifier {
   }
 
   /// 删除条目
-  Future<void> deleteEntry(String entryId) async {
-    final newEntries =
-        state.entries.where((e) => e.id != entryId).toList().reindex();
+  Future<void> deleteEntry(
+    String entryId, {
+    bool failOnPersistenceError = false,
+  }) async {
+    final previousEntries = state.entries;
+    final newEntries = previousEntries
+        .where((entry) => entry.id != entryId)
+        .toList()
+        .reindex();
     state = state.copyWith(entries: newEntries);
-    await _saveEntries();
+    try {
+      await _saveEntries(rethrowError: failOnPersistenceError);
+    } catch (_) {
+      state = state.copyWith(entries: previousEntries);
+      rethrow;
+    }
   }
 
   /// 切换收藏状态

--- a/lib/presentation/services/image_workflow_launcher.dart
+++ b/lib/presentation/services/image_workflow_launcher.dart
@@ -23,6 +23,8 @@ import '../utils/prompt_preset_import_utils.dart';
 import '../widgets/common/app_toast.dart';
 import '../widgets/image_editor/image_editor_screen.dart';
 
+typedef _ImageWorkflowRead = T Function<T>(ProviderListenable<T> provider);
+
 class ImageWorkflowLauncher {
   const ImageWorkflowLauncher._();
 
@@ -39,16 +41,40 @@ class ImageWorkflowLauncher {
     Uint8List imageBytes, {
     required ImageEditorMode mode,
   }) async {
-    final workflowNotifier = ref.read(imageWorkflowControllerProvider.notifier);
-    final workflow = ref.read(imageWorkflowControllerProvider);
+    await _openEditor(context, ref.read, imageBytes, mode: mode);
+  }
+
+  static Future<bool> openEditorFromRef(
+    BuildContext context,
+    Ref ref,
+    Uint8List imageBytes, {
+    required ImageEditorMode mode,
+    bool Function()? isCurrent,
+  }) => _openEditor(
+    context,
+    ref.read,
+    imageBytes,
+    mode: mode,
+    isCurrent: isCurrent,
+  );
+
+  static Future<bool> _openEditor(
+    BuildContext context,
+    _ImageWorkflowRead read,
+    Uint8List imageBytes, {
+    required ImageEditorMode mode,
+    bool Function()? isCurrent,
+  }) async {
+    final workflowNotifier = read(imageWorkflowControllerProvider.notifier);
+    final workflow = read(imageWorkflowControllerProvider);
 
     if (mode == ImageEditorMode.edit) {
       workflowNotifier.enterBaseMode(clearMask: true);
-    } else if (ref.read(imageWorkflowControllerProvider).isEnhance) {
+    } else if (read(imageWorkflowControllerProvider).isEnhance) {
       workflowNotifier.enterBaseMode(clearMask: false);
     }
 
-    final params = ref.read(generationParamsNotifierProvider);
+    final params = read(generationParamsNotifierProvider);
     final result = await ImageEditorScreen.show(
       context,
       initialImage: imageBytes,
@@ -67,21 +93,19 @@ class ImageWorkflowLauncher {
               model: params.model,
               steps: params.steps,
               batchCount: params.nSamples,
-              batchSize: ref.read(imagesPerRequestProvider),
+              batchSize: read(imagesPerRequestProvider),
               smea: params.effectiveSmea,
               smeaDyn: params.effectiveSmeaDyn,
               strength: params.inpaintStrength,
               subscriptionTier:
-                  ref.read(subscriptionNotifierProvider).subscription?.isOpus ==
+                  read(subscriptionNotifierProvider).subscription?.isOpus ==
                       true
                   ? AnlasCalculator.opusTier
                   : 0,
               opusQuotaExhausted:
-                  ref
-                      .read(subscriptionNotifierProvider)
-                      .subscription
-                      ?.usage
-                      ?.isNegative ??
+                  read(
+                    subscriptionNotifierProvider,
+                  ).subscription?.usage?.isNegative ??
                   false,
               extraPerSampleCost:
                   AnlasCalculator.resolvePreciseReferenceExtraCost(params),
@@ -94,8 +118,10 @@ class ImageWorkflowLauncher {
           : context.l10n.img2img_inpaint,
     );
 
-    if (result == null || !context.mounted) {
-      return;
+    if (result == null ||
+        !context.mounted ||
+        (isCurrent != null && !isCurrent())) {
+      return false;
     }
 
     AppLogger.d(
@@ -130,8 +156,9 @@ class ImageWorkflowLauncher {
         );
         workflowNotifier.setPanelExpanded(true);
         AppToast.success(context, context.l10n.img2img_editApplied);
+        return true;
       }
-      return;
+      return false;
     }
 
     final effectiveMask =
@@ -162,10 +189,17 @@ class ImageWorkflowLauncher {
     } else if (result.maskImage != null) {
       AppToast.warning(context, context.l10n.toast_noValidMaskIgnored);
     }
+    return true;
   }
 
-  static void openEnhance(WidgetRef ref, Uint8List imageBytes) {
-    final workflowNotifier = ref.read(imageWorkflowControllerProvider.notifier);
+  static void openEnhance(WidgetRef ref, Uint8List imageBytes) =>
+      _openEnhance(ref.read, imageBytes);
+
+  static void openEnhanceFromRef(Ref ref, Uint8List imageBytes) =>
+      _openEnhance(ref.read, imageBytes);
+
+  static void _openEnhance(_ImageWorkflowRead read, Uint8List imageBytes) {
+    final workflowNotifier = read(imageWorkflowControllerProvider.notifier);
     workflowNotifier.replaceSourceImage(imageBytes);
     workflowNotifier.enterEnhanceMode();
     workflowNotifier.setPanelExpanded(true);
@@ -183,8 +217,14 @@ class ImageWorkflowLauncher {
   }
 
   /// 打开图生图「超分」子面板（内嵌，非弹窗）
-  static void openUpscale(WidgetRef ref, Uint8List imageBytes) {
-    final workflowNotifier = ref.read(imageWorkflowControllerProvider.notifier);
+  static void openUpscale(WidgetRef ref, Uint8List imageBytes) =>
+      _openUpscale(ref.read, imageBytes);
+
+  static void openUpscaleFromRef(Ref ref, Uint8List imageBytes) =>
+      _openUpscale(ref.read, imageBytes);
+
+  static void _openUpscale(_ImageWorkflowRead read, Uint8List imageBytes) {
+    final workflowNotifier = read(imageWorkflowControllerProvider.notifier);
     workflowNotifier.replaceSourceImage(imageBytes);
     workflowNotifier.enterUpscaleMode();
     workflowNotifier.setPanelExpanded(true);
@@ -195,17 +235,86 @@ class ImageWorkflowLauncher {
     WidgetRef ref,
     Uint8List imageBytes,
   ) async {
+    await _openDirectorTools(context, ref.read, imageBytes);
+  }
+
+  static Future<bool> openDirectorToolsFromRef(
+    BuildContext context,
+    Ref ref,
+    Uint8List imageBytes, {
+    bool Function()? isCurrent,
+  }) => _openDirectorTools(context, ref.read, imageBytes, isCurrent: isCurrent);
+
+  static Future<bool> _openDirectorTools(
+    BuildContext context,
+    _ImageWorkflowRead read,
+    Uint8List imageBytes, {
+    bool Function()? isCurrent,
+  }) async {
     final result = await DirectorToolsScreen.show(
       context,
       sourceImage: imageBytes,
     );
-    if (result != null && context.mounted) {
-      final workflowNotifier = ref.read(
-        imageWorkflowControllerProvider.notifier,
-      );
+    if (result != null &&
+        context.mounted &&
+        (isCurrent == null || isCurrent())) {
+      final workflowNotifier = read(imageWorkflowControllerProvider.notifier);
       workflowNotifier.replaceSourceImage(result);
       workflowNotifier.setPanelExpanded(true);
       AppToast.success(context, context.l10n.img2img_directorApplied);
+      return true;
+    }
+    return false;
+  }
+
+  /// Prepares variation source and settings without starting generation.
+  static Future<void> prepareVariations(
+    BuildContext context,
+    WidgetRef ref,
+    Uint8List imageBytes,
+  ) => _prepareVariations(context, ref.read, imageBytes);
+
+  static Future<void> prepareVariationsFromRef(
+    BuildContext context,
+    Ref ref,
+    Uint8List imageBytes, {
+    bool Function()? isCurrent,
+  }) => _prepareVariations(context, ref.read, imageBytes, isCurrent: isCurrent);
+
+  static Future<void> _prepareVariations(
+    BuildContext context,
+    _ImageWorkflowRead read,
+    Uint8List imageBytes, {
+    bool Function()? isCurrent,
+  }) async {
+    final workflowNotifier = read(imageWorkflowControllerProvider.notifier);
+    final paramsNotifier = read(generationParamsNotifierProvider.notifier);
+    void prepareSource() {
+      workflowNotifier.replaceSourceImage(imageBytes);
+      workflowNotifier.enterBaseMode(clearMask: true);
+      workflowNotifier.setPanelExpanded(true);
+    }
+
+    // Existing UI callers expect the source panel to update immediately. Agent
+    // callers defer every mutation until the stable resource is still current.
+    if (isCurrent == null) prepareSource();
+    final metadata = await ImageMetadataService().getMetadataFromBytes(
+      imageBytes,
+    );
+    if (!context.mounted || (isCurrent != null && !isCurrent())) return;
+    if (isCurrent != null) prepareSource();
+
+    if (metadata != null && metadata.hasData) {
+      _applyVariationMetadata(
+        metadata,
+        read,
+        paramsNotifier,
+        fallbackModel: read(generationParamsNotifierProvider).model,
+      );
+    } else {
+      paramsNotifier.randomizeSeed();
+      paramsNotifier.updateStrength(0.45);
+      paramsNotifier.updateNoise(0.0);
     }
   }
 
@@ -214,33 +323,7 @@ class ImageWorkflowLauncher {
     WidgetRef ref,
     Uint8List imageBytes,
   ) async {
-    final workflowNotifier = ref.read(imageWorkflowControllerProvider.notifier);
-    final paramsNotifier = ref.read(generationParamsNotifierProvider.notifier);
-
-    workflowNotifier.replaceSourceImage(imageBytes);
-    workflowNotifier.enterBaseMode(clearMask: true);
-    workflowNotifier.setPanelExpanded(true);
-
-    final metadata = await ImageMetadataService().getMetadataFromBytes(
-      imageBytes,
-    );
-    if (!context.mounted) {
-      return;
-    }
-
-    if (metadata != null && metadata.hasData) {
-      _applyVariationMetadata(
-        metadata,
-        ref,
-        paramsNotifier,
-        fallbackModel: ref.read(generationParamsNotifierProvider).model,
-      );
-    } else {
-      paramsNotifier.randomizeSeed();
-      paramsNotifier.updateStrength(0.45);
-      paramsNotifier.updateNoise(0.0);
-    }
-
+    await prepareVariations(context, ref, imageBytes);
     if (!context.mounted) return;
     if (PlatformCapabilities.current.supportsKritaBridge &&
         ref.read(kritaBridgeNotifierProvider).isBridgeGenerating) {
@@ -265,7 +348,7 @@ class ImageWorkflowLauncher {
 
   static void _applyVariationMetadata(
     NaiImageMetadata metadata,
-    WidgetRef ref,
+    _ImageWorkflowRead read,
     GenerationParamsNotifier notifier, {
     required String fallbackModel,
   }) {
@@ -291,14 +374,14 @@ class ImageWorkflowLauncher {
         updateCfgRescale: notifier.updateCfgRescale,
         updateQualityToggle: (value) {
           notifier.updateQualityToggle(value);
-          applyImportedQualityToggle(ref.read, value);
+          applyImportedQualityToggle(read, value);
         },
         updateQualityTier: (value) {
-          ref.read(qualityPresetNotifierProvider.notifier).setNaiTier(value);
+          read(qualityPresetNotifierProvider.notifier).setNaiTier(value);
         },
         updateUcPreset: (value) {
           notifier.updateUcPreset(value);
-          applyImportedUcPreset(ref.read, value);
+          applyImportedUcPreset(read, value);
         },
         updateTransparentBackground: notifier.updateTransparentBackground,
       ),

--- a/test/core/agent/permissions/agent_permission_test.dart
+++ b/test/core/agent/permissions/agent_permission_test.dart
@@ -29,6 +29,99 @@ void main() {
       describeAgentToolPermission('clear_characters').operation,
       AgentPermissionOperation.delete,
     );
+    expect(
+      describeAgentToolPermission('select_generated_image'),
+      isA<AgentToolPermissionDescriptor>()
+          .having(
+            (value) => value.domain,
+            'domain',
+            AgentPermissionDomain.appNavigation,
+          )
+          .having(
+            (value) => value.operation,
+            'operation',
+            AgentPermissionOperation.execute,
+          ),
+    );
+    expect(
+      describeAgentToolPermission('open_generation_image_workflow'),
+      isA<AgentToolPermissionDescriptor>()
+          .having(
+            (value) => value.domain,
+            'domain',
+            AgentPermissionDomain.generation,
+          )
+          .having(
+            (value) => value.operation,
+            'operation',
+            AgentPermissionOperation.execute,
+          )
+          .having((value) => value.mayConsumeAnlas, 'mayConsumeAnlas', isFalse),
+    );
+    expect(
+      describeAgentToolPermission('set_generated_image_favorite').domain,
+      AgentPermissionDomain.localGallery,
+    );
+    expect(
+      describeAgentToolPermission('save_generated_image'),
+      isA<AgentToolPermissionDescriptor>()
+          .having((value) => value.domain, 'domain', AgentPermissionDomain.file)
+          .having(
+            (value) => value.operation,
+            'operation',
+            AgentPermissionOperation.create,
+          ),
+    );
+    for (final toolName in const [
+      'copy_generated_image_to_clipboard',
+      'send_generated_image_to_krita',
+    ]) {
+      expect(
+        describeAgentToolPermission(toolName).domain,
+        AgentPermissionDomain.externalActions,
+      );
+    }
+  });
+
+  test('image mutations follow safe, ask, and full-access policies', () {
+    const toolNames = [
+      'select_generated_image',
+      'open_generation_image_workflow',
+      'set_generated_image_favorite',
+      'save_generated_image',
+      'copy_generated_image_to_clipboard',
+      'send_generated_image_to_krita',
+    ];
+    final descriptors = [
+      for (final name in toolNames) describeAgentToolPermission(name),
+    ];
+    final catalog = AgentToolPermissionCatalog(
+      toolNames: toolNames,
+      descriptors: descriptors,
+    );
+
+    for (final mode in const {
+      AgentAccessMode.readOnly,
+      AgentAccessMode.askBeforeWrite,
+      AgentAccessMode.allowWrite,
+    }) {
+      final policy = AgentPermissionPolicy({
+        for (final domain in AgentPermissionDomain.values) domain: mode,
+      });
+      final expected = switch (mode) {
+        AgentAccessMode.readOnly => AgentPermissionDecision.block,
+        AgentAccessMode.askBeforeWrite => AgentPermissionDecision.ask,
+        AgentAccessMode.allowWrite => AgentPermissionDecision.allow,
+        AgentAccessMode.blocked => AgentPermissionDecision.block,
+      };
+      for (final name in toolNames) {
+        expect(
+          catalog.decide(toolName: name, policy: policy),
+          expected,
+          reason: '$mode/$name',
+        );
+      }
+    }
   });
 
   group('AgentPermissionPolicy', () {
@@ -133,6 +226,14 @@ void main() {
       expect(
         catalog.decide(toolName: 'generate', policy: policy, estimatedAnlas: 0),
         AgentPermissionDecision.allow,
+      );
+      expect(
+        catalog.decide(
+          toolName: 'generate',
+          policy: policy,
+          estimatedAnlas: -3,
+        ),
+        AgentPermissionDecision.block,
       );
       expect(() => catalog.descriptorFor('unknown'), throwsStateError);
     });

--- a/test/core/agent/validate_tool_arguments_test.dart
+++ b/test/core/agent/validate_tool_arguments_test.dart
@@ -40,6 +40,51 @@ void main() {
       {'value': 5},
     );
   });
+
+  test('rejects unknown properties for strict objects recursively', () {
+    expect(
+      () => validateToolArguments(
+        tool,
+        const ToolCallContent(
+          id: 'top-level-extra',
+          name: 'bounded',
+          arguments: {'value': 5, 'unexpected': true},
+        ),
+      ),
+      throwsFormatException,
+    );
+    expect(
+      () => validateToolArguments(
+        tool,
+        const ToolCallContent(
+          id: 'nested-extra',
+          name: 'bounded',
+          arguments: {
+            'value': 5,
+            'options': {'enabled': true, 'unexpected': true},
+          },
+        ),
+      ),
+      throwsFormatException,
+    );
+    expect(
+      validateToolArguments(
+        tool,
+        const ToolCallContent(
+          id: 'strict-valid',
+          name: 'bounded',
+          arguments: {
+            'value': 5,
+            'options': {'enabled': true},
+          },
+        ),
+      ),
+      {
+        'value': 5,
+        'options': {'enabled': true},
+      },
+    );
+  });
 }
 
 class _BoundedTool extends AgentTool {
@@ -52,8 +97,16 @@ class _BoundedTool extends AgentTool {
           'type': 'object',
           'properties': {
             'value': {'type': 'number', 'minimum': 1, 'maximum': 10},
+            'options': {
+              'type': 'object',
+              'properties': {
+                'enabled': {'type': 'boolean'},
+              },
+              'additionalProperties': false,
+            },
           },
           'required': ['value'],
+          'additionalProperties': false,
         },
       );
 

--- a/test/presentation/agent_chat/services/agent_tool_permission_controller_test.dart
+++ b/test/presentation/agent_chat/services/agent_tool_permission_controller_test.dart
@@ -46,6 +46,23 @@ void main() {
       expect(await pending, isNull);
     });
 
+    test('invalid negative estimate is blocked without approval', () async {
+      AgentToolApprovalRequest? approval;
+      final controller = _controller(
+        mode: AgentAccessMode.allowWrite,
+        estimate: -3,
+        onApproval: (value) => approval = value,
+      );
+
+      final result = await controller.beforeToolCall(
+        _context('invalid-cost'),
+        null,
+      );
+
+      expect(result?.block, isTrue);
+      expect(approval, isNull);
+    });
+
     test('ask mode still asks for a zero-cost mutation', () async {
       AgentToolApprovalRequest? approval;
       final controller = _controller(

--- a/test/presentation/agent_chat/services/business_toolbox_contract_test.dart
+++ b/test/presentation/agent_chat/services/business_toolbox_contract_test.dart
@@ -1,13 +1,24 @@
+import 'dart:typed_data';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/agent/agent_types.dart';
 import 'package:nai_launcher/core/agent/permissions/permissions.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
+import 'package:nai_launcher/core/agent/harness/env/dart_io_execution_env.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/agent_resource_resolver.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/application_toolbox.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/gallery_toolbox.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_favorite_toolbox.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_workflow_service.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_workflow_toolbox.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_resource_toolbox.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/image_resource_action_service.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/image_resource_action_toolbox.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/queue_toolbox.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/reference_library_toolbox.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/tag_toolbox.dart';
+import 'package:nai_launcher/presentation/providers/image_generation_provider.dart';
 
 final _refProvider = Provider<Ref>((ref) => ref);
 
@@ -22,6 +33,34 @@ void main() {
       ...ReferenceLibraryToolbox(ref, AgentResourceResolver(ref)).tools(),
       ...QueueToolbox(ref, QueueControlRuntime()).tools(),
       ...TagToolbox(ref).tools(),
+      ...GenerationResourceToolbox.withService(
+        GenerationResourceService(
+          readState: () => const ImageGenerationState(),
+          select: (_) {},
+          navigateToGeneration: () {},
+        ),
+      ).tools(),
+      ...GenerationImageWorkflowToolbox(
+        GenerationImageWorkflowService(
+          loadResource: (_) async => GenerationWorkflowResourceSnapshot(
+            status: GenerationWorkflowResourceStatus.ready,
+            bytes: Uint8List(0),
+          ),
+          launcher: _WorkflowLauncher(),
+        ),
+      ).tools(),
+      ...GenerationImageFavoriteToolbox.forTesting(
+        resolveImage: (_) => null,
+        readFavorite: (_) async => null,
+        writeFavorite: (_, __) async => false,
+      ).tools(),
+      ...ImageResourceActionToolbox(
+        ImageResourceActionService(
+          resolve: (_) async => null,
+          env: DartIoExecutionEnv(),
+          clipboardWriter: (_) async {},
+        ),
+      ).tools(),
     ];
     final names = tools.map((tool) => tool.name).toList();
 
@@ -53,6 +92,12 @@ void main() {
         'resume_generation_queue',
         'stop_generation_queue',
         'search_tags',
+        'select_generated_image',
+        'open_generation_image_workflow',
+        'set_generated_image_favorite',
+        'save_generated_image',
+        'copy_generated_image_to_clipboard',
+        'send_generated_image_to_krita',
       ]),
     );
     for (final tool in tools) {
@@ -69,4 +114,15 @@ void main() {
       );
     }
   });
+}
+
+final class _WorkflowLauncher
+    implements GenerationImageWorkflowLauncherAdapter {
+  @override
+  Future<Map<String, dynamic>> open(
+    GenerationImageWorkflowMode mode,
+    AgentChatResourceReference reference,
+    Uint8List imageBytes, {
+    required bool Function() isCurrent,
+  }) async => const {};
 }

--- a/test/presentation/agent_chat/services/display_images_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/display_images_toolbox_test.dart
@@ -7,6 +7,7 @@ import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.
 import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference_codec.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/agent_resource_resolver.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/display_images_toolbox.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_resource.dart';
 
 void main() {
   final references = [_reference('first'), _reference('second')];
@@ -29,6 +30,33 @@ void main() {
     expect(result.isError, isFalse);
     expect(result.content.whereType<ToolResultImageContent>(), hasLength(2));
     expect(result.details, containsPair('count', 2));
+  });
+
+  test('display_images emits the owner-normalized reference', () async {
+    final service = DisplayImagesService(
+      resolve: (reference) async => ResolvedAgentResource(
+        reference: generationImageResourceReference(reference.resourceId),
+        label: reference.resourceId,
+        bytes: _onePixelPng,
+      ),
+    );
+
+    final result = await service.display({
+      'resource_refs': [
+        AgentChatResourceReferenceCodec.encodeJsonMap(
+          AgentChatResourceReference(
+            kind: AgentChatResourceKind.generatedImage,
+            source: 'legacy_source',
+            resourceId: 'first',
+          ),
+        ),
+      ],
+    });
+
+    final images = result.details['images'] as List;
+    final resourceRef = images.single['resource_ref'] as Map<String, dynamic>;
+    expect(resourceRef['source'], generationImageResourceSource);
+    expect(resourceRef['resourceId'], 'first');
   });
 
   test('display_images rejects an invalid stable reference', () async {

--- a/test/presentation/agent_chat/services/generation_image_favorite_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/generation_image_favorite_toolbox_test.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference_codec.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_favorite_toolbox.dart';
+import 'package:nai_launcher/presentation/providers/image_generation_provider.dart';
+
+void main() {
+  late Directory root;
+  late File imageFile;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('generation-favorite-test-');
+    imageFile = File('${root.path}/image.png');
+    await imageFile.writeAsBytes(const [1, 2, 3]);
+  });
+
+  tearDown(() async {
+    if (await root.exists()) await root.delete(recursive: true);
+  });
+
+  test('persists favorite through the indexed local-gallery owner', () async {
+    final image = _image('generated', imageFile.path);
+    final writes = <bool>[];
+    final toolbox = GenerationImageFavoriteToolbox.forTesting(
+      resolveImage: (_) => image,
+      readFavorite: (_) async =>
+          const LocalGalleryFavoriteRecord(id: 17, favorite: false),
+      writeFavorite: (_, favorite) async {
+        writes.add(favorite);
+        return favorite;
+      },
+    );
+
+    final result = await toolbox.tools().single.execute('favorite', {
+      'resource_ref': _ref('generated'),
+      'favorite': true,
+    });
+
+    expect(result.isError, isFalse);
+    expect(result.details['local_gallery_image_id'], 17);
+    expect(result.details['favorite'], isTrue);
+    expect(writes, [true]);
+    expect(
+      (result.details['local_gallery_resource_ref'] as Map)['resourceId'],
+      '17',
+    );
+  });
+
+  test('rejects failed snapshots and unindexed history images', () async {
+    final failed = _image(
+      'failed',
+      imageFile.path,
+      kind: GeneratedImageKind.failedStreamSnapshot,
+    );
+    final failedToolbox = GenerationImageFavoriteToolbox.forTesting(
+      resolveImage: (_) => failed,
+      readFavorite: (_) async => fail('must not read local gallery'),
+      writeFavorite: (_, __) async => fail('must not mutate local gallery'),
+    );
+
+    final failedResult = await failedToolbox.tools().single.execute('failed', {
+      'resource_ref': _ref('failed'),
+      'favorite': true,
+    });
+    expect(failedResult.details['code'], 'failed_stream_snapshot');
+
+    final unindexedToolbox = GenerationImageFavoriteToolbox.forTesting(
+      resolveImage: (_) => _image('unindexed', imageFile.path),
+      readFavorite: (_) async => null,
+      writeFavorite: (_, __) async => fail('must not mutate local gallery'),
+    );
+    final unindexedResult = await unindexedToolbox.tools().single.execute(
+      'unindexed',
+      {'resource_ref': _ref('unindexed'), 'favorite': true},
+    );
+    expect(unindexedResult.details['code'], 'local_record_required');
+  });
+
+  test(
+    'rechecks generation history after asynchronous record lookup',
+    () async {
+      final image = _image('race', imageFile.path);
+      final read = Completer<LocalGalleryFavoriteRecord?>();
+      var available = true;
+      final toolbox = GenerationImageFavoriteToolbox.forTesting(
+        resolveImage: (_) => available ? image : null,
+        readFavorite: (_) => read.future,
+        writeFavorite: (_, __) async => fail('must not mutate stale resource'),
+      );
+
+      final pending = toolbox.tools().single.execute('race', {
+        'resource_ref': _ref('race'),
+        'favorite': true,
+      });
+      available = false;
+      read.complete(const LocalGalleryFavoriteRecord(id: 9, favorite: false));
+
+      final result = await pending;
+      expect(result.details['code'], 'stale_image_resource');
+    },
+  );
+}
+
+GeneratedImage _image(
+  String id,
+  String path, {
+  GeneratedImageKind kind = GeneratedImageKind.completed,
+}) => GeneratedImage(
+  id: id,
+  bytes: Uint8List.fromList(const [1, 2, 3]),
+  width: 1,
+  height: 1,
+  filePath: path,
+  kind: kind,
+);
+
+Map<String, Object> _ref(String id) =>
+    AgentChatResourceReferenceCodec.encodeJsonMap(
+      AgentChatResourceReference(
+        kind: AgentChatResourceKind.generatedImage,
+        source: 'generation_history',
+        resourceId: id,
+      ),
+    );

--- a/test/presentation/agent_chat/services/generation_image_workflow_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/generation_image_workflow_toolbox_test.dart
@@ -1,0 +1,304 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference_codec.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_workflow_service.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_workflow_toolbox.dart';
+
+void main() {
+  test('dispatches all six modes and only opens preparation UI', () async {
+    final launcher = _RecordingLauncher();
+    final service = GenerationImageWorkflowService(
+      loadResource: (_) async => GenerationWorkflowResourceSnapshot(
+        status: GenerationWorkflowResourceStatus.ready,
+        bytes: Uint8List.fromList([1, 2, 3]),
+      ),
+      launcher: launcher,
+    );
+    final tool = GenerationImageWorkflowToolbox(service).tools().single;
+    expect(tool.parameters['additionalProperties'], isFalse);
+
+    for (final mode in GenerationImageWorkflowMode.values) {
+      final result = await tool.execute('call-${mode.name}', {
+        'resource_ref': _encodedRef(mode.name),
+        'mode': mode.name,
+      });
+
+      expect(result.isError, isFalse, reason: mode.name);
+      expect(result.details['mode'], mode.name);
+      expect(result.details['submitted'], isFalse);
+      expect(result.details['next_step'], isNotEmpty);
+    }
+
+    expect(launcher.opened, GenerationImageWorkflowMode.values);
+    expect(launcher.submitCount, 0);
+  });
+
+  test(
+    'rejects failed snapshot, missing resource, and generating resource',
+    () async {
+      for (final entry in <GenerationWorkflowResourceStatus, String>{
+        GenerationWorkflowResourceStatus.failedSnapshot:
+            'failed_stream_snapshot',
+        GenerationWorkflowResourceStatus.missing: 'resource_unavailable',
+        GenerationWorkflowResourceStatus.generating: 'resource_generating',
+      }.entries) {
+        final launcher = _RecordingLauncher();
+        final service = GenerationImageWorkflowService(
+          loadResource: (_) async =>
+              GenerationWorkflowResourceSnapshot(status: entry.key),
+          launcher: launcher,
+        );
+
+        final result = await service.open({
+          'resource_ref': _encodedRef('image'),
+          'mode': 'edit',
+        });
+
+        expect(result.isError, isTrue);
+        expect(result.details['code'], entry.value);
+        expect(launcher.opened, isEmpty);
+      }
+    },
+  );
+
+  test(
+    'late resource resolution cannot open after a newer resource switch',
+    () async {
+      final first = Completer<GenerationWorkflowResourceSnapshot>();
+      final launcher = _RecordingLauncher();
+      final service = GenerationImageWorkflowService(
+        loadResource: (reference) {
+          if (reference.resourceId == 'first') return first.future;
+          return Future.value(
+            GenerationWorkflowResourceSnapshot(
+              status: GenerationWorkflowResourceStatus.ready,
+              bytes: Uint8List.fromList([2]),
+            ),
+          );
+        },
+        launcher: launcher,
+      );
+
+      final lateResult = service.open({
+        'resource_ref': _encodedRef('first'),
+        'mode': 'edit',
+      });
+      final currentResult = await service.open({
+        'resource_ref': _encodedRef('second'),
+        'mode': 'upscale',
+      });
+      first.complete(
+        GenerationWorkflowResourceSnapshot(
+          status: GenerationWorkflowResourceStatus.ready,
+          bytes: Uint8List.fromList([1]),
+        ),
+      );
+
+      final staleResult = await lateResult;
+      expect(currentResult.isError, isFalse);
+      expect(staleResult.isError, isTrue);
+      expect(staleResult.details['code'], 'resource_switched');
+      expect(launcher.opened, [GenerationImageWorkflowMode.upscale]);
+    },
+  );
+
+  test('session switch invalidates late resource resolution', () async {
+    var sessionId = 'session-a';
+    final pending = Completer<GenerationWorkflowResourceSnapshot>();
+    final launcher = _RecordingLauncher();
+    final service = GenerationImageWorkflowService(
+      loadResource: (_) => pending.future,
+      launcher: launcher,
+      activeSessionId: () => sessionId,
+      isMounted: () => true,
+    );
+
+    final resultFuture = service.open({
+      'resource_ref': _encodedRef('session-image'),
+      'mode': 'edit',
+    });
+    sessionId = 'session-b';
+    pending.complete(
+      GenerationWorkflowResourceSnapshot(
+        status: GenerationWorkflowResourceStatus.ready,
+        bytes: Uint8List.fromList([1]),
+      ),
+    );
+
+    final result = await resultFuture;
+    expect(result.details['code'], 'resource_switched');
+    expect(result.details['message'], contains('session changed'));
+    expect(launcher.opened, isEmpty);
+  });
+
+  test(
+    'late asynchronous launcher is invalidated by a newer resource',
+    () async {
+      final firstLaunch = Completer<void>();
+      final launcher = _GuardedLauncher(firstLaunch);
+      final service = GenerationImageWorkflowService(
+        loadResource: (_) async => GenerationWorkflowResourceSnapshot(
+          status: GenerationWorkflowResourceStatus.ready,
+          bytes: Uint8List.fromList([1]),
+        ),
+        launcher: launcher,
+      );
+
+      final stale = service.open({
+        'resource_ref': _encodedRef('first'),
+        'mode': 'variations',
+      });
+      await launcher.firstStarted.future;
+      final current = service.open({
+        'resource_ref': _encodedRef('second'),
+        'mode': 'enhance',
+      });
+      firstLaunch.complete();
+
+      final results = await Future.wait([stale, current]);
+      expect(results.first.details['code'], 'resource_switched');
+      expect(results.last.isError, isFalse);
+      expect(launcher.applied, [GenerationImageWorkflowMode.enhance]);
+    },
+  );
+
+  test(
+    'maps workflow UI startup failures to a structured safe error',
+    () async {
+      final service = GenerationImageWorkflowService(
+        loadResource: (_) async => GenerationWorkflowResourceSnapshot(
+          status: GenerationWorkflowResourceStatus.ready,
+          bytes: Uint8List.fromList([1]),
+        ),
+        launcher: const _ThrowingLauncher(),
+      );
+
+      final result = await service.open({
+        'resource_ref': _encodedRef('ui-broken'),
+        'mode': 'edit',
+      });
+
+      expect(result.details['code'], 'workflow_open_failed');
+      expect(result.details['message'], contains('ui-broken'));
+      expect(
+        result.details['message'],
+        isNot(contains('private dialog state')),
+      );
+    },
+  );
+
+  test('maps resource loader failures to a structured safe error', () async {
+    final launcher = _RecordingLauncher();
+    final service = GenerationImageWorkflowService(
+      loadResource: (_) => throw const FileSystemException(
+        'private path',
+        r'C:\private\secret.png',
+      ),
+      launcher: launcher,
+    );
+
+    final result = await service.open({
+      'resource_ref': _encodedRef('broken'),
+      'mode': 'edit',
+    });
+
+    expect(result.details['code'], 'resource_resolution_failed');
+    expect(result.details['message'], contains('broken'));
+    expect(result.details['message'], isNot(contains(r'C:\private')));
+    expect(launcher.opened, isEmpty);
+  });
+
+  test('requires a generated image reference and valid mode', () async {
+    final launcher = _RecordingLauncher();
+    final service = GenerationImageWorkflowService(
+      loadResource: (_) async => const GenerationWorkflowResourceSnapshot(
+        status: GenerationWorkflowResourceStatus.missing,
+      ),
+      launcher: launcher,
+    );
+    final local = AgentChatResourceReference(
+      kind: AgentChatResourceKind.localGalleryImage,
+      source: 'local',
+      resourceId: '1',
+    );
+
+    final wrongKind = await service.open({
+      'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(local),
+      'mode': 'edit',
+    });
+    final wrongMode = await service.open({
+      'resource_ref': _encodedRef('image'),
+      'mode': 'generate',
+    });
+
+    expect(wrongKind.details['code'], 'wrong_resource_kind');
+    expect(wrongMode.details['code'], 'invalid_mode');
+    expect(launcher.opened, isEmpty);
+  });
+}
+
+Map<String, dynamic> _encodedRef(String id) =>
+    AgentChatResourceReferenceCodec.encodeJsonMap(
+      AgentChatResourceReference(
+        kind: AgentChatResourceKind.generatedImage,
+        source: 'generation_history',
+        resourceId: id,
+      ),
+    );
+
+final class _GuardedLauncher implements GenerationImageWorkflowLauncherAdapter {
+  _GuardedLauncher(this.releaseFirst);
+
+  final Completer<void> releaseFirst;
+  final Completer<void> firstStarted = Completer<void>();
+  final List<GenerationImageWorkflowMode> applied = [];
+
+  @override
+  Future<Map<String, dynamic>> open(
+    GenerationImageWorkflowMode mode,
+    AgentChatResourceReference reference,
+    Uint8List imageBytes, {
+    required bool Function() isCurrent,
+  }) async {
+    if (reference.resourceId == 'first') {
+      firstStarted.complete();
+      await releaseFirst.future;
+    }
+    if (isCurrent()) applied.add(mode);
+    return const {};
+  }
+}
+
+final class _ThrowingLauncher
+    implements GenerationImageWorkflowLauncherAdapter {
+  const _ThrowingLauncher();
+
+  @override
+  Future<Map<String, dynamic>> open(
+    GenerationImageWorkflowMode mode,
+    AgentChatResourceReference reference,
+    Uint8List imageBytes, {
+    required bool Function() isCurrent,
+  }) => throw StateError('private dialog state');
+}
+
+final class _RecordingLauncher
+    implements GenerationImageWorkflowLauncherAdapter {
+  final List<GenerationImageWorkflowMode> opened = [];
+  int submitCount = 0;
+
+  @override
+  Future<Map<String, dynamic>> open(
+    GenerationImageWorkflowMode mode,
+    AgentChatResourceReference reference,
+    Uint8List imageBytes, {
+    required bool Function() isCurrent,
+  }) async {
+    opened.add(mode);
+    return const {};
+  }
+}

--- a/test/presentation/agent_chat/services/generation_resource_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/generation_resource_toolbox_test.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference_codec.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_resource.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_resource_toolbox.dart';
+import 'package:nai_launcher/presentation/providers/image_generation_provider.dart';
+
+GeneratedImage _image(
+  String id, {
+  GeneratedImageKind kind = GeneratedImageKind.completed,
+}) => GeneratedImage(
+  id: id,
+  bytes: Uint8List.fromList(const [1]),
+  width: 64,
+  height: 64,
+  kind: kind,
+);
+
+Map<String, Object> _ref(String id, {String source = 'legacy'}) =>
+    AgentChatResourceReferenceCodec.encodeJsonMap(
+      AgentChatResourceReference(
+        kind: AgentChatResourceKind.generatedImage,
+        source: source,
+        resourceId: id,
+      ),
+    );
+
+void main() {
+  test(
+    'resource_ref wins over compatibility image_id and is normalized',
+    () async {
+      final current = _image('current');
+      final history = _image('history');
+      var selected = '';
+      var navigations = 0;
+      final service = GenerationResourceService(
+        readState: () =>
+            ImageGenerationState(currentImages: [current], history: [history]),
+        select: (id) => selected = id,
+        navigateToGeneration: () => navigations++,
+      );
+
+      final result = await service.selectGeneratedImage({
+        'resource_ref': _ref('history'),
+        'image_id': 'current',
+      });
+
+      expect(result.isError, isFalse);
+      expect(selected, 'history');
+      expect(navigations, 1);
+      final reference = result.details['resource_ref'] as Map<String, dynamic>;
+      expect(reference['source'], generationImageResourceSource);
+      expect(reference['resourceId'], 'history');
+    },
+  );
+
+  test('resolves IDs from currentImages, history, and displayImages', () {
+    final state = ImageGenerationState(
+      currentImages: [_image('current')],
+      history: [_image('history')],
+      displayImages: [_image('display')],
+    );
+
+    for (final id in ['current', 'history', 'display']) {
+      final reference = parseGenerationImageResource({'image_id': id});
+      expect(requireAvailableGenerationImage(state, reference).id, id);
+    }
+  });
+
+  test(
+    'rejects missing, stale, failed snapshot, index, and bare path',
+    () async {
+      final failed = _image(
+        'failed',
+        kind: GeneratedImageKind.failedStreamSnapshot,
+      );
+      final service = GenerationResourceService(
+        readState: () => ImageGenerationState(history: [failed]),
+        select: (_) => fail('must not select'),
+        navigateToGeneration: () => fail('must not navigate'),
+      );
+
+      final cases = <Map<String, dynamic>, String>{
+        const {}: 'missing_image_resource',
+        const {'image_id': 'stale'}: 'stale_image_resource',
+        const {'image_id': 'failed'}: 'failed_stream_snapshot',
+        const {'index': 0}: 'missing_image_resource',
+        const {'path': 'history/image.png'}: 'missing_image_resource',
+      };
+      for (final entry in cases.entries) {
+        final result = await service.selectGeneratedImage(entry.key);
+        expect(result.isError, isTrue, reason: '${entry.key}');
+        expect(result.details['code'], entry.value, reason: '${entry.key}');
+      }
+    },
+  );
+
+  test(
+    'rechecks the ID before mutation after asynchronous resolution',
+    () async {
+      final gate = Completer<void>();
+      var state = ImageGenerationState(history: [_image('late')]);
+      var selected = false;
+      final service = GenerationResourceService(
+        readState: () => state,
+        select: (_) => selected = true,
+        navigateToGeneration: () => fail('must not navigate'),
+        beforeMutation: (_) => gate.future,
+      );
+
+      final pending = service.selectGeneratedImage({'image_id': 'late'});
+      await Future<void>.delayed(Duration.zero);
+      state = const ImageGenerationState();
+      gate.complete();
+      final result = await pending;
+
+      expect(result.isError, isTrue);
+      expect(result.details['code'], 'stale_image_resource');
+      expect(selected, isFalse);
+    },
+  );
+
+  test('navigate false selects without navigation', () async {
+    var selected = '';
+    var navigated = false;
+    final service = GenerationResourceService(
+      readState: () => ImageGenerationState(history: [_image('saved')]),
+      select: (id) => selected = id,
+      navigateToGeneration: () => navigated = true,
+    );
+
+    final result = await service.selectGeneratedImage({
+      'image_id': 'saved',
+      'navigate': false,
+    });
+
+    expect(result.isError, isFalse);
+    expect(selected, 'saved');
+    expect(navigated, isFalse);
+    expect(result.details['navigated'], isFalse);
+  });
+}

--- a/test/presentation/agent_chat/services/image_resource_action_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/image_resource_action_toolbox_test.dart
@@ -1,0 +1,341 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as image_lib;
+import 'package:nai_launcher/core/agent/agent_types.dart';
+import 'package:nai_launcher/core/agent/harness/env/dart_io_execution_env.dart';
+import 'package:nai_launcher/core/agent/harness/harness_types.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference_codec.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_resource.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/image_resource_action_service.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/image_resource_action_toolbox.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory workspace;
+
+  setUp(() async {
+    workspace = await Directory.systemTemp.createTemp('image-actions-');
+  });
+
+  tearDown(() async {
+    if (await workspace.exists()) {
+      await workspace.delete(recursive: true);
+    }
+  });
+
+  test('tool schemas put resource_ref first and require explicit target', () {
+    final toolbox = ImageResourceActionToolbox(_service(workspace));
+    final tools = toolbox.tools();
+
+    expect(tools.map((tool) => tool.name), [
+      'save_generated_image',
+      'copy_generated_image_to_clipboard',
+      'send_generated_image_to_krita',
+    ]);
+    for (final tool in tools) {
+      expect((tool.parameters['properties'] as Map).keys.first, 'resource_ref');
+      expect(tool.parameters['additionalProperties'], isFalse);
+    }
+    expect(tools.first.parameters['required'], [
+      'resource_ref',
+      'destination_path',
+    ]);
+  });
+
+  test(
+    'save uses a safe explicit workspace target without overwriting',
+    () async {
+      final service = _service(workspace);
+      final arguments = {
+        ..._resourceArgument,
+        'destination_path': 'exports/result.png',
+      };
+
+      final first = await service.save(arguments);
+      final output = File(
+        '${workspace.path}${Platform.pathSeparator}exports'
+        '${Platform.pathSeparator}result.png',
+      );
+      expect(first.isError, isFalse);
+      expect(await output.readAsBytes(), _pngBytes);
+      expect(first.details['destination_path'], 'exports/result.png');
+
+      await output.writeAsString('user data');
+      final second = await service.save(arguments);
+      expect(second.isError, isTrue);
+      expect(second.details['code'], 'destination_exists');
+      expect(await output.readAsString(), 'user data');
+    },
+  );
+
+  test(
+    'exclusive write rejects a destination created after preflight',
+    () async {
+      final target = File(
+        '${workspace.path}${Platform.pathSeparator}raced.png',
+      );
+      final service = _service(
+        workspace,
+        exclusiveWriter: (_, _, _) async {
+          await target.writeAsString('other writer');
+          throw FileSystemException('exclusive create failed', target.path);
+        },
+      );
+
+      final result = await service.save({
+        ..._resourceArgument,
+        'destination_path': 'raced.png',
+      });
+
+      expect(result.details['code'], 'destination_exists');
+      expect(await target.readAsString(), 'other writer');
+      expect(_text(result), isNot(contains(target.path)));
+    },
+  );
+
+  test('save rejects a parent replaced by an external symlink', () async {
+    final external = await Directory.systemTemp.createTemp(
+      'image-actions-symlink-target-',
+    );
+    addTearDown(() async {
+      if (await external.exists()) await external.delete(recursive: true);
+    });
+    final service = ImageResourceActionService(
+      resolve: (reference) async => _resolved(reference),
+      env: _ParentSwapExecutionEnv(
+        workingDirectory: workspace.path,
+        externalDirectory: external.path,
+      ),
+      clipboardWriter: (_) async {},
+    );
+
+    final result = await service.save({
+      ..._resourceArgument,
+      'destination_path': 'exports/result.png',
+    });
+
+    expect(result.details['code'], 'unsafe_destination');
+    expect(await File('${external.path}/result.png').exists(), isFalse);
+  });
+
+  test('full access permits an explicit external target safely', () async {
+    final externalDirectory = await Directory.systemTemp.createTemp(
+      'image-actions-external-',
+    );
+    addTearDown(() async {
+      if (await externalDirectory.exists()) {
+        await externalDirectory.delete(recursive: true);
+      }
+    });
+    final target = File(
+      '${externalDirectory.path}${Platform.pathSeparator}external.png',
+    );
+    final service = ImageResourceActionService(
+      resolve: (reference) async => _resolved(reference),
+      env: DartIoExecutionEnv(
+        workingDirectory: workspace.path,
+        allowOutsideWorkingDirectory: true,
+      ),
+      clipboardWriter: (_) async {},
+    );
+
+    final result = await service.save({
+      ..._resourceArgument,
+      'destination_path': target.path,
+    });
+
+    expect(result.isError, isFalse);
+    expect(await target.readAsBytes(), _pngBytes);
+    expect(result.details['destination_scope'], 'external');
+    expect(result.details['file_name'], 'external.png');
+    expect(_text(result), isNot(contains(externalDirectory.path)));
+  });
+
+  test(
+    'save rejects traversal and does not disclose an absolute path',
+    () async {
+      final outside = File(
+        '${workspace.parent.path}${Platform.pathSeparator}private-result.png',
+      );
+      final service = _service(workspace);
+
+      final result = await service.save({
+        ..._resourceArgument,
+        'destination_path': '../private-result.png',
+      });
+
+      expect(result.isError, isTrue);
+      expect(result.details['code'], 'unsafe_destination');
+      expect(_text(result), isNot(contains(outside.path)));
+      expect(await outside.exists(), isFalse);
+    },
+  );
+
+  test('resource lifecycle failures keep their structured code', () async {
+    final service = ImageResourceActionService(
+      resolve: (_) async => throw const GenerationImageResourceException(
+        'failed_stream_snapshot',
+        'generated image generated-1 is a failed stream snapshot.',
+      ),
+      env: DartIoExecutionEnv(workingDirectory: workspace.path),
+      clipboardWriter: (_) async {},
+    );
+
+    final result = await service.copy(_resourceArgument);
+
+    expect(result.details['code'], 'failed_stream_snapshot');
+    expect(_text(result), contains('generated-1'));
+  });
+
+  test('copy reports injected clipboard failure explicitly', () async {
+    final service = _service(
+      workspace,
+      clipboardWriter: (_) async => throw StateError('secret clipboard path'),
+    );
+
+    final result = await service.copy(_resourceArgument);
+
+    expect(result.isError, isTrue);
+    expect(result.details['code'], 'clipboard_write_failed');
+    expect(_text(result), isNot(contains('secret clipboard path')));
+  });
+
+  test('Krita checks platform capability before resolving resource', () async {
+    var resolveCount = 0;
+    final service = ImageResourceActionService(
+      resolve: (reference) async {
+        resolveCount += 1;
+        return _resolved(reference);
+      },
+      env: DartIoExecutionEnv(workingDirectory: workspace.path),
+      clipboardWriter: (_) async {},
+      supportsKritaBridge: () => false,
+      readKritaBridgeState: () => const ImageResourceKritaBridgeState(
+        configured: true,
+        connected: true,
+      ),
+      sendToKrita: (_, {required name}) => true,
+    );
+
+    final result = await service.sendKrita(_resourceArgument);
+
+    expect(result.details['code'], 'krita_unsupported');
+    expect(resolveCount, 0);
+  });
+
+  test('Krita reports disabled and disconnected bridge states', () async {
+    var state = const ImageResourceKritaBridgeState(
+      configured: false,
+      connected: false,
+    );
+    final service = _service(
+      workspace,
+      supportsKritaBridge: () => true,
+      readKritaBridgeState: () => state,
+      sendToKrita: (_, {required name}) => true,
+    );
+
+    final disabled = await service.sendKrita(_resourceArgument);
+    expect(disabled.details['code'], 'krita_not_configured');
+
+    state = const ImageResourceKritaBridgeState(
+      configured: true,
+      connected: false,
+    );
+    final disconnected = await service.sendKrita(_resourceArgument);
+    expect(disconnected.details['code'], 'krita_not_connected');
+  });
+
+  test('Krita prepares and sends through the injected bridge', () async {
+    Uint8List? sentBytes;
+    String? sentName;
+    final service = _service(
+      workspace,
+      supportsKritaBridge: () => true,
+      readKritaBridgeState: () => const ImageResourceKritaBridgeState(
+        configured: true,
+        connected: true,
+      ),
+      sendToKrita: (bytes, {required name}) {
+        sentBytes = bytes;
+        sentName = name;
+        return true;
+      },
+    );
+
+    final result = await service.sendKrita(_resourceArgument);
+
+    expect(result.isError, isFalse);
+    expect(sentBytes, _pngBytes);
+    expect(sentName, 'generated.png');
+  });
+}
+
+ImageResourceActionService _service(
+  Directory workspace, {
+  ResourceImageClipboardWriter? clipboardWriter,
+  bool Function()? supportsKritaBridge,
+  ImageResourceKritaBridgeState Function()? readKritaBridgeState,
+  ResourceImageKritaSender? sendToKrita,
+  ResourceImageExclusiveWriter? exclusiveWriter,
+}) => ImageResourceActionService(
+  resolve: (reference) async => _resolved(reference),
+  env: DartIoExecutionEnv(workingDirectory: workspace.path),
+  clipboardWriter: clipboardWriter ?? (_) async {},
+  supportsKritaBridge: supportsKritaBridge,
+  readKritaBridgeState: readKritaBridgeState,
+  sendToKrita: sendToKrita,
+  exclusiveWriter: exclusiveWriter,
+);
+
+final class _ParentSwapExecutionEnv extends DartIoExecutionEnv {
+  _ParentSwapExecutionEnv({
+    required super.workingDirectory,
+    required this.externalDirectory,
+  });
+
+  final String externalDirectory;
+  bool _swapped = false;
+
+  @override
+  Future<HarnessResult<bool, FileError>> exists(
+    String path, [
+    AbortSignal? abortSignal,
+  ]) async {
+    final result = await super.exists(path, abortSignal);
+    if (!_swapped && p.basename(path) == 'result.png') {
+      _swapped = true;
+      final parent = Directory(p.dirname(path));
+      await parent.delete(recursive: true);
+      await Link(parent.path).create(externalDirectory);
+    }
+    return result;
+  }
+}
+
+ResolvedImageResourceActionSource _resolved(
+  AgentChatResourceReference reference,
+) => ResolvedImageResourceActionSource(
+  label: 'generated.webp',
+  bytes: _pngBytes,
+);
+
+final AgentChatResourceReference _reference = AgentChatResourceReference(
+  kind: AgentChatResourceKind.generatedImage,
+  source: 'generation_history',
+  resourceId: 'generated-1',
+);
+
+final Map<String, dynamic> _resourceArgument = {
+  'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(_reference),
+};
+
+String _text(AgentToolResult result) =>
+    result.content.whereType<ToolResultTextContent>().single.text;
+
+final Uint8List _pngBytes = Uint8List.fromList(
+  image_lib.encodePng(image_lib.Image(width: 1, height: 1)),
+);

--- a/test/presentation/agent_chat/services/manual_inpaint_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/manual_inpaint_toolbox_test.dart
@@ -182,6 +182,44 @@ void main() {
     expect((await repository.get(id))!.status, InpaintDraftStatus.cancelled);
   });
 
+  test(
+    'session switch stops resource-backed draft before editor launch',
+    () async {
+      var sessionId = 'session-a';
+      final pendingSource = Completer<Uint8List?>();
+      var editorLaunches = 0;
+      final reference = AgentChatResourceReference(
+        kind: AgentChatResourceKind.generatedImage,
+        source: 'generation_history',
+        resourceId: 'generated-1',
+      );
+      final toolbox = ManualInpaintToolbox(
+        container.read(_refProvider),
+        supportDirectory: root,
+        anlasEstimator: (_, _) => 0,
+        repository: repository,
+        resourceLoader: (_) => pendingSource.future,
+        activeSessionId: () => sessionId,
+        editorLauncher: (_, __, ___) {
+          editorLaunches += 1;
+          return ManualInpaintEditorSession(
+            result: Future<ImageEditorResult?>.value(),
+            close: () {},
+          );
+        },
+      );
+
+      final resultFuture = toolbox.createDraftFromResource(reference);
+      sessionId = 'session-b';
+      pendingSource.complete(_png());
+
+      final result = await resultFuture;
+      expect(result.details['code'], 'session_switched');
+      expect(editorLaunches, 0);
+      expect(await repository.list(), isEmpty);
+    },
+  );
+
   test('create resolves and persists a stable source reference', () async {
     final source = _png(value: 72);
     final editorResult = Completer<ImageEditorResult?>();

--- a/test/presentation/agent_chat/services/tag_library_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/tag_library_toolbox_test.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as image_lib;
+import 'package:nai_launcher/core/agent/agent_types.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference_codec.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/data/services/tag_library_portable_thumbnail_store.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_resource_resolver.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/tag_library_toolbox.dart';
+import 'package:nai_launcher/presentation/providers/tag_library_page_provider.dart';
+
+final _refProvider = Provider<Ref>((ref) => ref);
+
+void main() {
+  test('create schema makes resource_ref mandatory inside thumbnail', () {
+    final container = _container();
+    addTearDown(container.dispose);
+    final create = _createTool(container, _RecordingThumbnailStore());
+    final properties = create.parameters['properties'] as Map;
+    final thumbnail = properties['thumbnail'] as Map;
+
+    expect(thumbnail['required'], contains('resource_ref'));
+    expect(thumbnail['description'], contains('generated image'));
+  });
+
+  test(
+    'create without thumbnail keeps the existing persistence behavior',
+    () async {
+      final store = _RecordingThumbnailStore();
+      var resourceLoads = 0;
+      final container = _container();
+      addTearDown(container.dispose);
+      final create = _createTool(
+        container,
+        store,
+        resourceLoader: (_) async {
+          resourceLoads++;
+          return null;
+        },
+      );
+
+      final result = await create.execute('without-image', {
+        'name': 'No image',
+        'content': '1girl',
+        'tags': ['portrait'],
+      });
+
+      expect(result.isError, isFalse);
+      expect(resourceLoads, 0);
+      expect(store.stagedEntryIds, isEmpty);
+      final entry = container
+          .read(tagLibraryPageNotifierProvider)
+          .entries
+          .single;
+      expect(entry.thumbnail, isNull);
+      expect(entry.content, '1girl');
+    },
+  );
+
+  test(
+    'create stages and commits generated image as the entry thumbnail',
+    () async {
+      final store = _RecordingThumbnailStore();
+      final storage = _MemoryStorage();
+      final reference = _generatedReference();
+      final container = _container(storage: storage);
+      addTearDown(container.dispose);
+      final create = _createTool(
+        container,
+        store,
+        resourceLoader: (loadedReference) async {
+          expect(loadedReference, reference);
+          return ResolvedAgentResource(
+            reference: loadedReference,
+            label: 'Generated image',
+            bytes: _onePixelPng,
+          );
+        },
+      );
+
+      final result = await create.execute('with-image', {
+        'name': 'With image',
+        'content': 'blue hair',
+        'thumbnail': {
+          'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(
+            reference,
+          ),
+        },
+      });
+
+      expect(result.isError, isFalse);
+      final entry = container
+          .read(tagLibraryPageNotifierProvider)
+          .entries
+          .single;
+      expect(store.stagedEntryIds, [entry.id]);
+      expect(store.extensions, ['.png']);
+      expect(store.stagedBytes.single, _onePixelPng);
+      expect(entry.thumbnail, 'memory://tag-library/${entry.id}.png');
+      final persistedEntries =
+          jsonDecode(storage.tagLibraryEntriesJson!) as List;
+      expect(persistedEntries.single['id'], entry.id);
+      expect(persistedEntries.single['thumbnail'], entry.thumbnail);
+      expect(store.mutations.single.committed, isTrue);
+      expect(store.mutations.single.rolledBack, isFalse);
+      expect(result.details['entry'], containsPair('has_thumbnail', true));
+    },
+  );
+
+  test(
+    'thumbnail is rolled back and no success is returned on persistence failure',
+    () async {
+      final store = _RecordingThumbnailStore();
+      final storage = _MemoryStorage(failOnWrite: 2);
+      final reference = _generatedReference();
+      final container = _container(storage: storage);
+      addTearDown(container.dispose);
+      final create = _createTool(
+        container,
+        store,
+        resourceLoader: (loadedReference) async => ResolvedAgentResource(
+          reference: loadedReference,
+          label: 'Generated image',
+          bytes: _onePixelPng,
+        ),
+      );
+
+      final result = await create.execute('rollback', {
+        'name': 'Rollback',
+        'content': 'failed persistence',
+        'thumbnail': {
+          'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(
+            reference,
+          ),
+        },
+      });
+
+      expect(result.isError, isTrue);
+      expect(result.details, containsPair('code', 'write_failed'));
+      expect(store.mutations.single.committed, isFalse);
+      expect(store.mutations.single.rolledBack, isTrue);
+      expect(container.read(tagLibraryPageNotifierProvider).entries, isEmpty);
+    },
+  );
+}
+
+ProviderContainer _container({LocalStorageService? storage}) =>
+    ProviderContainer(
+      overrides: [
+        localStorageServiceProvider.overrideWithValue(
+          storage ?? _MemoryStorage(),
+        ),
+      ],
+    );
+
+AgentTool _createTool(
+  ProviderContainer container,
+  TagLibraryPortableThumbnailStore store, {
+  TagLibraryImageResourceLoader? resourceLoader,
+}) => TagLibraryToolbox(
+  container.read(_refProvider),
+  resourceLoader: resourceLoader ?? (_) async => null,
+  thumbnailStore: store,
+).tools().singleWhere((tool) => tool.name == 'create_tag_library_entry');
+
+AgentChatResourceReference _generatedReference() => AgentChatResourceReference(
+  kind: AgentChatResourceKind.generatedImage,
+  source: 'generation_history',
+  resourceId: 'generated-1',
+);
+
+class _MemoryStorage extends LocalStorageService {
+  _MemoryStorage({this.failOnWrite});
+
+  final int? failOnWrite;
+  final Map<String, Object?> _values = {};
+  int _writeCount = 0;
+
+  String? get tagLibraryEntriesJson => getTagLibraryEntriesJson();
+
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) =>
+      (_values[key] ?? defaultValue) as T?;
+
+  @override
+  Future<void> setSetting<T>(String key, T value) async {
+    _writeCount++;
+    if (_writeCount == failOnWrite) throw StateError('persistence failed');
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> deleteSetting(String key) async {
+    _values.remove(key);
+  }
+}
+
+class _RecordingThumbnailStore extends TagLibraryPortableThumbnailStore {
+  final List<String> stagedEntryIds = [];
+  final List<String?> extensions = [];
+  final List<Uint8List> stagedBytes = [];
+  final List<_RecordingMutation> mutations = [];
+
+  @override
+  Future<PortableThumbnailMutation> stage(
+    String entryId, {
+    required String? extension,
+    required Stream<List<int>>? bytes,
+    String? existingPath,
+  }) async {
+    stagedEntryIds.add(entryId);
+    extensions.add(extension);
+    stagedBytes.add(
+      Uint8List.fromList(await bytes!.expand((chunk) => chunk).toList()),
+    );
+    final mutation = _RecordingMutation(
+      'memory://tag-library/$entryId$extension',
+    );
+    mutations.add(mutation);
+    return mutation;
+  }
+}
+
+class _RecordingMutation extends PortableThumbnailMutation {
+  _RecordingMutation(String path) : super(path, null, <File, File>{});
+
+  bool committed = false;
+  bool rolledBack = false;
+
+  @override
+  Future<void> commit() async {
+    committed = true;
+  }
+
+  @override
+  Future<void> rollback() async {
+    rolledBack = true;
+  }
+}
+
+final Uint8List _onePixelPng = Uint8List.fromList(
+  image_lib.encodePng(image_lib.Image(width: 1, height: 1)),
+);


### PR DESCRIPTION
## 变更概述

- 建立 generatedImage + resourceId 稳定资源引用，支持生成历史图片的解析、展示与真实预览选择，并结构化处理 missing、stale、generating、failed snapshot 与 session switch。
- 新增统一图片工作流工具，复用 ImageWorkflowLauncher、现有 workflow controller 与 manual inpaint，覆盖 edit、inpaint、variations、director、enhance、upscale；仅准备或打开现有 UI，不直接提交生成或扣除 Anlas。
- 复用本地图库、词库缩略图存储和外部图片动作服务，补齐生成历史收藏、带图片词库条目、保存、剪贴板与 Krita；缩略图使用 stage/commit/rollback，保存使用 exclusive write 与 symlink/TOCTOU 边界校验。
- 将全部新 mutation、导航/选择与外部动作纳入现有 Agent 权限目录，并补齐严格 schema、资源生命周期、异步竞态、单一事实源和安全回归测试。

## 架构约束

- 未模拟 Widget 点击。
- 未新增第二套 repository、生成队列或领域事实源。
- 所有实际 Anlas 消耗仍由现有提交入口估价并单独确认。
- 未发起真实生成请求，未修改在线画廊或 CHANGELOG.md。

## 验证

- lutter analyze <34 个变更 Dart 文件>：通过。
- 12 个核心相关测试文件：70 项通过。
- 变基前 scripts/test_affected.ps1：241 项通过。
- 变基最新 origin/main 后的大范围受影响选择额外命中未修改的 gent_chat_panel_test.dart，其中 mobile shortcuts respect keyboard, reduce motion, landscape and text scale 存在 58px RenderFlex overflow；本 PR 的核心相关测试仍全部通过。
- git diff --check origin/main...HEAD：通过。