### PR TITLE
fix(agent-chat): 统一生成图片读取路径契约

### DIFF
--- a/lib/core/agent/harness/tools/path_utils.dart
+++ b/lib/core/agent/harness/tools/path_utils.dart
@@ -6,8 +6,6 @@ import '../harness_types.dart';
 final RegExp _unicodeSpaces = RegExp(
   r'[\u00A0\u2000-\u200A\u202F\u205F\u3000]',
 );
-const String _narrowNoBreakSpace = '\u202F';
-
 String normalizeToolPath(String path) {
   final normalized = path.replaceAllMapped(_unicodeSpaces, (_) => ' ');
   return normalized.startsWith('@') ? normalized.substring(1) : normalized;
@@ -25,30 +23,7 @@ Future<String> resolveReadToolPath(
   ExecutionEnv env,
   String path, [
   AbortSignal? signal,
-]) async {
-  final resolved = await resolveToolPath(env, path, signal);
-  final variants = <String>[
-    resolved,
-    resolved.replaceAllMapped(
-      RegExp(r' (AM|PM)\.', caseSensitive: false),
-      (m) => '$_narrowNoBreakSpace${m[1]}.',
-    ),
-    resolved,
-    resolved.replaceAll("'", '\u2019'),
-    resolved.replaceAll("'", '\u2019'),
-  ];
-
-  final seen = <String>{};
-  for (final variant in variants) {
-    if (!seen.add(variant)) {
-      continue;
-    }
-    if (getOrThrow(await env.exists(variant, signal))) {
-      return variant;
-    }
-  }
-  return resolved;
-}
+]) => resolveToolPath(env, path, signal);
 
 /// 内置执行工具所需的文件系统与 shell 上下文
 /// 。

