### PR TITLE
fix(agent-chat): 居中用户消息气泡文字

### DIFF
--- a/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
@@ -436,62 +436,70 @@ class AgentChatMessages extends StatelessWidget {
                       bottomRight: Radius.circular(4),
                     ),
                   ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      if (message.images.isNotEmpty)
-                        Padding(
-                          padding: EdgeInsets.only(bottom: hasText ? 6 : 0),
-                          child: Wrap(
-                            spacing: 6,
-                            runSpacing: 6,
-                            alignment: WrapAlignment.end,
-                            children: [
-                              for (final image in message.images)
-                                _userImage(
-                                  theme,
-                                  image,
-                                  maxWidth: viewData.userBubbleMaxWidth - 24,
-                                ),
-                            ],
-                          ),
-                        ),
-                      if (hasText)
-                        Text(
-                          message.text,
-                          style:
-                              (viewData.mobile
-                                      ? theme.textTheme.bodyMedium
-                                      : theme.textTheme.bodySmall)
-                                  ?.copyWith(
-                                    color: theme.colorScheme.onPrimaryContainer,
-                                    height: 1.45,
+                  child: IntrinsicWidth(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        if (message.images.isNotEmpty)
+                          Padding(
+                            padding: EdgeInsets.only(bottom: hasText ? 6 : 0),
+                            child: Wrap(
+                              spacing: 6,
+                              runSpacing: 6,
+                              alignment: WrapAlignment.end,
+                              children: [
+                                for (final image in message.images)
+                                  _userImage(
+                                    theme,
+                                    image,
+                                    maxWidth: viewData.userBubbleMaxWidth - 24,
                                   ),
-                        ),
-                      const SizedBox(height: 4),
-                      Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            sentAt,
-                            style: theme.textTheme.labelSmall?.copyWith(
-                              color: theme.colorScheme.onPrimaryContainer
-                                  .withValues(alpha: 0.58),
-                              fontSize: 9,
-                              height: 1,
+                              ],
                             ),
                           ),
-                          const SizedBox(width: 3),
-                          Icon(
-                            Icons.done_all_rounded,
-                            size: 11,
-                            color: theme.colorScheme.onPrimaryContainer
-                                .withValues(alpha: 0.58),
+                        if (hasText)
+                          Text(
+                            message.text,
+                            key: ValueKey(
+                              'agent-user-message-text-$messageIndex',
+                            ),
+                            textAlign: TextAlign.center,
+                            style:
+                                (viewData.mobile
+                                        ? theme.textTheme.bodyMedium
+                                        : theme.textTheme.bodySmall)
+                                    ?.copyWith(
+                                      color:
+                                          theme.colorScheme.onPrimaryContainer,
+                                      height: 1.45,
+                                    ),
                           ),
-                        ],
-                      ),
-                    ],
+                        const SizedBox(height: 4),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              sentAt,
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                color: theme.colorScheme.onPrimaryContainer
+                                    .withValues(alpha: 0.58),
+                                fontSize: 9,
+                                height: 1,
+                              ),
+                            ),
+                            const SizedBox(width: 3),
+                            Icon(
+                              Icons.done_all_rounded,
+                              size: 11,
+                              color: theme.colorScheme.onPrimaryContainer
+                                  .withValues(alpha: 0.58),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
                 const SizedBox(height: 2),

--- a/test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart
@@ -107,6 +107,70 @@ void main() {
     });
   }
 
+  testWidgets(
+    'user message text stays centered while metadata and actions keep alignment',
+    (tester) async {
+      final controller = AgentChatPanelController();
+      addTearDown(controller.dispose);
+      final messages = [
+        UserMessage.text(
+          '嗯',
+          timestamp: DateTime(2025, 5, 16, 16, 19).millisecondsSinceEpoch,
+        ),
+        UserMessage.text(
+          'This is a deliberately long user message that wraps across '
+          'multiple lines without changing its centered alignment.',
+          timestamp: DateTime(2025, 5, 16, 16, 20).millisecondsSinceEpoch,
+        ),
+      ];
+      for (final width in [360.0, 840.0]) {
+        final textHeights = <double>[];
+        for (final message in messages) {
+          await _pumpMessages(
+            tester,
+            width: width,
+            controller: controller,
+            state: AgentChatState(
+              initialized: true,
+              routeReady: true,
+              messages: [message],
+            ),
+          );
+
+          final bubble = find.byKey(
+            const ValueKey('agent-user-message-bubble-0'),
+          );
+          final textFinder = find.byKey(
+            const ValueKey('agent-user-message-text-0'),
+          );
+          final text = tester.widget<Text>(textFinder);
+          final bubbleRect = tester.getRect(bubble);
+          final textRect = tester.getRect(textFinder);
+          final statusIcon = find.descendant(
+            of: bubble,
+            matching: find.byIcon(Icons.done_all_rounded),
+          );
+
+          textHeights.add(textRect.height);
+          expect(text.textAlign, TextAlign.center);
+          expect(textRect.center.dx, closeTo(bubbleRect.center.dx, 0.01));
+          expect(
+            tester.getRect(statusIcon).right,
+            closeTo(bubbleRect.right - 12, 0.01),
+          );
+          expect(
+            tester.getSize(
+              find.byKey(const ValueKey('agent-user-message-copy-0')),
+            ),
+            Size(48, width < 600 ? 48 : 32),
+          );
+        }
+        expect(textHeights.last, greaterThan(textHeights.first));
+      }
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets('streaming response exposes a live responding status', (
     tester,
   ) async {


### PR DESCRIPTION
## 用户可见变化
- 用户发送的消息气泡内，短文本和自动换行后的多行文本默认水平居中。
- 消息时间与已发送状态继续保持右对齐，编辑/复制操作及桌面、移动端布局不变。
- 覆盖窄屏、桌面宽度与 200% 字体缩放回归。

## 验证
- `flutter test test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart test/presentation/agent_chat/widgets/agent_chat_edit_message_test.dart`
- `flutter analyze lib/presentation/agent_chat/widgets/agent_chat_messages.dart test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart test/presentation/agent_chat/widgets/agent_chat_edit_message_test.dart`
- `git diff --check`