### PR TITLE
feat(android): 添加原图元数据读取入口

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3736,6 +3736,9 @@
       "count": {"type": "int"}
     }
   },
+  "metadataImport_readImageMetadata": "Read Image Metadata",
+  "metadataImport_readFailed": "Couldn't read the selected image",
+  "metadataImport_processFailed": "Couldn't process the selected image",
   "metadataImport_noDataFound": "No NovelAI metadata found",
   "metadataImport_noParamsSelected": "No parameters selected",
   "metadataImport_appliedCount": "Applied {count} parameters",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3677,6 +3677,9 @@
       }
     }
   },
+  "metadataImport_readImageMetadata": "画像メタデータを読み取る",
+  "metadataImport_readFailed": "選択した画像を読み込めませんでした",
+  "metadataImport_processFailed": "選択した画像を処理できませんでした",
   "metadataImport_noDataFound": "NovelAI メタデータが見つかりませんでした",
   "metadataImport_noParamsSelected": "パラメータが選択されていません",
   "metadataImport_appliedCount": "適用された {count} パラメータ",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -14110,6 +14110,24 @@ abstract class AppLocalizations {
   /// **'{count} selected'**
   String metadataImport_selectedCount(int count);
 
+  /// No description provided for @metadataImport_readImageMetadata.
+  ///
+  /// In en, this message translates to:
+  /// **'Read Image Metadata'**
+  String get metadataImport_readImageMetadata;
+
+  /// No description provided for @metadataImport_readFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t read the selected image'**
+  String get metadataImport_readFailed;
+
+  /// No description provided for @metadataImport_processFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t process the selected image'**
+  String get metadataImport_processFailed;
+
   /// No description provided for @metadataImport_noDataFound.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7955,6 +7955,16 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get metadataImport_readImageMetadata => 'Read Image Metadata';
+
+  @override
+  String get metadataImport_readFailed => 'Couldn\'t read the selected image';
+
+  @override
+  String get metadataImport_processFailed =>
+      'Couldn\'t process the selected image';
+
+  @override
   String get metadataImport_noDataFound => 'No NovelAI metadata found';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -7775,6 +7775,15 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get metadataImport_readImageMetadata => '画像メタデータを読み取る';
+
+  @override
+  String get metadataImport_readFailed => '選択した画像を読み込めませんでした';
+
+  @override
+  String get metadataImport_processFailed => '選択した画像を処理できませんでした';
+
+  @override
   String get metadataImport_noDataFound => 'NovelAI メタデータが見つかりませんでした';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7657,6 +7657,15 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get metadataImport_readImageMetadata => '读取图片元数据';
+
+  @override
+  String get metadataImport_readFailed => '无法读取所选图片';
+
+  @override
+  String get metadataImport_processFailed => '无法处理所选图片';
+
+  @override
   String get metadataImport_noDataFound => '未找到 NovelAI 元数据';
 
   @override
@@ -20826,6 +20835,15 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String metadataImport_selectedCount(int count) {
     return '已選擇 $count 項';
   }
+
+  @override
+  String get metadataImport_readImageMetadata => '讀取圖片後設資料';
+
+  @override
+  String get metadataImport_readFailed => '無法讀取所選圖片';
+
+  @override
+  String get metadataImport_processFailed => '無法處理所選圖片';
 
   @override
   String get metadataImport_noDataFound => '未找到 NovelAI 後設資料';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3759,6 +3759,9 @@
       "count": {"type": "int"}
     }
   },
+  "metadataImport_readImageMetadata": "读取图片元数据",
+  "metadataImport_readFailed": "无法读取所选图片",
+  "metadataImport_processFailed": "无法处理所选图片",
   "metadataImport_noDataFound": "未找到 NovelAI 元数据",
   "metadataImport_noParamsSelected": "未选择任何要应用的参数",
   "metadataImport_appliedCount": "已应用 {count} 项参数",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3768,6 +3768,9 @@
       }
     }
   },
+  "metadataImport_readImageMetadata": "讀取圖片後設資料",
+  "metadataImport_readFailed": "無法讀取所選圖片",
+  "metadataImport_processFailed": "無法處理所選圖片",
   "metadataImport_noDataFound": "未找到 NovelAI 後設資料",
   "metadataImport_noParamsSelected": "未選擇任何要應用的引數",
   "metadataImport_appliedCount": "已應用 {count} 項引數",