--- a/lib/presentation/agent_chat/services/agent_system_prompt.dart
+++ b/lib/presentation/agent_chat/services/agent_system_prompt.dart
@@ -63,10 +63,12 @@ String buildAgentSystemPrompt({
         'read, preview_generated_image, or display_images merely to inspect or '
         'repeat that same output. Only retrieve it again when the user '
         'explicitly asks to reopen, compare, inspect, or analyze the image.',
-    '- get_recent_images returns each saved image\'s read-safe relative path '
-        'and stable resource_ref. Never derive a filename or extension from a '
-        'resource_ref/resourceId; use the returned path with read, or pass the '
-        'resource_ref to preview_generated_image.',
+    '- generate_image and get_recent_images return the same generated-image '
+        'contract: path is the exact workspace-relative argument for read, '
+        'while resource_ref is an application-owned identity for resource '
+        'tools. Only call read when that image object contains path, and pass '
+        'the path unchanged. Never turn resource_ref/resourceId into a path, '
+        'filename, or extension.',
     '- Reuse that exact generated-image resource_ref for selection, favorites, '
         'tag-library thumbnails, saving, clipboard, Krita, and '
         'open_generation_image_workflow. Never substitute an index or raw path.',

--- a/lib/presentation/agent_chat/services/generation_execution_service.dart
+++ b/lib/presentation/agent_chat/services/generation_execution_service.dart
@@ -5,13 +5,12 @@ import 'dart:typed_data';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/agent/agent_types.dart';
 import '../../../core/agent/harness/tools/image.dart';
-import '../../../core/agent/resources/agent_chat_resource_reference.dart';
-import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
 import '../../../core/utils/app_logger.dart';
 import '../../../core/utils/display_thumbnail_utils.dart';
 import '../../../core/utils/nai_resolution_adapter.dart';
 import '../../../data/models/image/image_params.dart';
 import '../../providers/image_generation_provider.dart';
+import 'generation_image_read_contract.dart';
 import 'generation_preparation_runtime.dart';
 import 'generation_tool_results.dart';
 import 'generation_workspace_path_resolver.dart';
@@ -20,17 +19,15 @@ class GenerationExecutionService {
   GenerationExecutionService(
     this._ref, {
     required GenerationWorkspacePathResolver pathResolver,
+    required GenerationImageReadContract imageReadContract,
     required int maxGenerateCount,
-    required AgentChatResourceReference Function(String imageId)
-    generatedImageReference,
   }) : _pathResolver = pathResolver,
-       _maxGenerateCount = maxGenerateCount,
-       _generatedImageReference = generatedImageReference;
+       _imageReadContract = imageReadContract,
+       _maxGenerateCount = maxGenerateCount;
   final Ref _ref;
   final GenerationWorkspacePathResolver _pathResolver;
+  final GenerationImageReadContract _imageReadContract;
   final int _maxGenerateCount;
-  final AgentChatResourceReference Function(String imageId)
-  _generatedImageReference;
   Future<AgentToolResult> generate(
     String toolCallId,
     Map<String, dynamic> args, [
@@ -255,16 +252,11 @@ class GenerationExecutionService {
       final savedFiles = <String>[];
       for (final image
           in _ref.read(imageGenerationNotifierProvider).currentImages) {
-        final reference = _generatedImageReference(image.id);
-        if (image.filePath case final path?) savedFiles.add(path);
-        report.add({
-          'seed': image.metadata?.seed,
-          'size': '${image.width}x${image.height}',
-          'saved': image.filePath != null,
-          'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(
-            reference,
-          ),
-        });
+        final descriptor = await _imageReadContract.describe(image);
+        if (descriptor.saved) {
+          if (image.filePath case final path?) savedFiles.add(path);
+        }
+        report.add(descriptor.toModelJson());
       }
       final content = <ToolResultContent>[
         ToolResultTextContent(jsonEncode({'ok': true, 'images': report})),

--- a/lib/presentation/agent_chat/services/generation_history_service.dart
+++ b/lib/presentation/agent_chat/services/generation_history_service.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/agent/agent_types.dart';
@@ -10,22 +9,22 @@ import '../../../core/utils/display_thumbnail_utils.dart';
 import '../../providers/image_generation_provider.dart';
 import 'agent_resource_resolver.dart';
 import 'defined_agent_tool.dart';
+import 'generation_image_read_contract.dart';
 import 'generation_image_resource.dart';
 import 'generation_tool_results.dart';
-import 'generation_workspace_path_resolver.dart';
 
 class GenerationHistoryService {
   GenerationHistoryService(
     this._ref, {
     required AgentResourceResolver resourceResolver,
-    required GenerationWorkspacePathResolver pathResolver,
+    required GenerationImageReadContract imageReadContract,
     required int maxRecentImageLimit,
   }) : _resourceResolver = resourceResolver,
-       _pathResolver = pathResolver,
+       _imageReadContract = imageReadContract,
        _maxRecentImageLimit = maxRecentImageLimit;
   final Ref _ref;
   final AgentResourceResolver _resourceResolver;
-  final GenerationWorkspacePathResolver _pathResolver;
+  final GenerationImageReadContract _imageReadContract;
   final int _maxRecentImageLimit;
   Future<AgentToolResult> recentImages(Map<String, dynamic> args) async {
     final rawLimit = args['limit'];
@@ -48,18 +47,9 @@ class GenerationHistoryService {
     final report = <Map<String, dynamic>>[];
     for (final image in history) {
       if (image.isFailedStreamSnapshot) continue;
-      final filePath = image.filePath;
-      if (filePath == null || !await File(filePath).exists()) continue;
-      final readablePath = _pathResolver.readableRelativePath(filePath);
-      if (readablePath == null) continue;
-      report.add({
-        'seed': image.metadata?.seed,
-        'size': '${image.width}x${image.height}',
-        'path': readablePath,
-        'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(
-          generatedImageReference(image.id),
-        ),
-      });
+      final descriptor = await _imageReadContract.describe(image);
+      if (descriptor.readPath == null) continue;
+      report.add(descriptor.toModelJson());
       if (report.length == limit) break;
     }
     if (report.isEmpty) {
@@ -137,7 +127,4 @@ class GenerationHistoryService {
       details: details,
     );
   }
-
-  AgentChatResourceReference generatedImageReference(String imageId) =>
-      generationImageResourceReference(imageId);
 }

--- a/lib/presentation/agent_chat/services/generation_image_read_contract.dart
+++ b/lib/presentation/agent_chat/services/generation_image_read_contract.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
+import '../../providers/image_generation_provider.dart';
+import 'generation_image_resource.dart';
+import 'generation_workspace_path_resolver.dart';
+
+/// Defines the only model-visible bridge between an application-owned
+/// generated image and the file-system `read` tool.
+final class GenerationImageReadContract {
+  const GenerationImageReadContract(this._pathResolver);
+
+  final GenerationWorkspacePathResolver _pathResolver;
+
+  AgentChatResourceReference resourceReference(String imageId) =>
+      generationImageResourceReference(imageId);
+
+  Future<GenerationImageReadDescriptor> describe(GeneratedImage image) async {
+    final filePath = image.filePath;
+    final saved = filePath != null && await File(filePath).exists();
+    final readPath = saved
+        ? await _pathResolver.readPathForExistingFile(filePath)
+        : null;
+    return GenerationImageReadDescriptor(
+      image: image,
+      resourceReference: resourceReference(image.id),
+      saved: saved,
+      readPath: readPath,
+    );
+  }
+}
+
+final class GenerationImageReadDescriptor {
+  const GenerationImageReadDescriptor({
+    required this.image,
+    required this.resourceReference,
+    required this.saved,
+    required this.readPath,
+  });
+
+  final GeneratedImage image;
+  final AgentChatResourceReference resourceReference;
+  final bool saved;
+
+  /// Exact workspace-relative argument accepted by the current `read` tool.
+  /// Null means no file path may be exposed for this image.
+  final String? readPath;
+
+  Map<String, dynamic> toModelJson() => {
+    'seed': image.metadata?.seed,
+    'size': '${image.width}x${image.height}',
+    'saved': saved,
+    if (readPath case final path?) 'path': path,
+    'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(
+      resourceReference,
+    ),
+  };
+}

--- a/lib/presentation/agent_chat/services/generation_tool_definitions.dart
+++ b/lib/presentation/agent_chat/services/generation_tool_definitions.dart
@@ -172,8 +172,10 @@ class GenerationToolDefinitions {
             'text-to-image regardless of the generation page img2img '
             'state. '
             'If a generation is already running, this waits up to 300s and '
-            'runs in order. Returns the saved file paths plus thumbnails, '
-            'which appear in the chat. For normal "draw/generate" requests '
+            'runs in order. Each saved image returns path as the exact '
+            'workspace-relative argument for read plus an application-owned '
+            'resource_ref; never derive one from the other. Thumbnails appear '
+            'in the chat. For normal "draw/generate" requests '
             'always use this tool instead of queue_image_task.',
         parameters: const {
           'type': 'object',
@@ -338,9 +340,11 @@ class GenerationToolDefinitions {
         label: 'Get Recent Images',
         description:
             'Return the newest saved generation-history images (including '
-            'queue outputs) with read-safe workspace-relative paths and '
-            'stable resource references. Never derive a filename from a '
-            'resource ID. "limit" is required on every call. When the user '
+            'queue outputs) using the same contract as generate_image: path '
+            'is the exact workspace-relative argument for read and '
+            'resource_ref is the application-owned identity for resource '
+            'tools. Never derive one from the other. "limit" is required on '
+            'every call. When the user '
             'requests a specific number, pass that exact number.',
         parameters: const {
           'type': 'object',

--- a/lib/presentation/agent_chat/services/generation_toolbox.dart
+++ b/lib/presentation/agent_chat/services/generation_toolbox.dart
@@ -7,6 +7,7 @@ import 'agent_resource_resolver.dart';
 import 'generation_anlas_estimator.dart';
 import 'generation_execution_service.dart';
 import 'generation_history_service.dart';
+import 'generation_image_read_contract.dart';
 import 'generation_interrogation_service.dart';
 import 'generation_preparation_runtime.dart';
 import 'generation_preparation_service.dart';
@@ -35,17 +36,18 @@ class GenerationToolbox {
       workspaceDir: workspaceDir,
       allowOutsideWorkspace: allowOutsideWorkspace,
     );
+    final imageReadContract = GenerationImageReadContract(pathResolver);
     final history = GenerationHistoryService(
       ref,
       resourceResolver: resolver,
-      pathResolver: pathResolver,
+      imageReadContract: imageReadContract,
       maxRecentImageLimit: maxRecentImageLimit,
     );
     final execution = GenerationExecutionService(
       ref,
       pathResolver: pathResolver,
+      imageReadContract: imageReadContract,
       maxGenerateCount: maxGenerateCount,
-      generatedImageReference: history.generatedImageReference,
     );
     final queue = GenerationQueueTaskService(
       ref,
@@ -67,7 +69,7 @@ class GenerationToolbox {
       preparation: preparation,
       status: GenerationStatusService(
         ref,
-        generatedImageReference: history.generatedImageReference,
+        generatedImageReference: imageReadContract.resourceReference,
       ),
       settings: GenerationSettingsService(ref),
       history: history,

--- a/lib/presentation/agent_chat/services/generation_workspace_path_resolver.dart
+++ b/lib/presentation/agent_chat/services/generation_workspace_path_resolver.dart
@@ -13,19 +13,31 @@ class GenerationWorkspacePathResolver {
          p.absolute(workspaceDir ?? Directory.current.path),
        ),
        _fileEnv = DartIoExecutionEnv(
-         workingDirectory: workspaceDir,
+         workingDirectory: p.normalize(
+           p.absolute(workspaceDir ?? Directory.current.path),
+         ),
          allowOutsideWorkingDirectory: allowOutsideWorkspace,
        );
 
   final String _workspaceDir;
   final DartIoExecutionEnv _fileEnv;
 
-  String? readableRelativePath(String filePath) {
-    final absolutePath = p.normalize(
-      p.isAbsolute(filePath) ? filePath : p.join(_workspaceDir, filePath),
-    );
+  /// Returns the exact relative argument accepted by the `read` tool, but
+  /// only after the same execution environment proves that the existing file
+  /// resolves back to that path inside the configured workspace.
+  Future<String?> readPathForExistingFile(String filePath) async {
+    final absoluteResult = await _fileEnv.absolutePath(filePath);
+    final absolutePath = absoluteResult.valueOrNull;
+    if (absolutePath == null || !await File(absolutePath).exists()) return null;
     if (!p.isWithin(_workspaceDir, absolutePath)) return null;
-    return p.relative(absolutePath, from: _workspaceDir);
+
+    final relativePath = p.relative(absolutePath, from: _workspaceDir);
+    final roundTripResult = await _fileEnv.absolutePath(relativePath);
+    final roundTripPath = roundTripResult.valueOrNull;
+    if (roundTripPath == null || !p.equals(roundTripPath, absolutePath)) {
+      return null;
+    }
+    return relativePath;
   }
 
   Future<String> resolveLocalImagePath(String rawPath) async {

--- a/test/presentation/agent_chat/services/agent_system_prompt_test.dart
+++ b/test/presentation/agent_chat/services/agent_system_prompt_test.dart
@@ -23,5 +23,19 @@ void main() {
         'compare, inspect, or analyze the image.',
       ),
     );
+    expect(
+      prompt,
+      contains(
+        'path is the exact workspace-relative argument for read, while '
+        'resource_ref is an application-owned identity',
+      ),
+    );
+    expect(
+      prompt,
+      contains(
+        'Never turn resource_ref/resourceId into a path, filename, or '
+        'extension.',
+      ),
+    );
   });
 }

--- a/test/presentation/agent_chat/services/execution_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/execution_toolbox_test.dart
@@ -59,6 +59,17 @@ void main() {
     );
   });
 
+  test('read never guesses a typographic filename variant', () async {
+    await File(
+      '${tmp.path}${Platform.pathSeparator}model’s image.png',
+    ).writeAsBytes(const [1, 2, 3]);
+
+    await expectLater(
+      tool('read').execute('t6-exact', {'path': "model's image.png"}),
+      throwsA(isA<Object>()),
+    );
+  });
+
   test('read rejects parent traversal outside the workspace', () async {
     final outside = File(
       '${tmp.parent.path}${Platform.pathSeparator}outside-${tmp.path.hashCode}.txt',

--- a/test/presentation/agent_chat/services/generation_image_read_contract_test.dart
+++ b/test/presentation/agent_chat/services/generation_image_read_contract_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as image_lib;
+import 'package:nai_launcher/core/agent/agent_types.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/execution_toolbox.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_image_read_contract.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/generation_workspace_path_resolver.dart';
+import 'package:nai_launcher/presentation/providers/image_generation_provider.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  test('returned Windows path is the exact first-call read argument', () async {
+    final workspace = await Directory.systemTemp.createTemp(
+      'generation-read-contract-',
+    );
+    addTearDown(() => workspace.delete(recursive: true));
+    final bytes = Uint8List.fromList(
+      image_lib.encodePng(image_lib.Image(width: 1, height: 1)),
+    );
+    final file = File(
+      '${workspace.path}${Platform.pathSeparator}2026-08-30'
+      '${Platform.pathSeparator}real-seed-name.png',
+    );
+    await file.create(recursive: true);
+    await file.writeAsBytes(bytes);
+    final image = GeneratedImage(
+      id: '7df4051f-3b9b-4a4c-91f3-ebc4517c8df1',
+      bytes: bytes,
+      width: 832,
+      height: 1216,
+      filePath: file.path,
+    );
+    final contract = GenerationImageReadContract(
+      GenerationWorkspacePathResolver(workspaceDir: workspace.path),
+    );
+
+    final descriptor = await contract.describe(image);
+    final json = descriptor.toModelJson();
+
+    expect(
+      json['path'],
+      '2026-08-30${Platform.pathSeparator}real-seed-name.png',
+    );
+    expect(json['path'], isNot(contains(image.id)));
+    expect(json.toString(), isNot(contains(workspace.path)));
+    expect(json['resource_ref']['resourceId'], image.id);
+
+    final result = await ExecutionToolbox(
+      workspace.path,
+    ).tools().single.execute('read-image', {'path': json['path']});
+    expect(result.isError, isFalse);
+    expect(result.content.whereType<ToolResultImageContent>(), hasLength(1));
+  });
+
+  test(
+    'restored history keeps identity and read path without relocation',
+    () async {
+      final workspace = await Directory.systemTemp.createTemp(
+        'generation-read-restore-',
+      );
+      addTearDown(() => workspace.delete(recursive: true));
+      final file = File(
+        '${workspace.path}${Platform.pathSeparator}archive'
+        '${Platform.pathSeparator}restored.webp',
+      );
+      await file.create(recursive: true);
+      await file.writeAsBytes(const [0x52, 0x49, 0x46, 0x46]);
+      final restored = GeneratedImage(
+        id: 'persisted-resource-id',
+        bytes: Uint8List.fromList(const [0x52, 0x49, 0x46, 0x46]),
+        width: 640,
+        height: 640,
+        filePath: file.path,
+      );
+
+      final relativeWorkspace = p.relative(
+        workspace.path,
+        from: Directory.current.path,
+      );
+      final descriptor = await GenerationImageReadContract(
+        GenerationWorkspacePathResolver(workspaceDir: relativeWorkspace),
+      ).describe(restored);
+
+      expect(descriptor.resourceReference.resourceId, 'persisted-resource-id');
+      expect(
+        descriptor.readPath,
+        'archive${Platform.pathSeparator}restored.webp',
+      );
+    },
+  );
+
+  test('does not expose or guess a path outside the read workspace', () async {
+    final workspace = await Directory.systemTemp.createTemp(
+      'generation-read-boundary-',
+    );
+    final outside = await Directory.systemTemp.createTemp(
+      'generation-read-outside-',
+    );
+    addTearDown(() async {
+      await workspace.delete(recursive: true);
+      await outside.delete(recursive: true);
+    });
+    final file = await File(
+      '${outside.path}${Platform.pathSeparator}resource-id.png',
+    ).writeAsBytes(const [1, 2, 3]);
+    final image = GeneratedImage(
+      id: 'resource-id',
+      bytes: Uint8List.fromList(const [1, 2, 3]),
+      width: 1,
+      height: 1,
+      filePath: file.path,
+    );
+    final descriptor = await GenerationImageReadContract(
+      GenerationWorkspacePathResolver(workspaceDir: workspace.path),
+    ).describe(image);
+
+    expect(descriptor.saved, isTrue);
+    expect(descriptor.readPath, isNull);
+    expect(descriptor.toModelJson(), isNot(contains('path')));
+  });
+}

--- a/test/presentation/agent_chat/services/generation_toolbox_test.dart
+++ b/test/presentation/agent_chat/services/generation_toolbox_test.dart
@@ -24,6 +24,7 @@ import 'package:nai_launcher/data/models/image/image_params.dart'
 import 'package:nai_launcher/data/models/queue/replication_task.dart';
 import 'package:nai_launcher/data/models/queue/replication_task_generation_snapshot.dart';
 import 'package:nai_launcher/data/models/user/user_subscription.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/execution_toolbox.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/generation_toolbox.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/generation_preparation_runtime.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/agent_resource_resolver.dart';
@@ -624,9 +625,21 @@ void main() {
   );
 
   test(
-    'prepare lifecycle estimates before fake generation provider is called',
+    'prepare lifecycle returns a path that read accepts without translation',
     () async {
-      final fake = _FakeImageGenerationNotifier();
+      final workspace = await Directory.systemTemp.createTemp(
+        'generation-submit-contract-',
+      );
+      addTearDown(() => workspace.delete(recursive: true));
+      final savedFile = File(
+        '${workspace.path}${Platform.pathSeparator}dated'
+        '${Platform.pathSeparator}actual-name.png',
+      );
+      await savedFile.create(recursive: true);
+      await savedFile.writeAsBytes(
+        image_lib.encodePng(image_lib.Image(width: 1, height: 1)),
+      );
+      final fake = _FakeImageGenerationNotifier(savedFile.path);
       final container = ProviderContainer(
         overrides: [
           imageGenerationNotifierProvider.overrideWith(() => fake),
@@ -643,7 +656,10 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
-      final tools = GenerationToolbox(_makeRef(container)).tools();
+      final tools = GenerationToolbox(
+        _makeRef(container),
+        workspaceDir: workspace.path,
+      ).tools();
       final prepare = tools.firstWhere(
         (tool) => tool.name == 'prepare_generation',
       );
@@ -700,7 +716,26 @@ void main() {
           .source;
       expect(imageSource.mimeType, 'image/png');
       expect(imageSource.base64Data, isNotEmpty);
-      expect(submitted.details['files'], ['saved.png']);
+      expect(submitted.details['files'], [savedFile.path]);
+      final submittedJson = _json(submitted);
+      expect(submittedJson['images'], hasLength(1));
+      final generated = (submittedJson['images'] as List).single as Map;
+      expect(
+        generated['path'],
+        'dated${Platform.pathSeparator}actual-name.png',
+      );
+      expect(generated['resource_ref']['resourceId'], 'generated-1');
+      expect(generated['path'], isNot(contains('generated-1')));
+
+      final read = ExecutionToolbox(workspace.path).tools().single;
+      final readResult = await read.execute('read-generated', {
+        'path': generated['path'],
+      });
+      expect(readResult.isError, isFalse);
+      expect(
+        readResult.content.whereType<ToolResultImageContent>(),
+        hasLength(1),
+      );
 
       final replayed = await submit.execute('submit-replayed', {
         'preparation_id': payload['preparation_id'],
@@ -824,16 +859,19 @@ void main() {
       'generation-history-',
     );
     addTearDown(() => workspace.delete(recursive: true));
+    final imageBytes = Uint8List.fromList(
+      image_lib.encodePng(image_lib.Image(width: 1, height: 1)),
+    );
     final history = [
       for (var index = 0; index < 25; index++)
         GeneratedImage(
           id: 'image-$index',
-          bytes: Uint8List(0),
+          bytes: imageBytes,
           width: 832,
           height: 1216,
           filePath: (await File(
             '${workspace.path}/image-$index.png',
-          ).writeAsBytes(const [])).path,
+          ).writeAsBytes(imageBytes)).path,
         ),
       GeneratedImage(
         id: 'unsaved',
@@ -883,6 +921,15 @@ void main() {
     expect(
       jsonEncode(requestedResult.details),
       isNot(contains(workspace.path)),
+    );
+
+    final readResult = await ExecutionToolbox(
+      workspace.path,
+    ).tools().single.execute('read-recent', {'path': images.first['path']});
+    expect(readResult.isError, isFalse);
+    expect(
+      readResult.content.whereType<ToolResultImageContent>(),
+      hasLength(1),
     );
   });
 
@@ -1061,6 +1108,9 @@ class _TestImageGenerationNotifier extends ImageGenerationNotifier {
 }
 
 class _FakeImageGenerationNotifier extends ImageGenerationNotifier {
+  _FakeImageGenerationNotifier([this.savedPath = 'saved.png']);
+
+  final String savedPath;
   int generateCalls = 0;
   int? batchSize;
   ImageParams? params;
@@ -1089,7 +1139,7 @@ class _FakeImageGenerationNotifier extends ImageGenerationNotifier {
           ),
           width: 1,
           height: 1,
-          filePath: 'saved.png',
+          filePath: savedPath,
         ),
       ],
     );


### PR DESCRIPTION
## 根因

`get_recent_images` 会返回经过工作区换算的真实相对路径，但直接生成完成后的 `generate_image` / `submit_generation` 结果只返回 `resource_ref`，没有返回可供 `read` 使用的路径。模型因此把资源 ID 当作文件名，拼出 `<resourceId>.png`，与实际按日期/seed 保存的文件名不一致，第一次 `read` 触发 `FileError(notFound)`，之后重新查询历史才拿到真实路径。

此外，原 `read` 路径解析还会在文件不存在时尝试弯引号/特殊空格文件名变体，无法保证“返回什么就精确读取什么”。

## 行为

- 新增统一 `GenerationImageReadContract`：
  - `path` 仅在文件真实存在、位于 read 工作区内且可由同一执行环境精确 round-trip 时返回；
  - `path` 是可直接传给 `read` 的唯一工作区相对路径；
  - `resource_ref` 继续作为应用拥有的稳定资源身份，仅用于预览、显示和后续资源操作，绝不作为文件名；
  - `generate_image` 与 `get_recent_images` 共用同一序列化契约。
- 系统提示词和工具描述明确区分 `path` 与 `resource_ref`，禁止从资源 ID 猜路径/扩展名。
- `read` 不再静默尝试 typographic filename fallback；不存在的精确路径直接报错。
- 工作区解析统一绝对化，并保留 canonical boundary / symlink 越界防护与现有 full-access 权限边界。
- 会话恢复后的持久化 `GeneratedImage.filePath` 和资源 ID 仍通过同一契约恢复，不迁移、不重命名、不建立第二套资源所有权。

## 验证

- `flutter test test/presentation/agent_chat/services/generation_image_read_contract_test.dart test/presentation/agent_chat/services/generation_toolbox_test.dart test/presentation/agent_chat/services/execution_toolbox_test.dart test/presentation/agent_chat/services/agent_system_prompt_test.dart`
  - 37 tests passed
  - 覆盖真实生成返回路径第一次直接 `read`、`get_recent_images` 直接 `read`、Windows 分隔符、相对工作区、恢复历史、越界路径不暴露、资源 ID 不参与文件名、禁止 typographic fallback。
- `flutter analyze`（12 个受影响源码/测试文件）
  - No issues found
- `git diff --check`
  - passed

未执行任何真实图片生成，未消耗 Anlas，未访问或暴露 token，也未操作主工作区热重载会话。