### PR TITLE
fix(editor): 修复画笔光标滞后与外扩手柄误落笔

### DIFF
--- a/lib/presentation/widgets/image_editor/canvas/editor_canvas.dart
+++ b/lib/presentation/widgets/image_editor/canvas/editor_canvas.dart
@@ -124,11 +124,9 @@ class _EditorCanvasState extends State<EditorCanvas>
                 // renderNotifier 由 CustomPainter 内部监听
                 return ValueListenableBuilder<String?>(
                   valueListenable: widget.state.toolNotifier,
-                  builder: (context, toolId, _) {
+                  builder: (context, _, __) {
                     // Alt 模式或拾色器工具时都显示拾色器界面
-                    final isColorPicker =
-                        toolId == 'color_picker' ||
-                        _inputHandler.keyboard.isAltPressed;
+                    final isColorPicker = _inputHandler.isColorPickerActive;
                     final cursorPosition = _inputHandler.cursorPosition;
 
                     return ClipRect(
@@ -178,16 +176,16 @@ class _EditorCanvasState extends State<EditorCanvas>
                             ),
                           ),
 
-                          // 光标绘制 - 高频更新，不使用 RepaintBoundary
+                          // 光标绘制 - 独立重绘区域（每次指针移动都重绘，
+                          // 不隔离会连带整幅图层重绘，willChange 也会污染整块画布的光栅缓存）
                           // Alt 模式下不显示笔刷光标（显示系统精确光标）
                           if (cursorPosition != null && !isColorPicker)
                             Positioned.fill(
-                              child: CustomPaint(
-                                painter: CursorPainter(
-                                  state: widget.state,
-                                  cursorPosition: cursorPosition,
+                              child: RepaintBoundary(
+                                child: CustomPaint(
+                                  painter: CursorPainter(state: widget.state),
+                                  willChange: true,
                                 ),
-                                willChange: true,
                               ),
                             ),
 
@@ -227,6 +225,8 @@ class _EditorCanvasState extends State<EditorCanvas>
 
   void _handlePointerUp(PointerUpEvent event) {
     if (_suppressedPointers.remove(event.pointer)) {
+      // down 被抑制但 GestureDetector 仍收到了整段手势，这里必须补回状态出口
+      _inputHandler.cancelTransientGestures();
       return;
     }
 
@@ -235,6 +235,7 @@ class _EditorCanvasState extends State<EditorCanvas>
 
   void _handlePointerCancel(PointerCancelEvent event) {
     if (_suppressedPointers.remove(event.pointer)) {
+      _inputHandler.cancelTransientGestures();
       return;
     }
     _inputHandler.handlePointerCancel(event);

--- a/lib/presentation/widgets/image_editor/canvas/layer_painter.dart
+++ b/lib/presentation/widgets/image_editor/canvas/layer_painter.dart
@@ -460,19 +460,17 @@ class SelectionPainter extends CustomPainter {
 /// 绘制画笔光标预览和工具图标
 class CursorPainter extends CustomPainter {
   final EditorState state;
-  final Offset? cursorPosition;
 
   /// 缓存的图标 TextPainter
   static final Map<int, TextPainter> _iconCache = {};
 
-  /// 使用 cursorNotifier 而非整个 state
-  /// 这样只有光标位置变化时才会触发重绘
-  /// 避免其他 UI 操作导致光标不必要的重绘
-  CursorPainter({required this.state, this.cursorPosition})
-    : super(repaint: state.cursorNotifier);
+  /// 位置在 paint 时直接读 cursorNotifier，不经构造参数捕获，
+  /// 避免 widget 重建与重绘不同步时画出旧坐标
+  CursorPainter({required this.state}) : super(repaint: state.cursorNotifier);
 
   @override
   void paint(Canvas canvas, Size size) {
+    final cursorPosition = state.cursorNotifier.value;
     if (cursorPosition == null) return;
 
     final tool = state.currentTool;
@@ -488,7 +486,7 @@ class CursorPainter extends CustomPainter {
 
       // 光标圆圈
       canvas.drawCircle(
-        cursorPosition!,
+        cursorPosition,
         scaledRadius,
         Paint()
           ..color = Colors.black
@@ -497,7 +495,7 @@ class CursorPainter extends CustomPainter {
       );
 
       canvas.drawCircle(
-        cursorPosition!,
+        cursorPosition,
         scaledRadius,
         Paint()
           ..color = Colors.white
@@ -506,13 +504,13 @@ class CursorPainter extends CustomPainter {
       );
 
       // 中心点
-      canvas.drawCircle(cursorPosition!, 2, Paint()..color = Colors.black);
+      canvas.drawCircle(cursorPosition, 2, Paint()..color = Colors.black);
 
       // 图标位置：圆圈右下角
-      iconPosition = cursorPosition! + Offset(scaledRadius, scaledRadius);
+      iconPosition = cursorPosition + Offset(scaledRadius, scaledRadius);
     } else {
       // 非绘画工具：图标在光标右下角
-      iconPosition = cursorPosition! + const Offset(8, 8);
+      iconPosition = cursorPosition + const Offset(8, 8);
     }
 
     // 绘制工具图标
@@ -576,9 +574,7 @@ class CursorPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant CursorPainter oldDelegate) {
-    // repaint: cursorNotifier 已经处理了光标位置变化的监听
-    // shouldRepaint 只需处理 CustomPainter 本身的属性变化
-    // 返回 false 避免不必要的重绘检查
-    return false;
+    // 位置变化由 repaint: cursorNotifier 驱动，这里只处理 painter 自身依赖的变化
+    return state != oldDelegate.state;
   }
 }

--- a/lib/presentation/widgets/image_editor/core/editor_state.dart
+++ b/lib/presentation/widgets/image_editor/core/editor_state.dart
@@ -588,6 +588,14 @@ class EditorState extends ChangeNotifier {
 
   void _notifyRenderChange() => notifyRenderChange();
 
+  /// 光标位置未变但视觉参数变了（如 Shift 拖拽调笔刷半径）时强制光标层重绘
+  void notifyCursorVisualChange() {
+    if (_isDisposed) return;
+
+    // ignore: invalid_use_of_protected_member, invalid_use_of_visible_for_testing_member
+    cursorNotifier.notifyListeners();
+  }
+
   void _notifyStrokePreviewChange() {
     if (_isDisposed) return;
     _pendingStrokePreviewChange = false;

--- a/lib/presentation/widgets/image_editor/core/input_handler.dart
+++ b/lib/presentation/widgets/image_editor/core/input_handler.dart
@@ -121,6 +121,48 @@ class InputHandler {
     required this.onStateChanged,
   });
 
+  /// Alt 按下或拾色器工具生效时，画布改用跟随光标的放大镜覆盖层
+  bool get isColorPickerActive =>
+      state.currentTool?.id == 'color_picker' || keyboard.isAltPressed;
+
+  /// 更新光标位置。
+  ///
+  /// 位置变化只写 cursorNotifier 驱动光标层重绘；只有光标层挂载与否发生翻转、
+  /// 或放大镜覆盖层需要跟随定位时才请求 widget 重建，避免每个指针事件都重排画布子树。
+  void _setCursorPosition(Offset? position, {bool forceRepaint = false}) {
+    final wasVisible = gesture.cursorPosition != null;
+    gesture.cursorPosition = position;
+    if (forceRepaint && state.cursorNotifier.value == position) {
+      state.notifyCursorVisualChange();
+    } else {
+      state.cursorNotifier.value = position;
+    }
+    if (wasVisible != (position != null) || isColorPickerActive) {
+      onStateChanged();
+    }
+  }
+
+  /// 复位只能靠 pointerUp 退出的瞬时手势状态。
+  ///
+  /// 指针被画布按坐标抑制时收不到成对的 up，不兜底会让笔刷尺寸模式和中键平移永久卡住；
+  /// 平移与绘制指针另有 scaleEnd / pointerCancel 出口，这里不动，避免误伤并发手势。
+  void cancelTransientGestures() {
+    var changed = false;
+    if (gesture.isBrushSizeMode) {
+      gesture.isBrushSizeMode = false;
+      gesture.brushSizeStartPosition = null;
+      changed = true;
+    }
+    if (gesture.isMiddleButtonPanning) {
+      gesture.isMiddleButtonPanning = false;
+      gesture.lastPanPosition = null;
+      changed = true;
+    }
+    if (changed) {
+      onStateChanged();
+    }
+  }
+
   /// 处理键盘事件
   KeyEventResult handleKeyEvent(FocusNode node, KeyEvent event) {
     final isDown = event is KeyDownEvent;
@@ -277,9 +319,7 @@ class InputHandler {
 
   /// 处理鼠标悬停
   void handlePointerHover(PointerHoverEvent event) {
-    gesture.cursorPosition = event.localPosition;
-    state.cursorNotifier.value = gesture.cursorPosition;
-    onStateChanged();
+    _setCursorPosition(event.localPosition);
 
     // 触发工具的悬停事件
     final tool = state.currentTool;
@@ -413,6 +453,17 @@ class InputHandler {
     if (_drawingPointerId == event.pointer) {
       _cancelDrawingPointer();
     }
+    // 笔刷尺寸模式和中键平移只在 pointerUp 里退出，取消事件不兜底就会永久卡住
+    if (gesture.isBrushSizeMode) {
+      gesture.isBrushSizeMode = false;
+      gesture.brushSizeStartPosition = null;
+      onStateChanged();
+    }
+    if (gesture.isMiddleButtonPanning) {
+      gesture.isMiddleButtonPanning = false;
+      gesture.lastPanPosition = null;
+      onStateChanged();
+    }
     if (_activeTouchPointers.isEmpty) {
       gesture.isPanning = false;
       gesture.lastPanPosition = null;
@@ -426,9 +477,7 @@ class InputHandler {
       final delta = event.position - gesture.lastPanPosition!;
       state.canvasController.pan(delta);
       gesture.lastPanPosition = event.position;
-      gesture.cursorPosition = event.localPosition;
-      state.cursorNotifier.value = gesture.cursorPosition;
-      onStateChanged();
+      _setCursorPosition(event.localPosition);
       return;
     }
 
@@ -439,9 +488,8 @@ class InputHandler {
       final sizeFactor = 1.0 + deltaX / 200.0;
       final newSize = (gesture.initialBrushSize * sizeFactor).clamp(1.0, 500.0);
       state.setBrushSize(newSize);
-      gesture.cursorPosition = gesture.brushSizeStartPosition;
-      state.cursorNotifier.value = gesture.cursorPosition;
-      onStateChanged();
+      // 位置钉在锚点不动，必须显式重绘才能让光标环跟上新半径
+      _setCursorPosition(gesture.brushSizeStartPosition, forceRepaint: true);
       return;
     }
 
@@ -453,9 +501,7 @@ class InputHandler {
     }
 
     // 正常模式 - 更新光标位置
-    gesture.cursorPosition = event.localPosition;
-    state.cursorNotifier.value = gesture.cursorPosition;
-    onStateChanged();
+    _setCursorPosition(event.localPosition);
 
     // 直接调用工具的 onPointerMove（使用原始指针事件，避免 GestureDetector 延迟）
     if (_drawingPointerId == event.pointer &&
@@ -476,9 +522,7 @@ class InputHandler {
   /// 处理鼠标退出
   void handleMouseExit(PointerExitEvent event) {
     if (HardwareKeyboard.instance.isAltPressed) return;
-    gesture.cursorPosition = null;
-    state.cursorNotifier.value = gesture.cursorPosition;
-    onStateChanged();
+    _setCursorPosition(null);
   }
 
   /// 处理缩放/平移手势开始
@@ -512,9 +556,7 @@ class InputHandler {
     }
 
     // 更新光标位置
-    gesture.cursorPosition = details.localFocalPoint;
-    state.cursorNotifier.value = gesture.cursorPosition;
-    onStateChanged();
+    _setCursorPosition(details.localFocalPoint);
     // 工具事件已移至 handlePointerDown 直接处理
   }
 
@@ -540,9 +582,7 @@ class InputHandler {
           500.0,
         );
         state.setBrushSize(newSize);
-        gesture.cursorPosition = gesture.brushSizeStartPosition;
-        state.cursorNotifier.value = gesture.cursorPosition;
-        onStateChanged();
+        _setCursorPosition(gesture.brushSizeStartPosition, forceRepaint: true);
       }
       return;
     }
@@ -567,9 +607,7 @@ class InputHandler {
     }
 
     // 更新光标位置
-    gesture.cursorPosition = details.localFocalPoint;
-    state.cursorNotifier.value = gesture.cursorPosition;
-    onStateChanged();
+    _setCursorPosition(details.localFocalPoint);
     // 工具事件已移至 handlePointerMove 直接处理
   }
 
@@ -621,7 +659,9 @@ class InputHandler {
     switch (tool.id) {
       case 'brush':
       case 'eraser':
-        return SystemMouseCursors.none;
+        // 自绘光标环要走完整渲染管线、必然滞后于真实指针；
+        // 保留系统十字作为不滞后的锚点，光标环只表示笔刷直径。
+        return SystemMouseCursors.precise;
       case 'rect_selection':
       case 'ellipse_selection':
       case 'lasso_selection':

--- a/lib/presentation/widgets/image_editor/widgets/outpaint_edge_drag_overlay.dart
+++ b/lib/presentation/widgets/image_editor/widgets/outpaint_edge_drag_overlay.dart
@@ -24,6 +24,8 @@ typedef OutpaintFrameResizeCommitted =
 
 class OutpaintEdgeDragOverlay extends StatefulWidget {
   static const double edgeHitSlop = 48;
+  static const double handleSize = 22;
+  static const double cornerHandleSize = 24;
 
   final Size canvasSize;
   final CanvasController controller;
@@ -56,10 +58,67 @@ class OutpaintEdgeDragOverlay extends StatefulWidget {
       controller: controller,
       canvasSize: canvasSize,
     );
-    return _resizeZoneRects(
-      canvasRect,
-      viewportSize,
-    ).any((rect) => rect.contains(localPosition));
+    // 手柄可能被 clamp 到视口边缘、落在边缘条之外，必须一并算作拖拽热区，
+    // 否则画布会在手柄上开始一笔，和拖拽同时发生。
+    return [
+      ..._resizeZoneRects(canvasRect, viewportSize),
+      ..._handleSpecsFor(canvasRect).map((spec) => spec.rect(viewportSize)),
+    ].any((rect) => rect.contains(localPosition));
+  }
+
+  static List<_OutpaintHandleSpec> _handleSpecsFor(Rect canvasRect) {
+    return [
+      _OutpaintHandleSpec(
+        _OutpaintDragHandle.left,
+        Offset(canvasRect.left, canvasRect.center.dy),
+      ),
+      _OutpaintHandleSpec(
+        _OutpaintDragHandle.right,
+        Offset(canvasRect.right, canvasRect.center.dy),
+      ),
+      _OutpaintHandleSpec(
+        _OutpaintDragHandle.top,
+        Offset(canvasRect.center.dx, canvasRect.top),
+      ),
+      _OutpaintHandleSpec(
+        _OutpaintDragHandle.bottom,
+        Offset(canvasRect.center.dx, canvasRect.bottom),
+      ),
+      _OutpaintHandleSpec(
+        _OutpaintDragHandle.topLeft,
+        canvasRect.topLeft,
+        isCorner: true,
+      ),
+      _OutpaintHandleSpec(
+        _OutpaintDragHandle.topRight,
+        canvasRect.topRight,
+        isCorner: true,
+      ),
+      _OutpaintHandleSpec(
+        _OutpaintDragHandle.bottomLeft,
+        canvasRect.bottomLeft,
+        isCorner: true,
+      ),
+      _OutpaintHandleSpec(
+        _OutpaintDragHandle.bottomRight,
+        canvasRect.bottomRight,
+        isCorner: true,
+      ),
+    ];
+  }
+
+  static Offset _clampHandleCenter(
+    Offset center,
+    double size,
+    Size viewportSize,
+  ) {
+    final halfSize = size / 2;
+    final maxX = math.max(halfSize, viewportSize.width - halfSize);
+    final maxY = math.max(halfSize, viewportSize.height - halfSize);
+    return Offset(
+      center.dx.clamp(halfSize, maxX).toDouble(),
+      center.dy.clamp(halfSize, maxY).toDouble(),
+    );
   }
 
   static Rect _screenCanvasRectFor({
@@ -135,9 +194,6 @@ class OutpaintEdgeDragOverlay extends StatefulWidget {
 }
 
 class _OutpaintEdgeDragOverlayState extends State<OutpaintEdgeDragOverlay> {
-  static const double _handleSize = 22;
-  static const double _cornerHandleSize = 24;
-
   _OutpaintDragHandle? _activeHandle;
   _OutpaintDragHandle? _hoveredHandle;
   int? _activePointer;
@@ -242,60 +298,9 @@ class _OutpaintEdgeDragOverlayState extends State<OutpaintEdgeDragOverlay> {
   }
 
   List<Widget> _buildHandles(Rect canvasRect, Size viewportSize) {
-    return [
-      _buildHandle(
-        key: const Key('outpaint_handle_left'),
-        handle: _OutpaintDragHandle.left,
-        center: Offset(canvasRect.left, canvasRect.center.dy),
-        viewportSize: viewportSize,
-      ),
-      _buildHandle(
-        key: const Key('outpaint_handle_right'),
-        handle: _OutpaintDragHandle.right,
-        center: Offset(canvasRect.right, canvasRect.center.dy),
-        viewportSize: viewportSize,
-      ),
-      _buildHandle(
-        key: const Key('outpaint_handle_top'),
-        handle: _OutpaintDragHandle.top,
-        center: Offset(canvasRect.center.dx, canvasRect.top),
-        viewportSize: viewportSize,
-      ),
-      _buildHandle(
-        key: const Key('outpaint_handle_bottom'),
-        handle: _OutpaintDragHandle.bottom,
-        center: Offset(canvasRect.center.dx, canvasRect.bottom),
-        viewportSize: viewportSize,
-      ),
-      _buildHandle(
-        key: const Key('outpaint_handle_top_left'),
-        handle: _OutpaintDragHandle.topLeft,
-        center: canvasRect.topLeft,
-        isCorner: true,
-        viewportSize: viewportSize,
-      ),
-      _buildHandle(
-        key: const Key('outpaint_handle_top_right'),
-        handle: _OutpaintDragHandle.topRight,
-        center: canvasRect.topRight,
-        isCorner: true,
-        viewportSize: viewportSize,
-      ),
-      _buildHandle(
-        key: const Key('outpaint_handle_bottom_left'),
-        handle: _OutpaintDragHandle.bottomLeft,
-        center: canvasRect.bottomLeft,
-        isCorner: true,
-        viewportSize: viewportSize,
-      ),
-      _buildHandle(
-        key: const Key('outpaint_handle_bottom_right'),
-        handle: _OutpaintDragHandle.bottomRight,
-        center: canvasRect.bottomRight,
-        isCorner: true,
-        viewportSize: viewportSize,
-      ),
-    ];
+    return OutpaintEdgeDragOverlay._handleSpecsFor(
+      canvasRect,
+    ).map((spec) => _buildHandle(spec, viewportSize)).toList();
   }
 
   List<Widget> _buildEdgeZones(Rect canvasRect, Size viewportSize) {
@@ -361,13 +366,14 @@ class _OutpaintEdgeDragOverlayState extends State<OutpaintEdgeDragOverlay> {
       rect: clampedRect,
       child: MouseRegion(
         key: key,
-        opaque: true,
-        hitTestBehavior: HitTestBehavior.opaque,
+        // 不能挡住画布的 MouseRegion 与 hover 事件，否则画笔光标会在画布边缘消失再重现
+        opaque: false,
+        hitTestBehavior: HitTestBehavior.translucent,
         cursor: handle.cursor,
         onEnter: (_) => _setHoveredHandle(handle),
         onExit: (_) => _clearHoveredHandle(handle),
         child: Listener(
-          behavior: HitTestBehavior.opaque,
+          behavior: HitTestBehavior.translucent,
           onPointerDown: (event) => _handlePointerDown(event, handle),
           child: const SizedBox.expand(),
         ),
@@ -375,29 +381,20 @@ class _OutpaintEdgeDragOverlayState extends State<OutpaintEdgeDragOverlay> {
     );
   }
 
-  Widget _buildHandle({
-    required Key key,
-    required _OutpaintDragHandle handle,
-    required Offset center,
-    required Size viewportSize,
-    bool isCorner = false,
-  }) {
-    final size = isCorner ? _cornerHandleSize : _handleSize;
-    final visibleCenter = _clampHandleCenter(center, size, viewportSize);
-    return Positioned(
-      left: visibleCenter.dx - size / 2,
-      top: visibleCenter.dy - size / 2,
-      width: size,
-      height: size,
+  Widget _buildHandle(_OutpaintHandleSpec spec, Size viewportSize) {
+    final handle = spec.handle;
+    final isCorner = spec.isCorner;
+    return Positioned.fromRect(
+      rect: spec.rect(viewportSize),
       child: MouseRegion(
-        opaque: true,
-        hitTestBehavior: HitTestBehavior.opaque,
+        opaque: false,
+        hitTestBehavior: HitTestBehavior.translucent,
         cursor: handle.cursor,
         onEnter: (_) => _setHoveredHandle(handle),
         onExit: (_) => _clearHoveredHandle(handle),
         child: Listener(
-          key: key,
-          behavior: HitTestBehavior.opaque,
+          key: spec.key,
+          behavior: HitTestBehavior.translucent,
           onPointerDown: (event) => _handlePointerDown(event, handle),
           child: DecoratedBox(
             decoration: BoxDecoration(
@@ -472,16 +469,6 @@ class _OutpaintEdgeDragOverlayState extends State<OutpaintEdgeDragOverlay> {
     }
     _activePointer = null;
     _lastGlobalPosition = null;
-  }
-
-  Offset _clampHandleCenter(Offset center, double size, Size viewportSize) {
-    final halfSize = size / 2;
-    final maxX = math.max(halfSize, viewportSize.width - halfSize);
-    final maxY = math.max(halfSize, viewportSize.height - halfSize);
-    return Offset(
-      center.dx.clamp(halfSize, maxX).toDouble(),
-      center.dy.clamp(halfSize, maxY).toDouble(),
-    );
   }
 
   Rect _clampZoneRect(Rect rect, Size viewportSize) {
@@ -764,6 +751,30 @@ class _OutpaintEdgeDragOverlayState extends State<OutpaintEdgeDragOverlay> {
     return handle.affectsTop
         ? OutpaintVerticalSnapTarget.top
         : OutpaintVerticalSnapTarget.bottom;
+  }
+}
+
+/// 手柄几何：拖拽热区判定与实际渲染共用同一份，避免两处 clamp 逻辑漂移
+class _OutpaintHandleSpec {
+  const _OutpaintHandleSpec(this.handle, this.center, {this.isCorner = false});
+
+  final _OutpaintDragHandle handle;
+  final Offset center;
+  final bool isCorner;
+
+  double get size => isCorner
+      ? OutpaintEdgeDragOverlay.cornerHandleSize
+      : OutpaintEdgeDragOverlay.handleSize;
+
+  Key get key => Key('outpaint_handle_${handle.keySuffix}');
+
+  Rect rect(Size viewportSize) {
+    final visibleCenter = OutpaintEdgeDragOverlay._clampHandleCenter(
+      center,
+      size,
+      viewportSize,
+    );
+    return Rect.fromCenter(center: visibleCenter, width: size, height: size);
   }
 }
 

--- a/test/presentation/widgets/image_editor/canvas/editor_canvas_cursor_test.dart
+++ b/test/presentation/widgets/image_editor/canvas/editor_canvas_cursor_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/presentation/widgets/image_editor/canvas/editor_canvas.dart';
+import 'package:nai_launcher/presentation/widgets/image_editor/canvas/layer_painter.dart';
+import 'package:nai_launcher/presentation/widgets/image_editor/core/editor_state.dart';
+
+CursorPainter? _cursorPainter(WidgetTester tester) {
+  return tester
+      .widgetList<CustomPaint>(find.byType(CustomPaint))
+      .map((widget) => widget.painter)
+      .whereType<CursorPainter>()
+      .firstOrNull;
+}
+
+Widget _wrapCanvas(EditorState state) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 400,
+        height: 400,
+        child: EditorCanvas(state: state),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('悬停只驱动光标重绘，不重建画布子树', (tester) async {
+    final state = EditorState()..setCanvasSize(const Size(200, 200));
+    addTearDown(state.dispose);
+
+    await tester.pumpWidget(_wrapCanvas(state));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: const Offset(10, 10));
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(const Offset(100, 100));
+    await tester.pumpAndSettle();
+
+    expect(state.cursorNotifier.value, const Offset(100, 100));
+    final painterBefore = _cursorPainter(tester);
+    expect(painterBefore, isNotNull);
+
+    await gesture.moveTo(const Offset(150, 130));
+    await tester.pump();
+
+    expect(state.cursorNotifier.value, const Offset(150, 130));
+    expect(
+      identical(_cursorPainter(tester), painterBefore),
+      isTrue,
+      reason: '纯位置变化必须只走 cursorNotifier，不得重建画布子树',
+    );
+  });
+
+  testWidgets('光标离开画布时才重建并卸载光标层', (tester) async {
+    final state = EditorState()..setCanvasSize(const Size(200, 200));
+    addTearDown(state.dispose);
+
+    await tester.pumpWidget(_wrapCanvas(state));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: const Offset(10, 10));
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(const Offset(100, 100));
+    await tester.pumpAndSettle();
+
+    expect(_cursorPainter(tester), isNotNull);
+
+    await gesture.moveTo(const Offset(600, 500));
+    await tester.pumpAndSettle();
+
+    expect(state.cursorNotifier.value, isNull);
+    expect(_cursorPainter(tester), isNull);
+  });
+
+  testWidgets('画笔工具保留系统精确光标作为不滞后的锚点', (tester) async {
+    final state = EditorState()..setCanvasSize(const Size(200, 200));
+    addTearDown(state.dispose);
+    state.setToolById('brush');
+
+    await tester.pumpWidget(_wrapCanvas(state));
+    await tester.pumpAndSettle();
+
+    final region = tester.widget<MouseRegion>(
+      find
+          .descendant(
+            of: find.byType(EditorCanvas),
+            matching: find.byType(MouseRegion),
+          )
+          .first,
+    );
+    expect(region.cursor, SystemMouseCursors.precise);
+  });
+}

--- a/test/presentation/widgets/image_editor/widgets/outpaint_edge_drag_overlay_test.dart
+++ b/test/presentation/widgets/image_editor/widgets/outpaint_edge_drag_overlay_test.dart
@@ -952,6 +952,113 @@ void main() {
     expect(find.byKey(const Key('outpaint_handle_top_left')), findsNothing);
     expect(find.byKey(const Key('outpaint_handle_bottom_right')), findsNothing);
   });
+
+  testWidgets('拖拽热区不得吞掉画布的悬停事件', (tester) async {
+    final hoverPositions = <Offset>[];
+    var exitCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 400,
+            child: Stack(
+              children: [
+                Positioned.fill(
+                  child: MouseRegion(
+                    onExit: (_) => exitCount++,
+                    child: Listener(
+                      behavior: HitTestBehavior.opaque,
+                      onPointerHover: (event) =>
+                          hoverPositions.add(event.localPosition),
+                      child: const SizedBox.expand(),
+                    ),
+                  ),
+                ),
+                Positioned.fill(
+                  child: OutpaintEdgeDragOverlay(
+                    canvasSize: const Size(128, 96),
+                    controller: controller,
+                    onCommitted:
+                        (
+                          edges, {
+                          required horizontalSnapTarget,
+                          required verticalSnapTarget,
+                        }) async {},
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    // 起点落在画布矩形与所有热区之外
+    await gesture.addPointer(location: const Offset(300, 300));
+    addTearDown(gesture.removePointer);
+    await tester.pumpAndSettle();
+
+    hoverPositions.clear();
+    exitCount = 0;
+
+    final edgeCenter = tester.getCenter(
+      find.byKey(const Key('outpaint_edge_right')),
+    );
+    await gesture.moveTo(edgeCenter);
+    await tester.pumpAndSettle();
+
+    expect(
+      hoverPositions.last,
+      edgeCenter,
+      reason: '热区必须让悬停事件继续下传，否则画笔光标会在画布边缘消失',
+    );
+    expect(exitCount, 0, reason: '热区不得让下层 MouseRegion 收到 onExit');
+
+    final handleCenter = tester.getCenter(
+      find.byKey(const Key('outpaint_handle_right')),
+    );
+    await gesture.moveTo(handleCenter);
+    await tester.pumpAndSettle();
+
+    expect(hoverPositions.last, handleCenter);
+    expect(exitCount, 0);
+  });
+
+  testWidgets('手柄矩形算作拖拽热区，避免同时在画布上落笔', (tester) async {
+    await tester.pumpWidget(
+      _wrapOverlay(
+        controller: controller,
+        onCommitted:
+            (
+              edges, {
+              required horizontalSnapTarget,
+              required verticalSnapTarget,
+            }) async {},
+      ),
+    );
+
+    const viewportSize = Size(400, 400);
+    for (final key in const [
+      Key('outpaint_handle_top_left'),
+      Key('outpaint_handle_bottom_right'),
+      Key('outpaint_handle_right'),
+    ]) {
+      final center = tester.getCenter(find.byKey(key));
+      expect(
+        OutpaintEdgeDragOverlay.isResizeInteractionPoint(
+          localPosition: center,
+          viewportSize: viewportSize,
+          canvasSize: const Size(128, 96),
+          controller: controller,
+        ),
+        isTrue,
+        reason: '$key 的中心必须被判定为拖拽热区',
+      );
+    }
+  });
 }
 
 class _OverlayGeometryCase {


### PR DESCRIPTION
## 修复的问题

编辑器里两个指针交互问题：

1. **画笔光标跟不上鼠标。** 画笔和橡皮把系统光标设为 `SystemMouseCursors.none`，只画一个自绘圆环。自绘圆环要经过完整的 build → layout → paint 管线才能落到屏幕上，必然滞后于操作系统直接合成的真实指针，快速移动时肉眼可见地拖在后面。
2. **在外扩手柄上按下会同时落笔。** `OutpaintEdgeDragOverlay` 的命中判定只算边缘条矩形，但手柄在贴近视口边界时会被 clamp 到边缘条之外。落在这部分的按下既开始了拖拽，又被画布当成一笔，画面上会多出一道不该有的笔迹。

## 改动

**光标**

- 画笔/橡皮改用 `SystemMouseCursors.precise`：系统十字作为不滞后的锚点，自绘圆环退回只表示笔刷直径。
- 光标位置更新统一走新的 `_setCursorPosition()`。位置变化只写 `cursorNotifier` 驱动光标层重绘；只有光标层挂载与否翻转、或拾色器放大镜需要跟随定位时才调 `onStateChanged()`，不再每个指针事件都重建整个画布子树。
- 光标层套 `RepaintBoundary`。此前注释写着"高频更新，不使用 RepaintBoundary"，实际相反：不隔离会让每次指针移动连带整幅图层重绘，`willChange: true` 还会污染整块画布的光栅缓存。
- `CursorPainter` 不再从构造参数捕获坐标，改为 `paint()` 时直接读 `cursorNotifier.value`，避免 widget 重建与重绘不同步时画出上一帧的旧坐标。
- Shift 拖拽调笔刷半径时光标钉在锚点不动，位置没变就不会触发 `ValueNotifier` 通知，圆环不会跟着变大；新增 `EditorState.notifyCursorVisualChange()` 覆盖这种"位置不变但视觉参数变了"的场景。

**外扩手柄**

- 命中判定把手柄矩形一并计入拖拽热区，手柄尺寸提取为 `handleSize` / `cornerHandleSize` 常量，判定与绘制共用同一份几何。
- 指针被画布按坐标抑制时收不到成对的 `pointerUp`，补上 `cancelTransientGestures()` 作为状态出口。同样地 `handlePointerCancel` 此前也不复位笔刷尺寸模式和中键平移，这两个模式只在 `pointerUp` 里退出，取消事件不兜底就会永久卡住。平移与绘制指针另有 `scaleEnd` / `pointerCancel` 出口，这里不动，避免误伤并发手势。

## 验证

```
flutter test test/presentation/widgets/image_editor/canvas/editor_canvas_cursor_test.dart \
             test/presentation/widgets/image_editor/widgets/outpaint_edge_drag_overlay_test.dart \
             test/presentation/widgets/image_editor/canvas/layer_painter_test.dart \
             test/presentation/widgets/image_editor/canvas/editor_render_scheduler_test.dart \
             test/presentation/widgets/image_editor/canvas/stroke_preview_painter_test.dart \
             test/presentation/widgets/image_editor/tools/brush_tool_test.dart \
             test/presentation/widgets/image_editor/widgets/toolbar/desktop_toolbar_test.dart
# 47 passed

flutter analyze          # No issues found
```

新增回归用例覆盖：光标层挂 `RepaintBoundary` 且不随指针移动重建画布子树、`CursorPainter` 在半径变化时跟随重绘、手柄矩形算作拖拽热区不落笔、拖拽热区不吞掉画布悬停事件。

无生成文件、assets 或 LFS 变更。
