### PR TITLE
Fix transparent inpaint results retaining old pixels

### DIFF
--- a/.pi/skills/aaalice-dev-sessions/SKILL.md
+++ b/.pi/skills/aaalice-dev-sessions/SKILL.md
@@ -20,6 +20,8 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File .pi/skills/aaalice-hot-reload/scri
 
 该命令可能因任一端未启动而返回非零；分别读取输出，不把“另一端未启动”误判为已运行端失效。
 
+用户要求立即启动会话时，完成上述检查后直接创建或复用目标 Runner，不得先运行测试、Analyze 或 `build_runner`。若 Runner 预检明确报告生成文件缺失/过期，再将完整 `dart run build_runner build --delete-conflicting-outputs` 作为一次性环境准备：先说明全仓库扫描的预计耗时，确认两个 Flutter 会话均已停止，让生成命令完整结束后立即重启目标 Runner。不得把全量生成称为最小验证，不得因等待期间切换任务而反复中断重跑；命令中断时检查并恢复被删除但未重新生成的已有输出。
+
 ## 创建或复用终端
 
 先运行 `orca terminal list --worktree active --json`。有效会话标记与对应进程是会话存在的权威依据；标题和输出标记仅用于兼容旧会话。
@@ -39,7 +41,7 @@ orca terminal create --worktree active --title "安卓热重载" --command "pwsh
 规则：
 
 - Android 项目会话必须使用 `-EmulatorId Aaalice_API35`，不要使用 `-DeviceId emulator-5554`；后者只复用外部模拟器，会绕过项目的 GPU 和无设备外框启动参数。
-- 两个 runner 默认都复用现有依赖与生成文件，不运行 `pub get` / `build_runner`。依赖变化时显式传 `-RunPubGet`，Freezed/Riverpod 等生成源变化时先单独完成 `-RunBuildRunner`，不得与另一端 Flutter 构建并发。
+- 两个 runner 默认都复用现有依赖与生成文件，不运行 `pub get` / `build_runner`。纯 Dart/UI 改动及针对性测试不得预先运行生成器；依赖变化时显式传 `-RunPubGet`，Freezed/Riverpod 等生成源变化或 Runner 预检明确阻塞时才单独完成 `-RunBuildRunner`，不得与另一端 Flutter 构建并发。
 - 在 Orca 中直接创建项目终端；所有项目专用 runner/helper 都位于 `.pi/skills/`，不依赖仓库 `scripts/` 下的热重载入口。
 - 创建后轮询 `orca terminal read --terminal <handle> --json`。Windows 等待 `Starting Flutter in Windows debug mode`，Android 等待 `Starting Flutter in Android debug mode` 且应用启动完成。出现构建错误立即报告，不盲等。
 - Android runner 首次启动 emulator 时禁用 Quick Boot 快照、使用 host GPU、移除设备外框并等待系统完成启动；默认保留运行中的 emulator 作为下次会话的暖缓存。复用前会停止旧 App 并回到 Home，不会把旧界面当作本次启动结果。只有显式传 `-StopEmulatorOnExit` 才让 emulator 随会话关闭。

--- a/.pi/skills/aaalice-hot-reload/SKILL.md
+++ b/.pi/skills/aaalice-hot-reload/SKILL.md
@@ -24,7 +24,7 @@ compatibility: 项目的 PC热重载与安卓热重载会话已启动。
 
 ## 2. 修改后验证顺序
 
