### PR TITLE
feat(character): 添加提示词缩放与助手浮层

### DIFF
--- a/lib/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart
+++ b/lib/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart
@@ -40,6 +40,9 @@ class PromptAssistantOverlay extends ConsumerStatefulWidget {
     this.enabled = true,
     this.floatOverEditor = true,
     this.expandInPlace = true,
+    this.iconOnly = false,
+    this.expandInRootOverlay = false,
+    this.tapRegionGroupId,
   });
 
   final String sessionId;
@@ -57,6 +60,15 @@ class PromptAssistantOverlay extends ConsumerStatefulWidget {
   /// prompt surface free of controls and preserving its readable area.
   final bool expandInPlace;
 
+  /// Keeps the collapsed entry icon-only, including on desktop.
+  final bool iconOnly;
+
+  /// Renders the expanded action row in the root overlay above clipped cards.
+  final bool expandInRootOverlay;
+
+  /// Keeps root-overlay actions inside an owning editor's tap region.
+  final Object? tapRegionGroupId;
+
   @override
   ConsumerState<PromptAssistantOverlay> createState() =>
       _PromptAssistantOverlayState();
@@ -65,13 +77,85 @@ class PromptAssistantOverlay extends ConsumerStatefulWidget {
 class _PromptAssistantOverlayState
     extends ConsumerState<PromptAssistantOverlay> {
   StreamSubscription? _streamSub;
+  final LayerLink _rootOverlayLink = LayerLink();
+  OverlayEntry? _rootOverlayEntry;
+  Widget? _rootOverlayChild;
+  bool _rootOverlayDesiredVisible = false;
+  bool _overlaySyncScheduled = false;
 
   bool get _isDesktop => PlatformCapabilities.current.hasPrecisePointer;
 
   @override
+  void didUpdateWidget(PromptAssistantOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.sessionId != widget.sessionId) {
+      unawaited(_streamSub?.cancel());
+      _streamSub = null;
+    }
+    if (oldWidget.sessionId != widget.sessionId ||
+        oldWidget.expandInRootOverlay != widget.expandInRootOverlay) {
+      _syncRootOverlay(false);
+    }
+  }
+
+  @override
   void dispose() {
     _streamSub?.cancel();
+    _removeRootOverlay();
     super.dispose();
+  }
+
+  void _syncRootOverlay(bool visible) {
+    _rootOverlayDesiredVisible = visible;
+    if (_overlaySyncScheduled) return;
+    _overlaySyncScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _overlaySyncScheduled = false;
+      if (!mounted) return;
+      final expanded =
+          ref.read(promptAssistantStateProvider)[widget.sessionId]?.expanded ??
+          false;
+      if (!widget.expandInRootOverlay ||
+          !expanded ||
+          !_rootOverlayDesiredVisible) {
+        _removeRootOverlay();
+        return;
+      }
+      if (_rootOverlayEntry != null) {
+        _rootOverlayEntry!.markNeedsBuild();
+        return;
+      }
+      _rootOverlayEntry = OverlayEntry(
+        builder: (overlayContext) => CompositedTransformFollower(
+          link: _rootOverlayLink,
+          showWhenUnlinked: false,
+          targetAnchor: Alignment.topRight,
+          followerAnchor: Alignment.topRight,
+          child: TapRegion(
+            groupId: widget.tapRegionGroupId,
+            child: UnconstrainedBox(
+              alignment: Alignment.topRight,
+              child: Material(
+                type: MaterialType.transparency,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: MediaQuery.sizeOf(overlayContext).width - 16,
+                  ),
+                  child: _rootOverlayChild ?? const SizedBox.shrink(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      Overlay.of(context, rootOverlay: true).insert(_rootOverlayEntry!);
+    });
+  }
+
+  void _removeRootOverlay() {
+    _rootOverlayEntry?.remove();
+    _rootOverlayEntry = null;
+    _rootOverlayChild = null;
   }
 
   Future<void> _runTranslate() async {
@@ -541,9 +625,11 @@ class _PromptAssistantOverlayState
   Widget build(BuildContext context) {
     final config = ref.watch(promptAssistantConfigProvider);
     if (!widget.enabled || !config.enabled) {
+      if (widget.expandInRootOverlay) _syncRootOverlay(false);
       return const SizedBox.shrink();
     }
     if (_isDesktop && !config.desktopOverlayEnabled) {
+      if (widget.expandInRootOverlay) _syncRootOverlay(false);
       return const SizedBox.shrink();
     }
 
@@ -612,7 +698,7 @@ class _PromptAssistantOverlayState
               mainAxisSize: MainAxisSize.min,
               children: [
                 if (!isExpanded)
-                  if (widget.expandInPlace && _isDesktop)
+                  if (widget.expandInPlace && _isDesktop && !widget.iconOnly)
                     _collapsedInlineButton(
                       label: context.l10n.promptAssistant_assistant,
                       tooltip: context.l10n.promptAssistant_expandAssistant,
@@ -733,6 +819,18 @@ class _PromptAssistantOverlayState
         ),
       ),
     );
+
+    if (widget.expandInRootOverlay) {
+      _rootOverlayChild = isExpanded ? child : null;
+      _syncRootOverlay(isExpanded);
+      return CompositedTransformTarget(
+        link: _rootOverlayLink,
+        child: SizedBox.square(
+          dimension: PromptAssistantOverlay.inlineToolbarHeight,
+          child: isExpanded ? null : child,
+        ),
+      );
+    }
 
     if (!widget.floatOverEditor) {
       return child;

--- a/lib/presentation/screens/generation/widgets/resize_handle.dart
+++ b/lib/presentation/screens/generation/widgets/resize_handle.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+export '../../../widgets/common/vertical_resize_handle.dart';
+
 /// 水平拖拽分隔条
 ///
 /// 用于左右面板之间的宽度调整，提供视觉指示器和拖拽交互。
@@ -46,64 +48,6 @@ class ResizeHandle extends StatelessWidget {
               decoration: BoxDecoration(
                 color: theme.colorScheme.outline.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(1),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// 垂直拖拽分隔条
-///
-/// 用于上下区域之间的高度调整，提供视觉指示器和拖拽交互。
-/// 悬停时指示条加宽变色，明确提示可拖动。
-class VerticalResizeHandle extends StatefulWidget {
-  final void Function(double delta) onDrag;
-  final double height;
-
-  const VerticalResizeHandle({
-    super.key,
-    required this.onDrag,
-    this.height = 8.0,
-  });
-
-  @override
-  State<VerticalResizeHandle> createState() => _VerticalResizeHandleState();
-}
-
-class _VerticalResizeHandleState extends State<VerticalResizeHandle> {
-  bool _hovered = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return MouseRegion(
-      cursor: SystemMouseCursors.resizeRow,
-      onEnter: (_) => setState(() => _hovered = true),
-      onExit: (_) => setState(() => _hovered = false),
-      child: GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onVerticalDragUpdate: (details) {
-          final delta = details.primaryDelta ?? details.delta.dy;
-          if (delta == 0) return;
-          widget.onDrag(delta);
-        },
-        child: Container(
-          height: widget.height,
-          color: Colors.transparent,
-          child: Center(
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 120),
-              width: _hovered ? 72 : 48,
-              height: _hovered ? 4 : 3,
-              decoration: BoxDecoration(
-                color: _hovered
-                    ? theme.colorScheme.primary.withValues(alpha: 0.9)
-                    : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(2),
               ),
             ),
           ),

--- a/lib/presentation/widgets/character/inline_character_card.dart
+++ b/lib/presentation/widgets/character/inline_character_card.dart
@@ -207,7 +207,11 @@ class _InlineCharacterCardState extends ConsumerState<InlineCharacterCard> {
       opacity: enabled ? 1.0 : 0.48,
       child: Focus(
         focusNode: _cardFocusNode,
-        child: TapRegion(onTapOutside: (_) => _handleTapOutside(), child: card),
+        child: TapRegion(
+          groupId: CharacterPromptEditor.tapRegionGroupId(widget.character.id),
+          onTapOutside: (_) => _handleTapOutside(),
+          child: card,
+        ),
       ),
     );
   }

--- a/lib/presentation/widgets/character/inline_character_editor.dart
+++ b/lib/presentation/widgets/character/inline_character_editor.dart
@@ -1,11 +1,16 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/platform/platform_capabilities.dart';
 import '../../../data/models/character/character_prompt.dart';
 import '../../prompt_assistant/providers/prompt_assistant_history_provider.dart';
+import '../../prompt_assistant/widgets/prompt_assistant_overlay.dart';
 import '../../providers/character_prompt_provider.dart';
 import '../../providers/image_generation_provider.dart';
+import '../common/vertical_resize_handle.dart';
 import '../prompt/toolbar/toolbar.dart';
 import '../prompt/unified/unified.dart';
 
@@ -14,6 +19,9 @@ import '../prompt/unified/unified.dart';
 /// 官网布局的卡内编辑与经典布局的全宽编辑面板共用。
 /// 挂载时自动把光标送进当前输入框；输入实时写回 provider。
 class CharacterPromptEditor extends ConsumerStatefulWidget {
+  static String tapRegionGroupId(String characterId) =>
+      'character-prompt-editor-$characterId';
+
   final CharacterPrompt character;
   final bool compact;
 
@@ -40,6 +48,8 @@ class _CharacterPromptEditorState extends ConsumerState<CharacterPromptEditor> {
 
   /// 0 = 正向提示词，1 = 负向提示词
   int _tabIndex = 0;
+  double? _positiveEditorHeight;
+  double? _negativeEditorHeight;
 
   @override
   void initState() {
@@ -105,22 +115,71 @@ class _CharacterPromptEditorState extends ConsumerState<CharacterPromptEditor> {
       children: [
         Row(
           children: [
-            _EditorTab(
-              label: l10n.prompt_positivePrompt,
-              selected: _tabIndex == 0,
-              onTap: () {
-                setState(() => _tabIndex = 0);
-                _focusCurrentTab();
-              },
+            Expanded(
+              child: Row(
+                children: [
+                  Flexible(
+                    child: _EditorTab(
+                      label: l10n.prompt_positivePrompt,
+                      selected: _tabIndex == 0,
+                      onTap: () {
+                        setState(() => _tabIndex = 0);
+                        _focusCurrentTab();
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  Flexible(
+                    child: _EditorTab(
+                      label: l10n.prompt_negativePrompt,
+                      selected: _tabIndex == 1,
+                      onTap: () {
+                        setState(() => _tabIndex = 1);
+                        _focusCurrentTab();
+                      },
+                    ),
+                  ),
+                ],
+              ),
             ),
-            const SizedBox(width: 6),
-            _EditorTab(
-              label: l10n.prompt_negativePrompt,
-              selected: _tabIndex == 1,
-              onTap: () {
-                setState(() => _tabIndex = 1);
-                _focusCurrentTab();
-              },
+            const SizedBox(width: 8),
+            SizedBox.square(
+              key: const ValueKey('character-prompt-assistant-slot'),
+              dimension: PromptAssistantOverlay.inlineToolbarHeight,
+              child: PromptAssistantOverlay(
+                key: ValueKey(
+                  _tabIndex == 0
+                      ? PromptHistorySessionIds.characterPrompt(
+                          widget.character.id,
+                        )
+                      : PromptHistorySessionIds.characterNegative(
+                          widget.character.id,
+                        ),
+                ),
+                sessionId: _tabIndex == 0
+                    ? PromptHistorySessionIds.characterPrompt(
+                        widget.character.id,
+                      )
+                    : PromptHistorySessionIds.characterNegative(
+                        widget.character.id,
+                      ),
+                controller: _tabIndex == 0
+                    ? _promptController
+                    : _negativeController,
+                onChanged: _tabIndex == 0
+                    ? (value) => _updateCharacter(
+                        widget.character.copyWith(prompt: value),
+                      )
+                    : (value) => _updateCharacter(
+                        widget.character.copyWith(negativePrompt: value),
+                      ),
+                floatOverEditor: false,
+                iconOnly: true,
+                expandInRootOverlay: true,
+                tapRegionGroupId: CharacterPromptEditor.tapRegionGroupId(
+                  widget.character.id,
+                ),
+              ),
             ),
           ],
         ),
@@ -170,20 +229,66 @@ class _CharacterPromptEditorState extends ConsumerState<CharacterPromptEditor> {
       clearNeedsConfirm: true,
     );
 
-    return PromptEditorWithToolbar(
-      toolbarConfig: PromptEditorToolbarConfig.compactMode.copyWith(
-        showClearButton: false,
-      ),
-      inputConfig: inputConfig,
-      controller: controller,
-      focusNode: focusNode,
-      sessionId: _tabIndex == 0
-          ? PromptHistorySessionIds.characterPrompt(widget.character.id)
-          : PromptHistorySessionIds.characterNegative(widget.character.id),
-      onChanged: onChanged,
-      onCleared: () => onChanged(''),
-      minLines: widget.compact ? 1 : 2,
-      maxLines: widget.compact ? 4 : 6,
+    final isNegative = _tabIndex == 1;
+    final viewportHeight = MediaQuery.sizeOf(context).height;
+    final minimumHeight = widget.compact ? 88.0 : 112.0;
+    final maximumHeight = math.max(
+      minimumHeight,
+      math.min(viewportHeight * 0.5, widget.compact ? 360.0 : 480.0),
+    );
+    final storedHeight = isNegative
+        ? _negativeEditorHeight
+        : _positiveEditorHeight;
+    final editorHeight = (storedHeight ?? minimumHeight)
+        .clamp(minimumHeight, maximumHeight)
+        .toDouble();
+    final resizeHandleHeight = PlatformCapabilities.current.hasTouchInput
+        ? 40.0
+        : 20.0;
+    final fieldName = isNegative ? 'negative' : 'positive';
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          key: ValueKey('character-prompt-editor-area-$fieldName'),
+          height: editorHeight,
+          child: PromptEditorWithToolbar(
+            toolbarConfig: PromptEditorToolbarConfig.compactMode.copyWith(
+              showClearButton: false,
+            ),
+            inputConfig: inputConfig,
+            controller: controller,
+            focusNode: focusNode,
+            sessionId: isNegative
+                ? PromptHistorySessionIds.characterNegative(widget.character.id)
+                : PromptHistorySessionIds.characterPrompt(widget.character.id),
+            enableAssistant: false,
+            onChanged: onChanged,
+            onCleared: () => onChanged(''),
+            expands: true,
+          ),
+        ),
+        VerticalResizeHandle(
+          key: ValueKey('character-prompt-resize-handle-$fieldName'),
+          height: resizeHandleHeight,
+          onDrag: (delta) {
+            setState(() {
+              final currentHeight = isNegative
+                  ? (_negativeEditorHeight ?? editorHeight)
+                  : (_positiveEditorHeight ?? editorHeight);
+              final nextHeight = (currentHeight + delta)
+                  .clamp(minimumHeight, maximumHeight)
+                  .toDouble();
+              if (isNegative) {
+                _negativeEditorHeight = nextHeight;
+              } else {
+                _positiveEditorHeight = nextHeight;
+              }
+            });
+          },
+        ),
+      ],
     );
   }
 }
@@ -218,6 +323,8 @@ class _EditorTab extends StatelessWidget {
         ),
         child: Text(
           label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
           style: theme.textTheme.labelSmall?.copyWith(
             color: selected
                 ? colorScheme.primary

--- a/lib/presentation/widgets/character/inline_character_row.dart
+++ b/lib/presentation/widgets/character/inline_character_row.dart
@@ -374,6 +374,7 @@ class _RowEditorPanelState extends ConsumerState<_RowEditorPanel> {
     final iconColor = colorScheme.onSurfaceVariant;
 
     return TapRegion(
+      groupId: CharacterPromptEditor.tapRegionGroupId(widget.character.id),
       onTapOutside: (_) => _handleTapOutside(),
       child: Focus(
         focusNode: _panelFocusNode,

--- a/lib/presentation/widgets/common/vertical_resize_handle.dart
+++ b/lib/presentation/widgets/common/vertical_resize_handle.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Reusable handle for resizing vertically stacked editor or panel regions.
+class VerticalResizeHandle extends StatefulWidget {
+  const VerticalResizeHandle({
+    super.key,
+    required this.onDrag,
+    this.height = 8,
+  });
+
+  final ValueChanged<double> onDrag;
+  final double height;
+
+  @override
+  State<VerticalResizeHandle> createState() => _VerticalResizeHandleState();
+}
+
+class _VerticalResizeHandleState extends State<VerticalResizeHandle> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeRow,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onVerticalDragUpdate: (details) {
+          final delta = details.primaryDelta ?? details.delta.dy;
+          if (delta != 0) widget.onDrag(delta);
+        },
+        child: SizedBox(
+          height: widget.height,
+          child: Center(
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 120),
+              width: _hovered ? 72 : 48,
+              height: _hovered ? 4 : 3,
+              decoration: BoxDecoration(
+                color: _hovered
+                    ? colorScheme.primary.withValues(alpha: 0.9)
+                    : colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/prompt/toolbar/prompt_editor_with_toolbar.dart
+++ b/lib/presentation/widgets/prompt/toolbar/prompt_editor_with_toolbar.dart
@@ -43,6 +43,9 @@ class PromptEditorWithToolbar extends ConsumerStatefulWidget {
   /// 提示词助手的稳定会话标识
   final String? sessionId;
 
+  /// Whether the input owns its default bottom-right assistant entry.
+  final bool enableAssistant;
+
   /// 随机按钮点击回调
   final VoidCallback? onRandomPressed;
 
@@ -77,7 +80,7 @@ class PromptEditorWithToolbar extends ConsumerStatefulWidget {
   ///
   /// 当用户确认导入 ComfyUI 格式的多角色提示词时触发。
   final void Function(String globalPrompt, List<CharacterPrompt> characters)?
-      onComfyuiImport;
+  onComfyuiImport;
 
   const PromptEditorWithToolbar({
     super.key,
@@ -88,6 +91,7 @@ class PromptEditorWithToolbar extends ConsumerStatefulWidget {
     this.decoration,
     this.onChanged,
     this.sessionId,
+    this.enableAssistant = true,
     this.onRandomPressed,
     this.onRandomLongPressed,
     this.onFullscreenPressed,
@@ -153,7 +157,8 @@ class _PromptEditorWithToolbarState
   @override
   Widget build(BuildContext context) {
     // 检查是否有任何工具栏按钮需要显示
-    final hasToolbar = widget.toolbarConfig.showRandomButton ||
+    final hasToolbar =
+        widget.toolbarConfig.showRandomButton ||
         widget.toolbarConfig.showFullscreenButton ||
         widget.toolbarConfig.showClearButton ||
         widget.toolbarConfig.showSettingsButton ||
@@ -193,6 +198,7 @@ class _PromptEditorWithToolbarState
             decoration: widget.decoration,
             onChanged: widget.onChanged,
             sessionId: widget.sessionId,
+            enableAssistant: widget.enableAssistant,
             maxLines: widget.maxLines,
             minLines: widget.minLines,
             expands: widget.expands,

--- a/test/presentation/widgets/character/inline_character_section_test.dart
+++ b/test/presentation/widgets/character/inline_character_section_test.dart
@@ -3,11 +3,13 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/platform/platform_capabilities.dart';
 import 'package:nai_launcher/core/storage/local_storage_service.dart';
 import 'package:nai_launcher/data/models/character/character_prompt.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/providers/character_prompt_provider.dart';
 import 'package:nai_launcher/presentation/widgets/character/inline_character_card.dart';
+import 'package:nai_launcher/presentation/widgets/character/inline_character_editor.dart';
 import 'package:nai_launcher/presentation/widgets/character/inline_character_row.dart';
 import 'package:nai_launcher/presentation/widgets/character/inline_character_section.dart';
 
@@ -336,6 +338,282 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
 
     expect(find.byKey(const Key('character-hover-preview')), findsNothing);
+  });
+
+  testWidgets('角色提示词可拖拽调整高度且正负输入分别保留尺寸', (tester) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    addTearDown(() => PlatformCapabilities.debugOverride = null);
+    final container = createContainer();
+
+    await tester.pumpWidget(
+      subject(
+        container,
+        420,
+        child: const Padding(
+          padding: EdgeInsets.all(12),
+          child: CharacterPromptEditor(
+            character: CharacterPrompt(
+              id: 'alice',
+              name: 'Alice',
+              prompt: 'girl, red hair',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final positiveArea = find.byKey(
+      const ValueKey('character-prompt-editor-area-positive'),
+    );
+    final positiveHandle = find.byKey(
+      const ValueKey('character-prompt-resize-handle-positive'),
+    );
+    expect(tester.getSize(positiveArea).height, 112);
+
+    await tester.drag(positiveHandle, const Offset(0, 96));
+    await tester.pump();
+    final resizedPositiveHeight = tester.getSize(positiveArea).height;
+    expect(resizedPositiveHeight, greaterThan(112));
+
+    await tester.tap(find.text('负向提示词'));
+    await tester.pump();
+    final negativeArea = find.byKey(
+      const ValueKey('character-prompt-editor-area-negative'),
+    );
+    expect(tester.getSize(negativeArea).height, 112);
+
+    await tester.drag(
+      find.byKey(const ValueKey('character-prompt-resize-handle-negative')),
+      const Offset(0, 1000),
+    );
+    await tester.pump();
+    expect(tester.getSize(negativeArea).height, 300);
+
+    await tester.drag(
+      find.byKey(const ValueKey('character-prompt-resize-handle-negative')),
+      const Offset(0, -1000),
+    );
+    await tester.pump();
+    expect(tester.getSize(negativeArea).height, 112);
+
+    await tester.tap(find.text('正向提示词'));
+    await tester.pump();
+    expect(tester.getSize(positiveArea).height, resizedPositiveHeight);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('角色助手入口固定在切换区最右且展开到 root overlay', (tester) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    addTearDown(() => PlatformCapabilities.debugOverride = null);
+    final container = createContainer();
+
+    await tester.pumpWidget(
+      subject(
+        container,
+        420,
+        child: const Padding(
+          padding: EdgeInsets.all(12),
+          child: CharacterPromptEditor(
+            character: CharacterPrompt(
+              id: 'alice',
+              name: 'Alice',
+              prompt: 'girl, red hair',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final slot = find.byKey(const ValueKey('character-prompt-assistant-slot'));
+    final collapsedToolbar = find.byKey(
+      const ValueKey(
+        'prompt_assistant_toolbar_generation_character_alice_prompt',
+      ),
+    );
+    final editor = find.byType(CharacterPromptEditor);
+    final slotRect = tester.getRect(slot);
+    final editorRect = tester.getRect(editor);
+    final areaTop = tester
+        .getRect(
+          find.byKey(const ValueKey('character-prompt-editor-area-positive')),
+        )
+        .top;
+
+    expect(slotRect.right, closeTo(editorRect.right, 0.1));
+    expect(slotRect.height, 32);
+    expect(
+      find.descendant(
+        of: collapsedToolbar,
+        matching: find.byIcon(Icons.auto_awesome_rounded),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('助手'), findsNothing);
+
+    await tester.tap(find.byIcon(Icons.auto_awesome_rounded));
+    await tester.pump();
+    await tester.pump();
+
+    final expandedToolbar = find.byKey(
+      const ValueKey(
+        'prompt_assistant_toolbar_generation_character_alice_prompt',
+      ),
+    );
+    expect(find.ancestor(of: expandedToolbar, matching: editor), findsNothing);
+    expect(tester.getRect(expandedToolbar).left, lessThan(slotRect.left));
+    expect(tester.getRect(expandedToolbar).top, closeTo(slotRect.top, 0.1));
+    for (final icon in [
+      Icons.undo,
+      Icons.redo,
+      Icons.translate,
+      Icons.auto_fix_high,
+      Icons.tune_rounded,
+      Icons.manage_accounts_rounded,
+      Icons.more_horiz,
+      Icons.keyboard_arrow_down_rounded,
+    ]) {
+      expect(
+        find.descendant(of: expandedToolbar, matching: find.byIcon(icon)),
+        findsOneWidget,
+      );
+    }
+    expect(tester.getRect(slot).height, 32);
+    expect(
+      tester
+          .getRect(
+            find.byKey(const ValueKey('character-prompt-editor-area-positive')),
+          )
+          .top,
+      areaTop,
+    );
+
+    await tester.tap(
+      find.descendant(
+        of: expandedToolbar,
+        matching: find.byIcon(Icons.keyboard_arrow_down_rounded),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.byIcon(Icons.auto_awesome_rounded), findsOneWidget);
+    expect(tester.getRect(slot).height, 32);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('点击 root overlay 助手不会退出角色编辑态', (tester) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    addTearDown(() => PlatformCapabilities.debugOverride = null);
+    final container = createContainer();
+    const character = CharacterPrompt(
+      id: 'alice',
+      name: 'Alice',
+      prompt: 'girl, red hair',
+    );
+
+    await tester.pumpWidget(
+      subject(
+        container,
+        420,
+        child: const Padding(
+          padding: EdgeInsets.all(12),
+          child: InlineCharacterCard(character: character, index: 0, total: 1),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.text('girl, red hair'));
+    await tester.pumpAndSettle();
+    expect(find.byType(CharacterPromptEditor), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.auto_awesome_rounded));
+    await tester.pump();
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.keyboard_arrow_down_rounded));
+    await tester.pump();
+    await tester.pump();
+
+    expect(container.read(selectedCharacterIdProvider), 'alice');
+    expect(find.byType(CharacterPromptEditor), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('窄屏角色助手完整显示且 resize 受视口上限约束', (tester) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.android,
+    );
+    addTearDown(() => PlatformCapabilities.debugOverride = null);
+    await tester.binding.setSurfaceSize(const Size(320, 640));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final container = createContainer();
+
+    await tester.pumpWidget(
+      subject(
+        container,
+        320,
+        child: const Padding(
+          padding: EdgeInsets.all(8),
+          child: CharacterPromptEditor(
+            character: CharacterPrompt(
+              id: 'alice',
+              name: 'Alice',
+              prompt: 'girl, red hair',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final slot = find.byKey(const ValueKey('character-prompt-assistant-slot'));
+    expect(tester.getSize(slot), const Size(48, 48));
+    await tester.tap(find.byIcon(Icons.auto_awesome_rounded));
+    await tester.pump();
+    await tester.pump();
+
+    final toolbar = find.byKey(
+      const ValueKey(
+        'prompt_assistant_toolbar_generation_character_alice_prompt',
+      ),
+    );
+    final toolbarRect = tester.getRect(toolbar);
+    expect(toolbarRect.left, greaterThanOrEqualTo(8));
+    expect(toolbarRect.right, lessThanOrEqualTo(312));
+    for (final icon in [
+      Icons.translate,
+      Icons.auto_fix_high,
+      Icons.tune_rounded,
+      Icons.manage_accounts_rounded,
+      Icons.more_horiz,
+      Icons.keyboard_arrow_down_rounded,
+    ]) {
+      expect(
+        find.descendant(of: toolbar, matching: find.byIcon(icon)),
+        findsOneWidget,
+      );
+    }
+
+    await tester.drag(
+      find.byKey(const ValueKey('character-prompt-resize-handle-positive')),
+      const Offset(0, 1000),
+    );
+    await tester.pump();
+    expect(
+      tester
+          .getSize(
+            find.byKey(const ValueKey('character-prompt-editor-area-positive')),
+          )
+          .height,
+      300,
+    );
+    expect(tester.takeException(), isNull);
   });
 
   for (final width in [700.0, 840.0, 1180.0, 1600.0]) {


### PR DESCRIPTION
## 用户可见变化

- 角色正向/负向提示词输入区支持拖拽调整高度，分别保留当前尺寸，并按桌面与 Android 视口限制最小/最大高度。
- 将角色提示词助手入口移到正向/负向切换区最右侧，入口仅显示图标，复用现有提示词助手逻辑。
- 助手展开内容提升到 root overlay，可覆盖角色卡内容且不受裁剪；展开/收起时顶部区域高度保持不变。
- 窄屏下切换标签可自适应收缩，助手操作列表保持完整可访问。

## 验证

- `flutter test test/presentation/widgets/character/inline_character_section_test.dart`
- `flutter test test/presentation/screens/generation/widgets/prompt_input_test.dart`
- `flutter analyze`
- `git diff --check`

未执行运行时 UI 验收或全平台 release build（按任务要求）。