### PR TITLE
fix(generation): 保留退出增强与超分后的尺寸和强度

### DIFF
--- a/lib/presentation/providers/generation/image_workflow_controller.dart
+++ b/lib/presentation/providers/generation/image_workflow_controller.dart
@@ -391,8 +391,8 @@ class ImageWorkflowState {
     this.sourceImageHeight,
     this.baseWidth,
     this.baseHeight,
-    this.baseStrength,
-    this.baseNoise,
+    this.enhanceEntryStrength,
+    this.enhanceEntryNoise,
     this.enhance = const EnhanceWorkflowSettings(),
     this.upscale = const UpscaleWorkflowSettings(),
     this.isPanelExpanded = false,
@@ -409,8 +409,10 @@ class ImageWorkflowState {
   final int? sourceImageHeight;
   final int? baseWidth;
   final int? baseHeight;
-  final double? baseStrength;
-  final double? baseNoise;
+
+  // 只在进入增强时拍照：增强是唯一覆盖 strength/noise 的模式，提前拍会回写用户之后改的值
+  final double? enhanceEntryStrength;
+  final double? enhanceEntryNoise;
   final EnhanceWorkflowSettings enhance;
   final UpscaleWorkflowSettings upscale;
   final bool isPanelExpanded;
@@ -431,8 +433,8 @@ class ImageWorkflowState {
     int? sourceImageHeight,
     int? baseWidth,
     int? baseHeight,
-    double? baseStrength,
-    double? baseNoise,
+    double? enhanceEntryStrength,
+    double? enhanceEntryNoise,
     EnhanceWorkflowSettings? enhance,
     UpscaleWorkflowSettings? upscale,
     bool? isPanelExpanded,
@@ -442,6 +444,7 @@ class ImageWorkflowState {
     Rect? focusedSelectionRect,
     bool clearSourceSize = false,
     bool clearBaseSnapshot = false,
+    bool clearEnhanceEntryParams = false,
     bool clearFocusedSelectionRect = false,
   }) {
     return ImageWorkflowState(
@@ -458,10 +461,12 @@ class ImageWorkflowState {
           : (sourceImageHeight ?? this.sourceImageHeight),
       baseWidth: clearBaseSnapshot ? null : (baseWidth ?? this.baseWidth),
       baseHeight: clearBaseSnapshot ? null : (baseHeight ?? this.baseHeight),
-      baseStrength: clearBaseSnapshot
+      enhanceEntryStrength: clearBaseSnapshot || clearEnhanceEntryParams
           ? null
-          : (baseStrength ?? this.baseStrength),
-      baseNoise: clearBaseSnapshot ? null : (baseNoise ?? this.baseNoise),
+          : (enhanceEntryStrength ?? this.enhanceEntryStrength),
+      enhanceEntryNoise: clearBaseSnapshot || clearEnhanceEntryParams
+          ? null
+          : (enhanceEntryNoise ?? this.enhanceEntryNoise),
       enhance: enhance ?? this.enhance,
       upscale: upscale ?? this.upscale,
       isPanelExpanded: isPanelExpanded ?? this.isPanelExpanded,
@@ -1055,11 +1060,11 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
 
     switch (state.mode) {
       case ImageWorkflowMode.enhance:
-        _ensureBaseSnapshot();
+        _ensureBaseSizeSnapshot();
         _applyEnhanceToParams();
         break;
       case ImageWorkflowMode.upscale:
-        _ensureBaseSnapshot();
+        _ensureBaseSizeSnapshot();
         _applySourceSizeToParams();
         break;
       case ImageWorkflowMode.inpaint:
@@ -1075,7 +1080,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
         _paramsNotifier.updateAction(ImageGenerationAction.img2img);
         break;
       case ImageWorkflowMode.base:
-        _ensureBaseSnapshot();
+        _ensureBaseSizeSnapshot();
         _applySourceSizeToParams();
         _paramsNotifier.updateAction(ImageGenerationAction.img2img);
         break;
@@ -1132,7 +1137,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       _restoreBaseParams();
     }
 
-    _ensureBaseSnapshot();
+    _ensureBaseSizeSnapshot();
     state = state.copyWith(
       mode: ImageWorkflowMode.upscale,
       isPanelExpanded: true,
@@ -1149,18 +1154,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       return;
     }
 
-    _restoreBaseParams();
-    state = state.copyWith(
-      mode: ImageWorkflowMode.base,
-      isOutpaint: false,
-      clearBaseSnapshot: true,
-    );
-    _paramsNotifier.updateIsOutpaint(false);
-    _paramsNotifier.updateAction(
-      _params.sourceImage != null
-          ? ImageGenerationAction.img2img
-          : ImageGenerationAction.generate,
-    );
+    enterBaseMode(clearMask: false);
   }
 
   void updateUpscaleComfyScale(double scale) {
@@ -1367,7 +1361,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       }
     }
 
-    _ensureBaseSnapshot();
+    _ensureBaseSizeSnapshot();
 
     final actualSourceWidth = hasReplacementSource
         ? (importInfo?.originalWidth ?? sourceWidth)
@@ -1427,7 +1421,8 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       _restoreBaseParams();
     }
 
-    _ensureBaseSnapshot();
+    _ensureBaseSizeSnapshot();
+    _captureEnhanceEntryParams();
     state = state.copyWith(
       mode: ImageWorkflowMode.enhance,
       isPanelExpanded: true,
@@ -1443,18 +1438,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       return;
     }
 
-    _restoreBaseParams();
-    state = state.copyWith(
-      mode: ImageWorkflowMode.base,
-      isOutpaint: false,
-      clearBaseSnapshot: true,
-    );
-    _paramsNotifier.updateIsOutpaint(false);
-    _paramsNotifier.updateAction(
-      _params.sourceImage != null
-          ? ImageGenerationAction.img2img
-          : ImageGenerationAction.generate,
-    );
+    enterBaseMode(clearMask: false);
   }
 
   void enterInpaintMode() {
@@ -1469,7 +1453,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       _restoreBaseParams();
     }
 
-    _ensureBaseSnapshot();
+    _ensureBaseSizeSnapshot();
     state = state.copyWith(
       mode: ImageWorkflowMode.inpaint,
       isPanelExpanded: true,
@@ -1481,6 +1465,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
     _syncInpaintRequestState();
   }
 
+  /// 离开任一模式回到 base 的唯一实现：退出增强/超分都委托到这里，避免两条路径给出不同尺寸。
   void enterBaseMode({bool clearMask = true}) {
     final shouldRestoreBaseSnapshot =
         state.mode == ImageWorkflowMode.enhance ||
@@ -1592,19 +1577,22 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
     _applyEnhanceToParams();
   }
 
-  void _ensureBaseSnapshot() {
-    if (state.baseWidth != null &&
-        state.baseHeight != null &&
-        state.baseStrength != null &&
-        state.baseNoise != null) {
+  /// 尺寸在载入源图时就被源图尺寸覆盖，因此各模式共用一份、清空源图时还原。
+  void _ensureBaseSizeSnapshot() {
+    if (state.baseWidth != null && state.baseHeight != null) {
       return;
     }
 
     state = state.copyWith(
       baseWidth: _params.width,
       baseHeight: _params.height,
-      baseStrength: _params.strength,
-      baseNoise: _params.noise,
+    );
+  }
+
+  void _captureEnhanceEntryParams() {
+    state = state.copyWith(
+      enhanceEntryStrength: _params.strength,
+      enhanceEntryNoise: _params.noise,
     );
   }
 
@@ -1620,11 +1608,17 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
         persist: false,
       );
     }
-    if (state.baseStrength != null) {
-      _paramsNotifier.updateStrength(state.baseStrength!);
+    final entryStrength = state.enhanceEntryStrength;
+    final entryNoise = state.enhanceEntryNoise;
+    if (entryStrength != null) {
+      _paramsNotifier.updateStrength(entryStrength);
     }
-    if (state.baseNoise != null) {
-      _paramsNotifier.updateNoise(state.baseNoise!);
+    if (entryNoise != null) {
+      _paramsNotifier.updateNoise(entryNoise);
+    }
+    // 回写即消费：留着会在后续转场里二次覆盖用户改过的值
+    if (entryStrength != null || entryNoise != null) {
+      state = state.copyWith(clearEnhanceEntryParams: true);
     }
   }
 

--- a/test/presentation/providers/generation/image_workflow_controller_test.dart
+++ b/test/presentation/providers/generation/image_workflow_controller_test.dart
@@ -98,10 +98,265 @@ void main() {
       final params = container.read(generationParamsNotifierProvider);
 
       expect(workflow.mode, ImageWorkflowMode.base);
-      expect(params.width, equals(832));
-      expect(params.height, equals(1216));
+      // 源图仍在，尺寸跟随源图而不是载入前的 832x1216
+      expect(params.width, equals(768));
+      expect(params.height, equals(1024));
       expect(params.strength, equals(0.63));
       expect(params.noise, equals(0.04));
+    });
+
+    test(
+      'manual strength and noise edits should survive an enhance round-trip',
+      () {
+        final controller = container.read(
+          imageWorkflowControllerProvider.notifier,
+        );
+        final paramsNotifier = container.read(
+          generationParamsNotifierProvider.notifier,
+        );
+
+        paramsNotifier.updateSize(832, 1216, persist: false);
+        paramsNotifier.updateStrength(0.7);
+        paramsNotifier.updateNoise(0.0);
+        controller.replaceSourceImage(
+          _validImageBytes(width: 768, height: 1024),
+          sourceWidth: 768,
+          sourceHeight: 1024,
+        );
+
+        paramsNotifier.updateStrength(0.4);
+        paramsNotifier.updateNoise(0.12);
+
+        controller.enterEnhanceMode();
+        final enhanced = container.read(generationParamsNotifierProvider);
+        expect(enhanced.strength, equals(0.5));
+        expect(enhanced.noise, equals(0.0));
+
+        controller.exitEnhanceMode();
+
+        final params = container.read(generationParamsNotifierProvider);
+        expect(params.strength, equals(0.4));
+        expect(params.noise, equals(0.12));
+      },
+    );
+
+    test(
+      'manual strength and noise edits should survive an upscale round-trip',
+      () {
+        final controller = container.read(
+          imageWorkflowControllerProvider.notifier,
+        );
+        final paramsNotifier = container.read(
+          generationParamsNotifierProvider.notifier,
+        );
+
+        paramsNotifier.updateSize(832, 1216, persist: false);
+        paramsNotifier.updateStrength(0.7);
+        paramsNotifier.updateNoise(0.0);
+        controller.replaceSourceImage(
+          _validImageBytes(width: 768, height: 1024),
+          sourceWidth: 768,
+          sourceHeight: 1024,
+        );
+
+        paramsNotifier.updateStrength(0.4);
+        paramsNotifier.updateNoise(0.12);
+
+        controller.enterUpscaleMode();
+        controller.exitUpscaleMode();
+
+        final params = container.read(generationParamsNotifierProvider);
+        expect(params.strength, equals(0.4));
+        expect(params.noise, equals(0.12));
+      },
+    );
+
+    test(
+      'manual strength and noise edits should survive an inpaint round-trip',
+      () {
+        final controller = container.read(
+          imageWorkflowControllerProvider.notifier,
+        );
+        final paramsNotifier = container.read(
+          generationParamsNotifierProvider.notifier,
+        );
+
+        paramsNotifier.updateSize(832, 1216, persist: false);
+        paramsNotifier.updateStrength(0.7);
+        paramsNotifier.updateNoise(0.0);
+        controller.replaceSourceImage(
+          _validImageBytes(width: 768, height: 1024),
+          sourceWidth: 768,
+          sourceHeight: 1024,
+        );
+
+        paramsNotifier.updateStrength(0.4);
+        paramsNotifier.updateNoise(0.12);
+
+        controller.applyInpaintEditorResult(
+          maskImage: _validMaskBytes(width: 768, height: 1024),
+          focusedInpaintEnabled: false,
+          focusedSelectionRect: null,
+          minimumContextMegaPixels: 88,
+        );
+        controller.enterBaseMode();
+
+        final params = container.read(generationParamsNotifierProvider);
+        expect(params.strength, equals(0.4));
+        expect(params.noise, equals(0.12));
+      },
+    );
+
+    test(
+      'variation strength applied after the source load should survive an enhance round-trip',
+      () {
+        final controller = container.read(
+          imageWorkflowControllerProvider.notifier,
+        );
+        final paramsNotifier = container.read(
+          generationParamsNotifierProvider.notifier,
+        );
+
+        paramsNotifier.updateStrength(0.7);
+        paramsNotifier.updateNoise(0.0);
+        // 变体入口的顺序：先装源图并回到 base，再写入变体强度
+        controller.replaceSourceImage(
+          _validImageBytes(width: 768, height: 1024),
+          sourceWidth: 768,
+          sourceHeight: 1024,
+        );
+        controller.enterBaseMode(clearMask: true);
+        paramsNotifier.updateStrength(0.45);
+        paramsNotifier.updateNoise(0.0);
+
+        controller.enterEnhanceMode();
+        controller.exitEnhanceMode();
+
+        final params = container.read(generationParamsNotifierProvider);
+        expect(params.strength, equals(0.45));
+      },
+    );
+
+    test(
+      'leaving enhance for upscale should consume the enhance entry snapshot',
+      () {
+        final controller = container.read(
+          imageWorkflowControllerProvider.notifier,
+        );
+        final paramsNotifier = container.read(
+          generationParamsNotifierProvider.notifier,
+        );
+
+        paramsNotifier.updateStrength(0.4);
+        paramsNotifier.updateNoise(0.12);
+        paramsNotifier.setSourceImage(
+          _validImageBytes(width: 768, height: 1024),
+        );
+
+        controller.enterEnhanceMode();
+        expect(
+          container.read(imageWorkflowControllerProvider).enhanceEntryStrength,
+          equals(0.4),
+        );
+
+        controller.enterUpscaleMode();
+
+        final workflow = container.read(imageWorkflowControllerProvider);
+        expect(workflow.mode, ImageWorkflowMode.upscale);
+        expect(workflow.enhanceEntryStrength, isNull);
+        expect(workflow.enhanceEntryNoise, isNull);
+
+        final params = container.read(generationParamsNotifierProvider);
+        expect(params.strength, equals(0.4));
+        expect(params.noise, equals(0.12));
+      },
+    );
+
+    test('exitEnhanceMode should keep the loaded source resolution', () {
+      final controller = container.read(
+        imageWorkflowControllerProvider.notifier,
+      );
+      final paramsNotifier = container.read(
+        generationParamsNotifierProvider.notifier,
+      );
+
+      paramsNotifier.updateSize(832, 1216, persist: false);
+      controller.replaceSourceImage(
+        _validImageBytes(width: 768, height: 1024),
+        sourceWidth: 768,
+        sourceHeight: 1024,
+      );
+
+      final loaded = container.read(generationParamsNotifierProvider);
+      final loadedSize = (loaded.width, loaded.height);
+      expect(loadedSize, isNot(equals((832, 1216))));
+
+      controller.enterEnhanceMode();
+      controller.updateEnhanceUpscaleFactor(1.5);
+      final enhanced = container.read(generationParamsNotifierProvider);
+      expect((enhanced.width, enhanced.height), isNot(equals(loadedSize)));
+
+      controller.exitEnhanceMode();
+
+      final params = container.read(generationParamsNotifierProvider);
+      expect((params.width, params.height), equals(loadedSize));
+    });
+
+    test('exitUpscaleMode should keep the loaded source resolution', () {
+      final controller = container.read(
+        imageWorkflowControllerProvider.notifier,
+      );
+      final paramsNotifier = container.read(
+        generationParamsNotifierProvider.notifier,
+      );
+
+      paramsNotifier.updateSize(832, 1216, persist: false);
+      controller.replaceSourceImage(
+        _validImageBytes(width: 768, height: 1024),
+        sourceWidth: 768,
+        sourceHeight: 1024,
+      );
+
+      final loaded = container.read(generationParamsNotifierProvider);
+      final loadedSize = (loaded.width, loaded.height);
+      expect(loadedSize, isNot(equals((832, 1216))));
+
+      controller.enterUpscaleMode();
+      controller.exitUpscaleMode();
+
+      final params = container.read(generationParamsNotifierProvider);
+      expect((params.width, params.height), equals(loadedSize));
+    });
+
+    test('both routes out of enhance should agree on the resulting size', () {
+      final controller = container.read(
+        imageWorkflowControllerProvider.notifier,
+      );
+      final paramsNotifier = container.read(
+        generationParamsNotifierProvider.notifier,
+      );
+
+      paramsNotifier.updateSize(832, 1216, persist: false);
+      controller.replaceSourceImage(
+        _validImageBytes(width: 768, height: 1024),
+        sourceWidth: 768,
+        sourceHeight: 1024,
+      );
+
+      controller.enterEnhanceMode();
+      controller.updateEnhanceUpscaleFactor(1.5);
+      controller.exitEnhanceMode();
+      final viaExit = container.read(generationParamsNotifierProvider);
+
+      controller.enterEnhanceMode();
+      controller.updateEnhanceUpscaleFactor(1.5);
+      controller.enterBaseMode(clearMask: false);
+      final viaBaseMode = container.read(generationParamsNotifierProvider);
+
+      expect((
+        viaExit.width,
+        viaExit.height,
+      ), equals((viaBaseMode.width, viaBaseMode.height)));
     });
 
     test(


### PR DESCRIPTION
## 修复的问题

生成页在进出「增强」和「超分」子模式时，会把用户手动改过的**图生图强度 / 噪声**和**分辨率**悄悄改回旧值。

具体两种表现：

1. **强度和噪声被还原成过期的值。** 快照是由 `_ensureBaseSnapshot()` 在**第一次**进入任意子模式（含 base）时一次性拍下的，之后只要还没被清空就不再更新。也就是说快照可能是很早以前的状态，用户之后在面板上调过的 strength / noise，会在下一次离开增强或超分时被这份陈旧快照覆盖掉。载入源图后再改的变体强度同样会丢。
2. **退出后分辨率不一致。** `exitEnhanceMode` 和 `exitUpscaleMode` 各自复制了一份回到 base 的逻辑，与 `enterBaseMode` 并不等价，导致同样是"退出增强"，走不同入口得到的尺寸不一样，源图分辨率会丢失。

## 改动

- 尺寸快照与强度快照**拆成两件事**。尺寸在载入源图时就会被源图尺寸覆盖，所以各模式共用一份 `_ensureBaseSizeSnapshot()`，清空源图时还原；强度和噪声只在**进入增强时**拍照（`_captureEnhanceEntryParams()`），因为增强是唯一会覆盖它们的模式，提前拍就会回写用户之后改的值。
- 强度快照**回写即消费**：还原后立刻清空，避免留在状态里在后续转场中二次覆盖用户改过的值。
- `exitEnhanceMode` / `exitUpscaleMode` 不再各写一份退出逻辑，统一委托给 `enterBaseMode(clearMask: false)`，两条路径不可能再给出不同尺寸。
- 超分模式本来就不写 strength / noise，因此不再为它拍强度快照。

`baseStrength` / `baseNoise` 相应改名为 `enhanceEntryStrength` / `enhanceEntryNoise`，让字段名说清楚它只属于增强。已 grep 确认这两个字段没有 `ImageWorkflowState` 之外的消费方。

## 验证

```
flutter test test/presentation/providers/generation/image_workflow_controller_test.dart
# 48 passed

flutter test test/presentation/agent_chat/services/generation_image_workflow_toolbox_test.dart \
             test/presentation/providers/cost_estimate_provider_test.dart \
             test/presentation/providers/image_generation_provider_test.dart \
             test/presentation/screens/generation/widgets/img2img_panel_test.dart \
             test/presentation/agent_chat/services/business_toolbox_contract_test.dart
# 55 passed（依赖该 controller 的下游）

flutter analyze          # No issues found
flutter build windows --release   # 构建通过
```

新增 8 个回归测试：strength / noise 分别穿过增强、超分、蒙版三种往返；载入源图后再设的变体强度穿过增强往返；从增强直接切超分时消费掉增强入口快照；退出增强与退出超分各自保留源图分辨率；以及**两条退出增强的路径必须得到相同尺寸**。

无生成文件、assets 或 LFS 变更。
