### PR TITLE
fix(dialog): 修复移动端对话框布局溢出

### DIFF
--- a/lib/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog.dart
@@ -55,10 +55,11 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
   double _cropX = 0.0; // 裁剪框中心 X（相对于图像中心）
   double _cropY = 0.0; // 裁剪框中心 Y（相对于图像中心）
   double _cropScale = 1.0; // 裁剪框缩放（1.0 = 完整显示图像）
+  double _gestureStartScale = 1.0;
+  Offset? _lastGestureFocalPoint;
 
-  // 显示区域尺寸
-  static const double _displayWidth = 640.0;
-  static const double _displayHeight = 360.0;
+  // 桌面端保持原有高效预览尺寸，紧凑窗口由实际 constraints 决定。
+  static const Size _desktopDisplaySize = Size(640, 360);
 
   // EntryCard 比例
   static const double _cardAspectRatio = 2.5; // 200 / 80
@@ -66,6 +67,8 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
   @override
   void initState() {
     super.initState();
+    _cropX = widget.initialOffsetX.clamp(-1.0, 1.0);
+    _cropY = widget.initialOffsetY.clamp(-1.0, 1.0);
     _cropScale = widget.initialScale.clamp(1.0, 3.0);
     _loadImageSize();
   }
@@ -73,47 +76,41 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
   /// 加载图像尺寸
   void _loadImageSize() {
     final imageProvider = FileImage(File(widget.imagePath));
-    imageProvider.resolve(const ImageConfiguration()).addListener(
-      ImageStreamListener((ImageInfo info, bool synchronousCall) {
-        if (mounted) {
-          setState(() {
-            _imageSize = Size(
-              info.image.width.toDouble(),
-              info.image.height.toDouble(),
-            );
-            // 根据初始 offset 计算裁剪框位置
-            _cropX = widget.initialOffsetX;
-            _cropY = widget.initialOffsetY;
-          });
-        }
-      }),
-    );
+    imageProvider
+        .resolve(const ImageConfiguration())
+        .addListener(
+          ImageStreamListener((info, _) {
+            if (!mounted) return;
+            setState(() {
+              _imageSize = Size(
+                info.image.width.toDouble(),
+                info.image.height.toDouble(),
+              );
+            });
+          }),
+        );
   }
 