--- a/lib/presentation/router/mobile_more_panel.dart
+++ b/lib/presentation/router/mobile_more_panel.dart
@@ -9,16 +9,25 @@ import '../adaptive/adaptive_presenter.dart';
 import '../agent_chat/providers/agent_chat_notifier.dart';
 import '../providers/replication_queue_provider.dart';
 import '../providers/update_provider.dart';
+import '../services/mobile_image_metadata_importer.dart';
 import '../widgets/common/app_toast.dart';
 import '../widgets/navigation/main_nav_rail.dart';
 import 'app_branch.dart';
 import 'shell_panels_overlay.dart';
 
+typedef MobileMetadataImportAction =
+    Future<void> Function(BuildContext context, WidgetRef ref);
+
 Future<void> showMobileMorePanel({
   required BuildContext context,
   required WidgetRef ref,
   required StatefulNavigationShell navigationShell,
+  MobileMetadataImportAction? onImportImageMetadata,
 }) {
+  final importImageMetadata =
+      onImportImageMetadata ??
+      ((context, ref) =>
+          MobileImageMetadataImporter.shared.run(context: context, ref: ref));
   final queueCount = ref.read(replicationQueueNotifierProvider).count;
   final hasUpdate = ref.read(updateStateProvider).hasNewVersion;
   final activePanel = ref.read(shellPanelProvider);
@@ -57,6 +66,21 @@ Future<void> showMobileMorePanel({
           onTap: () {
             Navigator.of(panelContext).pop();
             ref.read(shellPanelProvider.notifier).state = ShellPanel.queue;
+          },
+        ),
+        _MobileMoreDestination(
+          key: const ValueKey('mobile-more-read-image-metadata'),
+          icon: Icons.document_scanner_outlined,
+          label: panelContext.l10n.metadataImport_readImageMetadata,
+          onTap: () async {
+            final panelRoute = ModalRoute.of(panelContext);
+            Navigator.of(panelContext).pop();
+            if (panelRoute != null) {
+              await panelRoute.completed;
+            }
+            if (context.mounted) {
+              await importImageMetadata(context, ref);
+            }
           },
         ),
         const Divider(indent: 16, endIndent: 16),
@@ -223,7 +247,7 @@ class _MobileMoreDestination extends StatelessWidget {
         smallSize: 7,
         child: Icon(icon),
       ),
-      title: Text(label),
+      title: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
       trailing: selected
           ? const Icon(Icons.check_rounded)
           : const Icon(Icons.chevron_right),

--- a/lib/presentation/services/image_metadata_import_workflow.dart
+++ b/lib/presentation/services/image_metadata_import_workflow.dart
@@ -1,0 +1,143 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/utils/localization_extension.dart';
+import '../../data/models/gallery/nai_image_metadata.dart';
+import '../../data/models/metadata/metadata_import_options.dart';
+import '../../data/services/image_metadata_service.dart';
+import '../../l10n/app_localizations.dart';
+import '../router/app_routes.dart';
+import '../utils/metadata_import_coordinator.dart';
+import '../utils/prompt_preset_import_utils.dart' show ProviderReader;
+import '../widgets/common/app_toast.dart';
+import '../widgets/metadata/metadata_import_dialog.dart';
+
+enum ImageMetadataImportResult {
+  cancelled,
+  noMetadata,
+  noParametersSelected,
+  applied,
+}
+
+typedef ImageMetadataReader =
+    Future<NaiImageMetadata?> Function(Uint8List bytes);
+typedef MetadataImportOptionsPicker =
+    Future<MetadataImportOptions?> Function(
+      BuildContext context,
+      NaiImageMetadata metadata,
+    );
+typedef MetadataImportApplier =
+    Future<int> Function(
+      ProviderReader read,
+      NaiImageMetadata metadata,
+      MetadataImportOptions options,
+      AppLocalizations l10n,
+    );
+typedef MetadataImportResultReporter =
+    void Function(
+      BuildContext context,
+      ImageMetadataImportResult result,
+      int appliedCount,
+    );
+typedef GenerationPageOpener = void Function(BuildContext context);
+
+/// Reusable image-metadata import flow for direct byte-based entry points.
+class ImageMetadataImportWorkflow {
+  ImageMetadataImportWorkflow({
+    ImageMetadataReader? metadataReader,
+    MetadataImportOptionsPicker? optionsPicker,
+    MetadataImportApplier? metadataApplier,
+    MetadataImportResultReporter? resultReporter,
+    GenerationPageOpener? generationPageOpener,
+  }) : _metadataReader =
+           metadataReader ?? ImageMetadataService().getMetadataFromBytes,
+       _optionsPicker =
+           optionsPicker ??
+           ((context, metadata) =>
+               MetadataImportDialog.show(context, metadata: metadata)),
+       _metadataApplier =
+           metadataApplier ??
+           ((read, metadata, options, l10n) => MetadataImportCoordinator.apply(
+             read: read,
+             metadata: metadata,
+             options: options,
+             l10n: l10n,
+           )),
+       _resultReporter = resultReporter ?? _reportResult,
+       _generationPageOpener =
+           generationPageOpener ?? ((context) => context.go(AppRoutes.home));
+
+  static final ImageMetadataImportWorkflow shared =
+      ImageMetadataImportWorkflow();
+
+  final ImageMetadataReader _metadataReader;
+  final MetadataImportOptionsPicker _optionsPicker;
+  final MetadataImportApplier _metadataApplier;
+  final MetadataImportResultReporter _resultReporter;
+  final GenerationPageOpener _generationPageOpener;
+
+  Future<ImageMetadataImportResult> run({
+    required BuildContext context,
+    required ProviderReader read,
+    required Uint8List bytes,
+  }) async {
+    final metadata = await _metadataReader(bytes);
+    if (!context.mounted) return ImageMetadataImportResult.cancelled;
+
+    if (metadata == null || !metadata.hasData) {
+      _resultReporter(context, ImageMetadataImportResult.noMetadata, 0);
+      return ImageMetadataImportResult.noMetadata;
+    }
+
+    final options = await _optionsPicker(context, metadata);
+    if (options == null || !context.mounted) {
+      return ImageMetadataImportResult.cancelled;
+    }
+
+    final appliedCount = await _metadataApplier(
+      read,
+      metadata,
+      options,
+      context.l10n,
+    );
+    if (!context.mounted) return ImageMetadataImportResult.cancelled;
+
+    if (appliedCount == 0) {
+      _resultReporter(
+        context,
+        ImageMetadataImportResult.noParametersSelected,
+        0,
+      );
+      return ImageMetadataImportResult.noParametersSelected;
+    }
+
+    _resultReporter(context, ImageMetadataImportResult.applied, appliedCount);
+    _generationPageOpener(context);
+    return ImageMetadataImportResult.applied;
+  }
+
+  static void _reportResult(
+    BuildContext context,
+    ImageMetadataImportResult result,
+    int appliedCount,
+  ) {
+    switch (result) {
+      case ImageMetadataImportResult.noMetadata:
+        AppToast.warning(context, context.l10n.metadataImport_noDataFound);
+        return;
+      case ImageMetadataImportResult.noParametersSelected:
+        AppToast.warning(context, context.l10n.metadataImport_noParamsSelected);
+        return;
+      case ImageMetadataImportResult.applied:
+        AppToast.success(
+          context,
+          context.l10n.metadataImport_appliedCount(appliedCount),
+        );
+        return;
+      case ImageMetadataImportResult.cancelled:
+        return;
+    }
+  }
+}

--- a/lib/presentation/services/image_send_action_dispatcher.dart
+++ b/lib/presentation/services/image_send_action_dispatcher.dart
@@ -17,13 +17,12 @@ import '../router/app_routes.dart';
 import '../utils/fixed_tag_metadata_matcher.dart';
 import '../utils/krita_send_helper.dart';
 import '../utils/local_gallery_reference_factory.dart';
-import '../utils/metadata_import_coordinator.dart';
 import '../utils/precise_ref_library_import_helper.dart';
 import '../widgets/common/app_toast.dart';
 import '../widgets/common/precise_reference_type_dialog.dart';
 import '../widgets/discord_share/discord_share_dialog.dart';
 import '../widgets/gallery/local_image_context_menu.dart';
-import '../widgets/metadata/metadata_import_dialog.dart';
+import 'image_metadata_import_workflow.dart';
 import 'image_workflow_launcher.dart';
 
 /// Dispatches the reusable "send image to..." actions shared by image menus.
@@ -106,34 +105,12 @@ class ImageSendActionDispatcher {
     BuildContext context,
     WidgetRef ref,
     Uint8List bytes,
-  ) async {
-    final metadata = await ImageMetadataService().getMetadataFromBytes(bytes);
-    if (!context.mounted) return;
-    if (metadata == null || !metadata.hasData) {
-      AppToast.warning(context, context.l10n.metadataImport_noDataFound);
-      return;
-    }
-    final options = await MetadataImportDialog.show(
-      context,
-      metadata: metadata,
-    );
-    if (options == null || !context.mounted) return;
-    final appliedCount = await MetadataImportCoordinator.apply(
+  ) {
+    return ImageMetadataImportWorkflow.shared.run(
+      context: context,
       read: ref.read,
-      metadata: metadata,
-      options: options,
-      l10n: context.l10n,
+      bytes: bytes,
     );
-    if (!context.mounted) return;
-    if (appliedCount == 0) {
-      AppToast.warning(context, context.l10n.metadataImport_noParamsSelected);
-      return;
-    }
-    AppToast.success(
-      context,
-      context.l10n.metadataImport_appliedCount(appliedCount),
-    );
-    context.go(AppRoutes.home);
   }
 
   static void _sendToStyleTransfer(

--- a/lib/presentation/services/mobile_image_metadata_importer.dart
+++ b/lib/presentation/services/mobile_image_metadata_importer.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/utils/app_logger.dart';
+import '../../core/utils/localization_extension.dart';
+import '../utils/dropped_file_reader.dart';
+import '../widgets/common/app_toast.dart';
+import '../widgets/drop/global_drop_action_coordinator.dart';
+
+class PickedImageData {
+  const PickedImageData({required this.fileName, required this.bytes});
+
+  final String fileName;
+  final Uint8List bytes;
+}
+
+typedef ImageBytesPicker = Future<PickedImageData?> Function();
+typedef PickedImageProcessor =
+    Future<void> Function(
+      BuildContext context,
+      WidgetRef ref,
+      PickedImageData image,
+    );
+
+/// Adapts a system-picked image to the shared desktop drop action flow.
+class MobileImageMetadataImporter {
+  MobileImageMetadataImporter({
+    ImageBytesPicker? imageBytesPicker,
+    PickedImageProcessor? imageProcessor,
+  }) : _imageBytesPicker = imageBytesPicker ?? _pickImageBytes,
+       _imageProcessor = imageProcessor ?? _processImage;
+
+  static final MobileImageMetadataImporter shared =
+      MobileImageMetadataImporter();
+
+  final ImageBytesPicker _imageBytesPicker;
+  final PickedImageProcessor _imageProcessor;
+
+  Future<void> run({
+    required BuildContext context,
+    required WidgetRef ref,
+  }) async {
+    final PickedImageData image;
+    try {
+      final selectedImage = await _imageBytesPicker();
+      if (selectedImage == null || !context.mounted) return;
+      image = selectedImage;
+      if (image.bytes.isEmpty) {
+        throw const FormatException('Selected image is empty');
+      }
+    } catch (error, stackTrace) {
+      AppLogger.e(
+        'Failed to read selected image',
+        error,
+        stackTrace,
+        'MobileMetadataImport',
+      );
+      if (context.mounted) {
+        AppToast.error(context, context.l10n.metadataImport_readFailed);
+      }
+      return;
+    }
+
+    try {
+      await _imageProcessor(context, ref, image);
+    } catch (error, stackTrace) {
+      AppLogger.e(
+        'Failed to process selected image',
+        error,
+        stackTrace,
+        'MobileMetadataImport',
+      );
+      if (context.mounted) {
+        AppToast.error(context, context.l10n.metadataImport_processFailed);
+      }
+    }
+  }
+
+  static Future<PickedImageData?> _pickImageBytes() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: const ['png', 'webp'],
+      allowMultiple: false,
+      withData: true,
+    );
+    if (result == null || result.files.isEmpty) return null;
+
+    final file = result.files.single;
+    final bytes = file.bytes;
+    if (bytes == null) {
+      throw StateError(
+        'The system picker did not provide readable image bytes',
+      );
+    }
+    return PickedImageData(fileName: file.name, bytes: bytes);
+  }
+
+  static Future<void> _processImage(
+    BuildContext context,
+    WidgetRef ref,
+    PickedImageData image,
+  ) {
+    return GlobalDropActionCoordinator(
+      context: context,
+      ref: ref,
+      openGenerationAfterAction: true,
+      respectCurrentRouteDropTarget: false,
+    ).processDroppedFile(
+      DroppedFileData(fileName: image.fileName, bytes: image.bytes),
+    );
+  }
+}

--- a/lib/presentation/widgets/drop/global_drop_action_coordinator.dart
+++ b/lib/presentation/widgets/drop/global_drop_action_coordinator.dart
@@ -71,11 +71,15 @@ class GlobalDropActionCoordinator {
     required this.context,
     required this.ref,
     DroppedImageInspector inspector = const DroppedImageInspector(),
+    this.openGenerationAfterAction = false,
+    this.respectCurrentRouteDropTarget = true,
   }) : _inspector = inspector;
 
   final BuildContext context;
   final WidgetRef ref;
   final DroppedImageInspector _inspector;
+  final bool openGenerationAfterAction;
+  final bool respectCurrentRouteDropTarget;
 
   static const Set<String> _plainImageExtensions = {
     '.png',
@@ -128,7 +132,8 @@ class GlobalDropActionCoordinator {
     final currentPath = GoRouter.of(
       context,
     ).routeInformationProvider.value.uri.path;
-    if (currentPath == AppRoutes.tagLibraryPage) {
+    if (respectCurrentRouteDropTarget &&
+        currentPath == AppRoutes.tagLibraryPage) {
       final originalBytes = await _resolveOriginalImageBytes(fileData);
       if (originalBytes == null || !context.mounted) return;
       await TagLibraryDropHandler.handle(
@@ -140,7 +145,8 @@ class GlobalDropActionCoordinator {
       return;
     }
 
-    if (currentPath == AppRoutes.preciseRefLibrary &&
+    if (respectCurrentRouteDropTarget &&
+        currentPath == AppRoutes.preciseRefLibrary &&
         _isPlainImageFile(fileName)) {
       final originalBytes = await _resolveOriginalImageBytes(fileData);
       if (originalBytes == null || !context.mounted) return;
@@ -178,7 +184,7 @@ class GlobalDropActionCoordinator {
       destinationBytes = originalBytes;
     }
 
-    await _handleDestination(
+    final actionCompleted = await _handleDestination(
       destination,
       fileName,
       destinationBytes,
@@ -188,6 +194,26 @@ class GlobalDropActionCoordinator {
       ref.read(generationParamsNotifierProvider.notifier),
       l10n,
     );
+    if (actionCompleted &&
+        openGenerationAfterAction &&
+        _isGenerationDestination(destination) &&
+        context.mounted) {
+      context.go(AppRoutes.home);
+    }
+  }
+
+  static bool _isGenerationDestination(ImageDestination destination) {
+    return switch (destination) {
+      ImageDestination.img2img ||
+      ImageDestination.reversePrompt ||
+      ImageDestination.vibeTransfer ||
+      ImageDestination.vibeTransferReuse ||
+      ImageDestination.vibeTransferRaw ||
+      ImageDestination.characterReference ||
+      ImageDestination.extractMetadata => true,
+      ImageDestination.saveToVibeLibrary ||
+      ImageDestination.addToQueue => false,
+    };
   }
 
   static bool _isPlainImageFile(String fileName) {
@@ -206,7 +232,7 @@ class GlobalDropActionCoordinator {
     return bytes;
   }
 
-  Future<void> _handleDestination(
+  Future<bool> _handleDestination(
     ImageDestination destination,
     String fileName,
     Uint8List bytes,
@@ -219,16 +245,17 @@ class GlobalDropActionCoordinator {
     switch (destination) {
       case ImageDestination.img2img:
         await _handleImg2Img(bytes, l10n);
+        return true;
       case ImageDestination.reversePrompt:
         await _handleReversePrompt(fileName, bytes, l10n);
+        return true;
       case ImageDestination.vibeTransfer:
-        await _handleVibeTransfer(fileName, bytes, notifier, l10n);
+        return _handleVibeTransfer(fileName, bytes, notifier, l10n);
       case ImageDestination.vibeTransferReuse:
-        if (detectedVibe != null) {
-          await _handleVibeReuse(detectedVibe, notifier, l10n);
-        }
+        if (detectedVibe == null) return false;
+        return _handleVibeReuse(detectedVibe, notifier, l10n);
       case ImageDestination.vibeTransferRaw:
-        await _handleVibeTransfer(
+        return _handleVibeTransfer(
           fileName,
           bytes,
           notifier,
@@ -239,12 +266,15 @@ class GlobalDropActionCoordinator {
         if (detectedVibes.isNotEmpty) {
           await _handleSaveToVibeLibrary(detectedVibes, l10n);
         }
+        return false;
       case ImageDestination.characterReference:
         await _handleCharacterReference(bytes, notifier, l10n);
+        return true;
       case ImageDestination.extractMetadata:
-        await _handleExtractMetadata(detectedMetadata, bytes, l10n);
+        return _handleExtractMetadata(detectedMetadata, bytes, l10n);
       case ImageDestination.addToQueue:
         await _handleAddToQueue(detectedMetadata, bytes, l10n);
+        return false;
     }
   }
 
@@ -268,7 +298,7 @@ class GlobalDropActionCoordinator {
     }
   }
 
-  Future<void> _handleVibeTransfer(
+  Future<bool> _handleVibeTransfer(
     String fileName,
     Uint8List bytes,
     GenerationParamsNotifier notifier,
@@ -287,7 +317,7 @@ class GlobalDropActionCoordinator {
             context.l10n.toast_styleReferenceLimit(maxCount),
           );
         }
-        return;
+        return false;
       }
       for (final vibe in vibes) {
         final vibeToAdd = forceRaw && vibe.vibeEncoding.isNotEmpty
@@ -305,11 +335,13 @@ class GlobalDropActionCoordinator {
           _buildVibeMessage(currentCount, vibes.length, l10n),
         );
       }
+      return true;
     } catch (error) {
       if (kDebugMode) {
         AppLogger.d('Error parsing vibe file: $error', 'DropHandler');
       }
       _showError(error.toString());
+      return false;
     }
   }
 
@@ -326,7 +358,7 @@ class GlobalDropActionCoordinator {
         : l10n.drop_addedMultipleToVibe(addedCount);
   }
 
-  Future<void> _handleVibeReuse(
+  Future<bool> _handleVibeReuse(
     VibeReference vibe,
     GenerationParamsNotifier notifier,
     AppLocalizations l10n,
@@ -340,7 +372,7 @@ class GlobalDropActionCoordinator {
           context.l10n.toast_styleReferenceLimit(maxCount),
         );
       }
-      return;
+      return false;
     }
     notifier.addVibeReference(vibe);
     if (context.mounted) {
@@ -349,6 +381,7 @@ class GlobalDropActionCoordinator {
           : l10n.toast_addedPreencodedVibe;
       AppToast.success(context, message);
     }
+    return true;
   }
 
   Future<void> _handleSaveToVibeLibrary(
@@ -461,7 +494,7 @@ class GlobalDropActionCoordinator {
     }
   }
 
-  Future<void> _handleExtractMetadata(
+  Future<bool> _handleExtractMetadata(
     NaiImageMetadata? detectedMetadata,
     Uint8List bytes,
     AppLocalizations l10n,
@@ -474,34 +507,36 @@ class GlobalDropActionCoordinator {
         if (context.mounted) {
           AppToast.warning(context, l10n.metadataImport_noDataFound);
         }
-        return;
+        return false;
       }
-      if (!context.mounted) return;
+      if (!context.mounted) return false;
       final options = await MetadataImportDialog.show(
         context,
         metadata: metadata,
       );
-      if (options == null || !context.mounted) return;
+      if (options == null || !context.mounted) return false;
       final appliedCount = await MetadataImportCoordinator.apply(
         read: ref.read,
         metadata: metadata,
         options: options,
         l10n: context.l10n,
       );
-      if (!context.mounted) return;
+      if (!context.mounted) return false;
       if (appliedCount > 0) {
         AppToast.success(
           context,
           l10n.metadataImport_appliedCount(appliedCount),
         );
-      } else {
-        AppToast.warning(context, l10n.metadataImport_noParamsSelected);
+        return true;
       }
+      AppToast.warning(context, l10n.metadataImport_noParamsSelected);
+      return false;
     } catch (error) {
       if (kDebugMode) {
         AppLogger.d('Error extracting metadata: $error', 'DropHandler');
       }
       _showError(l10n.toast_extractMetadataFailed(error.toString()));
+      return false;
     }
   }
 

--- a/test/presentation/router/mobile_more_panel_test.dart
+++ b/test/presentation/router/mobile_more_panel_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/router/mobile_more_panel.dart';
+
+class _MockNavigationShell extends Mock implements StatefulNavigationShell {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_MockNavigationShell';
+}
+
+void main() {
+  testWidgets(
+    'mobile more panel exposes one single-line metadata entry and wires tap',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final navigationShell = _MockNavigationShell();
+      var importCalls = 0;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            locale: const Locale('zh'),
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            home: Consumer(
+              builder: (context, ref, child) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () => showMobileMorePanel(
+                      context: context,
+                      ref: ref,
+                      navigationShell: navigationShell,
+                      onImportImageMetadata: (context, ref) async {
+                        importCalls++;
+                      },
+                    ),
+                    child: const Text('open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      const entryKey = ValueKey('mobile-more-read-image-metadata');
+      final entry = find.byKey(entryKey);
+      expect(entry, findsOneWidget);
+      expect(find.text('读取图片元数据'), findsOneWidget);
+
+      final tile = tester.widget<ListTile>(
+        find.descendant(of: entry, matching: find.byType(ListTile)),
+      );
+      expect(tile.subtitle, isNull);
+      final title = tile.title! as Text;
+      expect(title.maxLines, 1);
+
+      await tester.tap(entry);
+      await tester.pumpAndSettle();
+
+      expect(importCalls, 1);
+      expect(find.byKey(entryKey), findsNothing);
+    },
+  );
+}

--- a/test/presentation/services/image_metadata_import_workflow_test.dart
+++ b/test/presentation/services/image_metadata_import_workflow_test.dart
@@ -1,0 +1,216 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
+import 'package:nai_launcher/data/models/metadata/metadata_import_options.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/services/image_metadata_import_workflow.dart';
+import 'package:nai_launcher/presentation/services/mobile_image_metadata_importer.dart';
+
+void main() {
+  testWidgets('system picker cancellation stops without processing', (
+    tester,
+  ) async {
+    var processed = false;
+    final importer = MobileImageMetadataImporter(
+      imageBytesPicker: () async => null,
+      imageProcessor: (context, ref, image) async {
+        processed = true;
+      },
+    );
+
+    await _pumpAction(
+      tester,
+      action: (context, ref) => importer.run(context: context, ref: ref),
+    );
+
+    await tester.tap(find.text('run'));
+    await tester.pumpAndSettle();
+
+    expect(processed, isFalse);
+  });
+
+  testWidgets('picked image bytes and file name enter the shared action flow', (
+    tester,
+  ) async {
+    PickedImageData? processedImage;
+    final importer = MobileImageMetadataImporter(
+      imageBytesPicker: () async => PickedImageData(
+        fileName: 'original.webp',
+        bytes: Uint8List.fromList([1, 2, 3]),
+      ),
+      imageProcessor: (context, ref, image) async {
+        processedImage = image;
+      },
+    );
+
+    await _pumpAction(
+      tester,
+      action: (context, ref) => importer.run(context: context, ref: ref),
+    );
+
+    await tester.tap(find.text('run'));
+    await tester.pumpAndSettle();
+
+    expect(processedImage?.fileName, 'original.webp');
+    expect(processedImage?.bytes, [1, 2, 3]);
+  });
+
+  testWidgets('missing metadata reports noMetadata without opening dialog', (
+    tester,
+  ) async {
+    var optionsOpened = false;
+    final reports = <ImageMetadataImportResult>[];
+    final workflow = ImageMetadataImportWorkflow(
+      metadataReader: (bytes) async => null,
+      optionsPicker: (context, metadata) async {
+        optionsOpened = true;
+        return const MetadataImportOptions();
+      },
+      resultReporter: (context, result, appliedCount) => reports.add(result),
+    );
+
+    await _pumpAction(
+      tester,
+      action: (context, ref) => workflow.run(
+        context: context,
+        read: ref.read,
+        bytes: Uint8List.fromList([1, 2, 3]),
+      ),
+    );
+
+    await tester.tap(find.text('run'));
+    await tester.pumpAndSettle();
+
+    expect(optionsOpened, isFalse);
+    expect(reports, [ImageMetadataImportResult.noMetadata]);
+  });
+
+  testWidgets('dialog cancellation does not apply or report an error', (
+    tester,
+  ) async {
+    var applied = false;
+    final reports = <ImageMetadataImportResult>[];
+    final workflow = ImageMetadataImportWorkflow(
+      metadataReader: (bytes) async => const NaiImageMetadata(prompt: '1girl'),
+      optionsPicker: (context, metadata) async => null,
+      metadataApplier: (read, metadata, options, l10n) async {
+        applied = true;
+        return 1;
+      },
+      resultReporter: (context, result, appliedCount) => reports.add(result),
+    );
+
+    await _pumpAction(
+      tester,
+      action: (context, ref) => workflow.run(
+        context: context,
+        read: ref.read,
+        bytes: Uint8List.fromList([1]),
+      ),
+    );
+
+    await tester.tap(find.text('run'));
+    await tester.pumpAndSettle();
+
+    expect(applied, isFalse);
+    expect(reports, isEmpty);
+  });
+
+  testWidgets('zero applied parameters reports noParametersSelected', (
+    tester,
+  ) async {
+    final reports = <ImageMetadataImportResult>[];
+    var openedGeneration = false;
+    final workflow = ImageMetadataImportWorkflow(
+      metadataReader: (bytes) async => const NaiImageMetadata(prompt: '1girl'),
+      optionsPicker: (context, metadata) async =>
+          const MetadataImportOptions(importPrompt: true),
+      metadataApplier: (read, metadata, options, l10n) async => 0,
+      resultReporter: (context, result, appliedCount) => reports.add(result),
+      generationPageOpener: (context) => openedGeneration = true,
+    );
+
+    await _pumpAction(
+      tester,
+      action: (context, ref) => workflow.run(
+        context: context,
+        read: ref.read,
+        bytes: Uint8List.fromList([1]),
+      ),
+    );
+
+    await tester.tap(find.text('run'));
+    await tester.pumpAndSettle();
+
+    expect(reports, [ImageMetadataImportResult.noParametersSelected]);
+    expect(openedGeneration, isFalse);
+  });
+
+  testWidgets('successful selection applies parameters and opens generation', (
+    tester,
+  ) async {
+    var applyCalls = 0;
+    var openedGeneration = false;
+    final reports = <(ImageMetadataImportResult, int)>[];
+    final workflow = ImageMetadataImportWorkflow(
+      metadataReader: (bytes) async => const NaiImageMetadata(prompt: '1girl'),
+      optionsPicker: (context, metadata) async =>
+          const MetadataImportOptions(importPrompt: true),
+      metadataApplier: (read, metadata, options, l10n) async {
+        applyCalls++;
+        expect(metadata.prompt, '1girl');
+        expect(options.importPrompt, isTrue);
+        return 1;
+      },
+      resultReporter: (context, result, appliedCount) {
+        reports.add((result, appliedCount));
+      },
+      generationPageOpener: (context) => openedGeneration = true,
+    );
+
+    await _pumpAction(
+      tester,
+      action: (context, ref) => workflow.run(
+        context: context,
+        read: ref.read,
+        bytes: Uint8List.fromList([1]),
+      ),
+    );
+
+    await tester.tap(find.text('run'));
+    await tester.pumpAndSettle();
+
+    expect(applyCalls, 1);
+    expect(reports, [(ImageMetadataImportResult.applied, 1)]);
+    expect(openedGeneration, isTrue);
+  });
+}
+
+typedef _TestAction =
+    Future<Object?> Function(BuildContext context, WidgetRef ref);
+
+Future<void> _pumpAction(
+  WidgetTester tester, {
+  required _TestAction action,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        locale: const Locale('en'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        home: Consumer(
+          builder: (context, ref, child) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () async => action(context, ref),
+              child: const Text('run'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## 用户可见变化

- 在 Android/移动端底栏「更多」面板新增单行「读取图片元数据」入口。
- 关闭更多面板后通过系统文件选择器直接读取 PNG/WebP 原图字节，不依赖本地画廊，也不请求整库照片权限。
- 复用桌面拖图的图片目标菜单：有元数据时可导入 NovelAI 参数；无元数据时仍可使用反推提示词、图生图、Vibe、角色参考等已有操作。
- 元数据参数成功应用后返回生成页，并保留已应用的生成状态；取消、无元数据、未选择参数与处理失败均按现有本地化反馈处理。
- 同步简体中文、繁体中文、English、日本語本地化及生成代码。

## 验证

- `flutter test test/presentation/services/image_metadata_import_workflow_test.dart test/presentation/router/mobile_more_panel_test.dart test/presentation/widgets/drop/image_destination_dialog_test.dart test/presentation/widgets/drop/global_drop_handler_test.dart test/presentation/utils/metadata_import_coordinator_test.dart test/data/services/metadata/unified_metadata_parser_webp_test.dart`
- `flutter analyze`
- `git diff --check`

以上检查均通过。