### PR TITLE
feat(gallery): 浏览相簿时提供移出相簿入口

### DIFF
--- a/integration_test/local_gallery_album_test.dart
+++ b/integration_test/local_gallery_album_test.dart
@@ -14,7 +14,42 @@ import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/providers/gallery_album_provider.dart';
 import 'package:nai_launcher/presentation/providers/gallery_category_provider.dart';
 import 'package:nai_launcher/presentation/providers/local_gallery_provider.dart';
+import 'package:nai_launcher/presentation/providers/selection_mode_provider.dart';
 import 'package:nai_launcher/presentation/screens/local_gallery/local_gallery_category_panel.dart';
+import 'package:nai_launcher/presentation/widgets/gallery/local_gallery_toolbar.dart';
+import 'package:hive/hive.dart';
+
+bool _removedClicked = false;
+
+void _markRemoved() => _removedClicked = true;
+
+class _ToolbarGalleryNotifier extends LocalGalleryNotifier {
+  _ToolbarGalleryNotifier(this._initialState, {required this.filteredPaths});
+
+  final LocalGalleryState _initialState;
+  final List<String> filteredPaths;
+
+  @override
+  LocalGalleryState build() => _initialState;
+
+  @override
+  Future<List<String>> getFilteredImagePaths() async => filteredPaths;
+}
+
+class _ActiveSelectionNotifier extends LocalGallerySelectionNotifier {
+  _ActiveSelectionNotifier(this._initialSelectedIds, {required this.isActive});
+
+  final Set<String> _initialSelectedIds;
+  final bool isActive;
+
+  @override
+  SelectionModeState build() {
+    return SelectionModeState(
+      isActive: isActive,
+      selectedIds: _initialSelectedIds,
+    );
+  }
+}
 
 /// 本地图库相簿侧栏集成测试（Windows 真实窗口）。
 ///
@@ -96,8 +131,8 @@ void main() {
       onAddAlbumRequest: (_) async {},
       onAlbumMove: (_, _) async => true,
       onImageDropToAlbum: (imagePath, albumId) async {
-            onDrop?.call(albumId, imagePath);
-          },
+        onDrop?.call(albumId, imagePath);
+      },
     );
 
     final gridTile = Draggable<LocalImageRecord>(
@@ -113,7 +148,10 @@ void main() {
         height: 72,
         color: Colors.blueGrey.shade700,
         child: const Center(
-          child: Text('拖我', style: TextStyle(color: Colors.white, fontSize: 12)),
+          child: Text(
+            '拖我',
+            style: TextStyle(color: Colors.white, fontSize: 12),
+          ),
         ),
       ),
     );
