### PR TITLE
fix(agent): 修复 Gemini 3.7 首轮请求 400

### DIFF
--- a/lib/presentation/agent_chat/model/pi_reasoning_model_catalog.dart
+++ b/lib/presentation/agent_chat/model/pi_reasoning_model_catalog.dart
@@ -1268,15 +1268,9 @@ const piReasoningModelCatalog = <String, Map<String, AgentReasoningModelRule>>{
     ),
     'gemini-3.7-flash': AgentReasoningModelRule(
       api: AgentReasoningApi.geminiLevel,
-      levels: [
-        ThinkingLevel.minimal,
-        ThinkingLevel.low,
-        ThinkingLevel.medium,
-        ThinkingLevel.high,
-      ],
+      levels: [ThinkingLevel.low, ThinkingLevel.medium, ThinkingLevel.high],
       levelMap: {
         ThinkingLevel.off: null,
-        ThinkingLevel.minimal: 'MINIMAL',
         ThinkingLevel.low: 'LOW',
         ThinkingLevel.medium: 'MEDIUM',
         ThinkingLevel.high: 'HIGH',
@@ -1286,7 +1280,7 @@ const piReasoningModelCatalog = <String, Map<String, AgentReasoningModelRule>>{
       allowEmptySignature: false,
       alwaysIncludeEncryptedReasoning: false,
       thinkingBudgets: {},
-      disabledEffort: 'MINIMAL',
+      disabledEffort: 'LOW',
       contextWindow: 1048576,
       maxOutputTokens: 65536,
     ),

--- a/test/presentation/agent_chat/services/agent_chat_model_capability_test.dart
+++ b/test/presentation/agent_chat/services/agent_chat_model_capability_test.dart
@@ -280,17 +280,32 @@ void main() {
     );
   });
 
-  test('Gemini 3 missing reasoning uses Pi hidden minimum', () {
-    final capability = AgentChatModelCapability.resolve(
-      ProviderPreset.gemini.createConfig(id: 'google'),
+  test('Gemini 3 missing reasoning uses its supported hidden minimum', () {
+    final provider = ProviderPreset.gemini.createConfig(id: 'google');
+    final proCapability = AgentChatModelCapability.resolve(
+      provider,
       'gemini-3.1-pro-preview',
     );
+    final flashCapability = AgentChatModelCapability.resolve(
+      provider,
+      'gemini-3.7-flash',
+    );
 
-    final request = capability.resolveReasoningRequest(null);
+    final proRequest = proCapability.resolveReasoningRequest(null);
+    final flashRequest = flashCapability.resolveReasoningRequest(null);
 
-    expect(request?.enabled, isFalse);
-    expect(request?.sendWhenDisabled, isTrue);
-    expect(request?.effort, 'LOW');
+    expect(proRequest?.enabled, isFalse);
+    expect(proRequest?.sendWhenDisabled, isTrue);
+    expect(proRequest?.effort, 'LOW');
+    expect(flashCapability.levels, [
+      ThinkingLevel.low,
+      ThinkingLevel.medium,
+      ThinkingLevel.high,
+    ]);
+    expect(flashRequest?.enabled, isFalse);
+    expect(flashRequest?.sendWhenDisabled, isTrue);
+    expect(flashRequest?.effort, 'LOW');
+    expect(flashCapability.resolveReasoningRequest('minimal')?.effort, 'LOW');
   });
 
   test('omits missing reasoning on models whose off mapping is null', () {

--- a/tool/agent/generate_pi_reasoning_catalog.dart
+++ b/tool/agent/generate_pi_reasoning_catalog.dart
@@ -159,19 +159,16 @@ String _generate(Directory root, String version) {
 
     output.writeln("  ${_quote(provider)}: {");
     for (final model in models) {
+      final modelId = model['id'] as String;
       final sourceLevelMap =
           (model['thinkingLevelMap'] as Map<String, dynamic>?) ?? {};
-      final supportedLevels = <String>[
-        for (final level in _levels)
-          if (_supportsLevel(level, sourceLevelMap)) level,
-      ];
       final compat = (model['compat'] as Map<String, dynamic>?) ?? {};
       final api = _reasoningApi(model, compat);
-      final emittedLevelMap = _emittedLevelMap(
-        api,
-        model['id'] as String,
-        sourceLevelMap,
-      );
+      final supportedLevels = <String>[
+        for (final level in _levels)
+          if (_supportsLevel(api, modelId, level, sourceLevelMap)) level,
+      ];
+      final emittedLevelMap = _emittedLevelMap(api, modelId, sourceLevelMap);
       final mapEntries = <String>[
         for (final level in _levels)
           if (emittedLevelMap.containsKey(level))
@@ -205,7 +202,17 @@ String _generate(Directory root, String version) {
   return output.toString();
 }
 
-bool _supportsLevel(String level, Map<String, dynamic> levelMap) {
+bool _supportsLevel(
+  String api,
+  String modelId,
+  String level,
+  Map<String, dynamic> levelMap,
+) {
+  if (api == 'geminiLevel' &&
+      level == 'minimal' &&
+      _geminiMinimumLevel(modelId) == 'LOW') {
+    return false;
+  }
   if (levelMap[level] == null && levelMap.containsKey(level)) return false;
   if ((level == 'xhigh' || level == 'max') && !levelMap.containsKey(level)) {
     return false;
@@ -223,7 +230,7 @@ Map<String, dynamic> _emittedLevelMap(
     for (final level in _levels)
       if (source[level] == null && source.containsKey(level))
         level: null
-      else if (level != 'off' && _supportsLevel(level, source))
+      else if (level != 'off' && _supportsLevel(api, modelId, level, source))
         level: _geminiNativeLevel(
           modelId,
           (source[level] as String?)?.toLowerCase() ?? level,
@@ -258,9 +265,16 @@ Map<String, int> _thinkingBudgets(String api, String modelId) {
 
 String? _disabledEffort(String api, String modelId) {
   if (api != 'geminiLevel') return null;
-  return RegExp(r'gemini-3(?:\.\d+)?-pro').hasMatch(modelId.toLowerCase())
-      ? 'LOW'
-      : 'MINIMAL';
+  return _geminiMinimumLevel(modelId);
+}
+
+String _geminiMinimumLevel(String modelId) {
+  final normalizedId = modelId.toLowerCase();
+  if (RegExp(r'gemini-3(?:\.\d+)?-pro').hasMatch(normalizedId) ||
+      normalizedId == 'gemini-3.7-flash') {
+    return 'LOW';
+  }
+  return 'MINIMAL';
 }
 
 String _reasoningApi(Map<String, dynamic> model, Map<String, dynamic> compat) {


### PR DESCRIPTION
## 问题

Gemini 3.7 Flash 仅支持 LOW、MEDIUM 和 HIGH 思考等级，但模型目录仍将 MINIMAL 视为可用。新会话选择最低等级后会发送不受支持的 `thinkingLevel`，导致首轮请求返回 HTTP 400。

## 修改

- 从 Gemini 3.7 Flash 的可用等级中移除 `minimal`
- 将隐藏最低思考等级调整为 `LOW`
- 更新生成器，避免重新生成目录时恢复错误配置
- 增加模型能力回归测试，覆盖默认等级和 `minimal` 收敛行为

## 验证

- `scripts/test_affected.ps1`：相关测试 27 项全部通过
- `dart run tool/agent/generate_pi_reasoning_catalog.dart --check`
- `dart analyze`：相关文件无问题

Fixes #193