### PR TITLE
fix(generation): 修复 WebLeftPanel 窄宽溢出

### DIFF
--- a/lib/presentation/screens/generation/widgets/web_left_panel.dart
+++ b/lib/presentation/screens/generation/widgets/web_left_panel.dart
@@ -41,6 +41,9 @@ class WebLeftPanel extends ConsumerStatefulWidget {
 
 class _WebLeftPanelState extends ConsumerState<WebLeftPanel>
     with SingleTickerProviderStateMixin {
+  // 320px 的面板最小宽度包含右侧 1px 分隔线。
+  static const double _expandedContentMinWidth = 319;
+
   /// 参数二级菜单是否挂载（动画收起完毕后卸载）。
   bool _paramsMenuMounted = false;
 
@@ -129,15 +132,30 @@ class _WebLeftPanelState extends ConsumerState<WebLeftPanel>
       border: Border(right: BorderSide(color: theme.dividerColor, width: 1)),
     );
 
-    final child = layoutState.webLeftPanelExpanded
-        ? _buildExpanded(context, theme)
-        : CollapsedPanel(
-            icon: Icons.edit_note,
-            label: context.l10n.generation_params,
-            onTap: () => ref
-                .read(layoutStateNotifierProvider.notifier)
-                .setWebLeftPanelExpanded(true),
+    final child = LayoutBuilder(
+      builder: (context, constraints) {
+        // AnimatedContainer 会先切换业务状态，再逐帧过渡实际宽度。
+        // 只有当前帧真正容得下完整内容时才构建展开态，避免其内部所有
+        // Row 在 40px 附近仍按桌面侧栏排版。
+        final showExpandedContent =
+            layoutState.webLeftPanelExpanded &&
+            constraints.maxWidth >= _expandedContentMinWidth;
+        if (showExpandedContent) {
+          return KeyedSubtree(
+            key: const ValueKey('web-left-panel-expanded-content'),
+            child: _buildExpanded(context, theme),
           );
+        }
+        return CollapsedPanel(
+          key: const ValueKey('web-left-panel-compact-content'),
+          icon: Icons.edit_note,
+          label: context.l10n.generation_params,
+          onTap: () => ref
+              .read(layoutStateNotifierProvider.notifier)
+              .setWebLeftPanelExpanded(true),
+        );
+      },
+    );
 
     // 拖拽时不使用动画，避免粘滞感（与经典布局 LeftPanel 一致）
     if (widget.isResizing) {

--- a/lib/presentation/widgets/character/add_character_buttons.dart
+++ b/lib/presentation/widgets/character/add_character_buttons.dart
@@ -19,9 +19,10 @@ class AddCharacterButtons extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context)!;
+    final hasScaledText = MediaQuery.textScalerOf(context).scale(14) > 14;
 
     return Wrap(
-      spacing: 4,
+      spacing: compact && hasScaledText ? 2 : 4,
       runSpacing: 4,
       children: [
         _GenderButton(

--- a/test/presentation/screens/generation/widgets/web_left_panel_test.dart
+++ b/test/presentation/screens/generation/widgets/web_left_panel_test.dart
@@ -1,0 +1,262 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/core/platform/platform_capabilities.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/data/models/user/user_subscription.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/providers/auth_provider.dart';
+import 'package:nai_launcher/presentation/providers/cost_estimate_provider.dart';
+import 'package:nai_launcher/presentation/providers/krita/krita_bridge_notifier.dart';
+import 'package:nai_launcher/presentation/providers/queue_execution_provider.dart';
+import 'package:nai_launcher/presentation/providers/replication_queue_provider.dart';
+import 'package:nai_launcher/presentation/providers/subscription_provider.dart';
+import 'package:nai_launcher/presentation/screens/generation/widgets/collapsed_panel.dart';
+import 'package:nai_launcher/presentation/screens/generation/widgets/web_left_panel.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late Directory hiveDirectory;
+
+  setUpAll(() async {
+    hiveDirectory = await Directory.systemTemp.createTemp(
+      'web_left_panel_test_',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox(StorageKeys.settingsBox);
+    await Hive.openBox(StorageKeys.historyBox);
+  });
+
+  setUp(() async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    SharedPreferences.setMockInitialValues({});
+    await Hive.box(StorageKeys.settingsBox).clear();
+    await Hive.box(StorageKeys.historyBox).clear();
+  });
+
+  tearDown(() {
+    PlatformCapabilities.debugOverride = null;
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (await hiveDirectory.exists()) {
+      await hiveDirectory.delete(recursive: true);
+    }
+  });
+
+  for (final width in [39.0, 200.0, 319.0]) {
+    testWidgets('expanded panel uses its compact entry at ${width}px', (
+      tester,
+    ) async {
+      await _pumpPanel(tester, width: width, expanded: true);
+
+      expect(
+        find.byKey(const ValueKey('web-left-panel-compact-content')),
+        findsOneWidget,
+      );
+      expect(find.byType(CollapsedPanel), findsOneWidget);
+      expect(find.text('Parameters'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  testWidgets('320px Chinese panel fits at 200% text scaling', (tester) async {
+    await _pumpPanel(
+      tester,
+      width: 320,
+      expanded: true,
+      locale: const Locale('zh'),
+      textScaler: const TextScaler.linear(2),
+    );
+
+    expect(
+      find.byKey(const ValueKey('web-left-panel-expanded-content')),
+      findsOneWidget,
+    );
+    expect(find.text('参数'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('normal-width Chinese panel fits 200% text scaling', (
+    tester,
+  ) async {
+    await _pumpPanel(
+      tester,
+      width: 400,
+      expanded: true,
+      locale: const Locale('zh'),
+      textScaler: const TextScaler.linear(2),
+    );
+
+    expect(
+      find.byKey(const ValueKey('web-left-panel-expanded-content')),
+      findsOneWidget,
+    );
+    expect(find.text('参数'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('macOS expand and collapse animations do not overflow', (
+    tester,
+  ) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.macOS,
+    );
+    final storage = _MemoryLocalStorageService(expanded: false);
+    await _pumpPanel(
+      tester,
+      width: 400,
+      expanded: false,
+      storage: storage,
+      platform: TargetPlatform.macOS,
+    );
+
+    await tester.tap(find.byType(CollapsedPanel));
+    await tester.pump();
+    for (var frame = 0; frame < 10; frame++) {
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(tester.takeException(), isNull);
+    }
+
+    expect(
+      find.byKey(const ValueKey('web-left-panel-expanded-content')),
+      findsOneWidget,
+    );
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(find.byIcon(Icons.chevron_left));
+    await tester.pump();
+    for (var frame = 0; frame < 10; frame++) {
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(tester.takeException(), isNull);
+    }
+    expect(
+      find.byKey(const ValueKey('web-left-panel-compact-content')),
+      findsOneWidget,
+    );
+  });
+}
+
+Future<void> _pumpPanel(
+  WidgetTester tester, {
+  required double width,
+  required bool expanded,
+  Locale locale = const Locale('en'),
+  TextScaler textScaler = TextScaler.noScaling,
+  TargetPlatform platform = TargetPlatform.windows,
+  _MemoryLocalStorageService? storage,
+}) async {
+  final effectiveStorage =
+      storage ?? _MemoryLocalStorageService(expanded: expanded);
+  final negativeModeNotifier = ValueNotifier<bool>(false);
+  addTearDown(negativeModeNotifier.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authNotifierProvider.overrideWith(_AuthenticatedAuthNotifier.new),
+        localStorageServiceProvider.overrideWithValue(effectiveStorage),
+        kritaBridgeNotifierProvider.overrideWith(
+          (ref) => _TestKritaBridgeNotifier(),
+        ),
+        replicationQueueNotifierProvider.overrideWith(
+          _TestReplicationQueueNotifier.new,
+        ),
+        queueExecutionNotifierProvider.overrideWith(
+          _TestQueueExecutionNotifier.new,
+        ),
+        subscriptionNotifierProvider.overrideWith(
+          _TestSubscriptionNotifier.new,
+        ),
+        estimatedCostProvider.overrideWith((ref) => 0),
+        isFreeGenerationProvider.overrideWith((ref) => true),
+      ],
+      child: MaterialApp(
+        theme: ThemeData(platform: platform),
+        locale: locale,
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        home: MediaQuery(
+          data: MediaQueryData(
+            size: Size(width, 900),
+            textScaler: textScaler,
+            disableAnimations: false,
+          ),
+          child: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: width,
+                height: 900,
+                child: WebLeftPanel(negativeModeNotifier: negativeModeNotifier),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  if (expanded && width >= 320) {
+    await tester.pump(const Duration(milliseconds: 150));
+  }
+}
+
+class _MemoryLocalStorageService extends LocalStorageService {
+  _MemoryLocalStorageService({required this.expanded});
+
+  final Map<String, Object?> _values = {};
+  bool expanded;
+
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) {
+    final value = _values[key];
+    return value == null ? defaultValue : value as T;
+  }
+
+  @override
+  Future<void> setSetting<T>(String key, T value) async {
+    _values[key] = value;
+  }
+
+  @override
+  bool getWebLeftPanelExpanded() => expanded;
+
+  @override
+  Future<void> setWebLeftPanelExpanded(bool value) async {
+    expanded = value;
+  }
+}
+
+class _AuthenticatedAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => const AuthState(status: AuthStatus.authenticated);
+}
+
+class _TestKritaBridgeNotifier extends KritaBridgeNotifier {
+  @override
+  Future<void> close() async {}
+}
+
+class _TestReplicationQueueNotifier extends ReplicationQueueNotifier {
+  @override
+  ReplicationQueueState build() => const ReplicationQueueState();
+}
+
+class _TestQueueExecutionNotifier extends QueueExecutionNotifier {
+  @override
+  QueueExecutionState build() => const QueueExecutionState();
+}
+
+class _TestSubscriptionNotifier extends SubscriptionNotifier {
+  @override
+  SubscriptionState build() => const SubscriptionState.initial();
+}


### PR DESCRIPTION
## 根因

`WebLeftPanel` 过去只根据持久化的展开状态选择完整内容；`AnimatedContainer` 切换状态后，实际宽度仍会在 200ms 内经过 39px 等极窄约束，导致标题栏及其余展开态 `Row` 继续按桌面宽度布局并连续产生 `RenderFlex overflow`。

## 修复

- 在动画容器内部使用 `LayoutBuilder` 按当前帧真实约束选择布局。
- 内容宽度不足 319px（外层 320px 含 1px 分隔线）时只保留带“参数”文案的紧凑可点击入口；达到安全宽度后恢复原有完整布局。
- 保持正常桌面宽度的现有外观、功能和面板宽度策略，不裁切、不增加挤压主内容的固定最小宽度。
- 200% 字体缩放时仅收紧紧凑角色按钮之间的间距，保留全部图标、文字和操作。

## 验证

- `scripts/test_affected.ps1`：通过（6 项）
  - 39px、200px、319px 紧凑布局
  - 320px / 400px、中文、200% text scale
  - macOS 展开与折叠动画逐帧无 overflow，并验证紧凑入口可点击
- `flutter analyze lib/presentation/screens/generation/widgets/web_left_panel.dart lib/presentation/widgets/character/add_character_buttons.dart test/presentation/screens/generation/widgets/web_left_panel_test.dart`：通过
- `git diff --check`：通过

未启动或控制主工作区热重载会话。