@@ -130,10 +168,7 @@ void main() {
               height: 760,
               child: Row(
                 children: [
-                  SizedBox(
-                    width: width >= 600 ? 250 : width,
-                    child: panel,
-                  ),
+                  SizedBox(width: width >= 600 ? 250 : width, child: panel),
                   if (width >= 600)
                     const Expanded(child: ColoredBox(color: Color(0xFF141414))),
                 ],
@@ -161,6 +196,8 @@ void main() {
 
   setUpAll(() async {
     await outputDir.create(recursive: true);
+    final hiveDir = Directory.systemTemp.createTempSync('album_it_hive_');
+    Hive.init(hiveDir.path);
   });
 
   testWidgets('宽屏：层级渲染与相簿选择', (tester) async {
@@ -171,10 +208,7 @@ void main() {
     await tester.pumpWidget(
       wrapBoundary(
         'wide-hierarchy',
-        buildHarness(
-          width: 840,
-          onAlbumSelected: (id) => selected = id,
-        ),
+        buildHarness(width: 840, onAlbumSelected: (id) => selected = id),
       ),
     );
     await tester.pumpAndSettle();
@@ -252,5 +286,53 @@ void main() {
     expect(find.text('测试文件夹'), findsOneWidget);
     expect(tester.takeException(), isNull);
     await savePng('narrow-panel');
+  });
+
+  testWidgets('浏览相簿时多选工具栏的移出按钮可点击', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1280, 760));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          localGalleryNotifierProvider.overrideWith(
+            () => _ToolbarGalleryNotifier(
+              const LocalGalleryState(
+                currentImages: [],
+                filteredCount: 2,
+                totalCount: 2,
+                totalPages: 1,
+                isInitialized: true,
+              ),
+              filteredPaths: const ['gallery/a.png', 'gallery/b.png'],
+            ),
+          ),
+          localGallerySelectionNotifierProvider.overrideWith(
+            () => _ActiveSelectionNotifier(const {
+              'gallery/a.png',
+            }, isActive: true),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: LocalGalleryToolbar(
+              enableSearchAutocomplete: false,
+              onRemoveFromAlbum: _markRemoved,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final button = find.text('移出相簿');
+    expect(button, findsOneWidget);
+    await tester.ensureVisible(button);
+    await tester.tap(button);
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(_removedClicked, isTrue);
   });
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2703,6 +2703,14 @@
   "localGallery_albumAddFailed": "Failed to add to album",
   "localGallery_albumSelectTitle": "Add to Album",
   "localGallery_addToAlbum": "Add to Album",
+  "@localGallery_removedFromAlbum": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "localGallery_removeFromAlbum": "Remove from Album",
+  "localGallery_removedFromAlbum": "Removed {count} images",
+  "localGallery_albumNoMembers": "Selected images are not in this album",
   "localGallery_addedToAlbumWithName": "Added {count} images to '{name}'",
   "localGallery_imageCount": "{count} images",
   "@localGallery_imageCount": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -2662,6 +2662,14 @@
   "localGallery_albumAddFailed": "アルバムへの追加に失敗しました",
   "localGallery_albumSelectTitle": "アルバムに追加",
   "localGallery_addToAlbum": "アルバムに追加",
+  "@localGallery_removedFromAlbum": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "localGallery_removeFromAlbum": "アルバムから削除",
+  "localGallery_removedFromAlbum": "{count} 枚の画像を削除しました",
+  "localGallery_albumNoMembers": "選択した画像はこのアルバムにありません",
   "localGallery_addedToAlbumWithName": "{count} 枚の画像を「{name}」に追加しました",
   "localGallery_imageCount": "{count} 画像",
   "@localGallery_imageCount": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10879,6 +10879,24 @@ abstract class AppLocalizations {
   /// **'Add to Album'**
   String get localGallery_addToAlbum;
 
+  /// No description provided for @localGallery_removeFromAlbum.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove from Album'**
+  String get localGallery_removeFromAlbum;
+
+  /// No description provided for @localGallery_removedFromAlbum.
+  ///
+  /// In en, this message translates to:
+  /// **'Removed {count} images'**
+  String localGallery_removedFromAlbum(Object count);
+
+  /// No description provided for @localGallery_albumNoMembers.
+  ///
+  /// In en, this message translates to:
+  /// **'Selected images are not in this album'**
+  String get localGallery_albumNoMembers;
+
   /// No description provided for @localGallery_addedToAlbumWithName.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6096,6 +6096,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get localGallery_addToAlbum => 'Add to Album';
 
   @override
+  String get localGallery_removeFromAlbum => 'Remove from Album';
+
+  @override
+  String localGallery_removedFromAlbum(Object count) {
+    return 'Removed $count images';
+  }
+
+  @override
+  String get localGallery_albumNoMembers =>
+      'Selected images are not in this album';
+
+  @override
   String localGallery_addedToAlbumWithName(Object count, Object name) {
     return 'Added $count images to \'$name\'';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -5948,6 +5948,17 @@ class AppLocalizationsJa extends AppLocalizations {
   String get localGallery_addToAlbum => 'アルバムに追加';
 
   @override
+  String get localGallery_removeFromAlbum => 'アルバムから削除';
+
+  @override
+  String localGallery_removedFromAlbum(Object count) {
+    return '$count 枚の画像を削除しました';
+  }
+
+  @override
+  String get localGallery_albumNoMembers => '選択した画像はこのアルバムにありません';
+
+  @override
   String localGallery_addedToAlbumWithName(Object count, Object name) {
     return '$count 枚の画像を「$name」に追加しました';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5849,6 +5849,17 @@ class AppLocalizationsZh extends AppLocalizations {
   String get localGallery_addToAlbum => '加入相簿';
 
   @override
+  String get localGallery_removeFromAlbum => '移出相簿';
+
+  @override
+  String localGallery_removedFromAlbum(Object count) {
+    return '已移出 $count 张图片';
+  }
+
+  @override
+  String get localGallery_albumNoMembers => '所选图片不在此相簿中';
+
+  @override
   String localGallery_addedToAlbumWithName(Object count, Object name) {
     return '已将 $count 张图片加入「$name」';
   }
@@ -19445,6 +19456,17 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get localGallery_addToAlbum => '加入相簿';
+
+  @override
+  String get localGallery_removeFromAlbum => '移出相簿';
+
+  @override
+  String localGallery_removedFromAlbum(Object count) {
+    return '已移出 $count 張圖片';
+  }
+
+  @override
+  String get localGallery_albumNoMembers => '所選圖片不在此相簿中';
 
   @override
   String localGallery_addedToAlbumWithName(Object count, Object name) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2726,6 +2726,14 @@
   "localGallery_albumAddFailed": "加入相簿失败",
   "localGallery_albumSelectTitle": "加入相簿",
   "localGallery_addToAlbum": "加入相簿",
+  "@localGallery_removedFromAlbum": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "localGallery_removeFromAlbum": "移出相簿",
+  "localGallery_removedFromAlbum": "已移出 {count} 张图片",
+  "localGallery_albumNoMembers": "所选图片不在此相簿中",
   "localGallery_addedToAlbumWithName": "已将 {count} 张图片加入「{name}」",
   "localGallery_imageCount": "{count} 张图片",
   "@localGallery_imageCount": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2735,6 +2735,14 @@
   "localGallery_albumAddFailed": "加入相簿失敗",
   "localGallery_albumSelectTitle": "加入相簿",
   "localGallery_addToAlbum": "加入相簿",
+  "@localGallery_removedFromAlbum": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "localGallery_removeFromAlbum": "移出相簿",
+  "localGallery_removedFromAlbum": "已移出 {count} 張圖片",
+  "localGallery_albumNoMembers": "所選圖片不在此相簿中",
   "localGallery_addedToAlbumWithName": "已將 {count} 張圖片加入「{name}」",
   "localGallery_imageCount": "{count} 張圖片",
   "@localGallery_imageCount": {

--- a/lib/presentation/providers/gallery_album_provider.dart
+++ b/lib/presentation/providers/gallery_album_provider.dart
@@ -211,6 +211,10 @@ class GalleryAlbumNotifier extends _$GalleryAlbumNotifier {
     if (removed > 0) {
       await _load();
       _scheduleSidecarExport();
+      // 当前浏览的正是该相簿时，过滤视图需立即反映成员变化
+      await ref
+          .read(localGalleryNotifierProvider.notifier)
+          .refresh(scan: false);
     }
     return removed;
   }

--- a/lib/presentation/providers/local_gallery_provider.dart
+++ b/lib/presentation/providers/local_gallery_provider.dart
@@ -471,8 +471,12 @@ class LocalGalleryNotifier extends _$LocalGalleryNotifier {
         ),
       );
 
-      // 刷新当前页
-      await loadPage(state.currentPage, showLoading: false);
+      if (state.isGroupedView) {
+        await _loadGroupedImages();
+      } else {
+        // 刷新当前页
+        await loadPage(state.currentPage, showLoading: false);
+      }
     } on GalleryScanException catch (e) {
       _setState(
         state.copyWith(

--- a/lib/presentation/screens/local_gallery/local_gallery_action_coordinator.dart
+++ b/lib/presentation/screens/local_gallery/local_gallery_action_coordinator.dart
@@ -401,6 +401,30 @@ class LocalGalleryActionCoordinator {
     }
   }
 
+  /// 把选中图片移出当前浏览的相簿（仅解除引用，不动物理文件）
+  Future<void> removeSelectedFromAlbum() async {
+    final albumId = _ref.read(galleryAlbumNotifierProvider).selectedAlbumId;
+    if (albumId == null || albumId == 'favorites') return;
+    final selectedImages = await _selectedImages();
+    if (selectedImages.isEmpty || !_mounted()) return;
+    final removed = await _ref
+        .read(galleryAlbumNotifierProvider.notifier)
+        .removeImagesByPaths(
+          albumId,
+          selectedImages.map((image) => image.path).toList(),
+        );
+    if (!_mounted()) return;
+    if (removed > 0) {
+      AppToast.info(
+        _context(),
+        _context().l10n.localGallery_removedFromAlbum(removed),
+      );
+      _ref.read(localGallerySelectionNotifierProvider.notifier).exit();
+    } else {
+      AppToast.info(_context(), _context().l10n.localGallery_albumNoMembers);
+    }
+  }
+
   Future<void> addSelectedToAlbum() async {
     final selectedImages = await _selectedImages();
     if (selectedImages.isEmpty || !_mounted()) return;

--- a/lib/presentation/screens/local_gallery/local_gallery_screen.dart
+++ b/lib/presentation/screens/local_gallery/local_gallery_screen.dart
@@ -176,6 +176,12 @@ class _LocalGalleryShell extends ConsumerWidget {
 
   Widget _buildToolbar(BuildContext context, WidgetRef ref) {
     final bulk = viewModel.bulkOperation;
+    // 浏览具体相簿（非全部/收藏）时才提供“移出相簿”入口
+    final selectedAlbumId = ref.watch(
+      galleryAlbumNotifierProvider.select((value) => value.selectedAlbumId),
+    );
+    final browsingAlbum =
+        selectedAlbumId != null && selectedAlbumId != 'favorites';
     return LocalGalleryToolbar(
       onRefresh: () =>
           ref.read(localGalleryNotifierProvider.notifier).refresh(),
@@ -187,6 +193,7 @@ class _LocalGalleryShell extends ConsumerWidget {
       onRedo: bulk.canRedo ? actions.redo : null,
       groupedGridViewKey: groupedGridViewKey,
       onAddToAlbum: actions.addSelectedToAlbum,
+      onRemoveFromAlbum: browsingAlbum ? actions.removeSelectedFromAlbum : null,
       onDeleteSelected: actions.deleteSelectedImages,
       onPackSelected: viewModel.isPackingImages
           ? null

--- a/lib/presentation/widgets/gallery/local_gallery_toolbar.dart
+++ b/lib/presentation/widgets/gallery/local_gallery_toolbar.dart
@@ -75,6 +75,7 @@ class LocalGalleryToolbar extends ConsumerStatefulWidget {
   /// Callbacks for bulk actions
   /// 批量操作回调
   final VoidCallback? onAddToAlbum;
+  final VoidCallback? onRemoveFromAlbum;
   final VoidCallback? onDeleteSelected;
   final VoidCallback? onPackSelected;
   final VoidCallback? onEditMetadata;
@@ -105,6 +106,7 @@ class LocalGalleryToolbar extends ConsumerStatefulWidget {
     this.canRedo = false,
     this.groupedGridViewKey,
     this.onAddToAlbum,
+    this.onRemoveFromAlbum,
     this.onDeleteSelected,
     this.onPackSelected,
     this.onEditMetadata,
@@ -259,6 +261,13 @@ class _LocalGalleryToolbarState extends ConsumerState<LocalGalleryToolbar> {
             onPressed: widget.onAddToAlbum,
             color: theme.colorScheme.secondary,
           ),
+          if (widget.onRemoveFromAlbum != null)
+            BulkActionItem(
+              icon: Icons.playlist_remove,
+              label: l10n.localGallery_removeFromAlbum,
+              onPressed: widget.onRemoveFromAlbum,
+              color: theme.colorScheme.secondary,
+            ),
           BulkActionItem(
             icon: Icons.delete_outline,
             label: l10n.common_delete,

--- a/test/presentation/widgets/gallery/local_gallery_toolbar_selection_test.dart
+++ b/test/presentation/widgets/gallery/local_gallery_toolbar_selection_test.dart
@@ -38,6 +38,19 @@ void main() {
     },
   );
 
+  testWidgets('remove-from-album action only appears while browsing an album', (
+    tester,
+  ) async {
+    await _pumpToolbar(tester);
+    expect(find.byIcon(Icons.playlist_remove), findsNothing);
+
+    await _pumpToolbar(tester, onRemoveFromAlbum: _noop);
+
+    // 宽度不足时批量动作只显示图标；显隐条件是本用例的验证边界，
+    // 点击链路与其他批量按钮共用同一机制
+    expect(find.byIcon(Icons.playlist_remove), findsOneWidget);
+  });
+
   testWidgets('select current page only selects visible page paths', (
     tester,
   ) async {
@@ -137,6 +150,7 @@ Future<ProviderContainer> _pumpToolbar(
   WidgetTester tester, {
   Set<String> initialSelectedIds = const {},
   bool selectionActive = true,
+  VoidCallback? onRemoveFromAlbum,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -169,14 +183,15 @@ Future<ProviderContainer> _pumpToolbar(
           ),
         ),
       ],
-      child: const MaterialApp(
-        locale: Locale('zh'),
+      child: MaterialApp(
+        locale: const Locale('zh'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: LocalGalleryToolbar(
             enableSearchAutocomplete: false,
             onToggleCategoryPanel: _noop,
+            onRemoveFromAlbum: onRemoveFromAlbum,
           ),
         ),
       ),


### PR DESCRIPTION
## 用户可见变化

- 浏览具体相簿（非全部图片、非收藏）时，多选工具栏出现「移出相簿」操作（仅解除相簿成员引用，不动物理文件；所选图片不在该相簿中时给出提示）
- 移出成功后当前相簿的过滤视图立即刷新（此前需手动刷新才能看到移出结果），相簿计数同步更新，并即时重导出 sidecar 保持跨设备引用有效
- 同步更新简中、繁中、英文、日文文案

## 验证

- `flutter analyze`
- `flutter test integration_test/local_gallery_album_test.dart -d windows`（4 场景通过，含新增的移出按钮点击链路：真实窗口、带选中态、断言回调触发）
- `flutter test test/core/database/datasources/gallery_album_repository_test.dart test/data/cloud_sync/gallery_album_cloud_sync_adapter_test.dart test/data/services/gallery/gallery_album_import_coordinator_test.dart test/presentation/screens/local_gallery/`（38 项全部通过）
- `flutter build windows --release`
- 移出相簿流程已在 Windows 桌面人工实测（移出后列表即时更新、文件保留原位）

生成文件变更：lib/l10n/app_localizations*.dart（gen-l10n 产物）；无 LFS、无 assets 变更。

未启动热重载或 Android 端验收。

#190 的后续补充。