### PR TITLE
fix(windows): 保持最小化期间页面生命周期

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ Windows release 产物位于 `build/windows/x64/runner/Release/`。macOS 使用 
 ### Windows 窗口稳定性
 
 - 主 Runner 必须在 `WM_SIZE` 和 `WM_WINDOWPOSCHANGED` 后排队重新对齐 Flutter child view；不得只依赖 `WM_SIZE`。否则外层主 HWND 恢复后，内部 `FLUTTERVIEW` 可能仍停在 Windows 最小化哨兵坐标 `-32000,-32000`，表现为旧画面冻结、按钮 hover 不消失、点击无响应或出现调整尺寸光标。
+- Flutter Windows 最小化发送零尺寸 metrics 是官方已知生命周期行为；顶层 `SIZE_MINIMIZED` 仍须通过 `HandleTopLevelWindowProc` 传递 `hidden` 生命周期，但主 Runner 不得把 iconic/零尺寸 client rect 转发给 child HWND。Flutter 壳层遇到临时无效 constraints 时必须保留同一 child element/state，并暂停 ticker、语义和交互；正常非最小化缩放仍须响应真实 constraints。
+- `windows/runner/` 是受 Git 管理的项目原生源码，`test`、`analyze`、`flutter clean`、`flutter build`、Release CI 和 Flutter SDK 升级不会用官方模板还原；若删除/重建平台工程或人工同步模板，必须保留项目的 child resize、accessibility 和生命周期定制，并运行静态契约测试。
 - 调试“窗口可见但无法操作”时必须分别检查顶层 `FLUTTER_RUNNER_WIN32_WINDOW` 与其 `FLUTTERVIEW` 子窗口的 rect、enabled、capture 和 hit-test；不能只根据 Flutter 日志或外层 HWND 状态判断。
 - 修改插件版本或 Windows C++ 后必须完整重建。Orca 会话显示 `running` 或留有 PID 不等于构建成功；应确认控制台出现原生构建成功/启动标记、真实 `nai_launcher` 进程存在，依赖变化时再核对插件 DLL 时间戳，然后才让用户复现。
 - Windows 最小化会让窗口 constraints 短暂归零，响应式布局可能因此销毁并重建面板子树；滚动位置、是否跟随最新内容等必须跨 Widget/Controller 生命周期的 viewport 状态应由更高层稳定 owner 按会话保存。重建 ScrollController 时必须用保存值设置 `initialScrollOffset`，在首帧直接呈现原位置；不得先渲染默认位置再通过 post-frame `jumpTo` 恢复，否则会出现跳到底部后拉回的闪烁。

--- a/lib/presentation/widgets/common/desktop_window_frame.dart
+++ b/lib/presentation/widgets/common/desktop_window_frame.dart
@@ -16,7 +16,7 @@ const double desktopWindowButtonWidth = 48;
 /// Other platforms keep their native title bars. On Windows,
 /// `TitleBarStyle.hidden` retains the native resizable frame while this widget
 /// supplies the visible caption controls and drag region.
