### PR TITLE
fix(agent-chat): 调整消息引用与正文对齐

### DIFF
--- a/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
@@ -404,6 +404,24 @@ class AgentChatMessages extends StatelessWidget {
         ),
         alwaysUse24HourFormat: true,
       );
+      final hasBubbleContent = hasText || message.images.isNotEmpty;
+      Widget deliveryStatus(Color color) => Row(
+        key: ValueKey('agent-user-message-delivery-$messageIndex'),
+        mainAxisAlignment: MainAxisAlignment.end,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            sentAt,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: color,
+              fontSize: 9,
+              height: 1,
+            ),
+          ),
+          const SizedBox(width: 3),
+          Icon(Icons.done_all_rounded, size: 11, color: color),
+        ],
+      );
       return MouseRegion(
         key: ValueKey('agent-user-message-$messageIndex'),
         onEnter: (_) => controller.setHoveredUserMessageIndex(messageIndex),
@@ -420,147 +438,120 @@ class AgentChatMessages extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
-                Container(
-                  key: ValueKey('agent-user-message-bubble-$messageIndex'),
-                  constraints: BoxConstraints(
-                    minWidth: hasText ? 44 : 0,
-                    maxWidth: viewData.userBubbleMaxWidth,
-                  ),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 8,
-                  ),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.primaryContainer.withValues(
-                      alpha: 0.55,
+                if (resourceReferences.isNotEmpty)
+                  ConstrainedBox(
+                    key: ValueKey('agent-user-message-resources-$messageIndex'),
+                    constraints: BoxConstraints(
+                      maxWidth: viewData.userBubbleMaxWidth,
                     ),
-                    borderRadius: const BorderRadius.only(
-                      topLeft: Radius.circular(12),
-                      topRight: Radius.circular(12),
-                      bottomLeft: Radius.circular(12),
-                      bottomRight: Radius.circular(4),
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Wrap(
+                        spacing: 5,
+                        runSpacing: 4,
+                        alignment: WrapAlignment.end,
+                        children: [
+                          for (
+                            var index = 0;
+                            index < resourceReferences.length;
+                            index++
+                          )
+                            AgentChatSentResourceCard(
+                              key: ValueKey(
+                                'agent-user-message-resource-'
+                                '$messageIndex-$index',
+                              ),
+                              reference: resourceReferences[index],
+                              loadPreview: () =>
+                                  commands.resolveResourcePreview(
+                                    resourceReferences[index],
+                                  ),
+                              touchOptimized: viewData.mobile,
+                            ),
+                        ],
+                      ),
                     ),
                   ),
-                  child: IntrinsicWidth(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        if (resourceReferences.isNotEmpty)
-                          Padding(
-                            padding: EdgeInsets.only(
-                              bottom: message.images.isNotEmpty || hasText
-                                  ? 6
-                                  : 0,
-                            ),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.end,
-                              children: [
-                                for (
-                                  var rowStart = 0;
-                                  rowStart < resourceReferences.length;
-                                  rowStart += 2
-                                )
-                                  Padding(
-                                    padding: EdgeInsets.only(
-                                      bottom:
-                                          rowStart + 2 <
-                                              resourceReferences.length
-                                          ? 4
-                                          : 0,
+                if (hasBubbleContent)
+                  Container(
+                    key: ValueKey('agent-user-message-bubble-$messageIndex'),
+                    constraints: BoxConstraints(
+                      minWidth: hasText ? 44 : 0,
+                      maxWidth: viewData.userBubbleMaxWidth,
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.primaryContainer.withValues(
+                        alpha: 0.55,
+                      ),
+                      borderRadius: const BorderRadius.only(
+                        topLeft: Radius.circular(12),
+                        topRight: Radius.circular(12),
+                        bottomLeft: Radius.circular(12),
+                        bottomRight: Radius.circular(4),
+                      ),
+                    ),
+                    child: IntrinsicWidth(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          if (message.images.isNotEmpty)
+                            Padding(
+                              padding: EdgeInsets.only(bottom: hasText ? 6 : 0),
+                              child: Wrap(
+                                spacing: 6,
+                                runSpacing: 6,
+                                alignment: WrapAlignment.end,
+                                children: [
+                                  for (final image in message.images)
+                                    _userImage(
+                                      theme,
+                                      image,
+                                      maxWidth:
+                                          viewData.userBubbleMaxWidth - 24,
                                     ),
-                                    child: Row(
-                                      mainAxisSize: MainAxisSize.min,
-                                      children: [
-                                        for (
-                                          var index = rowStart;
-                                          index < resourceReferences.length &&
-                                              index < rowStart + 2;
-                                          index++
-                                        ) ...[
-                                          if (index > rowStart)
-                                            const SizedBox(width: 5),
-                                          AgentChatSentResourceCard(
-                                            key: ValueKey(
-                                              'agent-user-message-resource-'
-                                              '$messageIndex-$index',
-                                            ),
-                                            reference:
-                                                resourceReferences[index],
-                                            loadPreview: () =>
-                                                commands.resolveResourcePreview(
-                                                  resourceReferences[index],
-                                                ),
-                                            touchOptimized: viewData.mobile,
-                                          ),
-                                        ],
-                                      ],
-                                    ),
-                                  ),
-                              ],
-                            ),
-                          ),
-                        if (message.images.isNotEmpty)
-                          Padding(
-                            padding: EdgeInsets.only(bottom: hasText ? 6 : 0),
-                            child: Wrap(
-                              spacing: 6,
-                              runSpacing: 6,
-                              alignment: WrapAlignment.end,
-                              children: [
-                                for (final image in message.images)
-                                  _userImage(
-                                    theme,
-                                    image,
-                                    maxWidth: viewData.userBubbleMaxWidth - 24,
-                                  ),
-                              ],
-                            ),
-                          ),
-                        if (hasText)
-                          Text(
-                            message.text,
-                            key: ValueKey(
-                              'agent-user-message-text-$messageIndex',
-                            ),
-                            textAlign: TextAlign.center,
-                            style:
-                                (viewData.mobile
-                                        ? theme.textTheme.bodyMedium
-                                        : theme.textTheme.bodySmall)
-                                    ?.copyWith(
-                                      color:
-                                          theme.colorScheme.onPrimaryContainer,
-                                      height: 1.45,
-                                    ),
-                          ),
-                        const SizedBox(height: 4),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              sentAt,
-                              style: theme.textTheme.labelSmall?.copyWith(
-                                color: theme.colorScheme.onPrimaryContainer
-                                    .withValues(alpha: 0.58),
-                                fontSize: 9,
-                                height: 1,
+                                ],
                               ),
                             ),
-                            const SizedBox(width: 3),
-                            Icon(
-                              Icons.done_all_rounded,
-                              size: 11,
-                              color: theme.colorScheme.onPrimaryContainer
-                                  .withValues(alpha: 0.58),
+                          if (hasText)
+                            Text(
+                              message.text,
+                              key: ValueKey(
+                                'agent-user-message-text-$messageIndex',
+                              ),
+                              textAlign: TextAlign.left,
+                              style:
+                                  (viewData.mobile
+                                          ? theme.textTheme.bodyMedium
+                                          : theme.textTheme.bodySmall)
+                                      ?.copyWith(
+                                        color: theme
+                                            .colorScheme
+                                            .onPrimaryContainer,
+                                        height: 1.45,
+                                      ),
                             ),
-                          ],
-                        ),
-                      ],
+                          const SizedBox(height: 4),
+                          deliveryStatus(
+                            theme.colorScheme.onPrimaryContainer.withValues(
+                              alpha: 0.58,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                else
+                  Padding(
+                    padding: const EdgeInsets.only(right: 4),
+                    child: deliveryStatus(
+                      theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
                     ),
                   ),
-                ),
                 const SizedBox(height: 2),
                 Focus(
                   onFocusChange: (focused) =>

--- a/lib/presentation/agent_chat/widgets/agent_chat_resource_widgets.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_resource_widgets.dart
@@ -314,8 +314,8 @@ class _AgentChatSentResourceCardState extends State<AgentChatSentResourceCard> {
               height: widget.touchOptimized ? 30 : 27,
               padding: const EdgeInsets.all(3),
               decoration: BoxDecoration(
-                color: theme.colorScheme.onPrimaryContainer.withValues(
-                  alpha: 0.08,
+                color: theme.colorScheme.surfaceContainerHighest.withValues(
+                  alpha: 0.72,
                 ),
                 borderRadius: BorderRadius.circular(7),
               ),
@@ -349,7 +349,7 @@ class _AgentChatSentResourceCardState extends State<AgentChatSentResourceCard> {
                         size: 14,
                         color: unavailable
                             ? theme.colorScheme.error
-                            : theme.colorScheme.onPrimaryContainer,
+                            : theme.colorScheme.onSurface,
                       ),
                     ),
                   const SizedBox(width: 5),
@@ -361,7 +361,7 @@ class _AgentChatSentResourceCardState extends State<AgentChatSentResourceCard> {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: theme.textTheme.labelSmall?.copyWith(
-                          color: theme.colorScheme.onPrimaryContainer,
+                          color: theme.colorScheme.onSurface,
                           height: 1,
                         ),
                       ),

--- a/test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/agent/agent_types.dart';
 import 'package:nai_launcher/core/agent/harness/harness_messages.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/agent_chat/providers/agent_chat_notifier.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_resource_resolver.dart';
 import 'package:nai_launcher/presentation/agent_chat/widgets/agent_chat_messages.dart';
 import 'package:nai_launcher/presentation/agent_chat/widgets/agent_chat_panel_controller.dart';
 import 'package:nai_launcher/presentation/agent_chat/widgets/agent_chat_panel_view_data.dart';
@@ -109,7 +111,7 @@ void main() {
   }
 
   testWidgets(
-    'user message text stays centered while metadata and actions keep alignment',
+    'user message body stays left aligned while metadata and actions keep alignment',
     (tester) async {
       final controller = AgentChatPanelController();
       addTearDown(controller.dispose);
@@ -153,8 +155,8 @@ void main() {
           );
 
           textHeights.add(textRect.height);
-          expect(text.textAlign, TextAlign.center);
-          expect(textRect.center.dx, closeTo(bubbleRect.center.dx, 0.01));
+          expect(text.textAlign, TextAlign.left);
+          expect(textRect.left, closeTo(bubbleRect.left + 12, 0.01));
           expect(
             tester.getRect(statusIcon).right,
             closeTo(bubbleRect.right - 12, 0.01),
@@ -204,6 +206,27 @@ void main() {
                 'display': {'name': 'Group OC'},
                 'provenance': <String, String>{},
               },
+              {
+                'version': 1,
+                'kind': 'vibeLibraryEntry',
+                'source': 'vibe_library',
+                'resourceId': 'vibe-1',
+                'display': {'name': 'Soft light'},
+              },
+              {
+                'version': 1,
+                'kind': 'preciseRefLibraryEntry',
+                'source': 'precise_reference_library',
+                'resourceId': 'precise-1',
+                'display': {'name': 'Pose reference'},
+              },
+              {
+                'version': 1,
+                'kind': 'onlineGalleryMedia',
+                'source': 'online_gallery',
+                'resourceId': 'post-1',
+                'display': {'name': 'Gallery image'},
+              },
             ],
           },
           timestamp: 123,
@@ -219,23 +242,61 @@ void main() {
             messages: [message],
           ),
         );
-        await tester.pump();
 
         expect(find.text('Use these resources'), findsOneWidget);
         expect(find.text('Current canvas'), findsOneWidget);
         expect(find.text('Group OC'), findsOneWidget);
+        final bubble = find.byKey(
+          const ValueKey('agent-user-message-bubble-0'),
+        );
+        final resources = find.byKey(
+          const ValueKey('agent-user-message-resources-0'),
+        );
         final firstCard = find.byKey(
           const ValueKey('agent-user-message-resource-0-0'),
         );
         final secondCard = find.byKey(
           const ValueKey('agent-user-message-resource-0-1'),
         );
+        final thirdCard = find.byKey(
+          const ValueKey('agent-user-message-resource-0-2'),
+        );
         expect(firstCard, findsOneWidget);
         expect(secondCard, findsOneWidget);
+        expect(thirdCard, findsOneWidget);
+        expect(find.descendant(of: bubble, matching: firstCard), findsNothing);
+        expect(
+          find.descendant(of: resources, matching: firstCard),
+          findsOneWidget,
+        );
+        expect(
+          tester.getTopRight(resources).dx,
+          closeTo(tester.getTopRight(bubble).dx, 0.01),
+        );
+        expect(
+          find.descendant(
+            of: firstCard,
+            matching: find.byIcon(Icons.image_outlined),
+          ),
+          findsOneWidget,
+        );
+        await tester.pump();
+        expect(
+          find.descendant(
+            of: firstCard,
+            matching: find.byIcon(Icons.link_off_outlined),
+          ),
+          findsOneWidget,
+        );
         if (width >= 840) {
           expect(
             tester.getTopLeft(firstCard).dy,
             tester.getTopLeft(secondCard).dy,
+          );
+        } else {
+          expect(
+            tester.getTopLeft(thirdCard).dy,
+            greaterThan(tester.getTopLeft(firstCard).dy),
           );
         }
         expect(find.textContaining('agent-resource-references'), findsNothing);
@@ -243,6 +304,127 @@ void main() {
       },
     );
   }
+
+  testWidgets('reference-only message renders outside the empty body bubble', (
+    tester,
+  ) async {
+    final controller = AgentChatPanelController();
+    addTearDown(controller.dispose);
+    const message = HarnessCustomMessage(
+      customType: 'agentResourcePrompt',
+      display: true,
+      blockContent: [UserTextContent('<agent-resource-references />')],
+      details: {
+        'references': [
+          {
+            'version': 1,
+            'kind': 'vibeLibraryEntry',
+            'source': 'vibe_library',
+            'resourceId': 'vibe-1',
+            'display': {'name': 'Lighting vibe'},
+          },
+        ],
+      },
+      timestamp: 123,
+    );
+
+    await _pumpMessages(
+      tester,
+      width: 320,
+      controller: controller,
+      state: const AgentChatState(
+        initialized: true,
+        routeReady: true,
+        messages: [message],
+      ),
+    );
+
+    final reference = find.byKey(
+      const ValueKey('agent-user-message-resource-0-0'),
+    );
+    expect(find.text('Lighting vibe'), findsOneWidget);
+    expect(reference, findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('agent-user-message-bubble-0')),
+      findsNothing,
+    );
+    final delivery = find.byKey(
+      const ValueKey('agent-user-message-delivery-0'),
+    );
+    final resources = find.byKey(
+      const ValueKey('agent-user-message-resources-0'),
+    );
+    final copyAction = find.byKey(const ValueKey('agent-user-message-copy-0'));
+    expect(delivery, findsOneWidget);
+    expect(copyAction, findsOneWidget);
+    expect(
+      tester.getTopRight(delivery).dx,
+      lessThan(tester.getTopRight(resources).dx),
+    );
+    expect(tester.getSize(copyAction).width, greaterThanOrEqualTo(48));
+    expect(tester.getSize(copyAction).height, greaterThanOrEqualTo(48));
+    expect(find.textContaining('agent-resource-references'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('failed resource preview keeps the sent reference available', (
+    tester,
+  ) async {
+    final controller = AgentChatPanelController();
+    addTearDown(controller.dispose);
+    const message = HarnessCustomMessage(
+      customType: 'agentResourcePrompt',
+      display: true,
+      blockContent: [UserTextContent('Inspect this reference')],
+      details: {
+        'references': [
+          {
+            'version': 1,
+            'kind': 'localGalleryImage',
+            'source': 'local_gallery',
+            'resourceId': 'missing-image',
+            'display': {'name': 'Missing image'},
+          },
+        ],
+      },
+      timestamp: 123,
+    );
+
+    await _pumpMessages(
+      tester,
+      width: 320,
+      controller: controller,
+      state: const AgentChatState(
+        initialized: true,
+        routeReady: true,
+        messages: [message],
+      ),
+      commands: _commandsWithResolver(
+        (_) async => throw StateError('preview unavailable'),
+      ),
+    );
+
+    final reference = find.byKey(
+      const ValueKey('agent-user-message-resource-0-0'),
+    );
+    expect(
+      find.descendant(
+        of: reference,
+        matching: find.byIcon(Icons.image_outlined),
+      ),
+      findsOneWidget,
+    );
+    await tester.pump();
+    expect(
+      find.descendant(
+        of: reference,
+        matching: find.byIcon(Icons.link_off_outlined),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Missing image'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets('streaming response exposes a live responding status', (
     tester,
@@ -274,6 +456,7 @@ Future<void> _pumpMessages(
   required double width,
   required AgentChatPanelController controller,
   required AgentChatState state,
+  AgentChatPanelCommands? commands,
 }) {
   return tester.pumpWidget(
     MaterialApp(
@@ -305,7 +488,7 @@ Future<void> _pumpMessages(
               onOpenSettings: null,
               mobileHeaderWrapper: null,
             ),
-            commands: _commands,
+            commands: commands ?? _commands,
             controller: controller,
           ),
         ),
@@ -314,7 +497,12 @@ Future<void> _pumpMessages(
   );
 }
 
-final _commands = AgentChatPanelCommands(
+final _commands = _commandsWithResolver((_) async => null);
+
+AgentChatPanelCommands _commandsWithResolver(
+  Future<ResolvedAgentResource?> Function(AgentChatResourceReference reference)
+  resolveResourcePreview,
+) => AgentChatPanelCommands(
   collapse: () {},
   newSession: () async {},
   selectSession: (_) async {},
@@ -329,7 +517,7 @@ final _commands = AgentChatPanelCommands(
   attachCurrentCanvas: () async {},
   openReferenceGallery: () async {},
   openResourceLibrary: () async {},
-  resolveResourcePreview: (_) async => null,
+  resolveResourcePreview: resolveResourcePreview,
   send: () async {},
   sendFollowUp: () async {},
   stop: () {},


### PR DESCRIPTION
## 变更说明
- 将已发送消息的 `AgentChatResourceReference` 引用组提升为正文气泡的同级节点，继续右对齐并以紧凑间距归属于对应消息；多引用使用 `Wrap` 在窄宽下自适应换行
- 正文气泡只在存在正文或图片附件时渲染；仅引用消息直接展示引用、投递状态与原有消息操作，不再生成空正文气泡
- 用户正文统一左对齐，消息组位置、时间/投递状态和编辑/复制操作的原有对齐语义保持不变
- 复用现有 `AgentChatSentResourceCard`、`resolveResourcePreview` 与消息命令链路；在线画廊、标签词库、Vibe、精准参考等引用类型及预览加载/失败状态未复制实现或降级
- 引用卡片移出主色气泡后改用低对比 surface 配色，保持 Quiet Layered Utility 层级与可读性

## 回归覆盖
- 引用组件不再是正文气泡后代
- 正文左对齐，时间/状态/操作仍按原语义对齐
- 仅引用消息不渲染空正文气泡，移动端操作目标保持 48px
- 320 / 840 宽度、200% 字号下的五引用换行和无 overflow
- 引用预览 loading、空结果与异常失败状态
- 现有消息流、资源引用与 turn 回归测试

## 验证
- `dart format --output none --set-exit-if-changed lib/presentation/agent_chat/widgets/agent_chat_messages.dart lib/presentation/agent_chat/widgets/agent_chat_resource_widgets.dart test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run_flutter_tests.ps1 -Path "test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart" -TimeoutSeconds 180 -Concurrency 1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run_flutter_tests.ps1 -Path "test/presentation/agent_chat/widgets/agent_chat_turn_test.dart,test/presentation/agent_chat/widgets/agent_chat_resource_widgets_test.dart" -TimeoutSeconds 180 -Concurrency 2`
- `flutter analyze`
- `node C:/Users/Administrator/.pi/agent/skills/impeccable/scripts/detect.mjs --json --scope layout lib/presentation/agent_chat/widgets/agent_chat_messages.dart lib/presentation/agent_chat/widgets/agent_chat_resource_widgets.dart`
