### PR TITLE
fix(viewport): 保留最小化恢复后的浏览位置

### DIFF
--- a/lib/presentation/screens/generation/desktop_layout.dart
+++ b/lib/presentation/screens/generation/desktop_layout.dart
@@ -18,6 +18,7 @@ import '../../providers/prompt_maximize_provider.dart';
 import '../../providers/replication_queue_provider.dart';
 import '../../router/app_routes.dart';
 import '../../widgets/common/app_toast.dart';
+import '../../widgets/common/owned_scroll_controller.dart';
 import '../../widgets/shortcuts/shortcut_aware_widget.dart';
 import '../../services/image_workflow_launcher.dart';
 import 'handlers/generation_action_handlers.dart';
@@ -31,7 +32,9 @@ import 'package:nai_launcher/core/utils/localization_extension.dart';
 
 /// 桌面端三栏布局
 class DesktopGenerationLayout extends ConsumerStatefulWidget {
-  const DesktopGenerationLayout({super.key});
+  const DesktopGenerationLayout({super.key, required this.historyViewport});
+
+  final OwnedViewportOffset historyViewport;
 
   @override
   ConsumerState<DesktopGenerationLayout> createState() =>
@@ -193,6 +196,7 @@ class _DesktopGenerationLayoutState
         isResizing: _isResizingRight,
         width: width,
         expanded: expanded,
+        historyViewport: widget.historyViewport,
       ),
     );
   }

--- a/lib/presentation/screens/generation/generation_screen.dart
+++ b/lib/presentation/screens/generation/generation_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/platform/platform_capabilities.dart';
 import '../../providers/generation_layout_mode_provider.dart';
 import '../../providers/layout_state_provider.dart';
+import '../../widgets/common/owned_scroll_controller.dart';
 import '../../widgets/drop/global_drop_handler.dart';
 import 'desktop_layout.dart';
 import 'mobile_layout.dart';
@@ -13,11 +14,18 @@ import 'web_style_layout.dart';
 import 'widgets/fixed_tags_sidebar.dart';
 
 /// 图像生成页面