-class DesktopWindowFrame extends StatelessWidget {
+class DesktopWindowFrame extends StatefulWidget {
   const DesktopWindowFrame({
     super.key,
     required this.child,
@@ -29,26 +29,77 @@ class DesktopWindowFrame extends StatelessWidget {
   final bool? enabled;
 
   @override
+  State<DesktopWindowFrame> createState() => _DesktopWindowFrameState();
+}
+
+class _DesktopWindowFrameState extends State<DesktopWindowFrame> {
+  Size? _lastValidViewport;
+
+  bool _isValidViewport(BoxConstraints constraints) {
+    return constraints.hasBoundedWidth &&
+        constraints.hasBoundedHeight &&
+        constraints.maxWidth.isFinite &&
+        constraints.maxHeight.isFinite &&
+        constraints.maxHeight >= desktopWindowHeaderHeight &&
+        constraints.maxWidth >= desktopWindowButtonWidth * 3;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (!(enabled ?? PlatformCapabilities.current.isWindows)) return child;
+    if (!(widget.enabled ?? PlatformCapabilities.current.isWindows)) {
+      return widget.child;
+    }
 
     final surfaceColor = Theme.of(context).colorScheme.surface;
     return LayoutBuilder(
       builder: (context, constraints) {
-        // Windows briefly shrinks FLUTTERVIEW to a taskbar-sized surface while
-        // minimizing. Laying out a 40px caption there creates a visible debug
-        // overflow even though the top-level window is already disappearing.
-        if (constraints.maxHeight < desktopWindowHeaderHeight ||
-            constraints.maxWidth < desktopWindowButtonWidth * 3) {
-          return ColoredBox(color: surfaceColor);
-        }
-        return ColoredBox(
-          color: surfaceColor,
-          child: Column(
-            children: [
-              DesktopWindowHeader(controller: controller),
-              Expanded(child: child),
-            ],
+        final currentViewport = Size(
+          constraints.maxWidth,
+          constraints.maxHeight,
+        );
+        final isViewportValid = _isValidViewport(constraints);
+        if (isViewportValid) _lastValidViewport = currentViewport;
+
+        // The native view can report a zero or taskbar-sized surface while the
+        // top-level window is being minimized. Keep the same element tree laid
+        // out at its last real viewport so responsive shells and route state do
+        // not churn during that transient native lifecycle state.
+        final layoutViewport = isViewportValid
+            ? currentViewport
+            : _lastValidViewport ??
+                  const Size(
+                    desktopWindowButtonWidth * 3,
+                    desktopWindowHeaderHeight,
+                  );
+
+        return ClipRect(
+          child: OverflowBox(
+            alignment: Alignment.topLeft,
+            minWidth: layoutViewport.width,
+            maxWidth: layoutViewport.width,
+            minHeight: layoutViewport.height,
+            maxHeight: layoutViewport.height,
+            child: SizedBox.fromSize(
+              size: layoutViewport,
+              child: TickerMode(
+                enabled: isViewportValid,
+                child: ExcludeSemantics(
+                  excluding: !isViewportValid,
+                  child: IgnorePointer(
+                    ignoring: !isViewportValid,
+                    child: ColoredBox(
+                      color: surfaceColor,
+                      child: Column(
+                        children: [
+                          DesktopWindowHeader(controller: widget.controller),
+                          Expanded(child: widget.child),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
           ),
         );
       },

--- a/test/presentation/router/main_shell_minimize_lifecycle_test.dart
+++ b/test/presentation/router/main_shell_minimize_lifecycle_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nai_launcher/core/constants/app_version.dart';
+import 'package:nai_launcher/core/platform/platform_capabilities.dart';
+import 'package:nai_launcher/core/shortcuts/shortcut_config.dart';
+import 'package:nai_launcher/core/windowing/desktop_window_controller.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/providers/account_manager_provider.dart';
+import 'package:nai_launcher/presentation/providers/auth_provider.dart';
+import 'package:nai_launcher/presentation/providers/shortcuts_provider.dart';
+import 'package:nai_launcher/presentation/router/app_shell.dart';
+import 'package:nai_launcher/presentation/widgets/common/desktop_window_frame.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:window_manager/window_manager.dart';
+
+void main() {
+  setUpAll(() async {
+    PackageInfo.setMockInitialValues(
+      appName: 'NAI Launcher',
+      packageName: 'nai_launcher',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+    await AppVersion.initialize();
+  });
+
+  testWidgets('最小化尺寸不切换 MainShell 或销毁当前路由状态', (tester) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    addTearDown(() => PlatformCapabilities.debugOverride = null);
+    await tester.binding.setSurfaceSize(const Size(1280, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final lifecycle = _RouteProbeLifecycle();
+    final container = ProviderContainer(
+      overrides: [
+        accountManagerNotifierProvider.overrideWith(
+          _TestAccountManagerNotifier.new,
+        ),
+        authNotifierProvider.overrideWith(_UnauthenticatedAuthNotifier.new),
+        shortcutConfigNotifierProvider.overrideWith(
+          _TestShortcutConfigNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final router = GoRouter(
+      initialLocation: '/detail',
+      routes: [
+        StatefulShellRoute(
+          navigatorContainerBuilder: (context, navigationShell, children) {
+            return MainShell(
+              navigationShell: navigationShell,
+              children: children,
+            );
+          },
+          builder: (context, state, navigationShell) => navigationShell,
+          branches: [
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/',
+                  builder: (context, state) => const SizedBox.expand(),
+                  routes: [
+                    GoRoute(
+                      path: 'detail',
+                      builder: (context, state) => _RouteStateProbe(lifecycle),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          routerConfig: router,
+          locale: const Locale('zh'),
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          builder: (context, child) => DesktopWindowFrame(
+            enabled: true,
+            controller: _NoopDesktopWindowController(),
+            child: child!,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DesktopShell), findsOneWidget);
+    expect(find.byType(MobileShell), findsNothing);
+    expect(lifecycle.initCalls, 1);
+    expect(router.routeInformationProvider.value.uri.path, '/detail');
+
+    for (final size in [Size.zero, const Size(144, 19)]) {
+      await tester.binding.setSurfaceSize(size);
+      await tester.pump();
+      expect(find.byType(DesktopShell), findsOneWidget);
+      expect(find.byType(MobileShell), findsNothing);
+      expect(lifecycle.initCalls, 1);
+      expect(lifecycle.disposeCalls, 0);
+      expect(router.routeInformationProvider.value.uri.path, '/detail');
+      expect(tester.takeException(), isNull);
+    }
+
+    await tester.binding.setSurfaceSize(const Size(1280, 800));
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('route-state-probe')));
+    await tester.pump();
+
+    expect(lifecycle.initCalls, 1);
+    expect(lifecycle.disposeCalls, 0);
+    expect(lifecycle.tapCalls, 1);
+    expect(router.routeInformationProvider.value.uri.path, '/detail');
+    expect(tester.takeException(), isNull);
+  });
+}
+
+class _RouteProbeLifecycle {
+  int initCalls = 0;
+  int disposeCalls = 0;
+  int tapCalls = 0;
+}
+
+class _RouteStateProbe extends StatefulWidget {
+  const _RouteStateProbe(this.lifecycle);
+
+  final _RouteProbeLifecycle lifecycle;
+
+  @override
+  State<_RouteStateProbe> createState() => _RouteStateProbeState();
+}
+
+class _RouteStateProbeState extends State<_RouteStateProbe> {
+  @override
+  void initState() {
+    super.initState();
+    widget.lifecycle.initCalls++;
+  }
+
+  @override
+  void dispose() {
+    widget.lifecycle.disposeCalls++;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: FilledButton(
+        key: const ValueKey('route-state-probe'),
+        onPressed: () => widget.lifecycle.tapCalls++,
+        child: const Text('detail'),
+      ),
+    );
+  }
+}
+
+class _NoopDesktopWindowController implements DesktopWindowController {
+  @override
+  void addListener(WindowListener listener) {}
+
+  @override
+  void removeListener(WindowListener listener) {}
+
+  @override
+  Future<bool> isMaximized() async => false;
+
+  @override
+  Future<void> startDragging() async {}
+
+  @override
+  Future<void> minimize() async {}
+
+  @override
+  Future<void> maximize() async {}
+
+  @override
+  Future<void> unmaximize() async {}
+
+  @override
+  Future<void> close() async {}
+}
+
+class _TestAccountManagerNotifier extends AccountManagerNotifier {
+  @override
+  AccountManagerState build() => const AccountManagerState();
+}
+
+class _TestShortcutConfigNotifier extends ShortcutConfigNotifier {
+  @override
+  Future<ShortcutConfig> build() async => ShortcutConfig.createDefault();
+}
+
+class _UnauthenticatedAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => const AuthState(status: AuthStatus.unauthenticated);
+}

--- a/test/presentation/screens/settings/settings_screen_test.dart
+++ b/test/presentation/screens/settings/settings_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:nai_launcher/core/storage/local_storage_service.dart';
 import 'package:nai_launcher/core/storage/secure_storage_service.dart';
 import 'package:nai_launcher/core/agent/skill_catalog.dart';
+import 'package:nai_launcher/core/windowing/desktop_window_controller.dart';
 import 'package:nai_launcher/data/models/user/user_subscription.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/providers/account_manager_provider.dart';
@@ -22,6 +23,34 @@ import 'package:nai_launcher/presentation/screens/settings/sections/integrations
 import 'package:nai_launcher/presentation/screens/settings/sections/prompt_assistant_settings_section.dart';
 import 'package:nai_launcher/presentation/screens/settings/settings_screen.dart';
 import 'package:nai_launcher/presentation/screens/settings/settings_section.dart';
+import 'package:nai_launcher/presentation/widgets/common/desktop_window_frame.dart';
+import 'package:window_manager/window_manager.dart';
+
+class _NoopDesktopWindowController implements DesktopWindowController {
+  @override
+  void addListener(WindowListener listener) {}
+
+  @override
+  void removeListener(WindowListener listener) {}
+
+  @override
+  Future<bool> isMaximized() async => false;
+
+  @override
+  Future<void> startDragging() async {}
+
+  @override
+  Future<void> minimize() async {}
+
+  @override
+  Future<void> maximize() async {}
+
+  @override
+  Future<void> unmaximize() async {}
+
+  @override
+  Future<void> close() async {}
+}
 
 class _MemoryLocalStorage extends LocalStorageService {
   final Map<String, Object?> _values = {};
@@ -633,11 +662,18 @@ void main() {
             _FakeSubscriptionNotifier.new,
           ),
         ],
-        child: const MaterialApp(
-          locale: Locale('zh'),
+        child: MaterialApp(
+          locale: const Locale('zh'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: SettingsScreen(initialSection: SettingsSection.integrations),
+          builder: (context, child) => DesktopWindowFrame(
+            enabled: true,
+            controller: _NoopDesktopWindowController(),
+            child: child!,
+          ),
+          home: const SettingsScreen(
+            initialSection: SettingsSection.integrations,
+          ),
         ),
       ),
     );
@@ -658,6 +694,28 @@ void main() {
         .pixels;
     expect(desktopOffset, greaterThan(0));
 
+    for (final minimizedSize in [Size.zero, const Size(144, 19)]) {
+      await tester.binding.setSurfaceSize(minimizedSize);
+      await tester.pump();
+      expect(find.byType(NavigationRail), findsOneWidget);
+      expect(find.byType(IntegrationsSettingsSection), findsOneWidget);
+      expect(
+        tester.state<ScrollableState>(contentScrollable()).position.pixels,
+        closeTo(desktopOffset, 1),
+      );
+      expect(tester.takeException(), isNull);
+    }
+
+    await tester.binding.setSurfaceSize(const Size(1280, 700));
+    await tester.pump();
+    expect(find.byType(NavigationRail), findsOneWidget);
+    expect(find.byType(IntegrationsSettingsSection), findsOneWidget);
+    expect(
+      tester.state<ScrollableState>(contentScrollable()).position.pixels,
+      closeTo(desktopOffset, 1),
+    );
+
+    // A real manual resize still crosses the responsive breakpoint normally.
     await tester.binding.setSurfaceSize(const Size(390, 700));
     await tester.pumpAndSettle();
     expect(

--- a/test/presentation/widgets/common/desktop_window_frame_test.dart
+++ b/test/presentation/widgets/common/desktop_window_frame_test.dart
@@ -6,6 +6,46 @@ import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/widgets/common/desktop_window_frame.dart';
 import 'package:window_manager/window_manager.dart';
 
+class _ProbeLifecycle {
+  int initCalls = 0;
+  int disposeCalls = 0;
+  int tapCalls = 0;
+}
+
+class _StatefulProbe extends StatefulWidget {
+  const _StatefulProbe(this.lifecycle);
+
+  final _ProbeLifecycle lifecycle;
+
+  @override
+  State<_StatefulProbe> createState() => _StatefulProbeState();
+}
+
+class _StatefulProbeState extends State<_StatefulProbe> {
+  @override
+  void initState() {
+    super.initState();
+    widget.lifecycle.initCalls++;
+  }
+
+  @override
+  void dispose() {
+    widget.lifecycle.disposeCalls++;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: FilledButton(
+        key: const ValueKey('stateful-window-content'),
+        onPressed: () => widget.lifecycle.tapCalls++,
+        child: const Text('content'),
+      ),
+    );
+  }
+}
+
 class _FakeDesktopWindowController implements DesktopWindowController {
   WindowListener? listener;
   bool maximized = false;
@@ -100,35 +140,71 @@ void main() {
     );
   });
 
-  testWidgets('minimized Flutter surface does not lay out the caption', (
-    tester,
-  ) async {
-    final controller = _FakeDesktopWindowController();
+  testWidgets(
+    'transient minimized surfaces preserve child state and suspend activity',
+    (tester) async {
+      final controller = _FakeDesktopWindowController();
+      final lifecycle = _ProbeLifecycle();
+      final viewport = ValueNotifier(const Size(800, 600));
+      addTearDown(viewport.dispose);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        locale: const Locale('zh'),
-        supportedLocales: AppLocalizations.supportedLocales,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        home: Align(
-          alignment: Alignment.topLeft,
-          child: SizedBox(
-            width: 144,
-            height: 19,
-            child: DesktopWindowFrame(
-              enabled: true,
-              controller: controller,
-              child: const ColoredBox(color: Colors.black),
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('zh'),
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: ValueListenableBuilder<Size>(
+              valueListenable: viewport,
+              builder: (context, size, child) => SizedBox.fromSize(
+                size: size,
+                child: DesktopWindowFrame(
+                  enabled: true,
+                  controller: controller,
+                  child: child!,
+                ),
+              ),
+              child: _StatefulProbe(lifecycle),
             ),
           ),
         ),
-      ),
-    );
-    await tester.pump();
+      );
+      await tester.pump();
 
-    expect(tester.takeException(), isNull);
-    expect(find.byKey(const ValueKey('desktop-window-header')), findsNothing);
-  });
+      expect(lifecycle.initCalls, 1);
+      expect(lifecycle.disposeCalls, 0);
+
+      for (final minimizedSize in [Size.zero, const Size(144, 19)]) {
+        viewport.value = minimizedSize;
+        await tester.pump();
+
+        expect(lifecycle.initCalls, 1);
+        expect(lifecycle.disposeCalls, 0);
+        expect(
+          find.byKey(const ValueKey('desktop-window-header')),
+          findsOneWidget,
+        );
+        expect(
+          tester
+              .widgetList<IgnorePointer>(find.byType(IgnorePointer))
+              .any((widget) => widget.ignoring),
+          isTrue,
+        );
+        expect(tester.takeException(), isNull);
+      }
+
+      viewport.value = const Size(800, 600);
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('stateful-window-content')));
+      await tester.pump();
+
+      expect(lifecycle.initCalls, 1);
+      expect(lifecycle.disposeCalls, 0);
+      expect(lifecycle.tapCalls, 1);
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets(
     'Windows header exposes localized controls with desktop hit areas',

--- a/test/windows/runner/window_frame_contract_test.dart
+++ b/test/windows/runner/window_frame_contract_test.dart
@@ -37,7 +37,29 @@ void main() {
       ).hasMatch(source),
       isTrue,
     );
+    expect(source, contains('PostMessage(window_handle_,'));
+    expect(source, contains('case kResizeChildContentMessage:'));
+    expect(source, contains('ResizeChildContent();'));
   });
+
+  test(
+    'runner never forwards minimized or empty client geometry to Flutter',
+    () {
+      final source = File('windows/runner/win32_window.cpp').readAsStringSync();
+      final header = File('windows/runner/win32_window.h').readAsStringSync();
+
+      expect(source, contains('IsIconic(window_handle_)'));
+      expect(source, contains('width > 0 && height > 0'));
+      expect(source, contains('last_valid_client_rect_ = frame;'));
+      expect(source, contains('frame = last_valid_client_rect_;'));
+      expect(header, contains('RECT last_valid_client_rect_{};'));
+      expect(header, contains('bool has_last_valid_client_rect_ = false;'));
+      expect(
+        source.indexOf('if (IsIconic(window_handle_))'),
+        lessThan(source.indexOf('RECT frame = GetClientArea();')),
+      );
+    },
+  );
 
   test('Flutter caption closes through prevent-close event, never destroy', () {
     final source = File(

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -303,7 +303,30 @@ void Win32Window::ResizeChildContent() {
   if (window_handle_ == nullptr || child_content_ == nullptr) {
     return;
   }
+
+  // The top-level message has already passed through HandleTopLevelWindowProc,
+  // so Flutter still receives its hidden lifecycle event. Keep the child HWND
+  // at its last bounds while iconic instead of forwarding minimize geometry.
+  if (IsIconic(window_handle_)) {
+    return;
+  }
+
   RECT frame = GetClientArea();
+  const LONG width = frame.right - frame.left;
+  const LONG height = frame.bottom - frame.top;
+  if (width > 0 && height > 0) {
+    last_valid_client_rect_ = frame;
+    has_last_valid_client_rect_ = true;
+  } else {
+    // Restore can briefly expose an empty client area before the real client
+    // rect arrives. Reuse the last valid bounds until the queued resize from
+    // WM_SIZE or WM_WINDOWPOSCHANGED aligns the child to the restored window.
+    if (!has_last_valid_client_rect_) {
+      return;
+    }
+    frame = last_valid_client_rect_;
+  }
+
   MoveWindow(child_content_, frame.left, frame.top, frame.right - frame.left,
              frame.bottom - frame.top, TRUE);
 }

--- a/windows/runner/win32_window.h
+++ b/windows/runner/win32_window.h
@@ -103,6 +103,8 @@ class Win32Window {
   // window handle for hosted content.
   HWND child_content_ = nullptr;
   bool child_resize_pending_ = false;
+  RECT last_valid_client_rect_{};
+  bool has_last_valid_client_rect_ = false;
 };
 
 #endif  // RUNNER_WIN32_WINDOW_H_


### PR DESCRIPTION
## 变更说明

- Windows Runner 在窗口 iconic 或 client rect 临时归零时保留 Flutter child 的最近有效尺寸，同时保留 `WM_SIZE`、`WM_WINDOWPOSCHANGED` 和延迟重新对齐机制。
- `DesktopWindowFrame` 在最小化无效 constraints 下保持同一页面子树挂载，使用最近有效 viewport 布局，并暂停 ticker、语义和交互。
- 增加窗口框架、MainShell、Settings 和 Windows Runner 静态契约回归测试，并记录 Windows 最小化生命周期开发规范。

## 验证

- 针对性 Flutter/widget 与 Runner 静态契约测试：19 项通过
- `flutter analyze`：通过
- Windows Debug 完整原生重建：通过
- Windows 实际多次最小化/恢复：页面状态和交互保持正常，无冻结或残留 resize cursor

## 范围

- 未修改 OAuth、CloudSync 或任何具体业务状态。