### PR TITLE
fix(agent): 对齐 Pi 会话恢复语义

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,10 @@ Windows release 产物位于 `build/windows/x64/runner/Release/`。macOS 使用 
 
 遵循 `analysis_options.yaml` 和 Dart 默认格式化规则，使用两个空格缩进。变量和方法使用 `lowerCamelCase`，类型使用 `UpperCamelCase`。Riverpod provider 命名应以 `Provider` 或 `NotifierProvider` 结尾。新增功能优先复用现有 service、provider、widget 和 utility，保持 `core`、`data`、`presentation` 的职责边界清晰。
 
+### Pi Harness 上游对齐
+
+`lib/core/agent/harness/` 及其持久会话协议以 Pi 官方实现为唯一事实来源。排查 Harness 问题时必须先查看本机已安装的 `@earendil-works/pi-agent-core` 源码及 `https://github.com/earendil-works/pi` 对应实现，并以官方行为为准定位和修复；修改 Harness 的类型、记录格式、状态归约、恢复/续跑、队列、回放、错误语义或存储约束时，能够移植的直接等价移植，并同步相关 conformance/regression tests，不得自行发明替代协议、额外 outcome 或自动修复语义。Launcher 特有的 UI 和业务适配放在 Harness 边界之外；若 Pi 尚未实现某项能力，应明确保留边界，不在 Harness 内创建第二套事实来源。
+
 ### Dart / Flutter 代码组织约定
 
 1. **关注文件规模**：行数是职责和可维护性的风险信号，不是强制拆分门槛。业务代码接近 800 行时关注职责、可读性和后续扩展成本；超过 1000 行时必须仔细评估是否应按职责拆分。若文件仍保持单一职责和高内聚，或拆分会制造更差的跨文件耦合，可以保留并说明理由；不得仅为满足行数机械拆分。生成代码、大型枚举和静态常量表不参与规模判断。

--- a/lib/presentation/agent_chat/providers/agent_chat_notifier.dart
+++ b/lib/presentation/agent_chat/providers/agent_chat_notifier.dart
@@ -39,6 +39,7 @@ import '../services/agent_api_client.dart';
 import '../services/agent_chat_draft_controller.dart';
 import '../services/agent_chat_event_controller.dart';
 import '../services/agent_chat_session_controller.dart';
+import '../services/agent_chat_session_recovery.dart';
 import '../services/agent_chat_model_capability.dart';
 import '../services/agent_stream_bridge.dart';
 import '../services/agent_system_prompt.dart';
@@ -1046,8 +1047,11 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
 
     try {
       await previousDispatch;
+      if (state.sessionTransitioning) return false;
+      final dispatchSessionId = state.activeSessionId;
+      if (!await validatePendingResourcesForSend()) return false;
       if (state.sessionTransitioning ||
-          !await validatePendingResourcesForSend()) {
+          state.activeSessionId != dispatchSessionId) {
         return false;
       }
       final agent = _sessionController.agent;
@@ -1065,11 +1069,19 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
           : _draftController.resourcePromptMessage(message, attachedResources);
 
       if (_runActive) {
-        if (followUp) {
-          agent.followUp(promptMessage);
-        } else {
-          agent.steer(promptMessage);
-        }
+        await _sessionController.acceptQueuedPrompt(
+          promptMessage,
+          followUp
+              ? session_types.QueueKind.followUp
+              : session_types.QueueKind.steer,
+          enqueue: () {
+            if (followUp) {
+              agent.followUp(promptMessage);
+            } else {
+              agent.steer(promptMessage);
+            }
+          },
+        );
         await _draftController.consumePendingResources(attachedResources);
         state = state.copyWith(queuedMessages: _queuedMessages(agent));
         await onAccepted?.call();
@@ -1078,6 +1090,13 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
 
       ownsRun = true;
       _preparingRun = true;
+      state = state.copyWith(
+        status: AgentChatRunStatus.running,
+        error: '',
+        activities: const [],
+        clearStreamingMessage: true,
+        workPhase: AgentChatWorkPhase.preparing,
+      );
       await _settingsRefresh;
       if (_settingsApplyPending) await _applyAgentSettings();
       _refreshRoute();
@@ -1088,6 +1107,10 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
               : 'No LLM provider configured. Open Settings to add one.',
         );
         _preparingRun = false;
+        state = state.copyWith(
+          status: AgentChatRunStatus.idle,
+          workPhase: AgentChatWorkPhase.idle,
+        );
         return false;
       }
       final agentSettings = _ref.read(agentSettingsProvider).settings;
@@ -1107,14 +1130,42 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
       agent.setSystemPrompt(
         await _buildSystemPrompt(settingsOverride: agentSettings),
       );
-      state = state.copyWith(
-        status: AgentChatRunStatus.running,
-        error: '',
-        activities: const [],
-        clearStreamingMessage: true,
-        workPhase: AgentChatWorkPhase.preparing,
-      );
-      run = agent.prompt(promptMessage);
+      final resumeSuspendedRun = _sessionController.hasSuspendedRun;
+      AgentChatSuspendedRecovery? recovery;
+      if (resumeSuspendedRun) {
+        recovery = await _sessionController.restoreSuspendedRun();
+        agent.state.messages.addAll(
+          recovery.transcriptEntries.map((entry) => entry.message),
+        );
+        await _sessionController.acceptQueuedPrompt(
+          promptMessage,
+          session_types.QueueKind.steer,
+          enqueue: () {},
+        );
+      } else {
+        _sessionController.prepareRunPrompt(promptMessage);
+        await _sessionController.startTurn();
+      }
+      if (!resumeSuspendedRun) {
+        run = agent.prompt(promptMessage);
+      } else if (agent.state.messages.isEmpty) {
+        for (final queued in recovery!.followUpMessages) {
+          agent.followUp(queued.message);
+        }
+        run = agent.prompt([
+          ...recovery.steeringMessages.map((queued) => queued.message),
+          promptMessage,
+        ]);
+      } else {
+        for (final queued in recovery!.steeringMessages) {
+          agent.steer(queued.message);
+        }
+        for (final queued in recovery.followUpMessages) {
+          agent.followUp(queued.message);
+        }
+        agent.steer(promptMessage);
+        run = agent.continueRun();
+      }
       runAgent = agent;
       _preparingRun = false;
       await _draftController.consumePendingResources(attachedResources);
@@ -1177,9 +1228,10 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
       ),
   ];
 