-1. 先运行与改动范围匹配的格式化、affected tests 和 scoped analyze。
+1. 默认先运行与改动范围匹配的格式化、affected tests 和 scoped analyze；用户明确要求立即启动/刷新时跳过此步，先完成会话启动或 reload/restart，再补最小验证。纯 Dart/UI 改动不得把 `build_runner` 当作验证；只有生成输入变化或 Runner 预检明确阻塞时才按 `aaalice-dev-sessions` 执行一次性环境准备。
 2. 从 `tool/.tmp/windows_hot_reload_session.json` 与 `tool/.tmp/android_hot_reload_session.json` 读取 `terminalHandle`。
 3. 对每个目标运行 `orca terminal read --terminal <handle> --json`，记录返回的 `latestCursor`，作为本次日志基线。
 4. 触发动作但不读取历史 tail：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ Windows release 产物位于 `build/windows/x64/runner/Release/`。macOS 使用 
 
 项目热重载与按需运行验收由 `.pi/skills/` 中的三个项目 skill 管理：`aaalice-dev-sessions` 负责通过 Orca 创建、复用和关闭唯一的 `PC热重载` / `安卓热重载` 终端；`aaalice-hot-reload` 负责判定并触发 `r`、`R` 或完整重建，随后按 Orca cursor 增量读取两端日志；`aaalice-runtime-verify` 在用户明确要求自动化验收时负责真实 UI 自动化与布局检查。Agent 不得另开第二个 `flutter run` 或 `flutter attach`，仓库 `scripts/` 下不再保留项目热重载入口。
 
+`build_runner` 不是常规测试或纯 Dart/UI 改动的默认验证步骤。只有改动了 Riverpod/Freezed/JSON/Drift 等生成输入，或开发 Runner 预检明确报告生成文件缺失/过期时才运行；针对性测试直接运行相关测试文件，不得为此先扫描全仓库生成代码。用户要求立即启动热重载时先执行会话状态检查和 Runner 预检，不得先跑测试或生成器；若预检阻塞且必须全量生成，应明确说明这是一次性环境准备及预计耗时，让命令完整结束后立即继续启动，不得称其为“最小验证”或反复中断重跑。生成命令中断后必须检查并恢复被删除但未重新生成的已有输出。
+
 为本项目创建 Orca worktree 会话时，用户未明确指定 Agent 则默认使用 `pi`；仅在用户明确要求时改用其他 Agent。
 
 普通 Dart 方法、Widget 布局、样式和文案使用 `Reload`；状态字段、`initState`、Provider/依赖注入、路由/启动流程、静态缓存或生成 Dart 代码使用 `Restart`；依赖、Windows C++/插件注册、Android Kotlin/Manifest/Gradle/插件注册变化必须重建受影响会话。共享代码默认作用于 `All`，平台实现只作用于对应端。

--- a/lib/core/utils/focused_inpaint_utils.dart
+++ b/lib/core/utils/focused_inpaint_utils.dart
@@ -144,13 +144,22 @@ class FocusedInpaintRequest {
       blend: img.BlendMode.direct,
     );
 
