### PR TITLE
perf(gallery): 提升可见图片加载并发

### DIFF
--- a/lib/core/cache/online_gallery_prefetch_coordinator.dart
+++ b/lib/core/cache/online_gallery_prefetch_coordinator.dart
@@ -41,15 +41,18 @@ enum GalleryPrefetchPauseReason {
 class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
   OnlineGalleryPrefetchCoordinator({
     required GalleryImagePreloader preloader,
-    this.maxConcurrent = 4,
+    this.maxConcurrent = 8,
+    this.maxSpeculativeConcurrent = 4,
     this.maxQueued = 64,
     DateTime Function()? now,
   }) : assert(maxConcurrent > 0),
+       assert(maxSpeculativeConcurrent >= 0),
        _preloader = preloader,
        _now = now ?? DateTime.now;
 
   final GalleryImagePreloader _preloader;
   final int maxConcurrent;
+  final int maxSpeculativeConcurrent;
   final int maxQueued;
   final DateTime Function() _now;
   final Map<GalleryImagePriority, ListQueue<_PrefetchTask>> _queues = {
@@ -65,6 +68,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
 
   int _generation = 0;
   int _active = 0;
+  int _activeSpeculative = 0;
   int _interactiveStreak = 0;
   bool _notificationScheduled = false;
   bool _disposed = false;
@@ -75,6 +79,8 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
 
   int get generation => _generation;
   int get activeCount => _active;
+  @visibleForTesting
+  int get activeSpeculativeCount => _activeSpeculative;
   int get queueDepth => _pending.length;
   bool get isPaused => _pauseReasons.isNotEmpty;
   bool get isScrollingPaused =>
@@ -377,6 +383,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
       GalleryImagePriority.hover,
       GalleryImagePriority.lookahead,
     ]) {
+      if (_activeSpeculative >= maxSpeculativeConcurrent) return null;
       if (!_accepts(priority)) continue;
       final queue = _queues[priority]!;
       if (queue.isNotEmpty) return queue.removeFirst();
@@ -395,6 +402,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
         continue;
       }
       _active++;
+      if (_isSpeculative(task.priority)) _activeSpeculative++;
       _inFlight[key] = task;
       debugRequestCount++;
       unawaited(_run(task));
@@ -435,6 +443,7 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
     } finally {
       if (_inFlight[taskKey] == task) _inFlight.remove(taskKey);
       _active--;
+      if (_isSpeculative(task.priority)) _activeSpeculative--;
       _pump();
       _scheduleNotification();
     }
@@ -495,6 +504,10 @@ class OnlineGalleryPrefetchCoordinator extends ChangeNotifier {
       completed.remove(completed.keys.first);
     }
   }
+
+  bool _isSpeculative(GalleryImagePriority priority) =>
+      priority == GalleryImagePriority.hover ||
+      priority == GalleryImagePriority.lookahead;
 }
 
 class _PrefetchTask {

--- a/test/core/cache/online_gallery_prefetch_coordinator_test.dart
+++ b/test/core/cache/online_gallery_prefetch_coordinator_test.dart
@@ -27,7 +27,7 @@ Future<void> _waitUntil(bool Function() condition) async {
 }
 
 void main() {
-  test('limits active preloads to four', () async {
+  test('limits speculative preloads to four', () async {
     var active = 0;
     var maxActive = 0;
     final gates = <Completer<void>>[];
@@ -57,6 +57,56 @@ void main() {
     }
     expect(await Future.wait(futures), everyElement(isTrue));
     expect(maxActive, 4);
+  });
+
+  test('uses reserved capacity for visible thumbnails', () async {
+    var active = 0;
+    var maxActive = 0;
+    final gates = <Completer<void>>[];
+    final coordinator = OnlineGalleryPrefetchCoordinator(
+      preloader: (_) {
+        active++;
+        if (active > maxActive) maxActive = active;
+        final gate = Completer<void>();
+        gates.add(gate);
+        return _operation(gate.future.whenComplete(() => active--));
+      },
+    );
+    addTearDown(coordinator.dispose);
+
+    final speculative = [
+      for (var index = 0; index < 8; index++)
+        coordinator.submit(
+          _request(index),
+          priority: GalleryImagePriority.lookahead,
+        ),
+    ];
+    expect(coordinator.activeCount, 4);
+    expect(coordinator.activeSpeculativeCount, 4);
+
+    final visible = [
+      for (var index = 8; index < 12; index++)
+        coordinator.submit(
+          _request(index),
+          priority: GalleryImagePriority.visible,
+        ),
+    ];
+    expect(coordinator.activeCount, 8);
+    expect(coordinator.activeSpeculativeCount, 4);
+    expect(maxActive, 8);
+
+    for (var index = 0; index < gates.length; index++) {
+      gates[index].complete();
+    }
+    await _waitUntil(() => gates.length == 12);
+    for (final gate in gates.skip(8)) {
+      gate.complete();
+    }
+    expect(
+      await Future.wait([...speculative, ...visible]),
+      everyElement(isTrue),
+    );
+    expect(maxActive, 8);
   });
 
   test('hover work overtakes queued lookahead work', () async {


### PR DESCRIPTION
## 用户可见变化

- 提升当前可见画廊图片的并发加载速度，减少宽屏下分批显示缩略图的等待感。
- 可见图片总并发提升至 8，同时将悬浮预览和前瞻预取限制为 4，避免后台预取占满加载槽位。
- 保留滚动期间暂停前瞻请求、延后图片解码和界面刷新的现有机制，不改变滚动行为。

## 验证

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run_flutter_tests.ps1 -Path test/core/cache/online_gallery_prefetch_coordinator_test.dart`（27 项通过）
- 受影响的 5 个画廊测试文件（70 项通过）
- `E:/flutter/bin/flutter.bat analyze lib/core/cache/online_gallery_prefetch_coordinator.dart test/core/cache/online_gallery_prefetch_coordinator_test.dart`
- `git diff --check`

## 其他

- 无生成文件、LFS 资源或 assets 变更。