-  AgentMessage? removeQueuedMessage(AgentQueuedMessage queued) {
+  Future<AgentMessage?> removeQueuedMessage(AgentQueuedMessage queued) async {
     final agent = _sessionController.agent;
     if (agent == null) return null;
+    await _sessionController.cancelQueuedPrompt(queued.message);
     final message = switch (queued.kind) {
       AgentQueuedMessageKind.steering => agent.removeSteeringById(queued.id),
       AgentQueuedMessageKind.followUp => agent.removeFollowUpById(queued.id),
@@ -1188,9 +1240,12 @@ class AgentChatNotifier extends StateNotifier<AgentChatState> {
     return message;
   }
 
-  void clearQueuedMessages() {
+  Future<void> clearQueuedMessages() async {
     final agent = _sessionController.agent;
     if (agent == null) return;
+    for (final queued in _queuedMessages(agent)) {
+      await _sessionController.cancelQueuedPrompt(queued.message);
+    }
     agent.clearAllQueues();
     state = state.copyWith(queuedMessages: const []);
   }

--- a/lib/presentation/agent_chat/services/agent_chat_event_controller.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_event_controller.dart
@@ -202,6 +202,14 @@ class AgentChatEventController {
         }
         final failed = lastAssistant?.stopReason == StopReason.error;
         final aborted = lastAssistant?.stopReason == StopReason.aborted;
+        final agent = _sessionController.agent;
+        if (agent != null) {
+          final unconsumed = _queuedMessages(agent);
+          for (final queued in unconsumed) {
+            await _sessionController.cancelQueuedPrompt(queued.message);
+          }
+          agent.clearAllQueues();
+        }
         if (turnId != null) {
           await _sessionController.finishTurn(
             turnId: turnId,
@@ -216,7 +224,6 @@ class AgentChatEventController {
         if (runContext != null) {
           _runContexts.remove(runContext);
         }
-        final agent = _sessionController.agent;
         _writeState(
           _readState().copyWith(
             activities: const [],
@@ -227,36 +234,9 @@ class AgentChatEventController {
         );
       case AgentEventTurnEnd():
         final message = event.message;
-        final failure =
-            message is AssistantMessage &&
-            message.stopReason == StopReason.error;
-        final aborted =
-            message is AssistantMessage &&
-            message.stopReason == StopReason.aborted;
-        final completesUserTurn =
-            message is AssistantMessage &&
-            (failure ||
-                aborted ||
-                (message.toolCalls.isEmpty &&
-                    message.stopReason != StopReason.toolUse));
-        final runContext = _contextWithActiveTurn;
-        final turnId = runContext?.currentTurnId;
-        if (completesUserTurn && turnId != null) {
-          await _sessionController.finishTurn(
-            turnId: turnId,
-            outcome: failure
-                ? session_types.OperationOutcomeKind.failed
-                : aborted
-                ? session_types.OperationOutcomeKind.aborted
-                : session_types.OperationOutcomeKind.completed,
-            error: failure ? message.errorMessage : null,
-          );
-          if (runContext != null && runContext.currentTurnId == turnId) {
-            runContext
-              ..lastTurnId = turnId
-              ..currentTurnId = null;
-          }
-        }
+        // A Pi run operation spans the complete Agent lifecycle. Individual
+        // assistant turns may still be followed by steering, tools, or
+        // follow-up input, so only AgentEnd may persist operation_finished.
         if (message is AssistantMessage &&
             message.errorMessage != null &&
             message.stopReason == StopReason.error) {

--- a/lib/presentation/agent_chat/services/agent_chat_session_controller.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_session_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -20,6 +21,7 @@ import '../providers/agent_chat_session_view.dart';
 import '../providers/agent_chat_state.dart';
 import '../models/agent_chat_turn_timeline.dart';
 import 'agent_chat_draft_controller.dart';
+import 'agent_chat_session_recovery.dart';
 
 class AgentChatRewindCheckpoint {
   const AgentChatRewindCheckpoint({
@@ -77,11 +79,19 @@ class AgentChatSessionController {
   final List<session_types.LaneRecord> _visibleRecords = [];
   String? _activeTurnId;
   String? _activeAssistantEntryId;
+  session_types.OperationStartedRecord? _openOperation;
+  AgentMessage? _pendingRunPrompt;
   final Set<String> _finishedTurnIds = {};
   final Set<String> _finishingTurnIds = {};
+  final Set<String> _endingTurnIds = {};
+  final Map<Message, String> _pendingAcceptedMessageEntryIds = Map.identity();
   final Map<String, String> _pendingToolResultEntryIds = {};
+  Future<void> _operationMutation = Future.value();
 
   String? get activeTurnId => _activeTurnId;
+  bool get hasSuspendedRun =>
+      _activeTurnId == null &&
+      _openOperation?.intent.kind == session_types.RunIntentKind.run;
 
   Future<void> restoreLastSession() async {
     final sessions = await listSessions();
@@ -119,19 +129,22 @@ class AgentChatSessionController {
 
   Future<void> activateSession(String sessionId) async {
     await agent?.waitForIdle();
-    final metadata = (await _repository.list()).firstWhere(
-      (item) => item.id == sessionId,
-      orElse: () => session_types.SessionMetadata(
-        id: sessionId,
-        createdAt: DateTime.now().millisecondsSinceEpoch,
-      ),
+    final metadata = (await _repository.list())
+        .where((item) => item.id == sessionId)
+        .firstOrNull;
+    final nextSession = metadata == null
+        ? await _repository.create(
+            session_types.SessionCreateOptions(id: sessionId),
+          )
+        : await _repository.open(metadata);
+    final suspendedOperations = await nextSession.findOpenOperations(
+      'main',
+      limit: 2,
     );
-    Session nextSession;
-    try {
-      nextSession = await _repository.open(metadata);
-    } catch (_) {
-      nextSession = await _repository.create(
-        session_types.SessionCreateOptions(id: sessionId),
+    if (suspendedOperations.length > 1) {
+      throw session_types.SessionError(
+        session_types.SessionErrorCode.storage,
+        'Lane main has at least two open operations',
       );
     }
     final nextAgent = await _buildAgent();
@@ -181,6 +194,8 @@ class AgentChatSessionController {
       ..addAll(recentRecords);
     _activeTurnId = null;
     _activeAssistantEntryId = null;
+    _openOperation = suspendedOperations.firstOrNull;
+    _pendingRunPrompt = null;
     _finishedTurnIds
       ..clear()
       ..addAll(
@@ -189,6 +204,8 @@ class AgentChatSessionController {
         ),
       );
     _finishingTurnIds.clear();
+    _endingTurnIds.clear();
+    _pendingAcceptedMessageEntryIds.clear();
     _pendingToolResultEntryIds.clear();
     final timelinePage = _buildVisibleTimelinePage(
       hasEarlier: entries.length > recentEntries.length,
@@ -321,21 +338,161 @@ class AgentChatSessionController {
     }
   }
 
-  Future<String?> startTurn() async {
+  void prepareRunPrompt(AgentMessage prompt) {
+    final openOperation = _openOperation;
+    if (openOperation != null) {
+      throw session_types.SessionError(
+        session_types.SessionErrorCode.storage,
+        'Cannot start a chat run while ${openOperation.intent.kind.name} '
+        'operation ${openOperation.id} is suspended',
+      );
+    }
+    _pendingRunPrompt = prompt;
+  }
+
+  Future<AgentChatSuspendedRecovery> restoreSuspendedRun() async {
+    final currentSession = session;
+    final operation = _openOperation;
+    if (currentSession == null ||
+        operation == null ||
+        operation.intent.kind != session_types.RunIntentKind.run) {
+      return const AgentChatSuspendedRecovery();
+    }
+    final recovery = await AgentChatSessionRecovery.restore(
+      session: currentSession,
+      operation: operation,
+    );
+    for (final entry in recovery.transcriptEntries) {
+      _pendingAcceptedMessageEntryIds.remove(entry.message);
+      _visibleEntries.add(entry);
+    }
+    for (final queued in [
+      ...recovery.steeringMessages,
+      ...recovery.followUpMessages,
+    ]) {
+      _pendingAcceptedMessageEntryIds[queued.message] = queued.entryId;
+    }
+    if (recovery.transcriptEntries.isNotEmpty) {
+      _publishVisibleTimeline();
+    }
+    return recovery;
+  }
+
+  Future<void> acceptQueuedPrompt(
+    AgentMessage prompt,
+    session_types.QueueKind queue, {
+    required void Function() enqueue,
+  }) => _mutateOperation(() async {
+    final currentSession = session;
+    final operation = _openOperation;
+    if (currentSession == null ||
+        operation == null ||
+        operation.intent.kind != session_types.RunIntentKind.run) {
+      throw StateError('No open chat run can accept queued input');
+    }
+    if (_endingTurnIds.contains(operation.id)) {
+      throw StateError('The chat run is already ending');
+    }
+    final record = await AgentChatSessionRecovery.acceptPrompt(
+      session: currentSession,
+      operation: operation,
+      prompt: prompt,
+      queue: queue,
+    );
+    _visibleRecords.add(record);
+    if (_endingTurnIds.contains(operation.id)) {
+      final cancellation = await currentSession.appendRecord(
+        session_types.QueueCancelledRecord(
+          id: currentSession.idGenerator(),
+          lane: 'main',
+          entryId: record.target.id,
+          runId: operation.id,
+        ),
+      );
+      _visibleRecords.add(cancellation);
+      _publishVisibleTimeline();
+      throw StateError('The chat run ended before queued input was accepted');
+    }
+    _pendingAcceptedMessageEntryIds[prompt] = record.target.id;
+    enqueue();
+    _publishVisibleTimeline();
+  });
+
+  Future<void> cancelQueuedPrompt(AgentMessage prompt) =>
+      _mutateOperation(() async {
+        final currentSession = session;
+        final operation = _openOperation;
+        final entryId = _pendingAcceptedMessageEntryIds[prompt];
+        if (currentSession == null || operation == null || entryId == null) {
+          return;
+        }
+        final record = await currentSession.appendRecord(
+          session_types.QueueCancelledRecord(
+            id: currentSession.idGenerator(),
+            lane: 'main',
+            entryId: entryId,
+            runId: operation.id,
+          ),
+        );
+        _pendingAcceptedMessageEntryIds.remove(prompt);
+        _visibleRecords.add(record);
+        _publishVisibleTimeline();
+      });
+
+  Future<String?> startTurn() => _mutateOperation(_startTurn);
+
+  Future<String?> _startTurn() async {
     final currentSession = session;
     if (currentSession == null) return null;
+    final activeTurnId = _activeTurnId;
+    if (activeTurnId != null) return activeTurnId;
+
+    // Pi restore semantics treat one unfinished operation as suspended, and
+    // resume continues that operation instead of accepting a second start.
+    final openOperation = _openOperation;
+    if (openOperation != null) {
+      if (openOperation.intent.kind != session_types.RunIntentKind.run) {
+        throw session_types.SessionError(
+          session_types.SessionErrorCode.storage,
+          'Cannot resume ${openOperation.intent.kind.name} as a chat run',
+        );
+      }
+      _activeTurnId = openOperation.id;
+      _activeAssistantEntryId = null;
+      _publishVisibleTimeline();
+      return openOperation.id;
+    }
+
     final id = currentSession.idGenerator();
     final sourceLeafId = await currentSession.getLeafId();
-    final record = await currentSession.appendRecord(
-      session_types.OperationStartedRecord(
-        id: id,
-        lane: 'main',
-        sourceLeafId: sourceLeafId,
-        intent: const session_types.RunIntent(
-          kind: session_types.RunIntentKind.run,
-        ),
-      ),
-    );
+    final prompt = _pendingRunPrompt;
+    _pendingRunPrompt = null;
+    final initialMessages = prompt == null
+        ? const <session_types.MessageEntry>[]
+        : <session_types.MessageEntry>[
+            session_types.MessageEntry(
+              id: currentSession.idGenerator(),
+              message: prompt,
+            ),
+          ];
+    final record =
+        await currentSession.appendRecord(
+              session_types.OperationStartedRecord(
+                id: id,
+                lane: 'main',
+                sourceLeafId: sourceLeafId,
+                intent: session_types.RunIntent(
+                  kind: session_types.RunIntentKind.run,
+                  originalPrompt: prompt == null ? const [] : [prompt],
+                  initialMessages: initialMessages,
+                ),
+              ),
+            )
+            as session_types.OperationStartedRecord;
+    for (final entry in initialMessages) {
+      _pendingAcceptedMessageEntryIds[entry.message] = entry.id;
+    }
+    _openOperation = record;
     _activeTurnId = id;
     _activeAssistantEntryId = null;
     _visibleRecords.add(record);
@@ -344,6 +501,17 @@ class AgentChatSessionController {
   }
 
   Future<void> finishTurn({
+    required String turnId,
+    required session_types.OperationOutcomeKind outcome,
+    String? error,
+  }) {
+    _endingTurnIds.add(turnId);
+    return _mutateOperation(
+      () => _finishTurn(turnId: turnId, outcome: outcome, error: error),
+    ).whenComplete(() => _endingTurnIds.remove(turnId));
+  }
+
+  Future<void> _finishTurn({
     required String turnId,
     required session_types.OperationOutcomeKind outcome,
     String? error,
@@ -373,6 +541,10 @@ class AgentChatSessionController {
           _activeTurnId = null;
           _activeAssistantEntryId = null;
         }
+        if (_openOperation?.id == turnId) {
+          _openOperation = null;
+          _pendingAcceptedMessageEntryIds.clear();
+        }
         _publishVisibleTimeline();
         return;
       }
@@ -390,6 +562,10 @@ class AgentChatSessionController {
       if (_activeTurnId == turnId) {
         _activeTurnId = null;
         _activeAssistantEntryId = null;
+      }
+      if (_openOperation?.id == turnId) {
+        _openOperation = null;
+        _pendingAcceptedMessageEntryIds.clear();
       }
       _publishVisibleTimeline();
     } finally {
@@ -482,6 +658,18 @@ class AgentChatSessionController {
     final created = await _repository.create();
     final metadata = await created.getMetadata();
     await activateSession(metadata.id);
+  }
+
+  Future<T> _mutateOperation<T>(Future<T> Function() action) async {
+    final previous = _operationMutation;
+    final released = Completer<void>();
+    _operationMutation = released.future;
+    await previous;
+    try {
+      return await action();
+    } finally {
+      released.complete();
+    }
   }
 
   Future<void> _runTransition(
@@ -755,9 +943,11 @@ class AgentChatSessionController {
       return null;
     }
     try {
-      final preferredId = message is ToolResultMessage
-          ? _pendingToolResultEntryIds.remove(message.toolCallId)
-          : null;
+      final preferredId =
+          _pendingAcceptedMessageEntryIds.remove(message) ??
+          (message is ToolResultMessage
+              ? _pendingToolResultEntryIds.remove(message.toolCallId)
+              : null);
       final entry =
           await currentSession.appendEntry(
                 session_types.MessageEntry(

--- a/lib/presentation/agent_chat/services/agent_chat_session_recovery.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_session_recovery.dart
@@ -1,0 +1,188 @@
+import 'package:nai_launcher/core/agent/agent_types.dart';
+import 'package:nai_launcher/core/agent/harness/session/session.dart';
+import 'package:nai_launcher/core/agent/harness/session/session_types.dart'
+    as session_types;
+
+class AgentChatRecoveredQueueMessage {
+  const AgentChatRecoveredQueueMessage({
+    required this.message,
+    required this.entryId,
+  });
+
+  final AgentMessage message;
+  final String entryId;
+}
+
+class AgentChatSuspendedRecovery {
+  const AgentChatSuspendedRecovery({
+    this.transcriptEntries = const [],
+    this.steeringMessages = const [],
+    this.followUpMessages = const [],
+  });
+
+  final List<session_types.MessageEntry> transcriptEntries;
+  final List<AgentChatRecoveredQueueMessage> steeringMessages;
+  final List<AgentChatRecoveredQueueMessage> followUpMessages;
+}
+
+/// Applies persisted Pi suspended-run intents at the presentation boundary.
+///
+/// The durable Harness protocol stays in core; this adapter prepares its
+/// provisioned entries and queues for the legacy Agent loop to resume.
+abstract final class AgentChatSessionRecovery {
+  static Future<AgentChatSuspendedRecovery> restore({
+    required Session session,
+    required session_types.OperationStartedRecord operation,
+  }) async {
+    final transcriptEntries = <session_types.MessageEntry>[];
+
+    Future<void> appendProvisionedMessage(
+      session_types.MessageEntry provisioned,
+    ) async {
+      if (await session.getEntry(provisioned.id) != null) return;
+      final entry =
+          await session.appendEntry(
+                session_types.MessageEntry(
+                  id: provisioned.id,
+                  message: provisioned.message,
+                ),
+                'main',
+              )
+              as session_types.MessageEntry;
+      transcriptEntries.add(entry);
+    }
+
+    for (final provisioned
+        in operation.intent.initialMessages
+            .whereType<session_types.MessageEntry>()) {
+      await appendProvisionedMessage(provisioned);
+    }
+
+    await _restoreInterruptedToolResults(
+      session: session,
+      operation: operation,
+      appendProvisionedMessage: appendProvisionedMessage,
+    );
+    final queues = await _findPendingQueueMessages(
+      session: session,
+      operation: operation,
+    );
+    return AgentChatSuspendedRecovery(
+      transcriptEntries: transcriptEntries,
+      steeringMessages: queues.steering,
+      followUpMessages: queues.followUp,
+    );
+  }
+
+  static Future<session_types.QueueEnqueuedRecord> acceptPrompt({
+    required Session session,
+    required session_types.OperationStartedRecord operation,
+    required AgentMessage prompt,
+    required session_types.QueueKind queue,
+  }) async {
+    final target = session_types.MessageEntry(
+      id: session.idGenerator(),
+      message: prompt,
+    );
+    return await session.appendRecord(
+          session_types.QueueEnqueuedRecord(
+            id: session.idGenerator(),
+            lane: 'main',
+            queue: queue,
+            target: target,
+            runId: operation.id,
+          ),
+        )
+        as session_types.QueueEnqueuedRecord;
+  }
+
+  static Future<void> _restoreInterruptedToolResults({
+    required Session session,
+    required session_types.OperationStartedRecord operation,
+    required Future<void> Function(session_types.MessageEntry)
+    appendProvisionedMessage,
+  }) async {
+    final toolStarts = (await session.findRecords(
+      session_types.RecordQuery(
+        lane: 'main',
+        type: 'tool_started',
+        runId: operation.id,
+        order: session_types.EntryOrder.oldestFirst,
+      ),
+    )).whereType<session_types.ToolStartedRecord>();
+    for (final started in toolStarts) {
+      if (await session.getEntry(started.resultEntryId) != null) continue;
+      // The legacy Tool declaration has no current replay-safety marker, so it
+      // cannot satisfy Pi's persisted-and-current "safe" gate. Never replay an
+      // external effect unless both declarations prove that it is safe.
+      final result = ToolResultMessage(
+        toolCallId: started.toolCallId,
+        toolName: started.toolName,
+        content: const [
+          ToolResultTextContent(
+            'Tool execution was interrupted before its result was persisted.',
+          ),
+        ],
+        details: const {'reason': 'interrupted'},
+        isError: true,
+      );
+      await appendProvisionedMessage(
+        session_types.MessageEntry(id: started.resultEntryId, message: result),
+      );
+    }
+  }
+
+  static Future<
+    ({
+      List<AgentChatRecoveredQueueMessage> steering,
+      List<AgentChatRecoveredQueueMessage> followUp,
+    })
+  >
+  _findPendingQueueMessages({
+    required Session session,
+    required session_types.OperationStartedRecord operation,
+  }) async {
+    final cancelled =
+        (await session.findRecords(
+              session_types.RecordQuery(
+                lane: 'main',
+                type: 'queue_cancelled',
+                runId: operation.id,
+              ),
+            ))
+            .whereType<session_types.QueueCancelledRecord>()
+            .map((record) => record.entryId)
+            .toSet();
+    final queueRecords = (await session.findRecords(
+      session_types.RecordQuery(
+        lane: 'main',
+        type: 'queue_enqueued',
+        runId: operation.id,
+        order: session_types.EntryOrder.oldestFirst,
+      ),
+    )).whereType<session_types.QueueEnqueuedRecord>();
+    final steering = <AgentChatRecoveredQueueMessage>[];
+    final followUp = <AgentChatRecoveredQueueMessage>[];
+    for (final record in queueRecords) {
+      final target = record.target;
+      if (cancelled.contains(target.id) ||
+          target is! session_types.MessageEntry ||
+          await session.getEntry(target.id) != null) {
+        continue;
+      }
+      final recovered = AgentChatRecoveredQueueMessage(
+        message: target.message,
+        entryId: target.id,
+      );
+      switch (record.queue) {
+        case session_types.QueueKind.steer:
+          steering.add(recovered);
+        case session_types.QueueKind.followUp:
+          followUp.add(recovered);
+        case session_types.QueueKind.nextRun:
+          break;
+      }
+    }
+    return (steering: steering, followUp: followUp);
+  }
+}

--- a/lib/presentation/agent_chat/widgets/agent_chat_composer.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_composer.dart
@@ -521,7 +521,9 @@ class _AgentChatComposerState extends State<AgentChatComposer> {
                           ),
                           IconButton(
                             tooltip: l10n.common_delete,
-                            onPressed: () => commands.removeQueuedMessage(item),
+                            onPressed: () async {
+                              await commands.removeQueuedMessage(item);
+                            },
                             icon: const Icon(Icons.close, size: 16),
                             constraints: BoxConstraints.tightFor(
                               width: viewData.mobile ? 44 : 32,
@@ -544,7 +546,9 @@ class _AgentChatComposerState extends State<AgentChatComposer> {
                       label: Text(l10n.agentChat_queueFollowUp),
                     ),
                     TextButton(
-                      onPressed: commands.clearQueuedMessages,
+                      onPressed: () async {
+                        await commands.clearQueuedMessages();
+                      },
                       child: Text(l10n.common_clear),
                     ),
                   ],

--- a/lib/presentation/agent_chat/widgets/agent_chat_panel_coordinator.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_panel_coordinator.dart
@@ -90,7 +90,9 @@ class AgentChatPanelCoordinator {
       copyAssistantMessage: (message) =>
           _copyAssistantMessage(context, message),
       editQueuedMessage: _editQueuedMessage,
-      removeQueuedMessage: _notifier.removeQueuedMessage,
+      removeQueuedMessage: (message) async {
+        await _notifier.removeQueuedMessage(message);
+      },
       clearQueuedMessages: _notifier.clearQueuedMessages,
       addPendingResource: _notifier.addPendingResource,
       removePendingResource: _notifier.removePendingResource,
@@ -295,7 +297,7 @@ class AgentChatPanelCoordinator {
   }
 
   Future<void> _editQueuedMessage(AgentQueuedMessage queued) async {
-    final removed = _notifier.removeQueuedMessage(queued);
+    final removed = await _notifier.removeQueuedMessage(queued);
     if (removed == null || !_isMounted()) return;
     UserMessage? userMessage;
     if (removed is UserMessage) {

--- a/lib/presentation/agent_chat/widgets/agent_chat_panel_view_data.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_panel_view_data.dart
@@ -140,8 +140,8 @@ class AgentChatPanelCommands {
   final VoidCallback cancelUserMessageEdit;
   final Future<void> Function(AssistantMessage message) copyAssistantMessage;
   final Future<void> Function(AgentQueuedMessage message) editQueuedMessage;
-  final void Function(AgentQueuedMessage message) removeQueuedMessage;
-  final VoidCallback clearQueuedMessages;
+  final Future<void> Function(AgentQueuedMessage message) removeQueuedMessage;
+  final Future<void> Function() clearQueuedMessages;
   final Future<void> Function(AgentChatResourceReference reference)
   addPendingResource;
   final Future<void> Function(int index) removePendingResource;

--- a/test/presentation/agent_chat/providers/agent_chat_notifier_test.dart
+++ b/test/presentation/agent_chat/providers/agent_chat_notifier_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -266,14 +267,24 @@ User instructions.
     late _MemoryLocalStorage storage;
     late ProviderContainer container;
     late StateNotifierProvider<AgentChatNotifier, AgentChatState> provider;
+    late JsonlSessionRepo sessionRepo;
     late List<AgentChatRequest> requests;
+    late AgentWireCompletion wireCompletion;
 
     setUp(() async {
       tempDir = await Directory.systemTemp.createTemp(
         'agent_chat_notifier_test_',
       );
       storage = _MemoryLocalStorage();
+      sessionRepo = JsonlSessionRepo(tempDir);
       requests = [];
+      wireCompletion = (request) {
+        requests.add(request);
+        return Stream<AgentWireEvent>.fromIterable(const [
+          AgentWireTextDelta('done'),
+          AgentWireFinish(stopReason: StopReason.stop),
+        ]);
+      };
       provider = StateNotifierProvider<AgentChatNotifier, AgentChatState>((
         ref,
       ) {
@@ -282,13 +293,8 @@ User instructions.
           supportDir: tempDir,
           workspaceDir: tempDir,
           presetSkills: const [],
-          completeRequest: (request) {
-            requests.add(request);
-            return Stream<AgentWireEvent>.fromIterable(const [
-              AgentWireTextDelta('done'),
-              AgentWireFinish(stopReason: StopReason.stop),
-            ]);
-          },
+          sessionRepo: sessionRepo,
+          completeRequest: (request) => wireCompletion(request),
         );
       });
       container = ProviderContainer(
@@ -402,6 +408,167 @@ User instructions.
         );
       },
     );
+
+    test('resumes a suspended operation instead of starting another', () async {
+      final configNotifier = container.read(
+        promptAssistantConfigProvider.notifier,
+      );
+      await configNotifier.upsertProvider(
+        ProviderPreset.deepseek.createConfig(),
+      );
+      await configNotifier.upsertModel(
+        const ModelConfig(
+          providerId: 'deepseek',
+          name: 'deepseek-chat',
+          displayName: 'DeepSeek Chat',
+          forTask: AssistantTaskType.chat,
+        ),
+      );
+      await container
+          .read(agentSettingsProvider.notifier)
+          .setModelReference(
+            const AgentModelReference(
+              providerId: 'deepseek',
+              model: 'deepseek-chat',
+            ),
+          );
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final notifier = container.read(provider.notifier);
+      final suspendedSessionId = container.read(provider).activeSessionId;
+      await notifier.newSession();
+      final metadata = (await sessionRepo.list()).firstWhere(
+        (item) => item.id == suspendedSessionId,
+      );
+      final suspendedSession = await sessionRepo.open(metadata);
+      const suspendedRunId = 'suspended-run';
+      await suspendedSession.appendRecord(
+        OperationStartedRecord(
+          id: suspendedRunId,
+          lane: 'main',
+          sourceLeafId: null,
+          intent: const RunIntent(kind: RunIntentKind.run),
+        ),
+      );
+      await suspendedSession.appendMessage(UserMessage.text('original task'));
+      await suspendedSession.appendMessage(
+        AssistantMessage(
+          content: const [AssistantTextContent('partial answer')],
+          stopReason: StopReason.stop,
+        ),
+      );
+
+      await notifier.switchSession(suspendedSessionId);
+      expect(container.read(provider).turns.single.status.name, 'interrupted');
+
+      await notifier.send('continue the task');
+
+      expect(container.read(provider).error, isEmpty);
+      expect(requests, hasLength(1));
+      expect(
+        requests.single.messages.whereType<UserMessage>().map(
+          (message) => message.text,
+        ),
+        ['original task', 'continue the task'],
+      );
+      final reopened = await sessionRepo.open(metadata);
+      expect(await reopened.findOpenOperations('main'), isEmpty);
+      expect(
+        (await reopened.findRecords()).whereType<OperationStartedRecord>(),
+        hasLength(1),
+      );
+    });
+
+    test('persists steering and follow-up input before delivery', () async {
+      final configNotifier = container.read(
+        promptAssistantConfigProvider.notifier,
+      );
+      await configNotifier.upsertProvider(
+        ProviderPreset.deepseek.createConfig(),
+      );
+      await configNotifier.upsertModel(
+        const ModelConfig(
+          providerId: 'deepseek',
+          name: 'deepseek-chat',
+          displayName: 'DeepSeek Chat',
+          forTask: AssistantTaskType.chat,
+        ),
+      );
+      await container
+          .read(agentSettingsProvider.notifier)
+          .setModelReference(
+            const AgentModelReference(
+              providerId: 'deepseek',
+              model: 'deepseek-chat',
+            ),
+          );
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final stream = StreamController<AgentWireEvent>();
+      wireCompletion = (request) {
+        requests.add(request);
+        if (requests.length == 1) return stream.stream;
+        return Stream<AgentWireEvent>.value(
+          const AgentWireFinish(stopReason: StopReason.stop),
+        );
+      };
+      final notifier = container.read(provider.notifier);
+      final firstSend = notifier.send('start');
+      await _waitForCondition(
+        () => requests.isNotEmpty,
+        'Agent run did not reach the provider',
+      );
+
+      await notifier.send('steer now');
+      expect(
+        await notifier.sendContent(const [
+          UserTextContent('follow later'),
+        ], followUp: true),
+        isTrue,
+      );
+
+      final activeSessionId = container.read(provider).activeSessionId;
+      final metadata = (await sessionRepo.list()).firstWhere(
+        (item) => item.id == activeSessionId,
+      );
+      final activeSession = await sessionRepo.open(metadata);
+      final queueRecords = (await activeSession.findRecords(
+        const RecordQuery(
+          type: 'queue_enqueued',
+          order: EntryOrder.oldestFirst,
+        ),
+      )).whereType<QueueEnqueuedRecord>().toList();
+      expect(queueRecords.map((record) => record.queue), [
+        QueueKind.steer,
+        QueueKind.followUp,
+      ]);
+      expect(await activeSession.getEntry(queueRecords[0].target.id), isNull);
+      expect(await activeSession.getEntry(queueRecords[1].target.id), isNull);
+
+      stream.add(const AgentWireFinish(stopReason: StopReason.stop));
+      await stream.close();
+      await firstSend;
+
+      expect(requests, hasLength(3));
+      final completedSession = await sessionRepo.open(metadata);
+      final completedRecords = await completedSession.findRecords();
+      expect(
+        completedRecords.whereType<OperationStartedRecord>(),
+        hasLength(1),
+      );
+      expect(
+        completedRecords.whereType<OperationFinishedRecord>(),
+        hasLength(1),
+      );
+      expect(
+        (await completedSession.getEntry(queueRecords[0].target.id))?.id,
+        queueRecords[0].target.id,
+      );
+      expect(
+        (await completedSession.getEntry(queueRecords[1].target.id))?.id,
+        queueRecords[1].target.id,
+      );
+    });
 
     test(
       'override is the exact outbound prompt for new and restored sessions',
@@ -677,6 +844,17 @@ Future<void> _waitForInitialized(
     await Future<void>.delayed(const Duration(milliseconds: 10));
   }
   fail('AgentChatNotifier did not initialize');
+}
+
+Future<void> _waitForCondition(
+  bool Function() condition,
+  String failureMessage,
+) async {
+  for (var attempt = 0; attempt < 200; attempt++) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail(failureMessage);
 }
 
 Future<void> _waitForSkill(

--- a/test/presentation/agent_chat/services/agent_chat_session_controller_test.dart
+++ b/test/presentation/agent_chat/services/agent_chat_session_controller_test.dart
@@ -1,12 +1,14 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
 import 'package:nai_launcher/core/agent/agent.dart';
 import 'package:nai_launcher/core/agent/audit/audit_sink.dart';
 import 'package:nai_launcher/core/agent/harness/session/session.dart';
 import 'package:nai_launcher/core/agent/harness/session/session_jsonl.dart';
 import 'package:nai_launcher/core/agent/harness/session/session_memory.dart';
 import 'package:nai_launcher/core/agent/resources/agent_chat_resource_draft_store.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
 import 'package:nai_launcher/core/storage/local_storage_service.dart';
 import 'package:nai_launcher/presentation/agent_chat/providers/agent_chat_state.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/agent_chat_draft_controller.dart';
@@ -15,6 +17,23 @@ import 'package:nai_launcher/presentation/agent_chat/services/agent_chat_session
 import 'package:nai_launcher/presentation/agent_chat/services/agent_tool_permission_controller.dart';
 
 void main() {
+  late Directory hiveDirectory;
+
+  setUpAll(() async {
+    hiveDirectory = await Directory.systemTemp.createTemp(
+      'agent-chat-session-controller-hive-',
+    );
+    Hive.init(hiveDirectory.path);
+    await Hive.openBox(StorageKeys.settingsBox);
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (hiveDirectory.existsSync()) {
+      hiveDirectory.deleteSync(recursive: true);
+    }
+  });
+
   test(
     'finish is idempotent and a stale end cannot finish the new turn',
     () async {
@@ -52,7 +71,17 @@ void main() {
         isMounted: () => true,
       )..session = session;
 
+      final acceptedPrompt = UserMessage.text('persist before execution');
+      controller.prepareRunPrompt(acceptedPrompt);
       final oldTurnId = (await controller.startTurn())!;
+      final started = (await session.findRecords())
+          .whereType<OperationStartedRecord>()
+          .single;
+      expect(started.intent.originalPrompt, [acceptedPrompt]);
+      expect(started.intent.initialMessages, hasLength(1));
+      final persistedPrompt = await controller.persistMessage(acceptedPrompt);
+      expect(persistedPrompt?.id, started.intent.initialMessages.single.id);
+
       await controller.finishTurn(
         turnId: oldTurnId,
         outcome: OperationOutcomeKind.completed,
@@ -74,11 +103,31 @@ void main() {
       expect(oldFinishes.single.outcome, OperationOutcomeKind.completed);
       expect(controller.activeTurnId, newTurnId);
 
-      await controller.finishTurn(
+      var queuedInMemory = false;
+      final queuedPrompt = UserMessage.text('queued at run completion');
+      final accepting = controller.acceptQueuedPrompt(
+        queuedPrompt,
+        QueueKind.steer,
+        enqueue: () => queuedInMemory = true,
+      );
+      final finishing = controller.finishTurn(
         turnId: newTurnId,
         outcome: OperationOutcomeKind.completed,
       );
+      await expectLater(accepting, throwsStateError);
+      await finishing;
+      expect(queuedInMemory, isFalse);
       expect(controller.activeTurnId, isNull);
+      final serializedRecords = await session.findRecords(
+        const RecordQuery(order: EntryOrder.oldestFirst),
+      );
+      expect(serializedRecords.whereType<QueueEnqueuedRecord>(), isEmpty);
+      expect(
+        serializedRecords.whereType<OperationFinishedRecord>().where(
+          (record) => record.runId == newTurnId,
+        ),
+        hasLength(1),
+      );
 
       final reloadedController = AgentChatSessionController(
         repository: JsonlSessionRepo(directory),
@@ -103,6 +152,213 @@ void main() {
       );
     },
   );
+
+  test('reopening preserves and resumes the suspended operation', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'agent-chat-suspended-operation-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final repository = JsonlSessionRepo(directory);
+    final session = await repository.create(
+      const SessionCreateOptions(id: 'session'),
+    );
+    const suspendedTurnId = 'suspended-turn';
+    await session.appendRecord(
+      OperationStartedRecord(
+        id: suspendedTurnId,
+        lane: 'main',
+        sourceLeafId: null,
+        intent: const RunIntent(kind: RunIntentKind.run),
+      ),
+    );
+    await session.appendMessage(UserMessage.text('keep this request'));
+    final partialAssistant = await session.appendMessage(
+      AssistantMessage(
+        content: const [
+          AssistantTextContent('keep this partial response'),
+          ToolCallContent(
+            id: 'tool-call',
+            name: 'read',
+            arguments: {'path': 'unfinished.txt'},
+          ),
+        ],
+        stopReason: StopReason.toolUse,
+      ),
+    );
+    const interruptedResultId = 'interrupted-result';
+    await session.appendRecord(
+      ToolStartedRecord(
+        id: 'tool-started',
+        lane: 'main',
+        runId: suspendedTurnId,
+        assistantEntryId: partialAssistant,
+        toolIndex: 0,
+        toolCallId: 'tool-call',
+        toolName: 'read',
+        effectiveArgs: const {'path': 'unfinished.txt'},
+        resultEntryId: interruptedResultId,
+        replay: ReplayMode.never,
+      ),
+    );
+    final pendingSteer = MessageEntry(
+      id: 'pending-steer',
+      message: UserMessage.text('persisted steering'),
+    );
+    final pendingFollowUp = MessageEntry(
+      id: 'pending-follow-up',
+      message: UserMessage.text('persisted follow-up'),
+    );
+    final cancelledSteer = MessageEntry(
+      id: 'cancelled-steer',
+      message: UserMessage.text('cancelled steering'),
+    );
+    await session.appendRecord(
+      QueueEnqueuedRecord(
+        id: 'steer-queued',
+        lane: 'main',
+        queue: QueueKind.steer,
+        target: pendingSteer,
+        runId: suspendedTurnId,
+      ),
+    );
+    await session.appendRecord(
+      QueueEnqueuedRecord(
+        id: 'follow-up-queued',
+        lane: 'main',
+        queue: QueueKind.followUp,
+        target: pendingFollowUp,
+        runId: suspendedTurnId,
+      ),
+    );
+    await session.appendRecord(
+      QueueEnqueuedRecord(
+        id: 'cancelled-queued',
+        lane: 'main',
+        queue: QueueKind.steer,
+        target: cancelledSteer,
+        runId: suspendedTurnId,
+      ),
+    );
+    await session.appendRecord(
+      QueueCancelledRecord(
+        id: 'queue-cancelled',
+        lane: 'main',
+        entryId: cancelledSteer.id,
+        runId: suspendedTurnId,
+      ),
+    );
+
+    var state = const AgentChatState();
+    final localStorage = LocalStorageService();
+    final draftController = AgentChatDraftController(
+      resourceStore: AgentChatResourceDraftStore(
+        File('${directory.path}/drafts.json'),
+      ),
+      localStorage: localStorage,
+      readState: () => state,
+      writeState: (next) => state = next,
+      createResourceResolver: () => throw UnimplementedError(),
+      isMounted: () => true,
+    );
+    final controller = AgentChatSessionController(
+      repository: repository,
+      localStorage: localStorage,
+      draftController: draftController,
+      workspaceDir: directory.path,
+      buildAgent: () async => Agent(
+        AgentOptions(
+          streamFn: (model, context, [options]) => throw UnimplementedError(),
+        ),
+      ),
+      buildSystemPrompt: () async => '',
+      readState: () => state,
+      writeState: (next) => state = next,
+      isMounted: () => true,
+    );
+
+    await controller.activateSession('session');
+    final restoredSession = controller.session!;
+
+    expect(
+      (await restoredSession.findOpenOperations('main')).single.id,
+      suspendedTurnId,
+    );
+    expect(state.turns.single.status.name, 'interrupted');
+    expect(state.messages, hasLength(2));
+    expect((state.messages[0] as UserMessage).text, 'keep this request');
+    expect(
+      (state.messages[1] as AssistantMessage).text,
+      'keep this partial response',
+    );
+
+    final resumedPrompt = UserMessage.text('continue this task');
+    await controller.acceptQueuedPrompt(
+      resumedPrompt,
+      QueueKind.steer,
+      enqueue: () {},
+    );
+    final queueRecord = (await restoredSession.findRecords())
+        .whereType<QueueEnqueuedRecord>()
+        .where(
+          (record) =>
+              record.target is MessageEntry &&
+              (record.target as MessageEntry).message == resumedPrompt,
+        )
+        .single;
+
+    final recovery = await controller.restoreSuspendedRun();
+    final resumedTurnId = await controller.startTurn();
+
+    expect(recovery.transcriptEntries, hasLength(1));
+    final interruptedResult = recovery.transcriptEntries.single.message;
+    expect(interruptedResult, isA<ToolResultMessage>());
+    expect((interruptedResult as ToolResultMessage).toolCallId, 'tool-call');
+    expect(interruptedResult.isError, isTrue);
+    expect(
+      recovery.steeringMessages.map(
+        (queued) => (queued.message as UserMessage).text,
+      ),
+      ['persisted steering', 'continue this task'],
+    );
+    expect(
+      recovery.followUpMessages.map(
+        (queued) => (queued.message as UserMessage).text,
+      ),
+      ['persisted follow-up'],
+    );
+    expect(
+      (await restoredSession.getEntry(interruptedResultId))?.id,
+      interruptedResultId,
+    );
+    expect(await restoredSession.getEntry(queueRecord.target.id), isNull);
+    for (final queued in [
+      ...recovery.steeringMessages,
+      ...recovery.followUpMessages,
+    ]) {
+      await controller.persistMessage(queued.message);
+    }
+    expect(
+      (await restoredSession.getEntry(queueRecord.target.id))?.id,
+      queueRecord.target.id,
+    );
+    expect(await restoredSession.getEntry(pendingSteer.id), isNotNull);
+    expect(await restoredSession.getEntry(pendingFollowUp.id), isNotNull);
+    expect(await restoredSession.getEntry(cancelledSteer.id), isNull);
+    expect(resumedTurnId, suspendedTurnId);
+    expect(controller.activeTurnId, suspendedTurnId);
+    expect(state.turns.single.status.name, 'running');
+    expect(
+      (await restoredSession.findRecords()).whereType<OperationStartedRecord>(),
+      hasLength(1),
+    );
+    expect(await restoredSession.findOpenOperations('main'), hasLength(1));
+
+    await controller.finishTurn(
+      turnId: resumedTurnId!,
+      outcome: OperationOutcomeKind.completed,
+    );
+    expect(await restoredSession.findOpenOperations('main'), isEmpty);
+  });
 
   test(
     'rewind activation failure restores the branch and returns no checkpoint',
@@ -190,6 +446,8 @@ void main() {
       writeState: (next) => state = next,
       isMounted: () => true,
     )..session = session;
+    final agent = Agent(const AgentOptions(streamFn: _unusedStream));
+    sessionController.agent = agent;
     final eventController = AgentChatEventController(
       sessionController: sessionController,
       permissionController: AgentToolPermissionController(
@@ -209,6 +467,14 @@ void main() {
     );
 
     await eventController.handle(const AgentEventAgentStart(), signal);
+    final unconsumedPrompt = UserMessage.text('too late for the final poll');
+    await sessionController.acceptQueuedPrompt(
+      unconsumedPrompt,
+      QueueKind.steer,
+      enqueue: () => agent.steer(unconsumedPrompt),
+    );
+    expect(agent.steeringQueue, hasLength(1));
+
     await eventController.handle(
       AgentEventTurnEnd(message: assistant, toolResults: const []),
       signal,
@@ -222,8 +488,16 @@ void main() {
       (await session.findRecords()).whereType<OperationFinishedRecord>(),
       hasLength(1),
     );
+    expect(agent.steeringQueue, isEmpty);
+    expect(agent.followUpQueue, isEmpty);
   });
 }
+
+AssistantMessageEventStream _unusedStream(
+  Model model,
+  Context context, [
+  SimpleStreamOptions? options,
+]) => AssistantMessageEventStream();
 
 String Function() _ids() {
   var next = 0;

--- a/test/presentation/agent_chat/widgets/agent_chat_composer_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_composer_test.dart
@@ -813,8 +813,8 @@ class _ComposerHarnessState extends State<_ComposerHarness> {
       cancelUserMessageEdit: controller.cancelEditingUserMessage,
       copyAssistantMessage: (_) async {},
       editQueuedMessage: (_) async {},
-      removeQueuedMessage: (_) {},
-      clearQueuedMessages: () {},
+      removeQueuedMessage: (_) async {},
+      clearQueuedMessages: () async {},
       addPendingResource: (_) async {},
       removePendingResource: (_) async {},
     );

--- a/test/presentation/agent_chat/widgets/agent_chat_header_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_header_test.dart
@@ -179,8 +179,8 @@ Widget _app({
     cancelUserMessageEdit: () {},
     copyAssistantMessage: (_) async {},
     editQueuedMessage: (_) async {},
-    removeQueuedMessage: (_) {},
-    clearQueuedMessages: () {},
+    removeQueuedMessage: (_) async {},
+    clearQueuedMessages: () async {},
     addPendingResource: (_) async {},
     removePendingResource: (_) async {},
   );

--- a/test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart
@@ -269,8 +269,8 @@ final _commands = AgentChatPanelCommands(
   cancelUserMessageEdit: () {},
   copyAssistantMessage: (_) async {},
   editQueuedMessage: (_) async {},
-  removeQueuedMessage: (_) {},
-  clearQueuedMessages: () {},
+  removeQueuedMessage: (_) async {},
+  clearQueuedMessages: () async {},
   addPendingResource: (_) async {},
   removePendingResource: (_) async {},
 );

--- a/test/presentation/agent_chat/widgets/agent_chat_turn_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_turn_test.dart
@@ -790,8 +790,8 @@ final _commands = AgentChatPanelCommands(
   cancelUserMessageEdit: () {},
   copyAssistantMessage: (_) async {},
   editQueuedMessage: (_) async {},
-  removeQueuedMessage: (_) {},
-  clearQueuedMessages: () {},
+  removeQueuedMessage: (_) async {},
+  clearQueuedMessages: () async {},
   addPendingResource: (_) async {},
   removePendingResource: (_) async {},
 );


### PR DESCRIPTION
## 修复内容

- 按 Pi Harness 语义保留并恢复未完成的 operation，不再把恢复后的新消息错误地当作第二个 operation
- 恢复缺失的初始输入、未完成工具批次及 steering/follow-up 队列，并复用持久化的预分配 entry ID
- 队列输入先写入 session 再交给内存 Agent，取消和运行结束同步清理，避免跨 operation 遗留
- operation 生命周期覆盖完整 Agent run，结束写入幂等，并锁住发送准备期间的会话切换竞态
- 会话文件只有确实不存在时才创建，读取或回放失败不再静默覆盖原文件
- 在 `AGENTS.md` 记录 Harness 问题必须先核对 Pi 官方源码并保持行为一致

## 验证

- `scripts/test_affected.ps1`：125 tests passed
- `dart analyze`（全部受影响源码与测试）：No issues found
- `git diff --check`

Fixes #174