-    final display = img.Image.from(_originalSource, noAnimation: true);
-    img.compositeImage(
-      display,
-      cropPatch,
+    final cropGenerated = PicaLanczosResizer.resizeImage(
+      requestGenerated,
+      width: crop.width,
+      height: crop.height,
+    );
+    final cropCompositeMask = PicaLanczosResizer.resizeImage(
+      compositeMask,
+      width: crop.width,
+      height: crop.height,
+    );
+    final display = InpaintMaskUtils.compositeMaskedReplacement(
+      source: _originalSource,
+      generated: cropGenerated,
+      compositeMask: cropCompositeMask,
       dstX: crop.x,
       dstY: crop.y,
-      blend: img.BlendMode.alpha,
     );
     return ImageGenerationArtifact(
       displayImageBytes: Uint8List.fromList(img.encodePng(display, level: 1)),

--- a/lib/core/utils/inpaint_mask/inpaint_mask_operations.dart
+++ b/lib/core/utils/inpaint_mask/inpaint_mask_operations.dart
@@ -523,7 +523,7 @@ class InpaintMaskUtils {
             height: source.height,
           );
 
-    final composed = img.Image.from(source, noAnimation: true);
+    final composed = source.convert(numChannels: 4, noAnimation: true);
     img.compositeImage(
       composed,
       generatedCanvas,
@@ -574,8 +574,11 @@ class InpaintMaskUtils {
             height: source.height,
           );
     final patch = applyCompositeMaskToGeneratedImage(generatedCanvas, mask);
-    final display = img.Image.from(source, noAnimation: true);
-    img.compositeImage(display, patch, blend: img.BlendMode.alpha);
+    final display = compositeMaskedReplacement(
+      source: source,
+      generated: generatedCanvas,
+      compositeMask: mask,
+    );
 
     return ImageGenerationArtifact(
       displayImageBytes: Uint8List.fromList(img.encodePng(display, level: 1)),
@@ -1013,6 +1016,99 @@ class InpaintMaskUtils {
     return Isolate.run(
       () => maskToEditorOverlay(bytes, overlayAlpha: overlayAlpha),
     );
+  }
+
+  /// Replaces source pixels through a soft mask using straight RGBA output.
+  ///
+  /// Source-over cannot represent a transparent generated pixel clearing an
+  /// opaque source pixel. This instead interpolates premultiplied color and
+  /// alpha independently, then converts the result back to straight RGBA.
+  static img.Image compositeMaskedReplacement({
+    required img.Image source,
+    required img.Image generated,
+    required img.Image compositeMask,
+    int dstX = 0,
+    int dstY = 0,
+  }) {
+    if (generated.width != compositeMask.width ||
+        generated.height != compositeMask.height) {
+      throw ArgumentError('Generated image and composite mask must match');
+    }
+    if (dstX < 0 ||
+        dstY < 0 ||
+        dstX + generated.width > source.width ||
+        dstY + generated.height > source.height) {
+      throw ArgumentError('Generated image must fit inside the source image');
+    }
+
+    final result = source.convert(numChannels: 4, noAnimation: true);
+    for (var y = 0; y < generated.height; y++) {
+      for (var x = 0; x < generated.width; x++) {
+        final maskAlpha = compositeMask.getPixel(x, y).a.toInt();
+        if (maskAlpha == 0) continue;
+
+        final generatedPixel = generated.getPixel(x, y);
+        if (maskAlpha == 255) {
+          result.setPixelRgba(
+            dstX + x,
+            dstY + y,
+            generatedPixel.r,
+            generatedPixel.g,
+            generatedPixel.b,
+            generatedPixel.a,
+          );
+          continue;
+        }
+
+        final sourcePixel = result.getPixel(dstX + x, dstY + y);
+        final maskWeight = maskAlpha / 255;
+        final generatedWeight = maskWeight * generatedPixel.a.toInt() / 255;
+        final sourceWeight = (1 - maskWeight) * sourcePixel.a.toInt() / 255;
+        final outputAlpha = generatedWeight + sourceWeight;
+
+        result.setPixelRgba(
+          dstX + x,
+          dstY + y,
+          _blendReplacementChannel(
+            sourcePixel.r,
+            generatedPixel.r,
+            sourceWeight,
+            generatedWeight,
+            outputAlpha,
+          ),
+          _blendReplacementChannel(
+            sourcePixel.g,
+            generatedPixel.g,
+            sourceWeight,
+            generatedWeight,
+            outputAlpha,
+          ),
+          _blendReplacementChannel(
+            sourcePixel.b,
+            generatedPixel.b,
+            sourceWeight,
+            generatedWeight,
+            outputAlpha,
+          ),
+          (outputAlpha * 255).round(),
+        );
+      }
+    }
+    return result;
+  }
+
+  static int _blendReplacementChannel(
+    num sourceChannel,
+    num generatedChannel,
+    double sourceWeight,
+    double generatedWeight,
+    double outputAlpha,
+  ) {
+    if (outputAlpha == 0) return 0;
+    return ((sourceChannel * sourceWeight +
+                generatedChannel * generatedWeight) /
+            outputAlpha)
+        .round();
   }
 
   static img.Image applyCompositeMaskToGeneratedImage(

--- a/test/core/utils/focused_inpaint_utils_test.dart
+++ b/test/core/utils/focused_inpaint_utils_test.dart
@@ -316,6 +316,47 @@ void main() {
     );
 
     test(
+      'compositeGeneratedImage should clear old pixels for transparent focused results',
+      () {
+        final source = img.Image(width: 400, height: 300);
+        img.fill(source, color: img.ColorRgb8(16, 32, 64));
+        final mask = img.Image(width: 400, height: 300);
+        img.fill(mask, color: img.ColorRgb8(0, 0, 0));
+        img.fillRect(
+          mask,
+          x1: 150,
+          y1: 120,
+          x2: 189,
+          y2: 159,
+          color: img.ColorRgb8(255, 255, 255),
+        );
+        final request = FocusedInpaintUtils.prepareRequest(
+          sourceImage: Uint8List.fromList(img.encodePng(source)),
+          maskImage: Uint8List.fromList(img.encodePng(mask)),
+          minContextMegaPixels: 40,
+        )!;
+        final generated = img.Image(
+          width: request.targetWidth,
+          height: request.targetHeight,
+          numChannels: 4,
+        );
+        img.fill(generated, color: img.ColorRgba8(255, 255, 255, 0));
+
+        final result = request.compositeGeneratedImage(
+          Uint8List.fromList(img.encodePng(generated)),
+        );
+        final decoded = img.decodeImage(result)!;
+
+        expect(decoded.numChannels, equals(4));
+        expect(decoded.getPixel(170, 140).a.toInt(), equals(0));
+        expect(decoded.getPixel(110, 80).a.toInt(), equals(255));
+        expect(decoded.getPixel(110, 80).r.toInt(), equals(16));
+        expect(decoded.getPixel(110, 80).g.toInt(), equals(32));
+        expect(decoded.getPixel(110, 80).b.toInt(), equals(64));
+      },
+    );
+
+    test(
       'compositeGeneratedImage should use a soft edge and preserve distant pixels',
       () {
         final source = img.Image(width: 400, height: 300);

--- a/test/core/utils/inpaint_mask_utils_test.dart
+++ b/test/core/utils/inpaint_mask_utils_test.dart
@@ -564,6 +564,39 @@ void main() {
     );
 
     test(
+      'composeGeneratedImageArtifact replaces masked alpha with transparent result',
+      () {
+        final source = img.Image(width: 4, height: 4);
+        img.fill(source, color: img.ColorRgb8(10, 20, 30));
+        final generated = img.Image(width: 4, height: 4, numChannels: 4);
+        img.fill(generated, color: img.ColorRgba8(200, 210, 220, 0));
+        final mask = img.Image(width: 4, height: 4, numChannels: 4);
+        img.fill(mask, color: img.ColorRgba8(0, 0, 0, 0));
+        mask.setPixelRgba(1, 1, 255, 255, 255, 255);
+        mask.setPixelRgba(2, 1, 128, 128, 128, 128);
+
+        final result = InpaintMaskUtils.composeGeneratedImageArtifact(
+          normalizedSourceImage: Uint8List.fromList(img.encodePng(source)),
+          compositeMaskImage: Uint8List.fromList(img.encodePng(mask)),
+          generatedImage: Uint8List.fromList(img.encodePng(generated)),
+        );
+        final display = img.decodeImage(result.displayImageBytes)!;
+
+        expect(display.numChannels, equals(4));
+        expect(display.getPixel(1, 1).a.toInt(), equals(0));
+        final softPixel = display.getPixel(2, 1);
+        expect(softPixel.a.toInt(), inInclusiveRange(126, 128));
+        expect(softPixel.r.toInt(), equals(10));
+        expect(softPixel.g.toInt(), equals(20));
+        expect(softPixel.b.toInt(), equals(30));
+        expect(display.getPixel(0, 0).a.toInt(), equals(255));
+        expect(display.getPixel(0, 0).r.toInt(), equals(10));
+        expect(display.getPixel(0, 0).g.toInt(), equals(20));
+        expect(display.getPixel(0, 0).b.toInt(), equals(30));
+      },
+    );
+
+    test(
       'extractGeneratedPatch should make pixels outside mask transparent',
       () {
         final generated = img.Image(width: 4, height: 4);


### PR DESCRIPTION
## Problem
Transparent pixels generated during focused inpainting were composited over the original image, so old pixels remained visible underneath.

## Solution
Composite generated RGBA pixels using mask-aware replacement instead of source-over blending. Preserve transparency and soft mask edges while keeping pixels outside the inpaint region unchanged.

Added regression tests for transparent focused results and masked alpha replacement.

Fixes #99