-class GenerationScreen extends ConsumerWidget {
+class GenerationScreen extends ConsumerStatefulWidget {
   const GenerationScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<GenerationScreen> createState() => _GenerationScreenState();
+}
+
+class _GenerationScreenState extends ConsumerState<GenerationScreen> {
+  final _historyViewport = OwnedViewportOffset();
+
+  @override
+  Widget build(BuildContext context) {
     final content = LayoutBuilder(
       builder: (context, constraints) {
         // 桌面端布局 (宽度 >= 1000)
@@ -25,12 +33,14 @@ class GenerationScreen extends ConsumerWidget {
             PlatformCapabilities.current.hasPrecisePointer) {
           final layoutMode = ref.watch(generationLayoutModeNotifierProvider);
           return layoutMode == GenerationLayoutMode.webStyle
-              ? const WebStyleGenerationLayout()
-              : const DesktopGenerationLayout();
+              ? WebStyleGenerationLayout(historyViewport: _historyViewport)
+              : DesktopGenerationLayout(historyViewport: _historyViewport);
         }
 
         final layoutState = ref.watch(layoutStateNotifierProvider);
-        const mobileLayout = MobileGenerationLayout();
+        final mobileLayout = MobileGenerationLayout(
+          historyViewport: _historyViewport,
+        );
         if (!layoutState.fixedTagsSidebarExpanded) {
           return mobileLayout;
         }
@@ -42,7 +52,7 @@ class GenerationScreen extends ConsumerWidget {
           );
           return Stack(
             children: [
-              const Positioned.fill(child: mobileLayout),
+              Positioned.fill(child: mobileLayout),
               Positioned.fill(
                 child: ModalBarrier(
                   key: const Key('generation-fixed-tags-barrier'),
@@ -79,7 +89,7 @@ class GenerationScreen extends ConsumerWidget {
 
         return Row(
           children: [
-            const Expanded(child: mobileLayout),
+            Expanded(child: mobileLayout),
             Container(
               width: sidebarWidth,
               decoration: BoxDecoration(

--- a/lib/presentation/screens/generation/mobile_generation_chrome.dart
+++ b/lib/presentation/screens/generation/mobile_generation_chrome.dart
@@ -7,6 +7,7 @@ import '../../themes/design_tokens.dart';
 import '../../widgets/anlas/anlas_balance_chip.dart';
 import '../../widgets/anlas/opus_usage_chip.dart';
 import '../../widgets/common/anlas_cost_badge.dart';
+import '../../widgets/common/owned_scroll_controller.dart';
 import '../../widgets/common/themed_button.dart';
 import '../../widgets/common/themed_scaffold.dart';
 import 'mobile_generation_controller.dart';
@@ -20,11 +21,13 @@ class MobileGenerationChrome extends ConsumerWidget {
     super.key,
     required this.controller,
     required this.data,
+    required this.historyViewport,
     required this.body,
   });
 
   final MobileGenerationController controller;
   final MobileGenerationViewData data;
+  final OwnedViewportOffset historyViewport;
   final Widget body;
 
   PreferredSizeWidget? _buildAppBar(BuildContext context) {
@@ -124,7 +127,10 @@ class MobileGenerationChrome extends ConsumerWidget {
       key: const ValueKey('generation-history-drawer'),
       width: MediaQuery.sizeOf(context).width * 0.9,
       child: SafeArea(
-        child: HistoryPanel(onClose: controller.closeHistoryDrawer),
+        child: HistoryPanel(
+          onClose: controller.closeHistoryDrawer,
+          viewportOffset: historyViewport,
+        ),
       ),
     );
   }

--- a/lib/presentation/screens/generation/mobile_generation_shell.dart
+++ b/lib/presentation/screens/generation/mobile_generation_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../agent_chat/widgets/agent_chat_panel.dart';
+import '../../widgets/common/owned_scroll_controller.dart';
 import 'mobile_generation_chrome.dart';
 import 'mobile_generation_controller.dart';
 import 'mobile_generation_gestures.dart';
@@ -12,10 +13,12 @@ class MobileGenerationShell extends StatelessWidget {
     super.key,
     required this.controller,
     required this.data,
+    required this.historyViewport,
   });
 
   final MobileGenerationController controller;
   final MobileGenerationViewData data;
+  final OwnedViewportOffset historyViewport;
 
   @override
   Widget build(BuildContext context) {
@@ -27,6 +30,7 @@ class MobileGenerationShell extends StatelessWidget {
       child: MobileGenerationChrome(
         controller: controller,
         data: data,
+        historyViewport: historyViewport,
         body: Stack(
           key: const ValueKey('generation-mobile-primary-workspaces'),
           children: [

--- a/lib/presentation/screens/generation/mobile_layout.dart
+++ b/lib/presentation/screens/generation/mobile_layout.dart
@@ -13,6 +13,7 @@ import '../../providers/krita/krita_bridge_notifier.dart';
 import '../../providers/prompt_maximize_provider.dart';
 import '../../providers/quality_preset_provider.dart';
 import '../../providers/uc_preset_provider.dart';
+import '../../widgets/common/owned_scroll_controller.dart';
 import 'mobile_generation_controller.dart';
 import 'mobile_generation_shell.dart';
 import 'mobile_generation_view_data.dart';
@@ -20,7 +21,9 @@ import 'mobile_generation_view_data.dart';
 /// Stable mobile generation entry point. Stateful interaction and rendering
 /// responsibilities live in dedicated controller and component classes.
 class MobileGenerationLayout extends ConsumerStatefulWidget {
-  const MobileGenerationLayout({super.key});
+  const MobileGenerationLayout({super.key, this.historyViewport});
+
+  final OwnedViewportOffset? historyViewport;
 
   @override
   ConsumerState<MobileGenerationLayout> createState() =>
@@ -30,11 +33,13 @@ class MobileGenerationLayout extends ConsumerStatefulWidget {
 class _MobileGenerationLayoutState
     extends ConsumerState<MobileGenerationLayout> {
   late final MobileGenerationController _controller;
+  late final OwnedViewportOffset _historyViewport;
 
   @override
   void initState() {
     super.initState();
     _controller = MobileGenerationController(ref);
+    _historyViewport = widget.historyViewport ?? OwnedViewportOffset();
   }
 
   @override
@@ -116,7 +121,11 @@ class _MobileGenerationLayoutState
           negativePresetLabel: negativePresetLabel,
           fixedTagCount: fixedTagCount,
         );
-        return MobileGenerationShell(controller: _controller, data: data);
+        return MobileGenerationShell(
+          controller: _controller,
+          data: data,
+          historyViewport: _historyViewport,
+        );
       },
     );
   }

--- a/lib/presentation/screens/generation/web_style_layout.dart
+++ b/lib/presentation/screens/generation/web_style_layout.dart
@@ -18,6 +18,7 @@ import '../../providers/replication_queue_provider.dart';
 import '../../router/app_routes.dart';
 import '../../services/image_workflow_launcher.dart';
 import '../../widgets/common/app_toast.dart';
+import '../../widgets/common/owned_scroll_controller.dart';
 import '../../widgets/shortcuts/shortcut_aware_widget.dart';
 import 'handlers/generation_action_handlers.dart';
 import 'widgets/fixed_tags_sidebar_slot.dart';
@@ -29,7 +30,9 @@ import 'widgets/web_left_panel.dart';
 
 /// 官网式布局：提示词与设置固定在最左栏，中间为纯预览区
 class WebStyleGenerationLayout extends ConsumerStatefulWidget {
-  const WebStyleGenerationLayout({super.key});
+  const WebStyleGenerationLayout({super.key, required this.historyViewport});
+
+  final OwnedViewportOffset historyViewport;
 
   @override
   ConsumerState<WebStyleGenerationLayout> createState() =>
@@ -181,6 +184,7 @@ class _WebStyleGenerationLayoutState
           isResizing: _isResizingRight,
           width: width,
           expanded: expanded,
+          historyViewport: widget.historyViewport,
         ),
       ),
     );

--- a/lib/presentation/screens/generation/widgets/history_panel.dart
+++ b/lib/presentation/screens/generation/widgets/history_panel.dart
@@ -38,6 +38,7 @@ import '../../../widgets/common/image_detail/file_image_detail_data.dart';
 import '../../../widgets/common/image_detail/image_detail_data.dart';
 import '../../../widgets/common/image_detail/image_detail_viewer.dart';
 import '../../../widgets/common/draggable_memory_image.dart';
+import '../../../widgets/common/owned_scroll_controller.dart';
 import '../../../widgets/common/selectable_image_card.dart';
 import '../../../widgets/image_editor/image_editor_screen.dart';
 import '../../../utils/image_detail_opener.dart';
@@ -77,12 +78,18 @@ class _HistoryRowDescriptor {
 
 /// 历史面板组件
 class HistoryPanel extends ConsumerStatefulWidget {
-  const HistoryPanel({super.key, this.onClose, this.embedded = false});
+  const HistoryPanel({
+    super.key,
+    this.onClose,
+    this.embedded = false,
+    this.viewportOffset,
+  });
 
   final VoidCallback? onClose;
 
   /// 嵌入模式：隐藏自带标题行，由外层 Tab 栏承担标题职责。
   final bool embedded;
+  final OwnedViewportOffset? viewportOffset;
 
   @override
   ConsumerState<HistoryPanel> createState() => _HistoryPanelState();
@@ -104,7 +111,7 @@ class _HistoryPanelState extends ConsumerState<HistoryPanel> {
   final Map<String, String?> _favoriteStatePaths = {};
   final Set<String> _favoriteStatusLoadingIds = {};
   final Set<String> _favoriteToggleLoadingIds = {};
-  final ScrollController _scrollController = ScrollController();
+  late final OwnedScrollController _scrollController;
   final Map<String, GlobalKey> _imageKeys = {};
   List<_HistoryRowDescriptor> _rowDescriptors = const [];
   ProviderSubscription<String?>? _selectionSubscription;
@@ -113,6 +120,7 @@ class _HistoryPanelState extends ConsumerState<HistoryPanel> {
   @override
   void initState() {
     super.initState();
+    _scrollController = OwnedScrollController(viewport: widget.viewportOffset);
     _sharePreparationService.addListener(_handleSharePreparationChanged);
     _selectionSubscription = ref.listenManual(
       generationPreviewSelectionProvider,

--- a/lib/presentation/screens/generation/widgets/right_panel.dart
+++ b/lib/presentation/screens/generation/widgets/right_panel.dart
@@ -7,6 +7,7 @@ import '../../../../core/utils/localization_extension.dart';
 import '../../../../core/windowing/workspace_side_panel_contract.dart';
 import '../../../agent_chat/widgets/agent_chat_panel.dart';
 import '../../../providers/layout_state_provider.dart';
+import '../../../widgets/common/owned_scroll_controller.dart';
 import 'collapsed_panel.dart';
 import 'history_panel.dart';
 
@@ -18,12 +19,14 @@ class RightPanel extends ConsumerStatefulWidget {
   final bool isResizing;
   final double? width;
   final bool? expanded;
+  final OwnedViewportOffset? historyViewport;
 
   const RightPanel({
     super.key,
     this.isResizing = false,
     this.width,
     this.expanded,
+    this.historyViewport,
   });
 
   @override
@@ -31,11 +34,13 @@ class RightPanel extends ConsumerStatefulWidget {
 }
 
 class _RightPanelState extends ConsumerState<RightPanel> {
+  late final OwnedViewportOffset _historyViewport;
   int _activeView = 1;
 
   @override
   void initState() {
     super.initState();
+    _historyViewport = widget.historyViewport ?? OwnedViewportOffset();
     final saved = ref
         .read(localStorageServiceProvider)
         .getSetting<int>(StorageKeys.rightPanelTab);
@@ -83,7 +88,7 @@ class _RightPanelState extends ConsumerState<RightPanel> {
       // （见 AgentChatPanel），历史页用 HistoryPanel 自带 header。
       child = _activeView == 0
           ? const AgentChatPanel()
-          : const HistoryPanel(embedded: false);
+          : HistoryPanel(embedded: false, viewportOffset: _historyViewport);
     } else {
       // 折叠态：竖排两个独立入口（聊天 / 历史），点击展开对应页面。
       child = Column(

--- a/lib/presentation/screens/online_gallery/online_gallery_content.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_content.dart
@@ -316,8 +316,6 @@ class _OnlineGalleryContentPresenter {
           (state.randomEnabled ? state.randomSession.cache : state.currentCache)
               .isPageBoundaryStart(index)
           ? _controller.pageAnchorKey(post.stableKey)
-          : post.stableKey == _controller.pendingAnchorStableKey
-          ? _controller.anchorRestoreKey
           : null,
       onVisibilityChanged: _scrollCoordinator.handleCardVisibility,
       onGeometryMeasured: _controller.recordGeometryRead,

--- a/lib/presentation/screens/online_gallery/online_gallery_grid.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_grid.dart
@@ -91,6 +91,19 @@ class OnlineGalleryGrid extends StatelessWidget {
           0.0,
           double.infinity,
         );
+        final viewportScope = state.randomEnabled
+            ? 'random:${state.randomSession.scopeKey}'
+            : state.currentCacheKey;
+        final activeCache = state.randomEnabled
+            ? state.randomSession.cache
+            : state.currentCache;
+        if (availableWidth <= 0 || constraints.maxHeight <= 0) {
+          controller.markViewportUnavailable(
+            scope: viewportScope,
+            posts: state.posts,
+          );
+          return const SizedBox.shrink();
+        }
         final columnCount = ((availableWidth + spacing) / (160 + spacing))
             .floor()
             .clamp(1, 8);
@@ -103,9 +116,6 @@ class OnlineGalleryGrid extends StatelessWidget {
         final storageScope = state.randomEnabled
             ? 'random:${state.randomSession.scopeKey}'
             : 'normal';
-        final activeCache = state.randomEnabled
-            ? state.randomSession.cache
-            : state.currentCache;
         final showFooterBeforeRunway = activeCache.appendErrorCode != null;
         final placeholderCount = showFooterBeforeRunway
             ? 0
@@ -143,6 +153,14 @@ class OnlineGalleryGrid extends StatelessWidget {
           maxScrollExtent: masonryLayout.maxScrollExtent,
           elapsed: layoutStopwatch?.elapsed ?? Duration.zero,
         );
+        controller.prepareGridViewport(
+          scope: viewportScope,
+          cache: activeCache,
+          posts: state.posts,
+          layout: masonryLayout,
+          columnCount: columnCount,
+          itemWidth: itemWidth,
+        );
         final slotKeyPrefix =
             'gallery-slot:$storageScope:${state.currentCacheKey}:';
         int? findSlotIndex(Key key) {
@@ -171,9 +189,7 @@ class OnlineGalleryGrid extends StatelessWidget {
         }
 
         return CustomScrollView(
-          key: PageStorageKey<String>(
-            'online_gallery_$storageScope:${state.currentCacheKey}',
-          ),
+          key: ValueKey<String>('online-gallery-scroll:$viewportScope'),
           controller: controller.scrollController,
           scrollCacheExtent: ScrollCacheExtent.pixels(
             OnlineGalleryPreloadPolicy.cacheExtent(viewportHeight),

--- a/lib/presentation/screens/online_gallery/online_gallery_screen_controller.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_screen_controller.dart
@@ -8,7 +8,9 @@ import '../../../core/cache/online_gallery_prefetch_coordinator.dart';
 import '../../../core/utils/app_logger.dart';
 import '../../../data/models/online_gallery/danbooru_post.dart';
 import '../../providers/online_gallery_provider.dart';
+import '../../widgets/common/owned_scroll_controller.dart';
 import '../../widgets/online_gallery/online_gallery_hover_controller.dart';
+import 'online_gallery_masonry_layout.dart';
 import 'online_gallery_pagination_demand.dart';
 import 'online_gallery_viewport_tracker.dart';
 
@@ -17,6 +19,7 @@ import 'online_gallery_viewport_tracker.dart';
 /// current gallery query and loaded items.
 class OnlineGalleryScreenController extends ChangeNotifier {
   OnlineGalleryScreenController({required this.prefetchCoordinator}) {
+    scrollController = OwnedScrollController(viewport: _viewportOffset);
     _frameTimingsCallback = _recordFrameTimings;
     if (kDebugMode) {
       SchedulerBinding.instance.addTimingsCallback(_frameTimingsCallback);
@@ -33,13 +36,13 @@ class OnlineGalleryScreenController extends ChangeNotifier {
   final popularSearchFocusNode = FocusNode();
   final popularPromptSearchFocusNode = FocusNode();
   final favoriteSearchFocusNode = FocusNode();
-  final scrollController = ScrollController();
+  final OwnedViewportOffset _viewportOffset = OwnedViewportOffset();
+  late final OwnedScrollController scrollController;
   final pageController = TextEditingController();
   final pageFocusNode = FocusNode();
   final hoverController = OnlineGalleryHoverController();
   final OnlineGalleryPrefetchCoordinator prefetchCoordinator;
   final dateRangeLayerLink = LayerLink();
-  final anchorRestoreKey = GlobalKey();
   final primarySearchRevealKey = GlobalKey();
   final viewportTracker = OnlineGalleryViewportTracker();
   final paginationDemand = OnlineGalleryPaginationDemand();
@@ -52,8 +55,6 @@ class OnlineGalleryScreenController extends ChangeNotifier {
   Timer? idlePrefetchTimer;
   Timer? _pageFocusNotificationTimer;
   OverlayEntry? dateRangeOverlayEntry;
-  String? pendingAnchorStableKey;
-  double pendingAnchorLocalOffset = 0;
   double lastScrollOffset = 0;
   int scrollDirection = 1;
   int lookaheadItemCount = 12;
@@ -78,6 +79,13 @@ class OnlineGalleryScreenController extends ChangeNotifier {
   bool randomReplacePending = false;
   bool branchVisible = true;
   int _scrollRestoreRevision = 0;
+  String? _viewportScope;
+  String? _viewportAnchorStableKey;
+  double _viewportAnchorLocalOffset = 0;
+  int? _viewportColumnCount;
+  double? _viewportItemWidth;
+  bool _viewportUnavailable = false;
+  bool _viewportRestoreRequested = false;
   late final TimingsCallback _frameTimingsCallback;
   bool _scrollTraceActive = false;
   int _scrollTraceSequence = 0;
@@ -299,9 +307,109 @@ class OnlineGalleryScreenController extends ChangeNotifier {
   void resetViewportTracking() => viewportTracker.resetVisibleItems();
 
   int beginScrollRestore() => ++_scrollRestoreRevision;
-  void invalidateScrollRestore() => _scrollRestoreRevision++;
+  void invalidateScrollRestore() {
+    _scrollRestoreRevision++;
+    _viewportRestoreRequested = false;
+    scrollController.clearLayoutRestore();
+  }
+
   bool isCurrentScrollRestore(int revision) =>
       revision == _scrollRestoreRevision;
+
+  void stageViewportRestore({required String scope, required ModeCache cache}) {
+    beginScrollRestore();
+    _viewportScope = scope;
+    _viewportOffset.replace(cache.scrollOffset);
+    _viewportAnchorStableKey = cache.anchorStableKey;
+    _viewportAnchorLocalOffset = cache.anchorLocalOffset;
+    _viewportRestoreRequested = true;
+  }
+
+  bool get viewportAvailable => !_viewportUnavailable;
+
+  void markViewportUnavailable({
+    required String scope,
+    required List<GalleryItem> posts,
+  }) {
+    if (_viewportUnavailable) return;
+    if (!_viewportRestoreRequested && _viewportScope == scope) {
+      captureViewport(scope: scope, posts: posts);
+    }
+    _viewportUnavailable = true;
+    idlePrefetchTimer?.cancel();
+    scrollStopTimer?.cancel();
+    prefetchResumeTimer?.cancel();
+    paginationDemand.settleScroll();
+    setScrolling(false);
+    hoverController.dismiss();
+    prefetchCoordinator.setPageVisible(false);
+  }
+
+  void captureViewport({
+    required String scope,
+    required List<GalleryItem> posts,
+  }) {
+    if (!scrollController.hasClients) return;
+    final position = scrollController.position;
+    if (!OwnedViewportOffset.hasUsableViewport(position)) return;
+    _viewportScope = scope;
+    _viewportOffset.record(position);
+    final anchor = viewportTracker.resolveLeadingAnchor(
+      posts: posts,
+      metrics: position,
+    );
+    if (anchor == null) return;
+    _viewportAnchorStableKey = anchor.item.stableKey;
+    _viewportAnchorLocalOffset = position.pixels - anchor.leadingScrollOffset;
+  }
+
+  void prepareGridViewport({
+    required String scope,
+    required ModeCache cache,
+    required List<GalleryItem> posts,
+    required OnlineGalleryMasonryLayoutSnapshot layout,
+    required int columnCount,
+    required double itemWidth,
+  }) {
+    final scopeChanged = _viewportScope != scope;
+    if (scopeChanged) {
+      _viewportScope = scope;
+      _viewportOffset.replace(cache.scrollOffset);
+      _viewportAnchorStableKey = cache.anchorStableKey;
+      _viewportAnchorLocalOffset = cache.anchorLocalOffset;
+    }
+    final geometryChanged =
+        _viewportColumnCount != null &&
+        (_viewportColumnCount != columnCount ||
+            (_viewportItemWidth! - itemWidth).abs() >= 0.5);
+    if (geometryChanged && !scopeChanged) {
+      captureViewport(scope: scope, posts: posts);
+    }
+    final shouldRestore =
+        scopeChanged ||
+        geometryChanged ||
+        _viewportUnavailable ||
+        _viewportRestoreRequested;
+    _viewportColumnCount = columnCount;
+    _viewportItemWidth = itemWidth;
+    _viewportUnavailable = false;
+    prefetchCoordinator.setPageVisible(branchVisible);
+    _viewportRestoreRequested = false;
+    if (!shouldRestore) return;
+
+    var target = _viewportOffset.pixels;
+    final stableKey = _viewportAnchorStableKey;
+    if (stableKey != null) {
+      final index = viewportTracker.indexOfStableKey(posts, stableKey);
+      if (index != null && index < layout.childCount) {
+        target =
+            12 +
+            layout.placementFor(index).scrollOffset +
+            _viewportAnchorLocalOffset;
+      }
+    }
+    scrollController.restoreDuringLayout(target);
+  }
 
   bool updateLookaheadMetrics({
     required double viewportHeight,

--- a/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart
@@ -91,9 +91,17 @@ class OnlineGalleryScrollPrefetchCoordinator {
   }
 
   void onScroll() {
-    if (!controller.branchVisible) return;
+    if (!controller.branchVisible || !controller.scrollController.hasClients) {
+      return;
+    }
+    final position = controller.scrollController.position;
+    if (!position.hasContentDimensions ||
+        position.viewportDimension <= 0 ||
+        !position.pixels.isFinite) {
+      return;
+    }
     final callbackStopwatch = kDebugMode ? (Stopwatch()..start()) : null;
-    final offset = controller.scrollController.offset;
+    final offset = position.pixels;
     if (offset != controller.lastScrollOffset) {
       controller.paginationDemand.recordScroll(offset);
       final startedScrolling = !controller.isScrolling;
@@ -116,6 +124,11 @@ class OnlineGalleryScrollPrefetchCoordinator {
       controller.scrollStopTimer?.cancel();
       controller.scrollStopTimer = Timer(scrollIdleDelay, () {
         if (!isMounted() || !controller.branchVisible) return;
+        final state = readState();
+        controller.captureViewport(
+          scope: _paginationScope(state),
+          posts: state.posts,
+        );
         controller.paginationDemand.settleScroll();
         controller.setScrolling(false);
         _scheduleVisiblePageUpdate();
@@ -161,7 +174,11 @@ class OnlineGalleryScrollPrefetchCoordinator {
   }
 
   void _requestNextIfNeeded() {
-    if (!isMounted() || !controller.branchVisible) return;
+    if (!isMounted() ||
+        !controller.branchVisible ||
+        !controller.viewportAvailable) {
+      return;
+    }
     final state = readState();
     final cache = state.randomEnabled
         ? state.randomSession.cache
@@ -169,6 +186,10 @@ class OnlineGalleryScrollPrefetchCoordinator {
     final position = controller.scrollController.hasClients
         ? controller.scrollController.position
         : null;
+    if (position != null &&
+        (!position.hasContentDimensions || position.viewportDimension <= 0)) {
+      return;
+    }
     final needsMore =
         state.posts.isEmpty ||
         _isNearLoadedEdge(state) ||
@@ -242,6 +263,13 @@ class OnlineGalleryScrollPrefetchCoordinator {
     if (!controller.scrollController.hasClients) return;
     final state = readState();
     final position = controller.scrollController.position;
+    if (!position.hasContentDimensions ||
+        position.viewportDimension <= 0 ||
+        !position.pixels.isFinite) {
+      return;
+    }
+    final scope = _paginationScope(state);
+    controller.captureViewport(scope: scope, posts: state.posts);
     final anchor = controller.viewportTracker.resolveLeadingAnchor(
       posts: state.posts,
       metrics: position,
@@ -256,45 +284,10 @@ class OnlineGalleryScrollPrefetchCoordinator {
   }
 
   void restoreScrollOffset(ModeCache cache) {
-    final revision = controller.beginScrollRestore();
-    final scope = _paginationScope(readState());
-    final anchorStableKey = cache.anchorStableKey;
-    final anchorLocalOffset = cache.anchorLocalOffset;
-    controller.pendingAnchorStableKey = anchorStableKey;
-    controller.pendingAnchorLocalOffset = anchorLocalOffset;
-
-    bool isCurrent() =>
-        isMounted() &&
-        controller.isCurrentScrollRestore(revision) &&
-        _paginationScope(readState()) == scope;
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!isCurrent() || !controller.scrollController.hasClients) return;
-      final position = controller.scrollController.position;
-      controller.scrollController.jumpTo(
-        cache.scrollOffset.clamp(
-          position.minScrollExtent,
-          position.maxScrollExtent,
-        ),
-      );
-      WidgetsBinding.instance.addPostFrameCallback((_) async {
-        if (!isCurrent() ||
-            controller.pendingAnchorStableKey != anchorStableKey) {
-          return;
-        }
-        final anchorContext = controller.anchorRestoreKey.currentContext;
-        if (anchorContext == null) return;
-        await Scrollable.ensureVisible(anchorContext, duration: Duration.zero);
-        if (!isCurrent() || !controller.scrollController.hasClients) return;
-        final current = controller.scrollController.offset;
-        controller.scrollController.jumpTo(
-          (current + anchorLocalOffset).clamp(
-            controller.scrollController.position.minScrollExtent,
-            controller.scrollController.position.maxScrollExtent,
-          ),
-        );
-      });
-    });
+    controller.stageViewportRestore(
+      scope: _paginationScope(readState()),
+      cache: cache,
+    );
   }
 
   void beginPageJump() {

--- a/lib/presentation/screens/online_gallery/online_gallery_viewport_tracker.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_viewport_tracker.dart
@@ -188,13 +188,16 @@ class OnlineGalleryViewportTracker {
     );
   }
 
-  int? _indexOfStableKey(List<GalleryItem> posts, String stableKey) {
+  int? indexOfStableKey(List<GalleryItem> posts, String stableKey) {
     if (posts is ChunkedGalleryItems) {
       return posts.indexOfStableKey(stableKey);
     }
     final index = posts.indexWhere((item) => item.stableKey == stableKey);
     return index < 0 ? null : index;
   }
+
+  int? _indexOfStableKey(List<GalleryItem> posts, String stableKey) =>
+      indexOfStableKey(posts, stableKey);
 
   void dispose() {
     _visibleByStableKey.clear();

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/utils/localization_extension.dart';
 import '../../adaptive/window_size_class.dart';
+import '../../widgets/common/owned_scroll_controller.dart';
 import '../cloud_sync/cloud_sync_screen.dart';
 import 'sections/account_settings_section.dart';
 import 'sections/appearance_settings_section.dart';
@@ -50,7 +51,7 @@ class SettingsScreen extends ConsumerStatefulWidget {
 
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   late SettingsSection _selectedSection;
-  final _contentScrollController = ScrollController();
+  final _contentScrollController = OwnedScrollController();
   bool _isContentScrolled = false;
   bool _showCompactDetail = false;
   int _externalSectionRevision = 0;
@@ -191,6 +192,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     setState(() {
       _selectedSection = section;
       _showCompactDetail = showCompactDetail;
+      _contentScrollController.viewport.replace(0);
+      _contentScrollController.clearLayoutRestore();
       if (_contentScrollController.hasClients) {
         _contentScrollController.jumpTo(0);
       }

--- a/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
+++ b/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
@@ -19,6 +19,7 @@ import '../../router/app_routes.dart';
 
 import '../../agent_chat/widgets/agent_resource_drop_region.dart';
 import '../../widgets/common/app_toast.dart';
+import '../../widgets/common/owned_scroll_controller.dart';
 import '../../widgets/common/themed_confirm_dialog.dart';
 import '../../widgets/shortcuts/shortcut_aware_widget.dart';
 import 'widgets/category_tree_view.dart';
@@ -44,10 +45,22 @@ class TagLibraryPageScreen extends ConsumerStatefulWidget {
 class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
   /// 搜索框焦点节点
   final FocusNode _searchFocusNode = FocusNode();
+  final OwnedScrollController _cardScrollController = OwnedScrollController(
+    viewport: OwnedViewportOffset(),
+  );
+  final OwnedScrollController _listScrollController = OwnedScrollController(
+    viewport: OwnedViewportOffset(),
+  );
+  final OwnedScrollController _groupedScrollController = OwnedScrollController(
+    viewport: OwnedViewportOffset(),
+  );
 
   @override
   void dispose() {
     _searchFocusNode.dispose();
+    _cardScrollController.dispose();
+    _listScrollController.dispose();
+    _groupedScrollController.dispose();
     super.dispose();
   }
 
@@ -375,6 +388,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
         return _buildListView(theme, entries);
       case TagLibraryViewMode.grouped:
         return GroupedEntriesView(
+          scrollController: _groupedScrollController,
           onEdit: _showEditDialog,
           onDelete: _showDeleteEntryConfirmationForEntry,
           onSend: _showEntryDetail,
@@ -424,6 +438,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
   /// 构建卡片网格
   Widget _buildCardGrid(ThemeData theme, List<TagLibraryEntry> entries) {
     return GridView.builder(
+      controller: _cardScrollController,
       padding: const EdgeInsets.all(16),
       gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
         maxCrossAxisExtent: 240,
@@ -439,6 +454,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
   /// 构建列表视图
   Widget _buildListView(ThemeData theme, List<TagLibraryEntry> entries) {
     return ListView.builder(
+      controller: _listScrollController,
       padding: const EdgeInsets.all(16),
       itemCount: entries.length,
       itemBuilder: (context, index) => Padding(

--- a/lib/presentation/screens/tag_library_page/widgets/grouped_view/grouped_entries_view.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/grouped_view/grouped_entries_view.dart
@@ -11,12 +11,14 @@ import 'category_header.dart';
 
 /// 分组视图 - 按类别分组显示条目
 class GroupedEntriesView extends ConsumerWidget {
+  final ScrollController? scrollController;
   final void Function(TagLibraryEntry) onEdit;
   final void Function(TagLibraryEntry) onDelete;
   final void Function(TagLibraryEntry) onSend;
 
   const GroupedEntriesView({
     super.key,
+    this.scrollController,
     required this.onEdit,
     required this.onDelete,
     required this.onSend,
@@ -42,6 +44,7 @@ class GroupedEntriesView extends ConsumerWidget {
     }
 
     return CustomScrollView(
+      controller: scrollController,
       slivers: [
         for (final group in nonEmptyGroups) ...[
           // 吸顶分类标题

--- a/lib/presentation/widgets/common/owned_scroll_controller.dart
+++ b/lib/presentation/widgets/common/owned_scroll_controller.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+/// Keeps one bounded viewport offset above transient ScrollPosition instances.
+/// Invalid zero-sized layouts never replace the last usable position.
+class OwnedViewportOffset {
+  double _pixels = 0;
+  bool _hasValue = false;
+
+  bool get hasValue => _hasValue;
+  double get pixels => _hasValue ? _pixels : 0;
+
+  void replace(double pixels) {
+    if (!pixels.isFinite) return;
+    _pixels = pixels < 0 ? 0 : pixels;
+    _hasValue = true;
+  }
+
+  void record(ScrollMetrics metrics) {
+    if (!hasUsableViewport(metrics)) return;
+    replace(metrics.pixels);
+  }
+
+  static bool hasUsableViewport(ScrollMetrics metrics) =>
+      metrics.hasPixels &&
+      metrics.hasContentDimensions &&
+      metrics.viewportDimension > 0 &&
+      metrics.pixels.isFinite;
+}
+
+/// A ScrollController whose owner, rather than PageStorage, owns restoration.
+///
+/// New positions start at the last valid offset. A caller that can translate a
+/// stable item anchor after a responsive geometry change may also request a
+/// correction during sliver layout, before the restored frame is painted.
+class OwnedScrollController extends ScrollController {
+  OwnedScrollController({OwnedViewportOffset? viewport})
+    : viewport = viewport ?? OwnedViewportOffset(),
+      super(keepScrollOffset: false);
+
+  final OwnedViewportOffset viewport;
+  final Set<ScrollPosition> _positions = <ScrollPosition>{};
+  ScrollPosition? _activePosition;
+  double? _layoutRestoreOffset;
+
+  @override
+  ScrollPosition get position => _activePosition ?? super.position;
+
+  void restoreDuringLayout(double pixels) {
+    if (!pixels.isFinite) return;
+    _layoutRestoreOffset = pixels < 0 ? 0 : pixels;
+  }
+
+  void clearLayoutRestore() {
+    _layoutRestoreOffset = null;
+  }
+
+  @override
+  ScrollPosition createScrollPosition(
+    ScrollPhysics physics,
+    ScrollContext context,
+    ScrollPosition? oldPosition,
+  ) => _OwnedScrollPosition(
+    physics: physics,
+    context: context,
+    initialPixels: _layoutRestoreOffset ?? viewport.pixels,
+    oldPosition: oldPosition,
+    controller: this,
+  );
+
+  @override
+  void attach(ScrollPosition position) {
+    super.attach(position);
+    _positions.add(position);
+    _activePosition = position;
+    position.addListener(_recordActivePosition);
+  }
+
+  @override
+  void detach(ScrollPosition position) {
+    if (identical(position, _activePosition)) {
+      viewport.record(position);
+    }
+    position.removeListener(_recordActivePosition);
+    _positions.remove(position);
+    if (identical(position, _activePosition)) {
+      _activePosition = _positions.isEmpty ? null : _positions.last;
+    }
+    super.detach(position);
+  }
+
+  void _recordActivePosition() {
+    final activePosition = _activePosition;
+    if (activePosition != null) viewport.record(activePosition);
+  }
+
+  double? _takeLayoutRestoreOffset({
+    required double minScrollExtent,
+    required double maxScrollExtent,
+    required double viewportDimension,
+  }) {
+    final requested = _layoutRestoreOffset;
+    if (requested == null || viewportDimension <= 0) return null;
+    _layoutRestoreOffset = null;
+    return requested.clamp(minScrollExtent, maxScrollExtent).toDouble();
+  }
+}
+
+class _OwnedScrollPosition extends ScrollPositionWithSingleContext {
+  _OwnedScrollPosition({
+    required super.physics,
+    required super.context,
+    required super.initialPixels,
+    required this.controller,
+    super.oldPosition,
+  }) : super(keepScrollOffset: false);
+
+  final OwnedScrollController controller;
+
+  @override
+  bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
+    final accepted = super.applyContentDimensions(
+      minScrollExtent,
+      maxScrollExtent,
+    );
+    final target = controller._takeLayoutRestoreOffset(
+      minScrollExtent: minScrollExtent,
+      maxScrollExtent: maxScrollExtent,
+      viewportDimension: viewportDimension,
+    );
+    if (target == null || (pixels - target).abs() < 0.5) return accepted;
+    correctPixels(target);
+    controller.viewport.replace(target);
+    return false;
+  }
+}

--- a/test/presentation/screens/generation/widgets/right_panel_test.dart
+++ b/test/presentation/screens/generation/widgets/right_panel_test.dart
@@ -11,6 +11,7 @@ import 'package:nai_launcher/presentation/agent_chat/providers/agent_chat_notifi
 import 'package:nai_launcher/presentation/agent_chat/widgets/agent_chat_panel.dart';
 import 'package:nai_launcher/presentation/screens/generation/widgets/history_panel.dart';
 import 'package:nai_launcher/presentation/screens/generation/widgets/right_panel.dart';
+import 'package:nai_launcher/presentation/widgets/common/owned_scroll_controller.dart';
 
 void main() {
   late Directory hiveDir;
@@ -73,6 +74,48 @@ void main() {
     isResizing.value = false;
     await tester.pump();
     expect(tester.state(find.byType(HistoryPanel)), same(initialState));
+  });
+
+  testWidgets('recreated responsive panel keeps the stable history owner', (
+    tester,
+  ) async {
+    final viewport = OwnedViewportOffset()..replace(720);
+    final showPanel = ValueNotifier(true);
+    addTearDown(showPanel.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localStorageServiceProvider.overrideWithValue(_MemoryLocalStorage()),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: Scaffold(
+            body: ValueListenableBuilder<bool>(
+              valueListenable: showPanel,
+              builder: (_, visible, __) => visible
+                  ? RightPanel(historyViewport: viewport)
+                  : const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      ),
+    );
+    final firstState = tester.state(find.byType(RightPanel));
+
+    showPanel.value = false;
+    await tester.pump();
+    showPanel.value = true;
+    await tester.pump();
+
+    expect(tester.state(find.byType(RightPanel)), isNot(same(firstState)));
+    expect(
+      tester.widget<RightPanel>(find.byType(RightPanel)).historyViewport,
+      same(viewport),
+    );
+    expect(viewport.pixels, 720);
   });
 
   testWidgets('collapsed entries open the selected panel immediately', (

--- a/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_grid_test.dart
@@ -665,4 +665,174 @@ void main() {
       expect(builtColumnCount, 8);
     },
   );
+
+  testWidgets(
+    'restores a page seven anchor through zero constraints and column changes',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1400, 1000);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+      final controller = OnlineGalleryScreenController(
+        prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
+          preloader: (_) =>
+              GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
+        ),
+      );
+      addTearDown(controller.dispose);
+      final items = List.generate(
+        7 * 60,
+        (index) => GalleryItem(
+          id: index,
+          workId: 'page-seven-$index',
+          sourceId: GallerySourceId.danbooru,
+          width: 100 + index % 5 * 20,
+          height: 100 + index % 7 * 15,
+        ),
+      );
+      const anchorIndex = 365;
+      const localOffset = 18.0;
+      final state = OnlineGalleryState(
+        searchCache: ModeCache(
+          posts: items,
+          page: 7,
+          hasMore: false,
+          scrollOffset: 12000,
+          anchorStableKey: items[anchorIndex].stableKey,
+          anchorLocalOffset: localOffset,
+        ),
+      );
+
+      double expectedOffset(double width) {
+        const spacing = 6.0;
+        final availableWidth = width - 24;
+        final columns = ((availableWidth + spacing) / (160 + spacing))
+            .floor()
+            .clamp(1, 8);
+        final itemWidth = (availableWidth - (columns - 1) * spacing) / columns;
+        final layout = OnlineGalleryMasonryLayoutSnapshot(
+          aspectRatios: [for (final item in items) item.width / item.height],
+          placeholderCount: 0,
+          columnCount: columns,
+          itemWidth: itemWidth,
+          mainAxisSpacing: spacing,
+          crossAxisSpacing: spacing,
+        );
+        return 12 + layout.placementFor(anchorIndex).scrollOffset + localOffset;
+      }
+
+      Widget subject(double width, double height) => MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: width,
+              height: height,
+              child: OnlineGalleryGrid(
+                state: state,
+                controller: controller,
+                itemBuilder: (_, __, ___, ____) => const SizedBox.expand(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(subject(840, 700));
+      expect(
+        controller.scrollController.offset,
+        closeTo(expectedOffset(840), 1),
+      );
+
+      final retainedOffset = controller.scrollController.offset;
+      await tester.pumpWidget(subject(840, 0));
+      expect(controller.scrollController.hasClients, isFalse);
+
+      await tester.pumpWidget(subject(840, 700));
+      expect(controller.scrollController.offset, closeTo(retainedOffset, 1));
+
+      await tester.pumpWidget(subject(1180, 700));
+      expect(
+        controller.scrollController.offset,
+        closeTo(expectedOffset(1180), 1),
+      );
+      expect(state.currentCache.page, 7);
+      expect(state.posts, hasLength(420));
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('keeps viewport snapshots isolated by browsing scope', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(840, 700);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    final controller = OnlineGalleryScreenController(
+      prefetchCoordinator: OnlineGalleryPrefetchCoordinator(
+        preloader: (_) =>
+            GalleryImagePreloadOperation.fromFuture(Future<void>.value()),
+      ),
+    );
+    addTearDown(controller.dispose);
+    final items = List.generate(
+      180,
+      (index) => GalleryItem(
+        id: index,
+        workId: 'scope-$index',
+        sourceId: GallerySourceId.danbooru,
+        width: 1,
+        height: 1,
+      ),
+    );
+
+    OnlineGalleryState scopedState(String query, int anchorIndex) =>
+        OnlineGalleryState(
+          searchQuery: query,
+          searchCache: ModeCache(
+            posts: items,
+            page: 3,
+            hasMore: false,
+            anchorStableKey: items[anchorIndex].stableKey,
+            anchorLocalOffset: 10,
+          ),
+        );
+
+    Widget subject(OnlineGalleryState state, {double height = 700}) =>
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              height: height,
+              child: OnlineGalleryGrid(
+                state: state,
+                controller: controller,
+                itemBuilder: (_, __, ___, ____) => const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+    final first = scopedState('first', 80);
+    final second = scopedState('second', 140);
+    await tester.pumpWidget(subject(first));
+    final firstOffset = controller.scrollController.offset;
+    controller.stageViewportRestore(
+      scope: second.currentCacheKey,
+      cache: second.currentCache,
+    );
+    await tester.pumpWidget(subject(second, height: 0));
+    await tester.pumpWidget(subject(second));
+    final secondOffset = controller.scrollController.offset;
+    expect(secondOffset, greaterThan(firstOffset));
+
+    controller.stageViewportRestore(
+      scope: first.currentCacheKey,
+      cache: first.currentCache,
+    );
+    await tester.pumpWidget(subject(first));
+    expect(controller.scrollController.offset, closeTo(firstOffset, 1));
+    expect(first.currentCache.page, 3);
+    expect(second.currentCache.page, 3);
+  });
 }

--- a/test/presentation/screens/settings/settings_screen_test.dart
+++ b/test/presentation/screens/settings/settings_screen_test.dart
@@ -610,6 +610,72 @@ void main() {
     await tester.binding.setSurfaceSize(null);
   });
 
+  testWidgets('桌面与紧凑布局切换保持当前设置浏览位置', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    await tester.binding.setSurfaceSize(const Size(1280, 700));
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      return tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localStorageServiceProvider.overrideWithValue(storage),
+          secureStorageServiceProvider.overrideWithValue(
+            _MemorySecureStorage(),
+          ),
+          authNotifierProvider.overrideWith(_FakeAuthNotifier.new),
+          accountManagerNotifierProvider.overrideWith(
+            _FakeAccountManagerNotifier.new,
+          ),
+          subscriptionNotifierProvider.overrideWith(
+            _FakeSubscriptionNotifier.new,
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SettingsScreen(initialSection: SettingsSection.integrations),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    Finder contentScrollable() => find.descendant(
+      of: find.byKey(const ValueKey('settings-section-scroll-view')),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is Scrollable && widget.axisDirection == AxisDirection.down,
+      ),
+    );
+    await tester.drag(contentScrollable(), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    final desktopOffset = tester
+        .state<ScrollableState>(contentScrollable())
+        .position
+        .pixels;
+    expect(desktopOffset, greaterThan(0));
+
+    await tester.binding.setSurfaceSize(const Size(390, 700));
+    await tester.pumpAndSettle();
+    expect(
+      tester.state<ScrollableState>(contentScrollable()).position.pixels,
+      closeTo(desktopOffset, 1),
+    );
+
+    await tester.binding.setSurfaceSize(const Size(1280, 700));
+    await tester.pumpAndSettle();
+    expect(
+      tester.state<ScrollableState>(contentScrollable()).position.pixels,
+      closeTo(desktopOffset, 1),
+    );
+    expect(tester.takeException(), isNull);
+    debugDefaultTargetPlatformOverride = null;
+    await tester.binding.setSurfaceSize(null);
+  });
+
   testWidgets('取消外部 section 切换会恢复 URL 与智能体页面', (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.windows;
     await tester.binding.setSurfaceSize(const Size(1280, 900));

--- a/test/presentation/screens/tag_library_page/tag_library_page_screen_test.dart
+++ b/test/presentation/screens/tag_library_page/tag_library_page_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nai_launcher/core/shortcuts/shortcut_config.dart';
 import 'package:nai_launcher/data/models/tag_library/tag_library_category.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/providers/shortcuts_provider.dart';
 import 'package:nai_launcher/presentation/providers/tag_library_page_provider.dart';
@@ -64,11 +65,80 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets('responsive sidebar rebuild keeps the active library viewport', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1180, 700);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tagLibraryPageNotifierProvider.overrideWith(
+            _ScrollableTagLibraryPageNotifier.new,
+          ),
+          shortcutConfigNotifierProvider.overrideWith(
+            _TestShortcutConfigNotifier.new,
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: TagLibraryPageScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(GridView), const Offset(0, -420));
+    await tester.pumpAndSettle();
+    double offset() => tester
+        .state<ScrollableState>(
+          find.descendant(
+            of: find.byType(GridView),
+            matching: find.byType(Scrollable),
+          ),
+        )
+        .position
+        .pixels;
+    final desktopOffset = offset();
+    expect(desktopOffset, greaterThan(0));
+
+    tester.view.physicalSize = const Size(390, 700);
+    await tester.pumpAndSettle();
+    expect(offset(), closeTo(desktopOffset, 1));
+
+    tester.view.physicalSize = const Size(1180, 700);
+    await tester.pumpAndSettle();
+    expect(offset(), closeTo(desktopOffset, 1));
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class _TestShortcutConfigNotifier extends ShortcutConfigNotifier {
   @override
   Future<ShortcutConfig> build() async => ShortcutConfig.createDefault();
+}
+
+class _ScrollableTagLibraryPageNotifier extends TagLibraryPageNotifier {
+  @override
+  TagLibraryPageState build() => TagLibraryPageState(
+    viewMode: TagLibraryViewMode.card,
+    entries: [
+      for (var index = 0; index < 100; index++)
+        TagLibraryEntry(
+          id: 'entry-$index',
+          name: '条目 $index',
+          content: 'tag_$index',
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+    ],
+  );
 }
 
 class _TestTagLibraryPageNotifier extends TagLibraryPageNotifier {

--- a/test/presentation/widgets/common/owned_scroll_controller_test.dart
+++ b/test/presentation/widgets/common/owned_scroll_controller_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/presentation/widgets/common/owned_scroll_controller.dart';
+
+void main() {
+  testWidgets('reattach starts at the last usable viewport without a jump', (
+    tester,
+  ) async {
+    final viewport = OwnedViewportOffset();
+    var controller = OwnedScrollController(viewport: viewport);
+
+    Widget subject(ScrollController activeController) => MaterialApp(
+      home: SizedBox(
+        height: 300,
+        child: ListView.builder(
+          controller: activeController,
+          itemExtent: 50,
+          itemCount: 100,
+          itemBuilder: (_, index) => Text('item $index'),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(subject(controller));
+    controller.jumpTo(750);
+    await tester.pump();
+    expect(viewport.pixels, 750);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    controller.dispose();
+
+    controller = OwnedScrollController(viewport: viewport);
+    await tester.pumpWidget(subject(controller));
+
+    expect(controller.offset, 750);
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    controller.dispose();
+  });
+
+  testWidgets('a stale position cannot overwrite the newest attachment', (
+    tester,
+  ) async {
+    final viewport = OwnedViewportOffset()..replace(100);
+    final controller = OwnedScrollController(viewport: viewport);
+    addTearDown(controller.dispose);
+
+    Widget list(String key) => ListView.builder(
+      key: ValueKey(key),
+      controller: controller,
+      itemExtent: 50,
+      itemCount: 100,
+      itemBuilder: (_, index) => Text('$key-$index'),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Row(
+          children: [
+            Expanded(child: list('stale')),
+            Expanded(child: list('active')),
+          ],
+        ),
+      ),
+    );
+    final positions = controller.positions.toList(growable: false);
+    expect(positions, hasLength(2));
+    positions.first.jumpTo(300);
+    positions.last.jumpTo(700);
+    expect(controller.position, same(positions.last));
+    expect(viewport.pixels, 700);
+
+    await tester.pumpWidget(
+      MaterialApp(home: SizedBox(height: 300, child: list('active'))),
+    );
+
+    expect(controller.position.pixels, 700);
+    expect(viewport.pixels, 700);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  test('zero viewport never replaces a valid offset', () {
+    final viewport = OwnedViewportOffset()..replace(640);
+
+    viewport.record(
+      FixedScrollMetrics(
+        minScrollExtent: 0,
+        maxScrollExtent: 0,
+        pixels: 0,
+        viewportDimension: 0,
+        axisDirection: AxisDirection.down,
+        devicePixelRatio: 1,
+      ),
+    );
+
+    expect(viewport.pixels, 640);
+  });
+}


### PR DESCRIPTION
## 根因

Windows 最小化时主 Shell 会短暂收到零 constraints，在线画廊内容分支因此卸载网格的 `ScrollPosition`。原有 `OnlineGalleryScreenController` 虽然继续存活，但普通 `ScrollController` 重新 attach 时只使用构造期的初始值；同时已有 `ModeCache.scrollOffset/anchorStableKey` 只在浏览上下文切换或页面 dispose 时写回，所以最小化过程没有可供首帧恢复的最新 viewport，最终回到顶部。页码、已加载数据和查询状态本身仍在 Provider 中，丢失的是临时网格位置。

## 统一策略

- 新增轻量 `OwnedViewportOffset` / `OwnedScrollController`：由页面或会话级稳定 owner 持有单个有界内存快照，在 attach/detach 时读取和保存；新 `ScrollPosition` 通过 `initialPixels` 首帧恢复，不做 post-frame `jumpTo`。
- 在线画廊复用现有 cacheKey、`scrollOffset`、`anchorStableKey` 和 `anchorLocalOffset` 契约：
  - 零 viewport 不参与记录，并立即暂停可见性、hover、预取和分页需求；
  - 几何不变时恢复 offset；列数/卡片宽度变化时按 stable item anchor + local offset 重算；anchor 已消失时回退到有效 offset，并由 `ScrollPosition` 内容边界 clamp；
  - 当前 viewport 只保存在 screen controller 内，锚点只在滚动停止、布局几何变化、上下文切换或 viewport 消失时计算；主 Provider 仍只在既有上下文切换/dispose 路径写入，没有滚动期高频写入；
  - scope 切换后的待恢复快照不会被旧 `ScrollPosition` detach 或零尺寸分支覆盖。
- 设置长页面、标签/词库、生成历史改由各自稳定的页面/生成会话 owner 持有 viewport；桌面/紧凑、侧栏/面板分支重建时复用同一 owner，业务状态不另建事实来源。

该实现没有后台轮询、常驻 timer、每帧监听、全局单例或无界 viewport map；窗口不可见时在线画廊暂停原有预取工作，不增加后台空转开销。

## 有边界审计

### 已修改

- `lib/presentation/screens/online_gallery/`：Shell 零 constraints 会卸载网格 position；按浏览 scope、stable anchor 和首帧布局恢复。
- `lib/presentation/screens/generation/`：生成页响应式布局会重建右侧历史面板；viewport 提升到稳定的 `GenerationScreen` 会话 owner。
- `lib/presentation/screens/settings/settings_screen.dart`：桌面/紧凑分支会重建内容滚动面；viewport 由 `SettingsScreenState` 持有，切换 section 时显式重置。
- `lib/presentation/screens/tag_library_page/`：侧栏/分组/网格响应式分支可能替换滚动子树；按 grid/list/grouped 三个固定业务 scope 持有三个有界 viewport。

### 确认无需修改

- 本地图库 `local_gallery_screen.dart`：页面级 State、`AutomaticKeepAliveClientMixin`、稳定 `GlobalKey`/PageStorage owner 已跨 Shell 响应式分支存活；零 constraints 不创建第二个 controller。
- Vibe 库与精准参考库：各自稳定面板 State 持有 controller，并使用稳定 PageStorageKey；响应式变化只改内容布局，不替换业务 owner。
- 智能体对话：`AgentChatPanelController` 已按 session 保存 viewport，并由 `_AgentChatScrollController` 在 position 创建时恢复；现有 follow-latest、未读、首次到底部和会话隔离测试全部回归，无需重复实现。
- 智能体资源附件轨：controller 属于稳定 composer State，零 constraints 不切换 owner；它是当前草稿的短横向轨，不是会话级持续浏览面的第二份状态。
- 图片详情多媒体/缩略图轨：controller 与当前详情 overlay/page State 同生命周期，宽度变化不切换详情 owner；关闭详情后重新打开本来就是新的浏览会话。

临时 dialog、自动完成菜单等短生命周期滚动面不在本次范围。

## 测试

新增/扩展覆盖：

- 在线画廊第 7 页 stable anchor：有效 viewport → constraints 归零 → 子树恢复；同时覆盖列数变化。
- 零 viewport 不覆盖有效快照、浏览 scope 隔离、旧 position detach 不覆盖新 attachment。
- 隐藏网格不重复分页/不自动追加，已有分页 demand 回归继续通过。
- 设置桌面/紧凑切换、词库侧栏重建、生成历史响应式重建。
- 智能体 follow-latest、未读、首次到底部与 session viewport 回归。

实际执行：

```powershell
pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/verify_flutter_sources.ps1
flutter test test/presentation/widgets/common/owned_scroll_controller_test.dart test/presentation/screens/online_gallery/online_gallery_grid_test.dart test/presentation/screens/generation/widgets/right_panel_test.dart test/presentation/screens/settings/settings_screen_test.dart test/presentation/screens/tag_library_page/tag_library_page_screen_test.dart test/presentation/agent_chat/widgets/agent_chat_scroll_follow_test.dart
pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1
pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1 -Path "lib/presentation/widgets/common/owned_scroll_controller.dart,lib/presentation/screens/online_gallery/online_gallery_grid.dart,lib/presentation/screens/online_gallery/online_gallery_screen_controller.dart,lib/presentation/screens/online_gallery/online_gallery_scroll_prefetch_coordinator.dart,lib/presentation/screens/settings/settings_screen.dart,lib/presentation/screens/generation/generation_screen.dart,lib/presentation/screens/generation/widgets/history_panel.dart,lib/presentation/screens/tag_library_page/tag_library_page_screen.dart" -Include "test/presentation/widgets/common/owned_scroll_controller_test.dart,test/presentation/screens/online_gallery/online_gallery_grid_test.dart,test/presentation/screens/settings/settings_screen_test.dart,test/presentation/screens/generation/widgets/right_panel_test.dart,test/presentation/screens/tag_library_page/tag_library_page_screen_test.dart,test/presentation/agent_chat/widgets/agent_chat_scroll_follow_test.dart"
flutter analyze
```

结果：相关测试、`test_affected.ps1`（全改动选择 126 项；rebase 到最新 `main` 后显式范围 89 项）全部通过，`flutter analyze` 无问题。按要求未启动热重载、真机或自动化 UI。