-  /// 计算图像在显示区域中的尺寸（保持比例）
-  Size get _displayedImageSize {
-    if (_imageSize == null) return const Size(_displayWidth, _displayHeight);
+  /// 计算图像在当前预览区域中的尺寸（保持比例）
+  Size _displayedImageSize(Size displaySize) {
+    if (_imageSize == null) return displaySize;
 
     final imageAspectRatio = _imageSize!.width / _imageSize!.height;
-    const displayAspectRatio = _displayWidth / _displayHeight;
+    final displayAspectRatio = displaySize.width / displaySize.height;
 
     if (imageAspectRatio > displayAspectRatio) {
-      // 图像更宽，以宽度为准
-      const width = _displayWidth;
+      final width = displaySize.width;
       final height = width / imageAspectRatio;
       return Size(width, height);
     } else {
-      // 图像更高，以高度为准
-      const height = _displayHeight;
+      final height = displaySize.height;
       final width = height * imageAspectRatio;
       return Size(width, height);
     }
   }
 
   /// 计算裁剪框尺寸
-  Size get _cropBoxSize {
-    final displayedSize = _displayedImageSize;
-
+  Size _cropBoxSize(Size displayedSize) {
     // 裁剪框的比例是 EntryCard 的比例
     // 当 scale = 1.0 时，裁剪框尽可能大但保持比例
     // 当 scale > 1.0 时，裁剪框变小（放大图像）
@@ -136,25 +133,42 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
     return Size(baseWidth * scaleFactor, baseHeight * scaleFactor);
   }
 
-  /// 处理拖拽
-  void _onPanUpdate(DragUpdateDetails details) {
+  void _onScaleStart(ScaleStartDetails details) {
+    _gestureStartScale = _cropScale;
+    _lastGestureFocalPoint = details.localFocalPoint;
+  }
+
+  void _onScaleUpdate(ScaleUpdateDetails details, Size displaySize) {
     if (_imageSize == null) return;
 
-    setState(() {
-      // 将像素偏移转换为相对偏移（-1.0 ~ 1.0）
-      final displayedSize = _displayedImageSize;
-      final maxOffsetX = (displayedSize.width - _cropBoxSize.width) / 2;
-      final maxOffsetY = (displayedSize.height - _cropBoxSize.height) / 2;
+    final previousFocalPoint = _lastGestureFocalPoint;
+    final focalDelta = previousFocalPoint == null
+        ? Offset.zero
+        : details.localFocalPoint - previousFocalPoint;
+    _lastGestureFocalPoint = details.localFocalPoint;
 
-      if (maxOffsetX > 0) {
-        _cropX += details.delta.dx / maxOffsetX;
-        _cropX = _cropX.clamp(-1.0, 1.0);
-      }
-      if (maxOffsetY > 0) {
-        _cropY += details.delta.dy / maxOffsetY;
-        _cropY = _cropY.clamp(-1.0, 1.0);
-      }
+    setState(() {
+      _cropScale = (_gestureStartScale * details.scale).clamp(1.0, 3.0);
+      _moveCropBy(focalDelta, displaySize);
     });
+  }
+
+  void _onScaleEnd(ScaleEndDetails details) {
+    _lastGestureFocalPoint = null;
+  }
+
+  void _moveCropBy(Offset delta, Size displaySize) {
+    final displayedSize = _displayedImageSize(displaySize);
+    final cropSize = _cropBoxSize(displayedSize);
+    final maxOffsetX = (displayedSize.width - cropSize.width) / 2;
+    final maxOffsetY = (displayedSize.height - cropSize.height) / 2;
+
+    if (maxOffsetX > 0) {
+      _cropX = (_cropX + delta.dx / maxOffsetX).clamp(-1.0, 1.0);
+    }
+    if (maxOffsetY > 0) {
+      _cropY = (_cropY + delta.dy / maxOffsetY).clamp(-1.0, 1.0);
+    }
   }
 
   /// 重置
@@ -169,11 +183,7 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
   /// 确认
   void _confirm() {
     widget.onConfirm(
-      ThumbnailCropResult(
-        offsetX: _cropX,
-        offsetY: _cropY,
-        scale: _cropScale,
-      ),
+      ThumbnailCropResult(offsetX: _cropX, offsetY: _cropY, scale: _cropScale),
     );
     Navigator.of(context).pop();
   }
@@ -182,43 +192,75 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
   Widget build(BuildContext context) {
     final l10n = context.l10n;
     final theme = Theme.of(context);
+    final mediaQuery = MediaQuery.of(context);
+    final isCompact =
+        mediaQuery.size.width < 600 || mediaQuery.size.height < 600;
 
-    return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: SizedBox(
-        width: 720,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // 标题栏
-            _buildHeader(theme, l10n),
-
-            // 调整区域
-            Padding(
-              padding: const EdgeInsets.all(16),
+    final content = SafeArea(
+      child: Column(
+        children: [
+          _buildHeader(theme, l10n),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(
+                isCompact ? 12 : 16,
+                12,
+                isCompact ? 12 : 16,
+                12,
+              ),
               child: Column(
-                mainAxisSize: MainAxisSize.min,
                 children: [
-                  // 提示文字
                   _buildHint(theme, l10n),
                   const SizedBox(height: 12),
-
-                  // 图像调整区域 - 使用 AbsorbPointer 防止滚轮事件传播
-                  AbsorbPointer(
-                    absorbing: false,
-                    child: ScrollConfiguration(
-                      behavior: const _NoScrollBehavior(),
-                      child: _buildAdjustArea(),
+                  Expanded(
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        final displaySize = isCompact
+                            ? Size(constraints.maxWidth, constraints.maxHeight)
+                            : Size(
+                                constraints.maxWidth.clamp(
+                                  1,
+                                  _desktopDisplaySize.width,
+                                ),
+                                constraints.maxHeight.clamp(
+                                  1,
+                                  _desktopDisplaySize.height,
+                                ),
+                              );
+                        return Center(
+                          child: ScrollConfiguration(
+                            behavior: const _NoScrollBehavior(),
+                            child: _buildAdjustArea(displaySize),
+                          ),
+                        );
+                      },
                     ),
                   ),
                 ],
               ),
             ),
+          ),
+          _buildFooter(theme, l10n),
+        ],
+      ),
+    );
 
-            // 底部按钮
-            _buildFooter(theme, l10n),
-          ],
-        ),
+    if (isCompact) {
+      return Dialog.fullscreen(child: content);
+    }
+
+    final availableHeight =
+        mediaQuery.size.height -
+        mediaQuery.padding.vertical -
+        mediaQuery.viewInsets.bottom -
+        48;
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      clipBehavior: Clip.antiAlias,
+      child: SizedBox(
+        width: 720,
+        height: availableHeight.clamp(360, 566),
+        child: content,
       ),
     );
   }
@@ -234,18 +276,16 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
       ),
       child: Row(
         children: [
-          Icon(
-            Icons.crop_free,
-            color: theme.colorScheme.primary,
-          ),
+          Icon(Icons.crop_free, color: theme.colorScheme.primary),
           const SizedBox(width: 12),
-          Text(
-            l10n.tagLibrary_adjustThumbnailTitle,
-            style: theme.textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.w600,
+          Expanded(
+            child: Text(
+              l10n.tagLibrary_adjustThumbnailTitle,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
-          const Spacer(),
           IconButton(
             onPressed: () => Navigator.of(context).pop(),
             icon: const Icon(Icons.close),
@@ -260,11 +300,7 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
   Widget _buildHint(ThemeData theme, AppLocalizations l10n) {
     return Row(
       children: [
-        Icon(
-          Icons.touch_app,
-          size: 16,
-          color: theme.colorScheme.outline,
-        ),
+        Icon(Icons.touch_app, size: 16, color: theme.colorScheme.outline),
         const SizedBox(width: 8),
         Expanded(
           child: Text(
@@ -279,117 +315,100 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
   }
 
   /// 构建调整区域
-  Widget _buildAdjustArea() {
+  Widget _buildAdjustArea(Size displaySize) {
+    final decoration = BoxDecoration(
+      borderRadius: BorderRadius.circular(12),
+      color: Colors.grey.shade900,
+    );
     if (_imageSize == null) {
       return Container(
-        width: _displayWidth,
-        height: _displayHeight,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
-          color: Colors.grey.shade900,
-        ),
+        key: const ValueKey('thumbnail-crop-preview'),
+        width: displaySize.width,
+        height: displaySize.height,
+        decoration: decoration,
         child: const Center(child: CircularProgressIndicator()),
       );
     }
 
-    final displayedSize = _displayedImageSize;
-    final cropSize = _cropBoxSize;
-
-    // 图像在显示区域中的偏移（居中）
-    final imageOffsetX = (_displayWidth - displayedSize.width) / 2;
-    final imageOffsetY = (_displayHeight - displayedSize.height) / 2;
-
-    // 裁剪框位置（相对于显示区域左上角）
-    // 图像居中偏移 + 基础居中位置 + 用户拖拽偏移
-    // 公式: imageOffset + (displayed - crop) / 2 + _crop * (displayed - crop) / 2
-    //      = imageOffset + (displayed - crop) / 2 * (1 + _crop)
-    final cropLeft = imageOffsetX +
+    final displayedSize = _displayedImageSize(displaySize);
+    final cropSize = _cropBoxSize(displayedSize);
+    final imageOffsetX = (displaySize.width - displayedSize.width) / 2;
+    final imageOffsetY = (displaySize.height - displayedSize.height) / 2;
+    final cropLeft =
+        imageOffsetX +
         (displayedSize.width - cropSize.width) / 2 * (1 + _cropX);
-    final cropTop = imageOffsetY +
+    final cropTop =
+        imageOffsetY +
         (displayedSize.height - cropSize.height) / 2 * (1 + _cropY);
 
-    return Container(
-      width: _displayWidth,
-      height: _displayHeight,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
-        color: Colors.grey.shade900,
-      ),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: Stack(
-          children: [
-            // 背景图像（居中显示）
-            Positioned(
-              left: imageOffsetX,
-              top: imageOffsetY,
-              child: Image.file(
-                File(widget.imagePath),
-                fit: BoxFit.contain,
-                width: displayedSize.width,
-                height: displayedSize.height,
-                errorBuilder: (_, __, ___) => Container(
-                  width: displayedSize.width,
-                  height: displayedSize.height,
-                  color: Colors.grey.shade800,
-                  child: const Center(
-                    child: Icon(
-                      Icons.broken_image,
-                      size: 48,
-                      color: Colors.white38,
+    return Listener(
+      onPointerSignal: (event) {
+        if (event is! PointerScrollEvent) return;
+        final scaleDelta = event.scrollDelta.dy > 0 ? -0.1 : 0.1;
+        final newScale = (_cropScale + scaleDelta).clamp(1.0, 3.0);
+        if (newScale != _cropScale) {
+          setState(() => _cropScale = newScale);
+        }
+      },
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onScaleStart: _onScaleStart,
+        onScaleUpdate: (details) => _onScaleUpdate(details, displaySize),
+        onScaleEnd: _onScaleEnd,
+        child: Container(
+          key: const ValueKey('thumbnail-crop-preview'),
+          width: displaySize.width,
+          height: displaySize.height,
+          decoration: decoration,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: Stack(
+              children: [
+                Positioned(
+                  left: imageOffsetX,
+                  top: imageOffsetY,
+                  child: Image.file(
+                    File(widget.imagePath),
+                    key: const ValueKey('thumbnail-crop-image'),
+                    fit: BoxFit.contain,
+                    width: displayedSize.width,
+                    height: displayedSize.height,
+                    errorBuilder: (_, __, ___) => Container(
+                      width: displayedSize.width,
+                      height: displayedSize.height,
+                      color: Colors.grey.shade800,
+                      child: const Center(
+                        child: Icon(
+                          Icons.broken_image,
+                          size: 48,
+                          color: Colors.white38,
+                        ),
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ),
-
-            // 遮罩层（裁剪框外的暗色区域）
-            Positioned(
-              left: imageOffsetX,
-              top: imageOffsetY,
-              child: CustomPaint(
-                size: Size(displayedSize.width, displayedSize.height),
-                painter: _CropOverlayPainter(
-                  cropBoxSize: cropSize,
-                  offsetX: _cropX,
-                  offsetY: _cropY,
+                Positioned(
+                  left: imageOffsetX,
+                  top: imageOffsetY,
+                  child: CustomPaint(
+                    size: displayedSize,
+                    painter: _CropOverlayPainter(
+                      cropBoxSize: cropSize,
+                      offsetX: _cropX,
+                      offsetY: _cropY,
+                    ),
+                  ),
                 ),
-              ),
-            ),
-
-            // 可拖拽的裁剪框
-            Positioned(
-              left: cropLeft,
-              top: cropTop,
-              child: NotificationListener<ScrollNotification>(
-                onNotification: (notification) {
-                  return true;
-                },
-                child: GestureDetector(
-                  onPanUpdate: _onPanUpdate,
-                  child: Listener(
-                    onPointerSignal: (PointerSignalEvent event) {
-                      if (event is PointerScrollEvent) {
-                        final delta = event.scrollDelta.dy;
-                        final scaleDelta = delta > 0 ? -0.1 : 0.1;
-                        final newScale =
-                            (_cropScale + scaleDelta).clamp(1.0, 3.0);
-                        if (newScale != _cropScale) {
-                          setState(() {
-                            _cropScale = newScale;
-                          });
-                        }
-                      }
-                    },
-                    behavior: HitTestBehavior.opaque,
+                Positioned(
+                  left: cropLeft,
+                  top: cropTop,
+                  child: IgnorePointer(
                     child: Container(
+                      key: const ValueKey('thumbnail-crop-selection'),
                       width: cropSize.width,
                       height: cropSize.height,
                       decoration: BoxDecoration(
-                        border: Border.all(
-                          color: Colors.white,
-                          width: 2,
-                        ),
+                        border: Border.all(color: Colors.white, width: 2),
                         boxShadow: [
                           BoxShadow(
                             color: Colors.black.withValues(alpha: 0.5),
@@ -407,9 +426,9 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
                     ),
                   ),
                 ),
-              ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );
@@ -424,23 +443,21 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
           top: BorderSide(color: theme.colorScheme.outlineVariant),
         ),
       ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
+      child: Wrap(
+        alignment: WrapAlignment.end,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        spacing: 8,
+        runSpacing: 8,
         children: [
-          // 重置按钮
           TextButton.icon(
             onPressed: _reset,
             icon: const Icon(Icons.restart_alt),
             label: Text(l10n.common_reset),
           ),
-          const SizedBox(width: 8),
-          // 取消按钮
-          OutlinedButton(
+          TextButton(
             onPressed: () => Navigator.of(context).pop(),
             child: Text(l10n.common_cancel),
           ),
-          const SizedBox(width: 8),
-          // 确认按钮
           FilledButton.icon(
             onPressed: _confirm,
             icon: const Icon(Icons.check),
@@ -486,10 +503,7 @@ class _CropOverlayPainter extends CustomPainter {
     canvas.saveLayer(Rect.fromLTWH(0, 0, size.width, size.height), Paint());
 
     // 绘制半透明背景
-    canvas.drawRect(
-      Rect.fromLTWH(0, 0, size.width, size.height),
-      paint,
-    );
+    canvas.drawRect(Rect.fromLTWH(0, 0, size.width, size.height), paint);
 
     // 使用混合模式清除中间区域
     final clearPaint = Paint()..blendMode = BlendMode.clear;

--- a/lib/presentation/widgets/prompt/new_preset_dialog.dart
+++ b/lib/presentation/widgets/prompt/new_preset_dialog.dart
@@ -75,127 +75,161 @@ class _NewPresetDialogState extends State<NewPresetDialog> {
     final colorScheme = theme.colorScheme;
     final l10n = context.l10n;
 
-    return Dialog(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 420),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // 标题栏
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              decoration: BoxDecoration(
-                color: colorScheme.surfaceContainerHighest,
-                borderRadius: const BorderRadius.vertical(
-                  top: Radius.circular(12),
+    final mediaQuery = MediaQuery.of(context);
+    final isCompact =
+        mediaQuery.size.width < 600 || mediaQuery.size.height < 600;
+    final availableHeight =
+        mediaQuery.size.height -
+        mediaQuery.padding.vertical -
+        mediaQuery.viewInsets.bottom -
+        (isCompact ? 24 : 48);
+    final isShort = availableHeight < 320;
+
+    return SafeArea(
+      minimum: EdgeInsets.all(isCompact ? 12 : 24),
+      child: Dialog(
+        insetPadding: EdgeInsets.zero,
+        clipBehavior: Clip.antiAlias,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: 420,
+            maxHeight: availableHeight.clamp(160, 560),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // 标题栏
+              Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: isShort ? 12 : 16,
+                  vertical: isShort ? 4 : 12,
                 ),
-              ),
-              child: Row(
-                children: [
-                  Icon(Icons.add_circle_outline, color: colorScheme.primary),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      l10n.newPresetDialog_title,
-                      style: theme.textTheme.titleMedium,
-                    ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                ],
-              ),
-            ),
-
-            // 内容区域
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // 名称输入
-                  TextField(
-                    controller: _nameController,
-                    focusNode: _nameFocusNode,
-                    decoration: InputDecoration(
-                      labelText: l10n.newPresetDialog_nameLabel,
-                      hintText: l10n.newPresetDialog_nameHint,
-                      errorText: _nameError,
-                      border: const OutlineInputBorder(),
-                      prefixIcon: const Icon(Icons.edit_outlined),
-                    ),
-                    onChanged: (_) {
-                      if (_nameError != null) {
-                        setState(() => _nameError = null);
-                      }
-                    },
-                    onSubmitted: (_) => _validateAndSubmit(),
-                  ),
-                  const SizedBox(height: 20),
-
-                  // 创建模式选择
-                  Text(
-                    l10n.newPresetDialog_creationMode,
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-
-                  // 基于默认预设选项
-                  _ModeOptionCard(
-                    icon: Icons.content_copy_outlined,
-                    title: l10n.newPresetDialog_template,
-                    subtitle: l10n.newPresetDialog_templateDesc,
-                    isSelected: _selectedMode == PresetCreationMode.template,
-                    onTap: () => setState(
-                      () => _selectedMode = PresetCreationMode.template,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-
-                  // 完全空白选项
-                  _ModeOptionCard(
-                    icon: Icons.note_add_outlined,
-                    title: l10n.newPresetDialog_blank,
-                    subtitle: l10n.newPresetDialog_blankDesc,
-                    isSelected: _selectedMode == PresetCreationMode.blank,
-                    onTap: () => setState(
-                      () => _selectedMode = PresetCreationMode.blank,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-
-            // 底部按钮
-            Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                border: Border(
-                  top: BorderSide(
-                    color: colorScheme.outlineVariant.withValues(alpha: 0.3),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerHighest,
+                  borderRadius: const BorderRadius.vertical(
+                    top: Radius.circular(12),
                   ),
                 ),
+                child: Row(
+                  children: [
+                    Icon(Icons.add_circle_outline, color: colorScheme.primary),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        l10n.newPresetDialog_title,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close),
+                      tooltip: MaterialLocalizations.of(
+                        context,
+                      ).closeButtonTooltip,
+                      onPressed: () => Navigator.of(context).pop(),
+                    ),
+                  ],
+                ),
               ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: Text(l10n.common_cancel),
+
+              // 内容区域在键盘、小高度和大字体下滚动，标题与动作始终固定可达。
+              Flexible(
+                child: SingleChildScrollView(
+                  keyboardDismissBehavior:
+                      ScrollViewKeyboardDismissBehavior.onDrag,
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // 名称输入
+                      TextField(
+                        controller: _nameController,
+                        focusNode: _nameFocusNode,
+                        decoration: InputDecoration(
+                          labelText: l10n.newPresetDialog_nameLabel,
+                          hintText: l10n.newPresetDialog_nameHint,
+                          errorText: _nameError,
+                          border: const OutlineInputBorder(),
+                          prefixIcon: const Icon(Icons.edit_outlined),
+                        ),
+                        onChanged: (_) {
+                          if (_nameError != null) {
+                            setState(() => _nameError = null);
+                          }
+                        },
+                        onSubmitted: (_) => _validateAndSubmit(),
+                      ),
+                      const SizedBox(height: 20),
+
+                      // 创建模式选择
+                      Text(
+                        l10n.newPresetDialog_creationMode,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+
+                      // 基于默认预设选项
+                      _ModeOptionCard(
+                        icon: Icons.content_copy_outlined,
+                        title: l10n.newPresetDialog_template,
+                        subtitle: l10n.newPresetDialog_templateDesc,
+                        isSelected:
+                            _selectedMode == PresetCreationMode.template,
+                        onTap: () => setState(
+                          () => _selectedMode = PresetCreationMode.template,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+
+                      // 完全空白选项
+                      _ModeOptionCard(
+                        icon: Icons.note_add_outlined,
+                        title: l10n.newPresetDialog_blank,
+                        subtitle: l10n.newPresetDialog_blankDesc,
+                        isSelected: _selectedMode == PresetCreationMode.blank,
+                        onTap: () => setState(
+                          () => _selectedMode = PresetCreationMode.blank,
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 8),
-                  FilledButton.icon(
-                    onPressed: _validateAndSubmit,
-                    icon: const Icon(Icons.check, size: 18),
-                    label: Text(l10n.common_create),
-                  ),
-                ],
+                ),
               ),
-            ),
-          ],
+
+              // 底部按钮
+              Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: isShort ? 4 : 16,
+                ),
+                decoration: BoxDecoration(
+                  border: Border(
+                    top: BorderSide(
+                      color: colorScheme.outlineVariant.withValues(alpha: 0.3),
+                    ),
+                  ),
+                ),
+                child: Wrap(
+                  alignment: WrapAlignment.end,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: Text(l10n.common_cancel),
+                    ),
+                    FilledButton.icon(
+                      onPressed: _validateAndSubmit,
+                      icon: const Icon(Icons.check, size: 18),
+                      label: Text(l10n.common_create),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/test/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog_test.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog.dart';
+
+void main() {
+  final testImage = File('assets/icons/android/playstore-icon.png').absolute;
+
+  testWidgets('手机竖屏完整显示可操作预览与 SafeArea 内动作', (tester) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = const FakeViewPadding(top: 24, bottom: 24);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPadding();
+    });
+
+    await _cacheFileImage(tester, testImage);
+    ThumbnailCropResult? result;
+    await _pumpDialog(
+      tester,
+      imagePath: testImage.path,
+      onConfirm: (value) => result = value,
+    );
+
+    final preview = tester.getRect(
+      find.byKey(const ValueKey('thumbnail-crop-preview')),
+    );
+    final image = tester.getRect(
+      find.byKey(const ValueKey('thumbnail-crop-image')),
+    );
+    expect(preview.left, greaterThanOrEqualTo(12));
+    expect(preview.right, lessThanOrEqualTo(348));
+    expect(preview.width, greaterThan(300));
+    expect(image.left, greaterThanOrEqualTo(preview.left));
+    expect(image.right, lessThanOrEqualTo(preview.right));
+    expect(image.top, greaterThanOrEqualTo(preview.top));
+    expect(image.bottom, lessThanOrEqualTo(preview.bottom));
+    expect(image.width, greaterThan(150));
+
+    for (final label in ['重置', '取消', '确定']) {
+      final rect = tester.getRect(find.text(label));
+      expect(rect.top, greaterThanOrEqualTo(24));
+      expect(rect.bottom, lessThanOrEqualTo(776));
+    }
+
+    final center = preview.center;
+    final first = await tester.startGesture(
+      center.translate(-30, 0),
+      pointer: 1,
+    );
+    final second = await tester.startGesture(
+      center.translate(30, 0),
+      pointer: 2,
+    );
+    await first.moveBy(const Offset(-30, 0));
+    await second.moveBy(const Offset(30, 0));
+    await tester.pump();
+    await first.up();
+    await second.up();
+
+    await tester.tap(find.text('确定'));
+    await tester.pumpAndSettle();
+    expect(result, isNotNull);
+    expect(result!.scale, greaterThan(1));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('桌面保留 640x360 预览并支持滚轮缩放与拖拽', (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    await _cacheFileImage(tester, testImage);
+    ThumbnailCropResult? result;
+    await _pumpDialog(
+      tester,
+      imagePath: testImage.path,
+      onConfirm: (value) => result = value,
+    );
+
+    final previewFinder = find.byKey(const ValueKey('thumbnail-crop-preview'));
+    expect(tester.getSize(previewFinder), const Size(640, 360));
+    final center = tester.getCenter(previewFinder);
+    await tester.sendEventToBinding(
+      PointerScrollEvent(
+        position: center,
+        scrollDelta: const Offset(0, -40),
+        kind: PointerDeviceKind.mouse,
+      ),
+    );
+    await tester.dragFrom(center, const Offset(30, 20));
+    await tester.pump();
+
+    await tester.tap(find.text('确定'));
+    await tester.pumpAndSettle();
+    expect(result, isNotNull);
+    expect(result!.scale, greaterThan(1));
+    expect(result!.offsetX.abs() + result!.offsetY.abs(), greaterThan(0));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('手机横屏大字体无横向或纵向溢出', (tester) async {
+    tester.view.physicalSize = const Size(800, 360);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = const FakeViewPadding(left: 24, right: 24);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPadding();
+    });
+
+    await _cacheFileImage(tester, testImage);
+    await _pumpDialog(
+      tester,
+      imagePath: testImage.path,
+      textScale: 1.6,
+      onConfirm: (_) {},
+    );
+
+    final preview = tester.getRect(
+      find.byKey(const ValueKey('thumbnail-crop-preview')),
+    );
+    expect(preview.width, greaterThan(300));
+    expect(preview.height, greaterThan(80));
+    expect(tester.getRect(find.text('确定')).right, lessThanOrEqualTo(776));
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpDialog(
+  WidgetTester tester, {
+  required String imagePath,
+  required ValueChanged<ThumbnailCropResult> onConfirm,
+  double textScale = 1,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: const Locale('zh'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: TextScaler.linear(textScale)),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: ThumbnailCropDialog(imagePath: imagePath, onConfirm: onConfirm),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+Future<void> _cacheFileImage(WidgetTester tester, File file) async {
+  await tester.runAsync(() async {
+    final completed = Completer<void>();
+    final stream = FileImage(file).resolve(ImageConfiguration.empty);
+    late final ImageStreamListener listener;
+    listener = ImageStreamListener(
+      (_, __) {
+        if (!completed.isCompleted) completed.complete();
+        stream.removeListener(listener);
+      },
+      onError: (Object error, StackTrace? stackTrace) {
+        if (!completed.isCompleted) {
+          completed.completeError(error, stackTrace);
+        }
+        stream.removeListener(listener);
+      },
+    );
+    stream.addListener(listener);
+    await completed.future;
+  });
+}

--- a/test/presentation/widgets/prompt/new_preset_dialog_test.dart
+++ b/test/presentation/widgets/prompt/new_preset_dialog_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/widgets/prompt/new_preset_dialog.dart';
+
+void main() {
+  testWidgets('手机小高度弹出键盘后内容可滚动且动作始终可达', (tester) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = const FakeViewPadding(top: 24, bottom: 24);
+    tester.view.viewInsets = const FakeViewPadding(bottom: 320);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPadding();
+      tester.view.resetViewInsets();
+    });
+
+    await _pumpLauncher(tester, textScale: 1.35);
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('创建新预设'), findsOneWidget);
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    for (final label in ['取消', '创建']) {
+      final rect = tester.getRect(find.text(label));
+      expect(rect.left, greaterThanOrEqualTo(12));
+      expect(rect.right, lessThanOrEqualTo(348));
+      expect(rect.top, greaterThanOrEqualTo(24));
+      expect(rect.bottom, lessThanOrEqualTo(480));
+    }
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(find.text('创建'));
+    await tester.pump();
+    expect(find.text('请输入预设名称'), findsOneWidget);
+    expect(tester.getRect(find.text('创建')).bottom, lessThanOrEqualTo(480));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('横屏大字体和键盘下动作栏仍在可见区域', (tester) async {
+    tester.view.physicalSize = const Size(800, 360);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = const FakeViewPadding(left: 24, right: 24);
+    tester.view.viewInsets = const FakeViewPadding(bottom: 200);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPadding();
+      tester.view.resetViewInsets();
+    });
+
+    await _pumpLauncher(tester, textScale: 1.6);
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('创建新预设'), findsOneWidget);
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    for (final label in ['取消', '创建']) {
+      final rect = tester.getRect(find.text(label));
+      expect(rect.top, greaterThanOrEqualTo(0));
+      expect(rect.bottom, lessThanOrEqualTo(160));
+    }
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('滚动选择创建方式后返回完整结果', (tester) async {
+    tester.view.physicalSize = const Size(360, 640);
+    tester.view.devicePixelRatio = 1;
+    tester.view.viewInsets = const FakeViewPadding(bottom: 260);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetViewInsets();
+    });
+
+    NewPresetResult? result;
+    await _pumpLauncher(tester, onResult: (value) => result = value);
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '移动端预设');
+    await tester.drag(
+      find.byType(SingleChildScrollView),
+      const Offset(0, -240),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('完全空白'));
+    await tester.tap(find.text('创建'));
+    await tester.pumpAndSettle();
+
+    expect(result, isNotNull);
+    expect(result!.name, '移动端预设');
+    expect(result!.mode, PresetCreationMode.blank);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpLauncher(
+  WidgetTester tester, {
+  double textScale = 1,
+  ValueChanged<NewPresetResult?>? onResult,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: const Locale('zh'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: TextScaler.linear(textScale)),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: FilledButton(
+              onPressed: () async {
+                final result = await NewPresetDialog.show(context);
+                onResult?.call(result);
+              },
+              child: const Text('打开'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## 用户可见变化

- “调整预览图显示范围”在手机竖屏和横屏改为 SafeArea 内的全屏自适应界面，完整展示可操作图片、裁剪范围、说明和全部动作；桌面继续保留 640×360 预览效率。
- 裁剪预览的图片、遮罩、裁剪框和拖拽坐标统一使用实际 viewport constraints，不再由固定 720/640px 桌面宽度挤出手机屏幕。
- 补齐触屏双指缩放，同时保留单指拖拽和桌面滚轮缩放；裁剪 offset/scale 输出与保存语义不变。
- “创建新预设”在软键盘、小高度、横屏和大字体下限制于可见区域，中间内容可滚动，标题与取消/创建动作保持可达。

## 截图对应根因

- 预览只剩右侧窄条和巨大 RIGHT OVERFLOW：裁剪 Dialog 固定宽 720px、预览固定 640×360，所有 transform 几何都基于固定桌面尺寸。
- 创建预设底部溢出 41px：自动聚焦弹出键盘后，可用高度缩小，但对话框仍使用不可滚动、不可压缩的完整 Column，固定内容和动作栏超过 route constraints。

## 验证

- `flutter test test/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog_test.dart test/presentation/widgets/prompt/new_preset_dialog_test.dart test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart test/presentation/screens/prompt_config/random_config_screen_test.dart`
- `flutter analyze`
- `git diff --cached --check`

未运行真实 Android/Windows 自动化验收或 release build，符合本任务要求。
