### PR TITLE
fix(network): 保留代理服务错误详情

### DIFF
--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -11,6 +11,7 @@ import '../../presentation/providers/proxy_settings_provider.dart';
 import '../constants/api_constants.dart';
 import '../storage/secure_storage_service.dart';
 import '../utils/app_logger.dart';
+import 'dio_error_response_parser.dart';
 
 part 'dio_client.g.dart';
 
@@ -326,7 +327,7 @@ class ErrorInterceptor extends Interceptor {
         'DIO Error: ${err.type.name}\n'
         'Status: ${err.response?.statusCode}\n'
         'URL: ${err.requestOptions.uri}\n'
-        'Response Data: ${err.response?.data}';
+        'Response Data: ${formatDioErrorResponseDataForLog(err.response?.data)}';
 
     // 非致命网络抖动降级为 warning，避免错误日志噪音
     if (err.type == DioExceptionType.connectionTimeout ||
@@ -368,12 +369,10 @@ class ErrorInterceptor extends Interceptor {
   String _parseResponseError(Response? response, AppLocalizations l10n) {
     if (response == null) return l10n.networkError_noResponse;
 
-    // 尝试从响应中提取错误信息
-    final data = response.data;
-    if (data is Map<String, dynamic>) {
-      final message = data['message'] ?? data['error'];
-      if (message != null) return message.toString();
-    }
+    // 生成接口使用 bytes/stream 响应类型，失败时 JSON 错误体也可能以
+    // Uint8List 返回。先还原服务端信息，避免把具体原因降级成“请求参数错误”。
+    final responseDetails = parseDioErrorResponseDetails(response.data);
+    if (responseDetails != null) return responseDetails;
 
     // 根据状态码返回错误信息
     return switch (response.statusCode) {

--- a/lib/core/network/dio_error_response_parser.dart
+++ b/lib/core/network/dio_error_response_parser.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Extracts a useful server error from JSON, UTF-8 bytes, or plain text.
+///
+/// Dio keeps error bodies as bytes when the successful response is expected to
+/// be an image archive. Third-party APIs commonly return JSON in that case.
+String? parseDioErrorResponseDetails(Object? data) {
+  final decoded = _decodeDioErrorResponse(data);
+  if (decoded == null) return null;
+
+  if (decoded is String) {
+    final text = decoded.trim();
+    return text.isEmpty ? null : text;
+  }
+  if (decoded is! Map) return null;
+
+  final nestedError = decoded['error'];
+  final nestedMap = nestedError is Map ? nestedError : null;
+  final message = _firstNonEmpty([
+    decoded['message'],
+    decoded['detail'],
+    nestedMap?['message'],
+    nestedError is String ? nestedError : null,
+  ]);
+  final code = _firstNonEmpty([decoded['code'], nestedMap?['code']]);
+  final requestId = _firstNonEmpty([
+    decoded['request_id'],
+    decoded['requestId'],
+    nestedMap?['request_id'],
+    nestedMap?['requestId'],
+  ]);
+
+  var details = message ?? code;
+  if (details == null) return null;
+  if (code != null && code != details && !details.contains(code)) {
+    details = '$details (code: $code)';
+  }
+  if (requestId != null) {
+    details = '$details [request_id: $requestId]';
+  }
+  return details;
+}
+
+String formatDioErrorResponseDataForLog(Object? data) {
+  final decoded = _decodeDioErrorResponse(data);
+  final text = decoded is String
+      ? decoded.trim()
+      : decoded == null
+      ? data?.runtimeType.toString() ?? 'null'
+      : _encodeDioErrorResponseForLog(decoded);
+  const maximumLength = 4096;
+  if (text.length <= maximumLength) return text;
+  return '${text.substring(0, maximumLength)}… [truncated]';
+}
+
+String _encodeDioErrorResponseForLog(Object decoded) {
+  if (decoded is Map || decoded is List || decoded is num || decoded is bool) {
+    try {
+      return jsonEncode(decoded);
+    } on JsonUnsupportedObjectError {
+      // Fall through to the safe object representation.
+    }
+  }
+  return decoded.toString();
+}
+
+Object? _decodeDioErrorResponse(Object? data) {
+  Object? decoded = data;
+  if (data is Uint8List) {
+    try {
+      decoded = utf8.decode(data);
+    } on FormatException {
+      return null;
+    }
+  } else if (data is List<int>) {
+    try {
+      decoded = utf8.decode(data);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  if (decoded is! String) return decoded;
+  final text = decoded.trim();
+  if (text.isEmpty) return null;
+  try {
+    return jsonDecode(text);
+  } on FormatException {
+    return text;
+  }
+}
+
+String? _firstNonEmpty(Iterable<Object?> values) {
+  for (final value in values) {
+    final text = value?.toString().trim();
+    if (text != null && text.isNotEmpty) return text;
+  }
+  return null;
+}

--- a/test/core/network/dio_error_response_parser_test.dart
+++ b/test/core/network/dio_error_response_parser_test.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/network/dio_error_response_parser.dart';
+
+void main() {
+  group('parseDioErrorResponseDetails', () {
+    test('decodes byte JSON returned by image generation endpoints', () {
+      final body = Uint8List.fromList(
+        utf8.encode(
+          jsonEncode({
+            'message': '参数错误',
+            'code': 'INVALID_PARAMETERS',
+            'request_id': 'request-209',
+          }),
+        ),
+      );
+
+      expect(
+        parseDioErrorResponseDetails(body),
+        '参数错误 (code: INVALID_PARAMETERS) [request_id: request-209]',
+      );
+    });
+
+    test('extracts nested OpenAI-style errors', () {
+      expect(
+        parseDioErrorResponseDetails({
+          'error': {
+            'message': 'Model is unavailable',
+            'code': 'MODEL_UNAVAILABLE',
+          },
+          'requestId': 'request-nested',
+        }),
+        'Model is unavailable (code: MODEL_UNAVAILABLE) '
+        '[request_id: request-nested]',
+      );
+    });
+
+    test('preserves a plain-text server error', () {
+      expect(
+        parseDioErrorResponseDetails(
+          utf8.encode('failed to read multipart request'),
+        ),
+        'failed to read multipart request',
+      );
+    });
+
+    test('ignores binary response data', () {
+      expect(
+        parseDioErrorResponseDetails(Uint8List.fromList([0xFF, 0xD8, 0xFF])),
+        isNull,
+      );
+    });
+  });
+
+  test('bounds response data written to logs', () {
+    final output = formatDioErrorResponseDataForLog('x' * 5000);
+
+    expect(output.length, lessThan(4200));
+    expect(output, endsWith('… [truncated]'));
+  });
+}


### PR DESCRIPTION
## 变更\n- 解码图片生成接口以字节形式返回的 JSON 错误体\n- 在界面和日志中保留代理服务的 message、code 与 request_id\n- 限制错误响应日志长度，避免异常响应撑大日志\n\n## 验证\n- flutter test --no-pub test/core/network/dio_error_response_parser_test.dart\n- dart analyze lib/core/network/dio_error_response_parser.dart\n- git diff --check\n\n关联：#209