### PR TITLE
fix(generation): 完善 Issue #80 生成界面反馈

### DIFF
--- a/lib/presentation/screens/generation/widgets/main_workspace.dart
+++ b/lib/presentation/screens/generation/widgets/main_workspace.dart
@@ -29,6 +29,18 @@ class MainWorkspace extends ConsumerWidget {
   static const double _promptAreaChromeHeight = 132.0;
   static const double _promptTextSafetyPadding = 24.0;
 
+  @visibleForTesting
+  static double resolveClassicPromptAreaHeight({
+    required double storedHeight,
+    required double adaptiveHeight,
+    required double heightCap,
+  }) {
+    final preferredHeight = storedHeight
+        .clamp(_minPromptAreaHeight, heightCap)
+        .toDouble();
+    return preferredHeight > adaptiveHeight ? preferredHeight : adaptiveHeight;
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
@@ -88,8 +100,8 @@ class MainWorkspace extends ConsumerWidget {
                 ),
               ),
 
-            // 角色行：紧贴提示词区下方（画布模式收起，画布内有芯片条）
-            if (!canvasOpen) const InlineCharacterRow(),
+            // 角色二级菜单：紧贴提示词区下方（画布模式收起，画布内有芯片条）
+            if (!canvasOpen) const ClassicCharacterSection(),
 
             // 提示词区域拖拽分隔条（最大化/画布模式隐藏）
             if (!isPromptMaximized && !canvasOpen)
@@ -98,8 +110,7 @@ class MainWorkspace extends ConsumerWidget {
                   final maxHeight = _resolvePromptAreaHeightCap(
                     constraints.maxHeight,
                   );
-                  // 拖动调整的是「高度上限」，以存储值为基准；
-                  // 若基于显示高度（内容少时贴内容），一拖就会把上限意外缩小
+                  // 存储值是用户设置的基础高度；内容超过该高度时仍会自然增高。
                   final storedHeight = ref
                       .read(layoutStateNotifierProvider)
                       .promptAreaHeight;
@@ -151,9 +162,13 @@ class MainWorkspace extends ConsumerWidget {
       negativePrompt,
     ).clamp(_minPromptAreaHeight, heightCap).toDouble();
 
-    // 内容自适应为主，用户拖动的高度作为上限：
-    // 内容少时框贴内容收缩（不再留大片空白），超过上限时框内滚动
-    return storedHeight < adaptiveHeight ? storedHeight : adaptiveHeight;
+    // 用户设置值是基础高度，避免空提示词时编辑器默认缩成窄条；
+    // 内容更多时仍允许区域自适应增高，但不会突破预览区安全上限。
+    return resolveClassicPromptAreaHeight(
+      storedHeight: storedHeight,
+      adaptiveHeight: adaptiveHeight,
+      heightCap: heightCap,
+    );
   }
 
   double _resolvePromptAreaHeightCap(double availableHeight) {

--- a/lib/presentation/screens/generation/widgets/prompt_input_toolbar.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_input_toolbar.dart
@@ -186,7 +186,7 @@ class PromptInputToolbar extends ConsumerWidget {
               runSpacing: 6,
               crossAxisAlignment: WrapCrossAlignment.center,
               children: [
-                const FixedTagsButton(),
+                const FixedTagsButton(compact: true),
                 QualityTagsSelector(model: model),
                 UcPresetSelector(model: model),
                 const CharacterPromptButton(),

--- a/lib/presentation/widgets/character/inline_character_row.dart
+++ b/lib/presentation/widgets/character/inline_character_row.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,8 +9,10 @@ import '../../../core/utils/character_prompt_block_parser.dart';
 import '../../../data/models/character/character_prompt.dart';
 import '../../providers/character_position_canvas_provider.dart';
 import '../../providers/character_prompt_provider.dart';
+import '../../providers/generation/generation_panel_expansion_provider.dart';
 import '../../providers/image_generation_provider.dart';
 import '../../providers/tag_library_page_provider.dart';
+import '../common/collapsible_image_panel.dart';
 import '../tag_library/tag_library_picker_dialog.dart';
 import 'add_to_library_dialog.dart';
 import 'character_position_canvas.dart';
@@ -24,6 +28,65 @@ enum _CharacterAddAction {
   const _CharacterAddAction(this.gender);
 
   final CharacterGender? gender;
+}
+
+/// 经典布局角色二级菜单。
+///
+/// 只折叠角色管理界面，不改变角色启用状态或生成参数；展开后继续复用原有
+/// 横向卡片和全宽编辑器，避免为两种布局维护两套角色业务逻辑。
+class ClassicCharacterSection extends ConsumerWidget {
+  const ClassicCharacterSection({super.key});
+
+  static const panel = GenerationWorkbenchPanel.characters;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isV4Model = ref.watch(
+      generationParamsNotifierProvider.select(
+        (params) => ImageModels.isV4Model(params.model),
+      ),
+    );
+    if (!isV4Model) return const SizedBox.shrink();
+
+    final characters = ref.watch(characterPromptNotifierProvider).characters;
+    if (characters.isEmpty) return const SizedBox.shrink();
+
+    final isExpanded = ref.watch(
+      generationPanelExpansionProvider.select(
+        (state) => state.isExpanded(panel),
+      ),
+    );
+    final theme = Theme.of(context);
+
+    return CollapsibleImagePanel(
+      key: const Key('classic-character-secondary-menu'),
+      title: AppLocalizations.of(context)!.character_buttonLabel,
+      icon: Icons.people_outline_rounded,
+      isExpanded: isExpanded,
+      onToggle: () => unawaited(
+        ref.read(generationPanelExpansionProvider.notifier).toggle(panel),
+      ),
+      hasData: true,
+      badge: Container(
+        key: const Key('classic-character-count'),
+        constraints: const BoxConstraints(minWidth: 22),
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.primaryContainer,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Text(
+          '${characters.length}',
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onPrimaryContainer,
+            fontFeatures: const [FontFeature.tabularFigures()],
+          ),
+        ),
+      ),
+      childBuilder: (context) => const InlineCharacterRow(),
+    );
+  }
 }
 
 /// 内联角色行（经典布局用，横排）

--- a/lib/presentation/widgets/common/collapsible_image_panel.dart
+++ b/lib/presentation/widgets/common/collapsible_image_panel.dart
@@ -252,7 +252,10 @@ class _CollapsibleImagePanelState extends State<CollapsibleImagePanel>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final showBackground = widget.hasData && !widget.isExpanded;
+    // 白色前景只用于确实存在深色图片遮罩的折叠态。角色等纯色面板
+    // 即使有数据也必须继续使用主题前景色，否则浅色主题会变成白底白字。
+    final showBackground =
+        widget.hasData && !widget.isExpanded && widget.backgroundImage != null;
     final highContrast = MediaQuery.highContrastOf(context);
 
     return Card(

--- a/lib/presentation/widgets/prompt/fixed_tags_button.dart
+++ b/lib/presentation/widgets/prompt/fixed_tags_button.dart
@@ -10,7 +10,10 @@ import 'fixed_tags_dialog.dart';
 /// 固定词按钮组件
 /// 显示当前启用的固定词数量，点击打开管理对话框
 class FixedTagsButton extends ConsumerStatefulWidget {
-  const FixedTagsButton({super.key});
+  const FixedTagsButton({super.key, this.compact = false});
+
+  /// 经典桌面提示词工具栏使用紧凑外观；触屏和独立入口保留标准命中高度。
+  final bool compact;
 
   @override
   ConsumerState<FixedTagsButton> createState() => _FixedTagsButtonState();
@@ -74,12 +77,15 @@ class _FixedTagsButtonState extends ConsumerState<FixedTagsButton> {
                 .read(layoutStateNotifierProvider.notifier)
                 .toggleFixedTagsSidebar(),
             child: AnimatedContainer(
+              key: const Key('fixed-tags-button-surface'),
               duration: MediaQuery.disableAnimationsOf(context)
                   ? Duration.zero
                   : const Duration(milliseconds: 150),
-              constraints: const BoxConstraints(minHeight: 44),
-              alignment: Alignment.center,
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              constraints: BoxConstraints(minHeight: widget.compact ? 36 : 44),
+              padding: EdgeInsets.symmetric(
+                horizontal: widget.compact ? 8 : 10,
+                vertical: widget.compact ? 4 : 6,
+              ),
               decoration: BoxDecoration(
                 color: hasEnabled
                     ? theme.colorScheme.secondary.withValues(
@@ -95,7 +101,7 @@ class _FixedTagsButtonState extends ConsumerState<FixedTagsButton> {
                 children: [
                   Icon(
                     hasEnabled ? Icons.push_pin : Icons.push_pin_outlined,
-                    size: 16,
+                    size: widget.compact ? 15 : 16,
                     color: hasEnabled
                         ? theme.colorScheme.secondary
                         : theme.colorScheme.onSurface.withValues(alpha: 0.5),
@@ -104,7 +110,7 @@ class _FixedTagsButtonState extends ConsumerState<FixedTagsButton> {
                   Text(
                     context.l10n.fixedTags_label,
                     style: TextStyle(
-                      fontSize: 12,
+                      fontSize: widget.compact ? 11 : 12,
                       fontWeight: hasEnabled
                           ? FontWeight.w600
                           : FontWeight.w500,

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
@@ -459,6 +459,39 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('FixedTagsButton 经典工具栏紧凑模式不会拉伸', (tester) async {
+    final storage = _SidebarTestStorage(
+      fixedEntries: const [],
+      categories: const [],
+      libraryEntries: const [],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+        child: const MaterialApp(
+          locale: Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 1000,
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: FixedTagsButton(compact: true),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final surface = find.byKey(const Key('fixed-tags-button-surface'));
+    expect(tester.getSize(surface).height, 36);
+    expect(tester.getSize(surface).width, lessThan(100));
+  });
+
   testWidgets(
     'FixedTagsButton long press toggles sidebar and tap keeps it open',
     (tester) async {

--- a/test/presentation/screens/generation/widgets/main_workspace_test.dart
+++ b/test/presentation/screens/generation/widgets/main_workspace_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/presentation/screens/generation/widgets/main_workspace.dart';
+
+void main() {
+  group('MainWorkspace classic prompt height', () {
+    test('keeps the saved default height when prompt content is short', () {
+      expect(
+        MainWorkspace.resolveClassicPromptAreaHeight(
+          storedHeight: 200,
+          adaptiveHeight: 132,
+          heightCap: 420,
+        ),
+        200,
+      );
+    });
+
+    test('grows for longer prompt content', () {
+      expect(
+        MainWorkspace.resolveClassicPromptAreaHeight(
+          storedHeight: 200,
+          adaptiveHeight: 268,
+          heightCap: 420,
+        ),
+        268,
+      );
+    });
+
+    test('clamps a saved height to the current preview-safe cap', () {
+      expect(
+        MainWorkspace.resolveClassicPromptAreaHeight(
+          storedHeight: 520,
+          adaptiveHeight: 240,
+          heightCap: 360,
+        ),
+        360,
+      );
+    });
+  });
+}

--- a/test/presentation/widgets/character/inline_character_section_test.dart
+++ b/test/presentation/widgets/character/inline_character_section_test.dart
@@ -8,6 +8,7 @@ import 'package:nai_launcher/data/models/character/character_prompt.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/providers/character_prompt_provider.dart';
 import 'package:nai_launcher/presentation/widgets/character/inline_character_card.dart';
+import 'package:nai_launcher/presentation/widgets/character/inline_character_row.dart';
 import 'package:nai_launcher/presentation/widgets/character/inline_character_section.dart';
 
 class _TestCharacterPromptNotifier extends CharacterPromptNotifier {
@@ -117,7 +118,11 @@ void main() {
     return container;
   }
 
-  Widget subject(ProviderContainer container, double width) {
+  Widget subject(
+    ProviderContainer container,
+    double width, {
+    Widget child = const InlineCharacterSection(),
+  }) {
     return UncontrolledProviderScope(
       container: container,
       child: MaterialApp(
@@ -125,7 +130,7 @@ void main() {
         supportedLocales: AppLocalizations.supportedLocales,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         home: Scaffold(
-          body: SizedBox(width: width, child: const InlineCharacterSection()),
+          body: SizedBox(width: width, child: child),
         ),
       ),
     );
@@ -167,6 +172,30 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('character-stack-person-0')), findsOneWidget);
     expect(find.byKey(const Key('character-stack-person-1')), findsOneWidget);
+  });
+
+  testWidgets('经典布局默认折叠且展开不会改变角色状态', (tester) async {
+    final container = createContainer();
+    final before = container.read(characterPromptNotifierProvider);
+
+    await tester.pumpWidget(
+      subject(container, 1180, child: const ClassicCharacterSection()),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('classic-character-count')), findsOneWidget);
+    expect(find.byType(InlineCharacterCard), findsNothing);
+
+    await tester.tap(find.byKey(const Key('collapsible-chevron-角色')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(InlineCharacterCard), findsNWidgets(2));
+    expect(container.read(characterPromptNotifierProvider), before);
+
+    await tester.tap(find.byKey(const Key('collapsible-chevron-角色')));
+    await tester.pumpAndSettle();
+    expect(find.byType(InlineCharacterCard), findsNothing);
+    expect(container.read(characterPromptNotifierProvider), before);
   });
 
   testWidgets('标题栏添加按钮新增角色且不会切换面板展开状态', (tester) async {

--- a/test/presentation/widgets/common/collapsible_image_panel_test.dart
+++ b/test/presentation/widgets/common/collapsible_image_panel_test.dart
@@ -11,6 +11,7 @@ void main() {
     required VoidCallback onToggle,
     bool disableAnimations = false,
     bool showSummary = true,
+    bool hasData = false,
     WidgetBuilder? childBuilder,
   }) {
     return MaterialApp(
@@ -29,6 +30,7 @@ void main() {
                 icon: Icons.people_outline,
                 isExpanded: expanded,
                 onToggle: onToggle,
+                hasData: hasData,
                 summary: showSummary
                     ? const Text(
                         '3 个启用 · Alice +2',
@@ -185,5 +187,19 @@ void main() {
       tester.getTopRight(header).dx - tester.getCenter(chevron).dx,
       lessThanOrEqualTo(24),
     );
+  });
+
+  testWidgets('浅色主题下有数据但无背景图时不使用白色前景', (tester) async {
+    await tester.pumpWidget(
+      buildSubject(width: 416, expanded: false, hasData: true, onToggle: () {}),
+    );
+    await tester.pump();
+
+    final title = tester.widget<Text>(find.text('角色'));
+    final chevron = tester.widget<Icon>(
+      find.byKey(const Key('collapsible-chevron-角色')),
+    );
+    expect(title.style?.color, isNot(Colors.white));
+    expect(chevron.color, isNot(Colors.white));
   });
 }


### PR DESCRIPTION
## 用户可见变化

- 为经典布局的角色词管理器增加折叠入口，展开后继续复用原有角色卡片和编辑能力
- 修复固定词按钮被父布局拉伸成整行的问题，并让经典桌面工具栏使用紧凑尺寸
- 恢复提示词输入区的默认基础高度；短文本不再缩成窄条，长文本仍会自适应增高
- 修复浅色主题下角色折叠栏白底白字、内容不可读的问题

## 兼容性

- 折叠操作只改变界面展开状态，不修改角色启用状态、角色内容或生成参数
- 提示词高度继续尊重用户保存值，并受当前预览区域安全高度限制
- 触屏和独立固定词入口继续保留 44px 标准命中高度
- 未执行真实生成，不消耗 Anlas

## 验证

- `scripts/test_affected.ps1`：5 个相关测试文件、53 项测试通过
- `dart analyze`（变更源文件与测试）：无问题
- `git diff --check`：通过

Fixes #80
