### PR TITLE
fix(agent-chat): 默认由 NovelAI 决定角色位置

### DIFF
--- a/lib/data/models/character/character_prompt.dart
+++ b/lib/data/models/character/character_prompt.dart
@@ -475,15 +475,16 @@ class CharacterPromptConfig with _$CharacterPromptConfig {
           CharacterGender.other => '',
         };
 
-    // 获取默认位置
-    final defaultPosition = _getNextDefaultPosition();
+    final defaultPosition = globalAiChoice ? null : _getNextDefaultPosition();
 
     final newCharacter = CharacterPrompt.create(
       name: name ?? getNextCharacterName(),
       gender: gender,
       prompt: initialPrompt,
       negativePrompt: negativePrompt ?? 'lowres, aliasing, ',
-      positionMode: CharacterPositionMode.custom,
+      positionMode: globalAiChoice
+          ? CharacterPositionMode.aiChoice
+          : CharacterPositionMode.custom,
       customPosition: defaultPosition,
       thumbnailPath: thumbnailPath,
     );

--- a/lib/presentation/agent_chat/services/agent_system_prompt.dart
+++ b/lib/presentation/agent_chat/services/agent_system_prompt.dart
@@ -138,9 +138,12 @@ String buildAgentSystemPrompt({
         'weights tags near the start more heavily.',
     '- Character prompts exist only on V4+: put per-character appearance '
         'and actions in the character list via add_character, never into '
-        'the main prompt. V4.5 supports up to 6 characters with '
-        'interaction tags source# / target# / mutual#; V5 allows many '
-        'more (20+) with free canvas positioning.',
+        'the main prompt. Keep NovelAI AI character placement by default and '
+        'never estimate coordinates yourself. Switch to custom positioning '
+        'only when the user explicitly asks for manual placement or concrete '
+        'coordinates; preserve existing explicit positions when editing other '
+        'fields. V4.5 supports up to 6 characters with interaction tags '
+        'source# / target# / mutual#; V5 allows many more (20+).',
     '- V4/V4.5 share a ~512 T5 token budget across base + character '
         'prompts; V5 allows noticeably longer prompts. Avoid emoji / '
         'non-ASCII in V4 prompts.',

--- a/lib/presentation/agent_chat/services/generation_character_orchestration.dart
+++ b/lib/presentation/agent_chat/services/generation_character_orchestration.dart
@@ -1,6 +1,4 @@
 import '../../../core/constants/model_capabilities.dart';
-import '../../../data/models/character/character_prompt.dart'
-    show CharacterPositionLayout;
 import '../../../data/models/image/image_params.dart';
 
 enum GenerationCharacterLayoutMode { aiChoice, custom }
@@ -147,21 +145,31 @@ abstract final class GenerationCharacterOrchestrator {
       );
     }
 
-    final defaults = layoutMode == GenerationCharacterLayoutMode.custom
-        ? CharacterPositionLayout.positionsForCount(parsed.length)
-        : const [];
+    if (layoutMode == GenerationCharacterLayoutMode.custom) {
+      final missingPosition = parsed.indexWhere(
+        (character) => character.x == null || character.y == null,
+      );
+      if (missingPosition >= 0) {
+        throw GenerationCharacterValidationException(
+          'missing_character_coordinates',
+          'Character ${missingPosition + 1} requires both position_x and '
+              'position_y in custom layout.',
+        );
+      }
+    }
+
     return GenerationCharacterSnapshot(
       layoutMode: layoutMode,
       characters: [
-        for (var index = 0; index < parsed.length; index++)
+        for (final character in parsed)
           CharacterPrompt(
-            prompt: parsed[index].prompt,
-            negativePrompt: parsed[index].negativePrompt,
+            prompt: character.prompt,
+            negativePrompt: character.negativePrompt,
             positionX: layoutMode == GenerationCharacterLayoutMode.custom
-                ? parsed[index].x ?? defaults[index].column
+                ? character.x
                 : null,
             positionY: layoutMode == GenerationCharacterLayoutMode.custom
-                ? parsed[index].y ?? defaults[index].row
+                ? character.y
                 : null,
           ),
       ],

--- a/lib/presentation/agent_chat/services/generation_preparation_schema.dart
+++ b/lib/presentation/agent_chat/services/generation_preparation_schema.dart
@@ -41,21 +41,24 @@ Map<String, dynamic> generationPreparationProperties({
   'character_layout_mode': {
     'type': 'string',
     'enum': ['ai_choice', 'custom'],
+    'default': 'ai_choice',
     'description':
-        'Layout for an explicitly provided characters snapshot. ai_choice '
-        'lets NovelAI place every character and forbids coordinates. custom '
-        'uses continuous centers where x is left-to-right and y is '
-        'top-to-bottom, both 0..1. Omit to infer custom when any character '
-        'has a position, otherwise ai_choice.',
+        'Layout for an explicitly provided characters snapshot. Omit or use '
+        'ai_choice by default so NovelAI places every character; coordinates '
+        'are forbidden in that mode. Use custom only when the user explicitly '
+        'requests manual placement, and then provide every character position. '
+        'Coordinates use x left-to-right and y top-to-bottom, both 0..1.',
   },
   'characters': {
     'type': 'array',
     'description':
         'Complete ordered character snapshot for this call. Omit to inherit '
-        'the current character editor state. In custom mode, a complete x/y '
-        'pair or legacy A1-E5 position is accepted; characters with neither '
-        'receive stable non-overlapping defaults. Single-axis coordinates are '
-        'rejected. Legacy grid values map to continuous cell centers.',
+        'the current character editor state. Characters without positions use '
+        'NovelAI AI placement. Only when the user explicitly requests manual '
+        'placement may you provide a complete x/y pair or legacy A1-E5 '
+        'position for every character; never estimate coordinates proactively. '
+        'Single-axis or incomplete custom layouts are rejected. Legacy grid '
+        'values map to continuous cell centers.',
     'items': {
       'type': 'object',
       'additionalProperties': false,

--- a/lib/presentation/agent_chat/services/prompt_toolbox.dart
+++ b/lib/presentation/agent_chat/services/prompt_toolbox.dart
@@ -144,11 +144,13 @@ class PromptToolbox {
         label: 'Update Character',
         description:
             'Update one character matched by stable id or case-insensitive '
-            'name. Only provided fields change. position_mode ai_choice '
-            'keeps any saved custom point but lets AI choose while the global '
-            'layout is AI. position_mode custom may reuse the saved point or '
-            'accept both position_x and position_y. x is left-to-right and y '
-            'is top-to-bottom; both must be finite values from 0 to 1.',
+            'name. Only provided fields change, so omitting position fields '
+            'preserves an existing explicit manual position. Keep ai_choice '
+            'unless the user explicitly requests manual placement or concrete '
+            'coordinates. ai_choice preserves any saved custom point for later '
+            'restoration. custom accepts both position_x and position_y, or '
+            'reuses an existing saved point; it never invents a new point. x '
+            'is left-to-right and y is top-to-bottom, finite 0..1 values.',
         parameters: const {
           'type': 'object',
           'properties': {
@@ -168,6 +170,9 @@ class PromptToolbox {
             'position_mode': {
               'type': 'string',
               'enum': ['ai_choice', 'custom'],
+              'description':
+                  'Omit to preserve the current mode. Use custom only when '
+                  'the user explicitly requests manual placement.',
             },
             'position_x': {
               'type': 'number',
@@ -190,9 +195,11 @@ class PromptToolbox {
         name: 'add_character',
         label: 'Add Character',
         description:
-            'Add one ordered character using the current model limit. Optional '
-            'custom coordinates require both axes (x left-to-right, y '
-            'top-to-bottom, finite 0..1). ai_choice conflicts with coordinates.',
+            'Add one ordered character using the current model limit. NovelAI '
+            'AI placement is the default; do not estimate coordinates. Use '
+            'custom only when the user explicitly requests manual placement, '
+            'with both axes (x left-to-right, y top-to-bottom, finite 0..1). '
+            'ai_choice conflicts with coordinates.',
         parameters: const {
           'type': 'object',
           'properties': {
@@ -208,6 +215,10 @@ class PromptToolbox {
             'position_mode': {
               'type': 'string',
               'enum': ['ai_choice', 'custom'],
+              'default': 'ai_choice',
+              'description':
+                  'Default ai_choice. Use custom only for an explicit user '
+                  'request and provide both coordinates.',
             },
             'position_x': {'type': 'number', 'minimum': 0, 'maximum': 1},
             'position_y': {'type': 'number', 'minimum': 0, 'maximum': 1},
@@ -221,8 +232,9 @@ class PromptToolbox {
         label: 'Set Character Layout Mode',
         description:
             'Switch the whole scene between NovelAI AI placement and custom '
-            'continuous coordinates. Switching to custom assigns stable, '
-            'non-overlapping defaults only where needed. Switching to AI '
+            'continuous coordinates. Keep AI placement by default. Call custom '
+            'only when the user explicitly requests manual placement; it '
+            'assigns stable defaults only where needed. Switching to AI '
             'preserves every saved custom point for later restoration.',
         parameters: const {
           'type': 'object',
@@ -468,6 +480,24 @@ class PromptToolbox {
         'Character not found. Call get_prompt_state for stable IDs.',
       );
     }
+    if (positionChange.mode == CharacterPositionMode.custom &&
+        positionChange.x == null &&
+        target.customPosition == null) {
+      return agentToolError(
+        'missing_character_coordinates',
+        'position_mode custom requires both coordinates when the character '
+            'has no saved manual position.',
+      );
+    }
+
+    final requestedPositionMode = positionChange.mode;
+    if (requestedPositionMode != null) {
+      _ref
+          .read(characterPromptNotifierProvider.notifier)
+          .setGlobalAiChoice(
+            requestedPositionMode == CharacterPositionMode.aiChoice,
+          );
+    }
 
     var updated = target;
     final newName = (args['new_name'] as String?)?.trim();
@@ -556,6 +586,13 @@ class PromptToolbox {
       );
     }
     final positionMode = positionChange.mode ?? CharacterPositionMode.aiChoice;
+    if (positionMode == CharacterPositionMode.custom &&
+        positionChange.x == null) {
+      return agentToolError(
+        'missing_character_coordinates',
+        'A new custom character requires both position_x and position_y.',
+      );
+    }
     final customPosition = positionChange.x == null
         ? null
         : CharacterPosition(
@@ -563,6 +600,11 @@ class PromptToolbox {
             row: positionChange.y!,
             column: positionChange.x!,
           );
+    if (positionChange.mode != null) {
+      notifier.setGlobalAiChoice(
+        positionChange.mode == CharacterPositionMode.aiChoice,
+      );
+    }
     final result = await notifier.addCharacterPersisted(
       _parseGender(args['gender']) ?? CharacterGender.female,
       name: name,
@@ -704,14 +746,13 @@ class PromptToolbox {
     if (change.mode == CharacterPositionMode.aiChoice) {
       return character.copyWith(positionMode: CharacterPositionMode.aiChoice);
     }
-    final config = _ref.read(characterPromptNotifierProvider);
     final position = change.x != null
         ? CharacterPosition(
             mode: CharacterPositionMode.custom,
             row: change.y!,
             column: change.x!,
           )
-        : character.customPosition ?? config.resolvePosition(character);
+        : character.customPosition!;
     return character.copyWith(
       positionMode: CharacterPositionMode.custom,
       customPosition: position,

--- a/test/core/services/character_conversion_service_test.dart
+++ b/test/core/services/character_conversion_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/services/character_conversion_service.dart';
 import 'package:nai_launcher/data/models/character/character_prompt.dart'
@@ -30,6 +32,54 @@ void main() {
 
       expect(character.prompt, 'girl, blue eyes');
       expect(character.negativePrompt, 'red hair, glasses');
+    });
+
+    test('uses AI placement by default and custom only in manual layout', () {
+      final automatic = const ui_character.CharacterPromptConfig()
+          .addCharacter(prompt: 'girl')
+          .characters
+          .single;
+      final manual = const ui_character.CharacterPromptConfig(
+        globalAiChoice: false,
+      ).addCharacter(prompt: 'girl').characters.single;
+
+      expect(
+        automatic.positionMode,
+        ui_character.CharacterPositionMode.aiChoice,
+      );
+      expect(automatic.customPosition, isNull);
+      expect(manual.positionMode, ui_character.CharacterPositionMode.custom);
+      expect(manual.customPosition, isNotNull);
+    });
+
+    test('serializes AI/custom enums and defaults missing mode to AI', () {
+      const automatic = ui_character.CharacterPrompt(
+        id: 'automatic',
+        name: 'Automatic',
+      );
+      const manual = ui_character.CharacterPrompt(
+        id: 'manual',
+        name: 'Manual',
+        positionMode: ui_character.CharacterPositionMode.custom,
+        customPosition: ui_character.CharacterPosition(
+          mode: ui_character.CharacterPositionMode.custom,
+          row: 0.25,
+          column: 0.75,
+        ),
+      );
+
+      final automaticJson =
+          jsonDecode(jsonEncode(automatic)) as Map<String, dynamic>;
+      final manualJson = jsonDecode(jsonEncode(manual)) as Map<String, dynamic>;
+      expect(automaticJson['positionMode'], 'aiChoice');
+      expect(manualJson['positionMode'], 'custom');
+      final withoutMode = Map<String, dynamic>.from(automaticJson)
+        ..remove('positionMode');
+      expect(
+        ui_character.CharacterPrompt.fromJson(withoutMode).positionMode,
+        ui_character.CharacterPositionMode.aiChoice,
+      );
+      expect(ui_character.CharacterPrompt.fromJson(manualJson), manual);
     });
   });
 

--- a/test/presentation/agent_chat/services/generation_character_orchestration_test.dart
+++ b/test/presentation/agent_chat/services/generation_character_orchestration_test.dart
@@ -26,23 +26,59 @@ void main() {
       );
     });
 
-    test('normalizes legacy grid and deterministic custom defaults', () {
+    test('defaults multiple positionless characters to NovelAI AI layout', () {
+      final snapshot = GenerationCharacterOrchestrator.normalizeExplicit(
+        model: ImageModels.animeDiffusionV5Curated,
+        rawLayoutMode: null,
+        rawCharacters: const [
+          {'prompt': 'hero'},
+          {'prompt': 'companion'},
+        ],
+      );
+
+      expect(snapshot.layoutMode, GenerationCharacterLayoutMode.aiChoice);
+      expect(snapshot.useCoords, isFalse);
+      expect(snapshot.characters.first.positionX, isNull);
+      expect(snapshot.characters.first.positionY, isNull);
+      expect(snapshot.characters.last.positionX, isNull);
+      expect(snapshot.characters.last.positionY, isNull);
+    });
+
+    test('normalizes complete explicit manual positions', () {
       final snapshot = GenerationCharacterOrchestrator.normalizeExplicit(
         model: ImageModels.animeDiffusionV5Curated,
         rawLayoutMode: 'custom',
         rawCharacters: const [
           {'prompt': 'hero', 'position': 'B3'},
-          {'prompt': 'companion'},
+          {'prompt': 'companion', 'position_x': 0.8, 'position_y': 0.25},
         ],
       );
 
       expect(snapshot.useCoords, isTrue);
       expect(snapshot.characters.first.positionX, 0.3);
       expect(snapshot.characters.first.positionY, 0.5);
-      expect(snapshot.characters.last.positionX, isNotNull);
-      expect(snapshot.characters.last.positionY, isNotNull);
-      expect(snapshot.characters.last.positionX, inInclusiveRange(0, 1));
-      expect(snapshot.characters.last.positionY, inInclusiveRange(0, 1));
+      expect(snapshot.characters.last.positionX, 0.8);
+      expect(snapshot.characters.last.positionY, 0.25);
+    });
+
+    test('custom layout never invents missing character coordinates', () {
+      expect(
+        () => GenerationCharacterOrchestrator.normalizeExplicit(
+          model: ImageModels.animeDiffusionV5Curated,
+          rawLayoutMode: 'custom',
+          rawCharacters: const [
+            {'prompt': 'hero', 'position_x': 0.2, 'position_y': 0.5},
+            {'prompt': 'companion'},
+          ],
+        ),
+        throwsA(
+          isA<GenerationCharacterValidationException>().having(
+            (error) => error.code,
+            'code',
+            'missing_character_coordinates',
+          ),
+        ),
+      );
     });
 
     test('AI layout rejects coordinates instead of silently ignoring them', () {

--- a/test/presentation/agent_chat/services/generation_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/generation_toolbox_test.dart
@@ -530,6 +530,75 @@ void main() {
   );
 
   test(
+    'positionless multi-character preparation stays AI through submission',
+    () async {
+      final fake = _FakeImageGenerationNotifier();
+      final container = ProviderContainer(
+        overrides: [
+          imageGenerationNotifierProvider.overrideWith(() => fake),
+          generationParamsNotifierProvider.overrideWith(
+            _TestV5GenerationParamsNotifier.new,
+          ),
+          characterPromptNotifierProvider.overrideWith(
+            _TestCharacterPromptNotifier.new,
+          ),
+          subscriptionNotifierProvider.overrideWith(
+            _TestSubscriptionNotifier.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final tools = GenerationToolbox(_makeRef(container)).tools();
+      final prepare = tools.firstWhere(
+        (tool) => tool.name == 'prepare_generation',
+      );
+      final submit = tools.firstWhere(
+        (tool) => tool.name == 'submit_generation',
+      );
+      final layoutSchema =
+          (prepare.parameters['properties']
+                  as Map<String, dynamic>)['character_layout_mode']
+              as Map<String, dynamic>;
+      expect(layoutSchema['default'], 'ai_choice');
+
+      final prepared = _json(
+        await prepare.execute('prepare-ai-characters', const {
+          'operation': 'generate',
+          'prompt': 'two friends',
+          'characters': [
+            {'prompt': 'hero, black hair'},
+            {'prompt': 'companion, blonde hair'},
+          ],
+        }),
+      );
+      expect(prepared['parameters']['character_layout_mode'], 'ai_choice');
+      expect(
+        prepared['parameters']['characters'][0],
+        isNot(contains('center')),
+      );
+      expect(
+        prepared['parameters']['characters'][1],
+        isNot(contains('center')),
+      );
+
+      final submitted = await submit.execute('submit-ai-characters', {
+        'preparation_id': prepared['preparation_id'],
+        'confirmed': true,
+      });
+      expect(submitted.isError, isFalse);
+      expect(fake.params?.useCoords, isFalse);
+      expect(fake.params?.characters, hasLength(2));
+
+      final request = await NAIImageRequestBuilder(
+        params: fake.params!,
+        encodeVibe: _fakeEncodeVibe,
+      ).build(sampler: Samplers.kEulerAncestral);
+      expect(request.requestParameters['use_coords'], isFalse);
+      expect(request.requestParameters['v4_prompt']['use_coords'], isFalse);
+    },
+  );
+
+  test(
     'Agent custom characters reach the final request as one immutable scene',
     () async {
       final fake = _FakeImageGenerationNotifier();

--- a/test/presentation/agent_chat/services/prompt_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/prompt_toolbox_test.dart
@@ -157,6 +157,29 @@ void main() {
       expect(initial['characters'][0]['order'], 0);
       expect(initial['characters'][0]['position_x'], 0.2);
 
+      final preserved = await tool('update_character').execute(
+        'preserve-position',
+        const {'id': 'first', 'prompt': 'updated hero'},
+      );
+      expect(preserved.isError, isFalse);
+      final preservedCharacter = container
+          .read(characterPromptNotifierProvider)
+          .characters
+          .firstWhere((character) => character.id == 'first');
+      expect(preservedCharacter.positionMode, CharacterPositionMode.aiChoice);
+      expect(preservedCharacter.customPosition?.column, 0.2);
+      expect(preservedCharacter.customPosition?.row, 0.4);
+
+      final missingCustom = await tool('update_character').execute(
+        'missing-custom',
+        const {'id': 'second', 'position_mode': 'custom'},
+      );
+      expect(missingCustom.isError, isTrue);
+      expect(
+        _resultText(missingCustom),
+        contains('missing_character_coordinates'),
+      );
+
       final partial = await tool(
         'update_character',
       ).execute('partial', const {'id': 'second', 'position_x': 0.5});
@@ -172,6 +195,10 @@ void main() {
       expect(
         jsonDecode(_resultText(updated))['character']['position_mode'],
         'custom',
+      );
+      expect(
+        container.read(characterPromptNotifierProvider).globalAiChoice,
+        isFalse,
       );
 
       await tool(
@@ -289,6 +316,26 @@ void main() {
     expect(characters.first.negativePrompt, 'old negative');
     expect(characters.last.negativePrompt, 'red hair');
     expect(characters.last.positionMode, CharacterPositionMode.aiChoice);
+    expect(characters.last.customPosition, isNull);
+
+    final customWithoutCoordinates = await tool.execute(
+      'add-custom-without-coordinates',
+      const {
+        'name': 'Manual',
+        'prompt': 'green hair',
+        'position_mode': 'custom',
+      },
+    );
+    expect(customWithoutCoordinates.isError, isTrue);
+    expect(
+      _resultText(customWithoutCoordinates),
+      contains('missing_character_coordinates'),
+    );
+
+    final positionModeSchema =
+        (tool.parameters['properties'] as Map<String, dynamic>)['position_mode']
+            as Map<String, dynamic>;
+    expect(positionModeSchema['default'], 'ai_choice');
   });
 }
 

--- a/test/presentation/providers/character_prompt_provider_test.dart
+++ b/test/presentation/providers/character_prompt_provider_test.dart
@@ -89,6 +89,33 @@ void main() {
       expect(container.read(characterLimitReachedProvider), isTrue);
     });
 
+    test('new characters follow the active AI or manual layout mode', () {
+      final notifier = container.read(characterPromptNotifierProvider.notifier);
+      notifier.clearAllCharacters();
+
+      notifier.addCharacter(CharacterGender.female, name: 'Automatic');
+      var config = container.read(characterPromptNotifierProvider);
+      expect(config.globalAiChoice, isTrue);
+      expect(
+        config.characters.single.positionMode,
+        CharacterPositionMode.aiChoice,
+      );
+      expect(config.characters.single.customPosition, isNull);
+
+      notifier.setGlobalAiChoice(false);
+      notifier.addCharacter(CharacterGender.male, name: 'Manual');
+      config = container.read(characterPromptNotifierProvider);
+      expect(config.globalAiChoice, isFalse);
+      expect(
+        config.characters.every(
+          (character) =>
+              character.positionMode == CharacterPositionMode.custom &&
+              character.customPosition != null,
+        ),
+        isTrue,
+      );
+    });
+
     test('reports the limit as reachable again after removals', () {
       final notifier = container.read(characterPromptNotifierProvider.notifier);
       container

--- a/test/presentation/widgets/character/character_position_canvas_test.dart
+++ b/test/presentation/widgets/character/character_position_canvas_test.dart
@@ -184,13 +184,25 @@ void main() {
   });
 
   group('CharacterPromptConfig 默认位置', () {
-    test('addCharacter 产生的默认位置均为 0-1 百分比', () {
+    test('AI 布局新增角色不预填手动坐标', () {
       var config = const CharacterPromptConfig();
       for (var i = 0; i < 6; i++) {
         config = config.addCharacter(gender: CharacterGender.female);
       }
       for (final character in config.characters) {
+        expect(character.positionMode, CharacterPositionMode.aiChoice);
+        expect(character.customPosition, isNull);
+      }
+    });
+
+    test('自定义布局新增角色会分配有效手动坐标', () {
+      var config = const CharacterPromptConfig(globalAiChoice: false);
+      for (var i = 0; i < 6; i++) {
+        config = config.addCharacter(gender: CharacterGender.female);
+      }
+      for (final character in config.characters) {
         final position = character.customPosition;
+        expect(character.positionMode, CharacterPositionMode.custom);
         expect(position, isNotNull);
         expect(position!.row, inInclusiveRange(0.0, 1.0));
         expect(position.column, inInclusiveRange(0.0, 1.0));


### PR DESCRIPTION
## 变更内容

- 将角色编辑状态和 Agent 的 `add_character` / `prepare_generation` 默认位置统一为 NovelAI `ai_choice`，默认不再生成或提交角色坐标。
- 更新 Agent system prompt、工具 schema 与参数说明：只有用户明确要求手动位置或具体坐标时才进入 `custom`。
- 显式手动位置必须为每个角色提供完整坐标；不再用稳定网格替 Agent 补造缺失坐标。
- `update_character` 未携带位置字段时保留当前模式和已保存坐标；显式切换 AI 后仍保留手动坐标，之后可恢复。
- 显式的角色位置更新会同步场景全局位置模式，确保 UI 状态、准备态和最终 NovelAI 请求一致。

## 迁移与兼容性

- 不需要数据迁移；现有持久化的 `globalAiChoice`、`positionMode` 和 `customPosition` 原样读取。
- 缺少旧版 `positionMode` 字段的记录继续按 `aiChoice` 反序列化。
- 已有显式手动布局和坐标保持有效；只修改角色名称、提示词、负向词或启用状态不会覆盖位置。
- 行为收紧：Agent 显式选择 `custom` 却没有完整坐标、且角色没有可复用的已保存坐标时，会返回 `missing_character_coordinates`，而不是静默估算位置。

## 验证

- `dart run build_runner build --delete-conflicting-outputs`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run_flutter_tests.ps1 -Path "test/core/services/character_conversion_service_test.dart,test/presentation/agent_chat/services/generation_character_orchestration_test.dart,test/presentation/agent_chat/services/generation_toolbox_test.dart,test/presentation/agent_chat/services/prompt_toolbox_test.dart,test/presentation/providers/character_prompt_provider_test.dart,test/presentation/widgets/character/character_position_canvas_test.dart" -TimeoutSeconds 180`（68 项通过）
- 对 5 个变更源文件逐一执行 `dart analyze <path>`（全部无问题）
- 全量 `flutter analyze` 仍有 1 条与本 PR 无关的既有 warning：`lib/core/agent/context_usage.dart:70 unnecessary_null_comparison`
- `git diff --check`

未执行真实生成，不消耗 Anlas；未操作主热重载会话。
