### PR TITLE
fix(android): 支持直接导入 ONNX 模型压缩包

### DIFF
--- a/lib/data/services/local_onnx_model_service.dart
+++ b/lib/data/services/local_onnx_model_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:archive/archive_io.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -41,6 +42,10 @@ final localOnnxModelServiceProvider = Provider<LocalOnnxModelService>((ref) {
 class LocalOnnxModelService {
   const LocalOnnxModelService(this._storage);
 
+  static const int _archiveFileCountLimit = 64;
+  static const int _archiveExpandedBytesLimit = 4 * 1024 * 1024 * 1024;
+  static const int _archiveEntryBytesLimit = 2 * 1024 * 1024 * 1024;
+
   final LocalStorageService _storage;
 
   String get taggerDirectory =>
@@ -53,6 +58,151 @@ class LocalOnnxModelService {
   Future<String> getManagedTaggerDirectory() async {
     final supportDirectory = await getApplicationSupportDirectory();
     return p.join(supportDirectory.path, 'models', 'onnx_taggers');
+  }
+
+  Future<int> importTaggerSelections(
+    List<LocalOnnxImportSource> sources,
+  ) async {
+    if (sources.isEmpty) return 0;
+    if (!sources.any(
+      (source) => p.extension(source.name).toLowerCase() == '.zip',
+    )) {
+      return importTaggerFiles(sources);
+    }
+
+    final temporaryDirectory = await getTemporaryDirectory();
+    final extractionDirectory = Directory(
+      p.join(
+        temporaryDirectory.path,
+        'onnx-tagger-import-${DateTime.now().microsecondsSinceEpoch}',
+      ),
+    );
+    final expandedSources = <LocalOnnxImportSource>[];
+    var extractionCreated = false;
+    try {
+      for (var index = 0; index < sources.length; index++) {
+        final source = sources[index];
+        if (p.extension(source.name).toLowerCase() != '.zip') {
+          expandedSources.add(source);
+          continue;
+        }
+        extractionCreated = true;
+        expandedSources.addAll(
+          await _extractTaggerArchive(
+            source,
+            Directory(p.join(extractionDirectory.path, '$index')),
+          ),
+        );
+      }
+      return await importTaggerFiles(expandedSources);
+    } finally {
+      if (extractionCreated && await extractionDirectory.exists()) {
+        await extractionDirectory.delete(recursive: true);
+      }
+    }
+  }
+
+  Future<List<LocalOnnxImportSource>> _extractTaggerArchive(
+    LocalOnnxImportSource source,
+    Directory outputDirectory,
+  ) async {
+    final sourceFile = File(source.path);
+    if (!await sourceFile.exists()) {
+      throw FileSystemException(
+        'Selected model archive is unavailable',
+        source.path,
+      );
+    }
+
+    final input = InputFileStream(source.path);
+    late final Archive archive;
+    try {
+      archive = ZipDecoder().decodeBuffer(input);
+    } catch (error) {
+      input.closeSync();
+      throw FormatException('Invalid ONNX model ZIP: $error');
+    }
+
+    if (archive.files.isEmpty ||
+        archive.files.length > _archiveFileCountLimit) {
+      for (final entry in archive.files) {
+        entry.closeSync();
+      }
+      input.closeSync();
+      throw const FormatException('ONNX model ZIP has an invalid file count');
+    }
+
+    final extracted = <LocalOnnxImportSource>[];
+    final selectedNames = <String>{};
+    final budget = _OnnxArchiveExtractionBudget(
+      entryBytesLimit: _archiveEntryBytesLimit,
+      expandedBytesLimit: _archiveExpandedBytesLimit,
+    );
+    try {
+      for (final entry in archive.files) {
+        final source = await _extractTaggerArchiveEntry(
+          entry,
+          outputDirectory: outputDirectory,
+          selectedNames: selectedNames,
+          budget: budget,
+        );
+        if (source != null) extracted.add(source);
+      }
+    } finally {
+      for (final entry in archive.files) {
+        entry.closeSync();
+      }
+      input.closeSync();
+    }
+    if (extracted.isEmpty) {
+      throw const FormatException(
+        'ONNX model ZIP contains no supported model files',
+      );
+    }
+    return extracted;
+  }
+
+  Future<LocalOnnxImportSource?> _extractTaggerArchiveEntry(
+    ArchiveFile entry, {
+    required Directory outputDirectory,
+    required Set<String> selectedNames,
+    required _OnnxArchiveExtractionBudget budget,
+  }) async {
+    if (entry.isSymbolicLink) {
+      throw FormatException(
+        'Symbolic links are not allowed in ONNX model ZIPs: ${entry.name}',
+      );
+    }
+    if (!entry.isFile) return null;
+
+    final fileName = _sanitizeImportedFileName(entry.name);
+    if (!_isSupportedImportFile(fileName)) return null;
+    budget.reserveDeclared(entry.size, entry.name);
+    if (!selectedNames.add(fileName.toLowerCase())) {
+      throw FormatException(
+        'Duplicate model file name in ONNX model ZIP: $fileName',
+      );
+    }
+
+    await outputDirectory.create(recursive: true);
+    final outputPath = p.join(outputDirectory.path, fileName);
+    final output = OutputFileStream(outputPath, bufferSize: 64 * 1024);
+    try {
+      entry.clear();
+      entry.decompress(output);
+      await output.close();
+    } catch (error) {
+      await output.close();
+      throw FormatException(
+        'Cannot extract ${entry.name} from ONNX model ZIP: $error',
+      );
+    }
+    if (output.length != entry.size) {
+      throw FormatException(
+        'ONNX model ZIP entry has an invalid size: ${entry.name}',
+      );
+    }
+    return LocalOnnxImportSource(name: fileName, path: outputPath);
   }
 
   Future<int> importTaggerFiles(List<LocalOnnxImportSource> sources) async {
@@ -454,4 +604,25 @@ class _OnnxImportEntry {
   final File source;
   final String fileName;
   final bool hadDestination;
+}
+
+class _OnnxArchiveExtractionBudget {
+  _OnnxArchiveExtractionBudget({
+    required this.entryBytesLimit,
+    required this.expandedBytesLimit,
+  });
+
+  final int entryBytesLimit;
+  final int expandedBytesLimit;
+  var _declaredBytes = 0;
+
+  void reserveDeclared(int count, String entryName) {
+    if (count < 0 || count > entryBytesLimit) {
+      throw FormatException('ONNX model ZIP entry is too large: $entryName');
+    }
+    _declaredBytes += count;
+    if (_declaredBytes > expandedBytesLimit) {
+      throw const FormatException('Expanded ONNX model ZIP is too large');
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6340,7 +6340,7 @@
   "queue_selectTask": "Select task",
   "settings_notificationSoundImportFailed": "Couldn't import the sound. Choose the file again.",
   "settings_androidManagedStorage": "Securely managed by the system; choose a location when exporting",
-  "settings_importLocalOnnxTaggerFiles": "Import ONNX model and label files",
+  "settings_importLocalOnnxTaggerFiles": "Import ONNX model, label files, or a ZIP archive",
   "settings_localOnnxFilesImported": "Imported {count} model files",
   "@settings_localOnnxFilesImported": {"placeholders":{"count":{"type":"int"}}},
   "settings_localOnnxManagedFiles": "{count} model files in app storage",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -6363,7 +6363,7 @@
   "queue_selectTask": "タスクを選択",
   "settings_notificationSoundImportFailed": "サウンドを読み込めませんでした。ファイルを選び直してください。",
   "settings_androidManagedStorage": "システムが安全に管理します。エクスポート時に保存先を選択できます",
-  "settings_importLocalOnnxTaggerFiles": "ONNX モデルとラベルファイルをインポート",
+  "settings_importLocalOnnxTaggerFiles": "ONNX モデル、ラベルファイル、ZIP をインポート",
   "settings_localOnnxFilesImported": "モデルファイルを {count} 件インポートしました",
   "@settings_localOnnxFilesImported": {"placeholders":{"count":{"type":"int"}}},
   "settings_localOnnxManagedFiles": "アプリストレージ内のモデルファイル: {count} 件",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -23057,7 +23057,7 @@ abstract class AppLocalizations {
   /// No description provided for @settings_importLocalOnnxTaggerFiles.
   ///
   /// In en, this message translates to:
-  /// **'Import ONNX model and label files'**
+  /// **'Import ONNX model, label files, or a ZIP archive'**
   String get settings_importLocalOnnxTaggerFiles;
 
   /// No description provided for @settings_localOnnxFilesImported.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -13237,7 +13237,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settings_importLocalOnnxTaggerFiles =>
-      'Import ONNX model and label files';
+      'Import ONNX model, label files, or a ZIP archive';
 
   @override
   String settings_localOnnxFilesImported(int count) {

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -12895,7 +12895,8 @@ class AppLocalizationsJa extends AppLocalizations {
       'システムが安全に管理します。エクスポート時に保存先を選択できます';
 
   @override
-  String get settings_importLocalOnnxTaggerFiles => 'ONNX モデルとラベルファイルをインポート';
+  String get settings_importLocalOnnxTaggerFiles =>
+      'ONNX モデル、ラベルファイル、ZIP をインポート';
 
   @override
   String settings_localOnnxFilesImported(int count) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -12680,7 +12680,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_androidManagedStorage => '由系统安全管理；导出时可选择保存位置';
 
   @override
-  String get settings_importLocalOnnxTaggerFiles => '导入 ONNX 模型及标签文件';
+  String get settings_importLocalOnnxTaggerFiles => '导入 ONNX 模型、标签文件或 ZIP 压缩包';
 
   @override
   String settings_localOnnxFilesImported(int count) {
@@ -26497,7 +26497,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_androidManagedStorage => '由系統安全管理；匯出時可選擇儲存位置';
 
   @override
-  String get settings_importLocalOnnxTaggerFiles => '匯入 ONNX 模型及標籤檔案';
+  String get settings_importLocalOnnxTaggerFiles => '匯入 ONNX 模型、標籤檔案或 ZIP 壓縮檔';
 
   @override
   String settings_localOnnxFilesImported(int count) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -6409,7 +6409,7 @@
   "queue_selectTask": "选择任务",
   "settings_notificationSoundImportFailed": "无法导入音效，请重新选择文件。",
   "settings_androidManagedStorage": "由系统安全管理；导出时可选择保存位置",
-  "settings_importLocalOnnxTaggerFiles": "导入 ONNX 模型及标签文件",
+  "settings_importLocalOnnxTaggerFiles": "导入 ONNX 模型、标签文件或 ZIP 压缩包",
   "settings_localOnnxFilesImported": "已导入 {count} 个模型文件",
   "@settings_localOnnxFilesImported": {"placeholders":{"count":{"type":"int"}}},
   "settings_localOnnxManagedFiles": "应用存储中有 {count} 个模型文件",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -6684,7 +6684,7 @@
   "queue_selectTask": "選擇任務",
   "settings_notificationSoundImportFailed": "無法匯入音效，請重新選擇檔案。",
   "settings_androidManagedStorage": "由系統安全管理；匯出時可選擇儲存位置",
-  "settings_importLocalOnnxTaggerFiles": "匯入 ONNX 模型及標籤檔案",
+  "settings_importLocalOnnxTaggerFiles": "匯入 ONNX 模型、標籤檔案或 ZIP 壓縮檔",
   "settings_localOnnxFilesImported": "已匯入 {count} 個模型檔案",
   "@settings_localOnnxFilesImported": {"placeholders":{"count":{"type":"int"}}},
   "settings_localOnnxManagedFiles": "應用程式儲存空間中有 {count} 個模型檔案",

--- a/lib/presentation/screens/settings/sections/storage_settings_section.dart
+++ b/lib/presentation/screens/settings/sections/storage_settings_section.dart
@@ -88,8 +88,10 @@ class _StorageSettingsSectionState
     try {
       final selection = await FilePicker.platform.pickFiles(
         dialogTitle: context.l10n.settings_importLocalOnnxTaggerFiles,
-        type: FileType.custom,
-        allowedExtensions: const ['onnx', 'data', 'csv', 'txt', 'json'],
+        // Android maps custom extensions to MIME types before opening its
+        // document picker. ONNX and external-data extensions have no standard
+        // mapping and would be hidden, so let the service validate selections.
+        type: FileType.any,
         allowMultiple: true,
       );
       if (selection == null) return;
@@ -101,7 +103,7 @@ class _StorageSettingsSectionState
           .toList(growable: false);
       final importedCount = await ref
           .read(localOnnxModelServiceProvider)
-          .importTaggerFiles(sources);
+          .importTaggerSelections(sources);
       if (mounted) {
         setState(() {});
         AppToast.success(

--- a/test/data/services/local_onnx_model_service_test.dart
+++ b/test/data/services/local_onnx_model_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:archive/archive.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:nai_launcher/core/constants/storage_keys.dart';
@@ -25,7 +26,8 @@ void main() {
       p.join(tempDirectory.path, 'support'),
     ).create(recursive: true);
     PathProviderPlatform.instance = _TestPathProviderPlatform(
-      supportDirectory.path,
+      supportPath: supportDirectory.path,
+      temporaryPath: p.join(tempDirectory.path, 'cache'),
     );
     Hive.init(p.join(tempDirectory.path, 'hive'));
     await Hive.openBox(StorageKeys.settingsBox);
@@ -150,13 +152,102 @@ void main() {
       expect(service.taggerDirectory, isEmpty);
     },
   );
+
+  test(
+    'rejects unsupported files selected by an unrestricted picker',
+    () async {
+      final unsupported = await File(
+        p.join(tempDirectory.path, 'unrelated.zip'),
+      ).writeAsBytes([1, 2, 3]);
+
+      await expectLater(
+        service.importTaggerFiles([
+          LocalOnnxImportSource(name: 'unrelated.zip', path: unsupported.path),
+        ]),
+        throwsA(isA<FormatException>()),
+      );
+
+      final managedDirectory = Directory(
+        await service.getManagedTaggerDirectory(),
+      );
+      expect(
+        managedDirectory.existsSync() ? managedDirectory.listSync() : const [],
+        isEmpty,
+      );
+      expect(service.taggerDirectory, isEmpty);
+    },
+  );
+
+  test('imports supported model files from a ZIP archive', () async {
+    final labels = utf8.encode('name,category\ntag,0\n');
+    final archive = Archive()
+      ..addFile(ArchiveFile('tagger/model.onnx', 4, [1, 2, 3, 4]))
+      ..addFile(ArchiveFile('tagger/selected_tags.csv', labels.length, labels))
+      ..addFile(ArchiveFile('tagger/README.md', 7, utf8.encode('ignored')));
+    final zip = await File(
+      p.join(tempDirectory.path, 'tagger.zip'),
+    ).writeAsBytes(ZipEncoder().encode(archive)!);
+
+    final count = await service.importTaggerSelections([
+      LocalOnnxImportSource(name: 'tagger.zip', path: zip.path),
+    ]);
+
+    final managedDirectory = await service.getManagedTaggerDirectory();
+    expect(count, 2);
+    expect(await File(p.join(managedDirectory, 'model.onnx')).readAsBytes(), [
+      1,
+      2,
+      3,
+      4,
+    ]);
+    expect(
+      await File(p.join(managedDirectory, 'selected_tags.csv')).readAsString(),
+      contains('tag,0'),
+    );
+    expect(service.taggerDirectory, managedDirectory);
+    expect(Directory(p.join(tempDirectory.path, 'cache')).listSync(), isEmpty);
+  });
+
+  test('rejects duplicate flattened names in a ZIP archive', () async {
+    final archive = Archive()
+      ..addFile(ArchiveFile('first/model.onnx', 1, [1]))
+      ..addFile(ArchiveFile('second/model.onnx', 1, [2]));
+    final zip = await File(
+      p.join(tempDirectory.path, 'duplicate.zip'),
+    ).writeAsBytes(ZipEncoder().encode(archive)!);
+
+    await expectLater(
+      service.importTaggerSelections([
+        LocalOnnxImportSource(name: 'duplicate.zip', path: zip.path),
+      ]),
+      throwsA(isA<FormatException>()),
+    );
+
+    final managedDirectory = Directory(
+      await service.getManagedTaggerDirectory(),
+    );
+    expect(
+      managedDirectory.existsSync() ? managedDirectory.listSync() : const [],
+      isEmpty,
+    );
+  });
 }
 
 class _TestPathProviderPlatform extends PathProviderPlatform {
-  _TestPathProviderPlatform(this.supportPath);
+  _TestPathProviderPlatform({
+    required this.supportPath,
+    required this.temporaryPath,
+  });
 
   final String supportPath;
+  final String temporaryPath;
 
   @override
   Future<String?> getApplicationSupportPath() async => supportPath;
+
+  @override
+  Future<String?> getTemporaryPath() async {
+    await Directory(temporaryPath).create(recursive: true);
+    return temporaryPath;
+  }
 }

--- a/test/presentation/screens/settings/sections/storage_settings_section_test.dart
+++ b/test/presentation/screens/settings/sections/storage_settings_section_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -81,6 +82,40 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets(
+    'Android ONNX import does not hide extensions behind MIME filters',
+    (tester) async {
+      FilePicker? originalFilePicker;
+      try {
+        originalFilePicker = FilePicker.platform;
+      } catch (_) {
+        originalFilePicker = null;
+      }
+      final filePicker = _RecordingFilePicker();
+      FilePicker.platform = filePicker;
+      addTearDown(() {
+        if (originalFilePicker != null) {
+          FilePicker.platform = originalFilePicker;
+        }
+      });
+      PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+        TargetPlatform.android,
+      );
+
+      await tester.pumpWidget(_buildSubject(storage));
+      await tester.pump();
+
+      final importButton = find.byTooltip('导入 ONNX 模型、标签文件或 ZIP 压缩包');
+      expect(importButton, findsOneWidget);
+      await tester.tap(importButton);
+      await tester.pump();
+
+      expect(filePicker.type, FileType.any);
+      expect(filePicker.allowedExtensions, isNull);
+      expect(filePicker.allowMultiple, isTrue);
+    },
+  );
 
   testWidgets('聚焦数据与存储：保护模式移出，数据源缓存迁入', (tester) async {
     await tester.binding.setSurfaceSize(const Size(1000, 2400));
@@ -257,6 +292,33 @@ class _ReadyCooccurrenceService extends CooccurrenceDataPackService {
   @override
   Future<void> deleteData() async {
     state = const CooccurrenceDataPackState();
+  }
+}
+
+class _RecordingFilePicker extends FilePicker {
+  FileType? type;
+  List<String>? allowedExtensions;
+  bool? allowMultiple;
+
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    bool allowCompression = true,
+    int compressionQuality = 30,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+  }) async {
+    this.type = type;
+    this.allowedExtensions = allowedExtensions;
+    this.allowMultiple = allowMultiple;
+    return null;
   }
 }
 


### PR DESCRIPTION
## 修改内容

- 修复 Android 文件选择器因 MIME 映射缺失而隐藏 `.onnx`、`.data` 文件的问题
- 支持直接选择 ZIP 模型包，并自动导入其中的 ONNX 模型、外部数据和标签文件
- 保留原有多文件导入，继续由应用校验支持的文件类型
- 同步简体中文、繁体中文、英文和日文提示文案

## 验证

- `dart analyze lib/data/services/local_onnx_model_service.dart lib/presentation/screens/settings/sections/storage_settings_section.dart test/data/services/local_onnx_model_service_test.dart test/presentation/screens/settings/sections/storage_settings_section_test.dart`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test_affected.ps1 -Path "lib/presentation/screens/settings/sections/storage_settings_section.dart,lib/data/services/local_onnx_model_service.dart" -Include "test/presentation/screens/settings/sections/storage_settings_section_test.dart,test/data/services/local_onnx_model_service_test.dart"`（16 项通过）
- `git diff --check`

未执行 Android emulator 系统文件选择器实机验收。

Closes #216