### PR TITLE
refactor(metadata): 统一固定词快照与导入恢复

### DIFF
--- a/lib/core/utils/image_save_utils.dart
+++ b/lib/core/utils/image_save_utils.dart
@@ -5,6 +5,9 @@ import 'dart:typed_data';
 import 'package:path/path.dart' as p;
 
 import '../../data/models/gallery/nai_image_metadata.dart';
+import '../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
+import '../../data/models/fixed_tag/fixed_tag_entry.dart';
+import '../../data/models/fixed_tag/fixed_tag_prompt_type.dart';
 import '../../data/models/image/image_params.dart';
 import '../../data/services/image_metadata_service.dart';
 import '../../data/services/metadata/unified_metadata_parser.dart';
@@ -38,6 +41,7 @@ class ImageSaveUtils {
     List<String>? fixedSuffixTags,
     List<String>? fixedNegativePrefixTags,
     List<String>? fixedNegativeSuffixTags,
+    FixedTagUsageSnapshot? fixedTagUsageSnapshot,
     List<Map<String, dynamic>>? charCaptions,
     List<Map<String, dynamic>>? charNegCaptions,
     bool useCoords = false,
@@ -92,17 +96,24 @@ class ImageSaveUtils {
         'upscale': {'declared_blur_sigma': E2eUpscale.declaredBlurSigma},
     };
 
-    if (fixedPrefixTags?.isNotEmpty == true) {
-      commentJson['fixed_prefix'] = fixedPrefixTags;
+    if (fixedTagUsageSnapshot != null) {
+      commentJson['aaalice_fixed_tags'] = fixedTagUsageSnapshot.toJson();
     }
-    if (fixedSuffixTags?.isNotEmpty == true) {
-      commentJson['fixed_suffix'] = fixedSuffixTags;
+    if (fixedTagUsageSnapshot != null || fixedPrefixTags?.isNotEmpty == true) {
+      commentJson['fixed_prefix'] = fixedPrefixTags ?? const <String>[];
     }
-    if (fixedNegativePrefixTags?.isNotEmpty == true) {
-      commentJson['fixed_negative_prefix'] = fixedNegativePrefixTags;
+    if (fixedTagUsageSnapshot != null || fixedSuffixTags?.isNotEmpty == true) {
+      commentJson['fixed_suffix'] = fixedSuffixTags ?? const <String>[];
     }
-    if (fixedNegativeSuffixTags?.isNotEmpty == true) {
-      commentJson['fixed_negative_suffix'] = fixedNegativeSuffixTags;
+    if (fixedTagUsageSnapshot != null ||
+        fixedNegativePrefixTags?.isNotEmpty == true) {
+      commentJson['fixed_negative_prefix'] =
+          fixedNegativePrefixTags ?? const <String>[];
+    }
+    if (fixedTagUsageSnapshot != null ||
+        fixedNegativeSuffixTags?.isNotEmpty == true) {
+      commentJson['fixed_negative_suffix'] =
+          fixedNegativeSuffixTags ?? const <String>[];
     }
 
     // V4多角色提示词
@@ -192,6 +203,7 @@ class ImageSaveUtils {
     List<String>? fixedSuffixTags,
     List<String>? fixedNegativePrefixTags,
     List<String>? fixedNegativeSuffixTags,
+    FixedTagUsageSnapshot? fixedTagUsageSnapshot,
     List<Map<String, dynamic>>? charCaptions,
     List<Map<String, dynamic>>? charNegCaptions,
     bool useCoords = false,
@@ -223,6 +235,7 @@ class ImageSaveUtils {
       fixedSuffixTags: fixedSuffixTags,
       fixedNegativePrefixTags: fixedNegativePrefixTags,
       fixedNegativeSuffixTags: fixedNegativeSuffixTags,
+      fixedTagUsageSnapshot: fixedTagUsageSnapshot,
       charCaptions: charCaptions,
       charNegCaptions: charNegCaptions,
       useCoords: useCoords,
@@ -251,6 +264,58 @@ class ImageSaveUtils {
     );
   }
 
+  /// Adds Launcher fixed-tag provenance without replacing existing NAI fields.
+  static Future<Uint8List> mergeFixedTagUsageMetadata({
+    required Uint8List imageBytes,
+    required FixedTagUsageSnapshot snapshot,
+    bool useStealth = false,
+  }) async {
+    final existing = _extractEmbeddedPngMetadata(imageBytes);
+    if (existing?.commentJson == null) return imageBytes;
+    final commentJson = <String, dynamic>{
+      ...existing!.commentJson,
+      'aaalice_fixed_tags': snapshot.toJson(),
+      'fixed_prefix': _fixedTagContents(
+        snapshot,
+        FixedTagPromptType.positive,
+        FixedTagPosition.prefix,
+      ),
+      'fixed_suffix': _fixedTagContents(
+        snapshot,
+        FixedTagPromptType.positive,
+        FixedTagPosition.suffix,
+      ),
+      'fixed_negative_prefix': _fixedTagContents(
+        snapshot,
+        FixedTagPromptType.negative,
+        FixedTagPosition.prefix,
+      ),
+      'fixed_negative_suffix': _fixedTagContents(
+        snapshot,
+        FixedTagPromptType.negative,
+        FixedTagPosition.suffix,
+      ),
+    };
+    return _embedNaiAlignedMetadata(
+      imageBytes: imageBytes,
+      commentJson: commentJson,
+      description: existing.description,
+      source: existing.source,
+      software: existing.software,
+      useStealth: useStealth,
+    );
+  }
+
+  static List<String> _fixedTagContents(
+    FixedTagUsageSnapshot snapshot,
+    FixedTagPromptType promptType,
+    FixedTagPosition position,
+  ) => snapshot
+      .entriesFor(promptType: promptType, position: position)
+      .map((entry) => entry.renderedContent)
+      .where((content) => content.isNotEmpty)
+      .toList(growable: false);
+
   /// 保存图像并嵌入完整元数据
   ///
   /// [imageBytes] - 图像字节数据
@@ -276,6 +341,7 @@ class ImageSaveUtils {
     List<String>? fixedSuffixTags,
     List<String>? fixedNegativePrefixTags,
     List<String>? fixedNegativeSuffixTags,
+    FixedTagUsageSnapshot? fixedTagUsageSnapshot,
     List<Map<String, dynamic>>? charCaptions,
     List<Map<String, dynamic>>? charNegCaptions,
     bool useCoords = false,
@@ -290,6 +356,7 @@ class ImageSaveUtils {
       fixedSuffixTags: fixedSuffixTags,
       fixedNegativePrefixTags: fixedNegativePrefixTags,
       fixedNegativeSuffixTags: fixedNegativeSuffixTags,
+      fixedTagUsageSnapshot: fixedTagUsageSnapshot,
       charCaptions: charCaptions,
       charNegCaptions: charNegCaptions,
       useCoords: useCoords,

--- a/lib/data/models/fixed_tag/fixed_tag_entry.dart
+++ b/lib/data/models/fixed_tag/fixed_tag_entry.dart
@@ -57,6 +57,12 @@ class FixedTagEntry with _$FixedTagEntry {
     /// 如果不为 null，表示此固定词是从词库关联过来的
     String? sourceEntryId,
 
+    /// 导入的历史版本对应的原固定词 ID。
+    String? importedFromFixedTagId,
+
+    /// 历史版本对应的固定词快照指纹，用于避免重复创建。
+    String? importedSnapshotFingerprint,
+
     /// 排序顺序
     @Default(0) int sortOrder,
 
@@ -80,6 +86,8 @@ class FixedTagEntry with _$FixedTagEntry {
     FixedTagPromptType promptType = FixedTagPromptType.positive,
     String? categoryId,
     String? sourceEntryId, // 【新增】来源词库条目ID
+    String? importedFromFixedTagId,
+    String? importedSnapshotFingerprint,
     int sortOrder = 0,
   }) {
     final now = DateTime.now();
@@ -93,6 +101,8 @@ class FixedTagEntry with _$FixedTagEntry {
       promptType: promptType,
       categoryId: categoryId,
       sourceEntryId: sourceEntryId, // 【新增】
+      importedFromFixedTagId: importedFromFixedTagId,
+      importedSnapshotFingerprint: importedSnapshotFingerprint,
       sortOrder: sortOrder,
       createdAt: now,
       updatedAt: now,
@@ -177,6 +187,8 @@ class FixedTagEntry with _$FixedTagEntry {
     FixedTagPromptType? promptType,
     String? categoryId,
     String? sourceEntryId,
+    String? importedFromFixedTagId,
+    String? importedSnapshotFingerprint,
     int? sortOrder,
   }) {
     return copyWith(
@@ -188,6 +200,10 @@ class FixedTagEntry with _$FixedTagEntry {
       promptType: promptType ?? this.promptType,
       categoryId: categoryId ?? this.categoryId,
       sourceEntryId: sourceEntryId ?? this.sourceEntryId,
+      importedFromFixedTagId:
+          importedFromFixedTagId ?? this.importedFromFixedTagId,
+      importedSnapshotFingerprint:
+          importedSnapshotFingerprint ?? this.importedSnapshotFingerprint,
       sortOrder: sortOrder ?? this.sortOrder,
       updatedAt: DateTime.now(),
     );

--- a/lib/data/models/fixed_tag/fixed_tag_usage_snapshot.dart
+++ b/lib/data/models/fixed_tag/fixed_tag_usage_snapshot.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+import 'fixed_tag_entry.dart';
+import 'fixed_tag_prompt_type.dart';
+
+/// The fixed-tag configuration that was actually applied to one generation.
+class FixedTagUsageSnapshot {
+  const FixedTagUsageSnapshot({this.version = 1, this.entries = const []});
+
+  factory FixedTagUsageSnapshot.capture(Iterable<FixedTagEntry> entries) {
+    final enabled = entries.where((entry) => entry.enabled).toList()
+      ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    return FixedTagUsageSnapshot(
+      entries: [
+        for (var index = 0; index < enabled.length; index++)
+          FixedTagUsageEntry.fromFixedTag(enabled[index], order: index),
+      ],
+    );
+  }
+
+  factory FixedTagUsageSnapshot.fromJson(Map<String, dynamic> json) {
+    final rawEntries = json['entries'];
+    return FixedTagUsageSnapshot(
+      version: (json['version'] as num?)?.toInt() ?? 1,
+      entries: rawEntries is List
+          ? rawEntries
+                .whereType<Map>()
+                .map(
+                  (entry) => FixedTagUsageEntry.fromJson(
+                    Map<String, dynamic>.from(entry),
+                  ),
+                )
+                .toList(growable: false)
+          : const [],
+    );
+  }
+
+  final int version;
+  final List<FixedTagUsageEntry> entries;
+
+  Map<String, dynamic> toJson() => {
+    'version': version,
+    'entries': entries.map((entry) => entry.toJson()).toList(growable: false),
+  };
+
+  String get fingerprint =>
+      sha256.convert(utf8.encode(jsonEncode(toJson()))).toString();
+
+  List<FixedTagUsageEntry> entriesFor({
+    required FixedTagPromptType promptType,
+    required FixedTagPosition position,
+  }) => entries
+      .where(
+        (entry) => entry.promptType == promptType && entry.position == position,
+      )
+      .toList(growable: false);
+}
+
+class FixedTagUsageEntry {
+  const FixedTagUsageEntry({
+    this.fixedTagId,
+    required this.name,
+    required this.content,
+    required this.weight,
+    required this.renderedContent,
+    required this.position,
+    required this.promptType,
+    required this.order,
+  });
+
+  factory FixedTagUsageEntry.fromFixedTag(
+    FixedTagEntry entry, {
+    required int order,
+  }) => FixedTagUsageEntry(
+    fixedTagId: entry.id,
+    name: entry.name,
+    content: entry.content,
+    weight: entry.weight,
+    renderedContent: entry.weightedContent,
+    position: entry.position,
+    promptType: entry.promptType,
+    order: order,
+  );
+
+  factory FixedTagUsageEntry.legacy({
+    required String renderedContent,
+    required FixedTagPosition position,
+    required FixedTagPromptType promptType,
+    required int order,
+  }) => FixedTagUsageEntry(
+    name: renderedContent,
+    content: renderedContent,
+    weight: 1,
+    renderedContent: renderedContent,
+    position: position,
+    promptType: promptType,
+    order: order,
+  );
+
+  factory FixedTagUsageEntry.fromJson(Map<String, dynamic> json) {
+    final position = FixedTagPosition.values.firstWhere(
+      (value) => value.name == json['position'],
+      orElse: () => FixedTagPosition.prefix,
+    );
+    final promptType = FixedTagPromptType.values.firstWhere(
+      (value) => value.name == json['prompt_type'],
+      orElse: () => FixedTagPromptType.positive,
+    );
+    final content = json['content'] as String? ?? '';
+    final weight = (json['weight'] as num?)?.toDouble() ?? 1;
+    return FixedTagUsageEntry(
+      fixedTagId: json['fixed_tag_id'] as String?,
+      name: json['name'] as String? ?? content,
+      content: content,
+      weight: weight,
+      renderedContent:
+          json['rendered_content'] as String? ??
+          FixedTagEntry.applyWeight(content, weight),
+      position: position,
+      promptType: promptType,
+      order: (json['order'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  final String? fixedTagId;
+  final String name;
+  final String content;
+  final double weight;
+  final String renderedContent;
+  final FixedTagPosition position;
+  final FixedTagPromptType promptType;
+  final int order;
+
+  Map<String, dynamic> toJson() => {
+    if (fixedTagId != null) 'fixed_tag_id': fixedTagId,
+    'name': name,
+    'content': content,
+    'weight': weight,
+    'rendered_content': renderedContent,
+    'position': position.name,
+    'prompt_type': promptType.name,
+    'order': order,
+  };
+}
+
+class FixedTagScope {
+  const FixedTagScope(this.promptType, this.position);
+
+  final FixedTagPromptType promptType;
+  final FixedTagPosition position;
+
+  @override
+  bool operator ==(Object other) =>
+      other is FixedTagScope &&
+      other.promptType == promptType &&
+      other.position == position;
+
+  @override
+  int get hashCode => Object.hash(promptType, position);
+}

--- a/lib/data/models/gallery/nai_image_metadata.dart
+++ b/lib/data/models/gallery/nai_image_metadata.dart
@@ -4,6 +4,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hive/hive.dart';
 
 import '../image/image_params.dart';
+import '../fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../vibe/vibe_reference.dart';
 import 'nai_image_metadata_raw_decoder.dart';
 import 'nai_metadata_prompt_projection.dart';
@@ -173,9 +174,26 @@ class NaiImageMetadata with _$NaiImageMetadata {
 
     /// 透明背景开关（V5 起，comment 里的 tag_hint_transparent_background）
     @HiveField(38) bool? transparentBackground,
+
+    /// Launcher 写入的版本化固定词使用快照。
+    @HiveField(40) Map<String, dynamic>? fixedTagUsageData,
+
+    /// Comment 中是否明确出现过旧版 fixed_* 字段，包括空列表。
+    @HiveField(41, defaultValue: false)
+    @Default(false)
+    bool hasRecordedFixedTagFields,
   }) = _NaiImageMetadata;
 
   const NaiImageMetadata._();
+
+  FixedTagUsageSnapshot? get fixedTagUsageSnapshot {
+    final data = fixedTagUsageData;
+    if (data == null) return null;
+    return FixedTagUsageSnapshot.fromJson(data);
+  }
+
+  bool get hasExplicitFixedTagMetadata =>
+      fixedTagUsageData != null || hasRecordedFixedTagFields;
 
   /// 从 PNG Source 字段解析出的可用模型 ID。
   String? get sourceModel =>
@@ -238,6 +256,10 @@ class NaiImageMetadata with _$NaiImageMetadata {
         fixedNegativeSuffixTags: base.fixedNegativeSuffixTags.isEmpty
             ? reparsed.fixedNegativeSuffixTags
             : base.fixedNegativeSuffixTags,
+        fixedTagUsageData: base.fixedTagUsageData ?? reparsed.fixedTagUsageData,
+        hasRecordedFixedTagFields:
+            base.hasRecordedFixedTagFields ||
+            reparsed.hasRecordedFixedTagFields,
         qualityTags: base.qualityTags.isEmpty
             ? reparsed.qualityTags
             : base.qualityTags,
@@ -369,6 +391,8 @@ NaiImageMetadata _metadataFromFields(NaiImageMetadataFields fields) =>
       fixedNegativePrefixTags: fields.fixedNegativePrefixTags,
       fixedNegativeSuffixTags: fields.fixedNegativeSuffixTags,
       transparentBackground: fields.transparentBackground,
+      fixedTagUsageData: fields.fixedTagUsageData,
+      hasRecordedFixedTagFields: fields.hasRecordedFixedTagFields,
     );
 
 bool _rawJsonMayContainUpgrade(String raw) {
@@ -388,6 +412,7 @@ bool _rawJsonMayContainUpgrade(String raw) {
     'fixed_suffix',
     'fixed_negative_prefix',
     'fixed_negative_suffix',
+    'aaalice_fixed_tags',
     'v4_prompt',
     'char_captions',
   ];

--- a/lib/data/models/gallery/nai_image_metadata_raw_decoder.dart
+++ b/lib/data/models/gallery/nai_image_metadata_raw_decoder.dart
@@ -189,6 +189,8 @@ class NaiImageMetadataRawDecoder {
         fixedSuffixTags: parts['fixedSuffix'] ?? [],
         fixedNegativePrefixTags: parts['fixedNegativePrefix'] ?? [],
         fixedNegativeSuffixTags: parts['fixedNegativeSuffix'] ?? [],
+        fixedTagUsageData: _extractFixedTagUsageData(commentData),
+        hasRecordedFixedTagFields: _hasRecordedFixedTagFields(commentData),
         qualityTags: parts['qualityTags'] ?? [],
         characterInfos: characterInfos,
         characterUseCoords: characterUseCoords,
@@ -392,6 +394,24 @@ class NaiImageMetadataRawDecoder {
     }
 
     return parts;
+  }
+
+  static Map<String, dynamic>? _extractFixedTagUsageData(
+    Map<String, dynamic> commentData,
+  ) {
+    final value = commentData['aaalice_fixed_tags'];
+    if (value is Map<String, dynamic>) return Map<String, dynamic>.from(value);
+    if (value is Map) return Map<String, dynamic>.from(value);
+    return null;
+  }
+
+  static bool _hasRecordedFixedTagFields(Map<String, dynamic> commentData) {
+    return const {
+      'fixed_prefix',
+      'fixed_suffix',
+      'fixed_negative_prefix',
+      'fixed_negative_suffix',
+    }.any(commentData.containsKey);
   }
 
   /// 提取角色提示词信息
@@ -1042,6 +1062,8 @@ class NaiImageMetadataFields {
     this.fixedNegativePrefixTags = const [],
     this.fixedNegativeSuffixTags = const [],
     this.transparentBackground,
+    this.fixedTagUsageData,
+    this.hasRecordedFixedTagFields = false,
   });
 
   final String prompt;
@@ -1084,4 +1106,6 @@ class NaiImageMetadataFields {
   final List<String> fixedNegativePrefixTags;
   final List<String> fixedNegativeSuffixTags;
   final bool? transparentBackground;
+  final Map<String, dynamic>? fixedTagUsageData;
+  final bool hasRecordedFixedTagFields;
 }

--- a/lib/data/models/gallery/nai_image_metadata_raw_decoder.dart
+++ b/lib/data/models/gallery/nai_image_metadata_raw_decoder.dart
@@ -391,43 +391,7 @@ class NaiImageMetadataRawDecoder {
       parts['fixedNegativeSuffix'] = fixedNegativeSuffix.cast<String>();
     }
 
-    // 如果没有读取到，从 prompt 提取
-    final v4Prompt = commentData['v4_prompt'];
-    final promptStr = commentData['prompt'] as String? ?? '';
-
-    if (parts['fixedPrefix']!.isEmpty) {
-      if (v4Prompt is Map<String, dynamic>) {
-        final caption = v4Prompt['caption'];
-        if (caption is Map<String, dynamic>) {
-          // 支持 base_caption（NAI官方格式）和 main_caption（旧版）
-          final baseCaption =
-              caption['base_caption'] as String? ??
-              caption['main_caption'] as String? ??
-              '';
-          if (baseCaption.isNotEmpty) {
-            _mergeInferredPromptParts(parts, _extractPromptParts(baseCaption));
-            return parts;
-          }
-        }
-      }
-      if (promptStr.isNotEmpty) {
-        _mergeInferredPromptParts(parts, _extractPromptParts(promptStr));
-        return parts;
-      }
-    }
-
     return parts;
-  }
-
-  static void _mergeInferredPromptParts(
-    Map<String, List<String>> target,
-    Map<String, List<String>> inferred,
-  ) {
-    for (final key in ['fixedPrefix', 'fixedSuffix', 'qualityTags']) {
-      if (target[key]?.isEmpty == true && inferred[key]?.isNotEmpty == true) {
-        target[key] = inferred[key]!;
-      }
-    }
   }
 
   /// 提取角色提示词信息
@@ -991,83 +955,6 @@ class NaiImageMetadataRawDecoder {
     }
 
     return null;
-  }
-
-  // 常见的固定前缀词
-  static const _commonPrefixTags = [
-    'masterpiece',
-    'best quality',
-    'amazing quality',
-    'great quality',
-    'high quality',
-    'good quality',
-    'normal quality',
-    'low quality',
-    'worst quality',
-  ];
-
-  // 常见的质量/细节词
-  static const _commonQualityTags = [
-    'very aesthetic',
-    'aesthetic',
-    'highres',
-    'absurdres',
-    'incredibly absurdres',
-    'ultra-detailed',
-    'highly detailed',
-    'detailed',
-    '4k',
-    '8k',
-    'wallpaper',
-  ];
-
-  /// 从主提示词中提取各部分（固定前缀、后缀、质量词）
-  static Map<String, List<String>> _extractPromptParts(String prompt) {
-    final result = <String, List<String>>{
-      'fixedPrefix': [],
-      'fixedSuffix': [],
-      'fixedNegativePrefix': [],
-      'fixedNegativeSuffix': [],
-      'qualityTags': [],
-    };
-
-    if (prompt.isEmpty) return result;
-
-    final tags = NaiPromptParser.splitSegments(prompt);
-
-    // 识别固定前缀词（通常位于开头）
-    var prefixEnd = 0;
-    for (var i = 0; i < tags.length; i++) {
-      final tagLower = tags[i].toLowerCase();
-      if (_commonPrefixTags.any((p) => tagLower.contains(p))) {
-        prefixEnd = i + 1;
-      } else {
-        break;
-      }
-    }
-    if (prefixEnd > 0) {
-      result['fixedPrefix'] = tags.sublist(0, prefixEnd);
-    }
-
-    // 识别固定后缀词和质量词（通常位于结尾）
-    final suffixTags = <String>[];
-    final qualityTags = <String>[];
-
-    for (var i = tags.length - 1; i >= prefixEnd; i--) {
-      final tagLower = tags[i].toLowerCase();
-      if (_commonQualityTags.any((q) => tagLower.contains(q))) {
-        qualityTags.insert(0, tags[i]);
-      } else if (_commonPrefixTags.any((p) => tagLower.contains(p))) {
-        suffixTags.insert(0, tags[i]);
-      } else {
-        break;
-      }
-    }
-
-    result['fixedSuffix'] = suffixTags;
-    result['qualityTags'] = qualityTags;
-
-    return result;
   }
 }
 

--- a/lib/data/models/metadata/metadata_import_options.dart
+++ b/lib/data/models/metadata/metadata_import_options.dart
@@ -4,6 +4,8 @@ import '../gallery/nai_image_metadata.dart';
 
 part 'metadata_import_options.freezed.dart';
 
+enum UnknownFixedTagPolicy { disableCurrent, keepCurrent }
+
 /// 元数据导入选项模型
 ///
 /// 用于选择性地套用图片元数据中的参数
@@ -18,6 +20,10 @@ class MetadataImportOptions with _$MetadataImportOptions {
     @Default(true) bool importFixedTags,
     @Default(true) bool importFixedPrefix,
     @Default(true) bool importFixedSuffix,
+    @Default(true) bool importFixedNegativePrefix,
+    @Default(true) bool importFixedNegativeSuffix,
+    @Default(UnknownFixedTagPolicy.disableCurrent)
+    UnknownFixedTagPolicy unknownFixedTagPolicy,
 
     // 质量词
     @Default(true) bool importQualityTags,
@@ -106,6 +112,8 @@ class MetadataImportOptions with _$MetadataImportOptions {
     importFixedTags: false,
     importFixedPrefix: false,
     importFixedSuffix: false,
+    importFixedNegativePrefix: false,
+    importFixedNegativeSuffix: false,
     importQualityTags: false,
     importCharacterPrompts: false,
     importVibeReferences: true,
@@ -133,6 +141,8 @@ class MetadataImportOptions with _$MetadataImportOptions {
     importFixedTags: false,
     importFixedPrefix: false,
     importFixedSuffix: false,
+    importFixedNegativePrefix: false,
+    importFixedNegativeSuffix: false,
     importQualityTags: false,
     importCharacterPrompts: false,
     importVibeReferences: false,
@@ -164,14 +174,25 @@ class MetadataImportOptions with _$MetadataImportOptions {
     if (importNegativePrompt && metadata.negativePrompt.isNotEmpty) count++;
 
     final hasSelectedFixedPrefix =
-        importFixedPrefix &&
-        (metadata.fixedPrefixTags.isNotEmpty ||
-            metadata.fixedNegativePrefixTags.isNotEmpty);
+        importFixedPrefix && metadata.fixedPrefixTags.isNotEmpty;
     final hasSelectedFixedSuffix =
-        importFixedSuffix &&
-        (metadata.fixedSuffixTags.isNotEmpty ||
-            metadata.fixedNegativeSuffixTags.isNotEmpty);
-    if (importFixedTags && (hasSelectedFixedPrefix || hasSelectedFixedSuffix)) {
+        importFixedSuffix && metadata.fixedSuffixTags.isNotEmpty;
+    final hasSelectedNegativeFixedPrefix =
+        importFixedNegativePrefix &&
+        metadata.fixedNegativePrefixTags.isNotEmpty;
+    final hasSelectedNegativeFixedSuffix =
+        importFixedNegativeSuffix &&
+        metadata.fixedNegativeSuffixTags.isNotEmpty;
+    if (importFixedTags &&
+        (hasSelectedFixedPrefix ||
+            hasSelectedFixedSuffix ||
+            hasSelectedNegativeFixedPrefix ||
+            hasSelectedNegativeFixedSuffix ||
+            (metadata.hasExplicitFixedTagMetadata &&
+                (importFixedPrefix ||
+                    importFixedSuffix ||
+                    importFixedNegativePrefix ||
+                    importFixedNegativeSuffix)))) {
       count++;
     }
 
@@ -236,7 +257,13 @@ class MetadataImportOptions with _$MetadataImportOptions {
     var count = 0;
     if (importPrompt) count++;
     if (importNegativePrompt) count++;
-    if (importFixedTags && (importFixedPrefix || importFixedSuffix)) count++;
+    if (importFixedTags &&
+        (importFixedPrefix ||
+            importFixedSuffix ||
+            importFixedNegativePrefix ||
+            importFixedNegativeSuffix)) {
+      count++;
+    }
     if (importQualityTags && selectedQualityTags.isNotEmpty) count++;
     if (importCharacterPrompts && selectedCharacterIndices.isNotEmpty) count++;
     if (importVibeReferences && selectedVibeIndices.isNotEmpty) count++;
@@ -270,7 +297,11 @@ class MetadataImportOptions with _$MetadataImportOptions {
   bool get isImportingAnyPrompt =>
       importPrompt ||
       importNegativePrompt ||
-      (importFixedTags && (importFixedPrefix || importFixedSuffix)) ||
+      (importFixedTags &&
+          (importFixedPrefix ||
+              importFixedSuffix ||
+              importFixedNegativePrefix ||
+              importFixedNegativeSuffix)) ||
       (importQualityTags && selectedQualityTags.isNotEmpty) ||
       (importCharacterPrompts && selectedCharacterIndices.isNotEmpty);
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3733,6 +3733,15 @@
   "metadataImport_clear": "Clear",
   "metadataImport_mainPrompt": "Main Prompt",
   "metadataImport_fixedTags": "Fixed Tags",
+  "metadataImport_fixedSourceStructured": "Source: explicitly recorded by the image",
+  "metadataImport_fixedSourceLegacy": "Source: legacy image fields",
+  "metadataImport_fixedSourceLibrary": "Source: exact match from the current fixed-tag library",
+  "metadataImport_fixedSourceUnknown": "Source: not recorded; cannot be determined",
+  "metadataImport_unknownFixedTagsHint": "This image does not record fixed tags. Choose how to handle the currently enabled fixed tags.",
+  "metadataImport_disableCurrentFixedTags": "Disable current fixed tags (recommended)",
+  "metadataImport_keepCurrentFixedTags": "Keep and stack with the image prompt",
+  "metadataImport_imageVersionName": "{name} (image version)",
+  "@metadataImport_imageVersionName": {"placeholders": {"name": {}}},
   "metadataImport_fixedPrefix": "Prefix: {text}",
   "@metadataImport_fixedPrefix": {
     "placeholders": {
@@ -3941,8 +3950,8 @@
     }
   },
   "drop_addedToCharacterRef": "Added to Precise Reference",
-  "drop_extractMetadata": "Extract Metadata",
-  "drop_extractMetadataSubtitle": "Read Prompt, Seed and other parameters from image",
+  "drop_extractMetadata": "Send to Text to Image",
+  "drop_extractMetadataSubtitle": "Choose prompts, fixed tags, and generation parameters to apply",
   "drop_addToQueue": "Add to Queue",
   "drop_addToQueueSubtitle": "Extract prompt and add to generation queue",
   "drop_vibeDetected": "Pre-encoded Vibe detected (saves 2 Anlas)",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3660,6 +3660,15 @@
   "metadataImport_clear": "クリア",
   "metadataImport_mainPrompt": "メイン プロンプト",
   "metadataImport_fixedTags": "固定タグ",
+  "metadataImport_fixedSourceStructured": "ソース：画像に明示的に記録",
+  "metadataImport_fixedSourceLegacy": "ソース：旧形式の画像フィールド",
+  "metadataImport_fixedSourceLibrary": "ソース：現在の固定タグライブラリとの完全一致",
+  "metadataImport_fixedSourceUnknown": "ソース：記録がなく判別不能",
+  "metadataImport_unknownFixedTagsHint": "この画像には固定タグの記録がありません。現在有効な固定タグの扱いを選択してください。",
+  "metadataImport_disableCurrentFixedTags": "現在の固定タグを無効にする（推奨）",
+  "metadataImport_keepCurrentFixedTags": "保持して画像プロンプトに重ねる",
+  "metadataImport_imageVersionName": "{name}（画像バージョン）",
+  "@metadataImport_imageVersionName": {"placeholders": {"name": {}}},
   "metadataImport_fixedPrefix": "プレフィックス: {text}",
   "@metadataImport_fixedPrefix": {
     "placeholders": {
@@ -3887,8 +3896,8 @@
     }
   },
   "drop_addedToCharacterRef": "精密参照に追加しました",
-  "drop_extractMetadata": "メタデータの抽出",
-  "drop_extractMetadataSubtitle": "画像からプロンプト、シード、その他のパラメーターを読み取ります",
+  "drop_extractMetadata": "テキストから画像へ送信",
+  "drop_extractMetadataSubtitle": "適用するプロンプト、固定タグ、生成パラメータを選択します",
   "drop_addToQueue": "キューに追加",
   "drop_addToQueueSubtitle": "プロンプトを抽出して生成キューに追加します",
   "drop_vibeDetected": "事前にエンコードされた Vibe を検出しました (2 Anlas を節約)",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -14393,6 +14393,54 @@ abstract class AppLocalizations {
   /// **'Fixed Tags'**
   String get metadataImport_fixedTags;
 
+  /// No description provided for @metadataImport_fixedSourceStructured.
+  ///
+  /// In en, this message translates to:
+  /// **'Source: explicitly recorded by the image'**
+  String get metadataImport_fixedSourceStructured;
+
+  /// No description provided for @metadataImport_fixedSourceLegacy.
+  ///
+  /// In en, this message translates to:
+  /// **'Source: legacy image fields'**
+  String get metadataImport_fixedSourceLegacy;
+
+  /// No description provided for @metadataImport_fixedSourceLibrary.
+  ///
+  /// In en, this message translates to:
+  /// **'Source: exact match from the current fixed-tag library'**
+  String get metadataImport_fixedSourceLibrary;
+
+  /// No description provided for @metadataImport_fixedSourceUnknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Source: not recorded; cannot be determined'**
+  String get metadataImport_fixedSourceUnknown;
+
+  /// No description provided for @metadataImport_unknownFixedTagsHint.
+  ///
+  /// In en, this message translates to:
+  /// **'This image does not record fixed tags. Choose how to handle the currently enabled fixed tags.'**
+  String get metadataImport_unknownFixedTagsHint;
+
+  /// No description provided for @metadataImport_disableCurrentFixedTags.
+  ///
+  /// In en, this message translates to:
+  /// **'Disable current fixed tags (recommended)'**
+  String get metadataImport_disableCurrentFixedTags;
+
+  /// No description provided for @metadataImport_keepCurrentFixedTags.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep and stack with the image prompt'**
+  String get metadataImport_keepCurrentFixedTags;
+
+  /// No description provided for @metadataImport_imageVersionName.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} (image version)'**
+  String metadataImport_imageVersionName(Object name);
+
   /// No description provided for @metadataImport_fixedPrefix.
   ///
   /// In en, this message translates to:
@@ -15145,13 +15193,13 @@ abstract class AppLocalizations {
   /// No description provided for @drop_extractMetadata.
   ///
   /// In en, this message translates to:
-  /// **'Extract Metadata'**
+  /// **'Send to Text to Image'**
   String get drop_extractMetadata;
 
   /// No description provided for @drop_extractMetadataSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Read Prompt, Seed and other parameters from image'**
+  /// **'Choose prompts, fixed tags, and generation parameters to apply'**
   String get drop_extractMetadataSubtitle;
 
   /// No description provided for @drop_addToQueue.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8104,6 +8104,38 @@ class AppLocalizationsEn extends AppLocalizations {
   String get metadataImport_fixedTags => 'Fixed Tags';
 
   @override
+  String get metadataImport_fixedSourceStructured =>
+      'Source: explicitly recorded by the image';
+
+  @override
+  String get metadataImport_fixedSourceLegacy => 'Source: legacy image fields';
+
+  @override
+  String get metadataImport_fixedSourceLibrary =>
+      'Source: exact match from the current fixed-tag library';
+
+  @override
+  String get metadataImport_fixedSourceUnknown =>
+      'Source: not recorded; cannot be determined';
+
+  @override
+  String get metadataImport_unknownFixedTagsHint =>
+      'This image does not record fixed tags. Choose how to handle the currently enabled fixed tags.';
+
+  @override
+  String get metadataImport_disableCurrentFixedTags =>
+      'Disable current fixed tags (recommended)';
+
+  @override
+  String get metadataImport_keepCurrentFixedTags =>
+      'Keep and stack with the image prompt';
+
+  @override
+  String metadataImport_imageVersionName(Object name) {
+    return '$name (image version)';
+  }
+
+  @override
   String metadataImport_fixedPrefix(Object text) {
     return 'Prefix: $text';
   }
@@ -8515,11 +8547,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get drop_addedToCharacterRef => 'Added to Precise Reference';
 
   @override
-  String get drop_extractMetadata => 'Extract Metadata';
+  String get drop_extractMetadata => 'Send to Text to Image';
 
   @override
   String get drop_extractMetadataSubtitle =>
-      'Read Prompt, Seed and other parameters from image';
+      'Choose prompts, fixed tags, and generation parameters to apply';
 
   @override
   String get drop_addToQueue => 'Add to Queue';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -7910,6 +7910,33 @@ class AppLocalizationsJa extends AppLocalizations {
   String get metadataImport_fixedTags => '固定タグ';
 
   @override
+  String get metadataImport_fixedSourceStructured => 'ソース：画像に明示的に記録';
+
+  @override
+  String get metadataImport_fixedSourceLegacy => 'ソース：旧形式の画像フィールド';
+
+  @override
+  String get metadataImport_fixedSourceLibrary => 'ソース：現在の固定タグライブラリとの完全一致';
+
+  @override
+  String get metadataImport_fixedSourceUnknown => 'ソース：記録がなく判別不能';
+
+  @override
+  String get metadataImport_unknownFixedTagsHint =>
+      'この画像には固定タグの記録がありません。現在有効な固定タグの扱いを選択してください。';
+
+  @override
+  String get metadataImport_disableCurrentFixedTags => '現在の固定タグを無効にする（推奨）';
+
+  @override
+  String get metadataImport_keepCurrentFixedTags => '保持して画像プロンプトに重ねる';
+
+  @override
+  String metadataImport_imageVersionName(Object name) {
+    return '$name（画像バージョン）';
+  }
+
+  @override
   String metadataImport_fixedPrefix(Object text) {
     return 'プレフィックス: $text';
   }
@@ -8318,10 +8345,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get drop_addedToCharacterRef => '精密参照に追加しました';
 
   @override
-  String get drop_extractMetadata => 'メタデータの抽出';
+  String get drop_extractMetadata => 'テキストから画像へ送信';
 
   @override
-  String get drop_extractMetadataSubtitle => '画像からプロンプト、シード、その他のパラメーターを読み取ります';
+  String get drop_extractMetadataSubtitle => '適用するプロンプト、固定タグ、生成パラメータを選択します';
 
   @override
   String get drop_addToQueue => 'キューに追加';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7789,6 +7789,33 @@ class AppLocalizationsZh extends AppLocalizations {
   String get metadataImport_fixedTags => '固定词';
 
   @override
+  String get metadataImport_fixedSourceStructured => '来源：图片明确记录';
+
+  @override
+  String get metadataImport_fixedSourceLegacy => '来源：旧版图片字段';
+
+  @override
+  String get metadataImport_fixedSourceLibrary => '来源：根据当前固定词库严格匹配';
+
+  @override
+  String get metadataImport_fixedSourceUnknown => '来源：图片未记录，无法确认';
+
+  @override
+  String get metadataImport_unknownFixedTagsHint =>
+      '图片没有记录固定词。请选择如何处理当前已启用的固定词。';
+
+  @override
+  String get metadataImport_disableCurrentFixedTags => '关闭当前固定词（推荐）';
+
+  @override
+  String get metadataImport_keepCurrentFixedTags => '保留并与图片提示词叠加';
+
+  @override
+  String metadataImport_imageVersionName(Object name) {
+    return '$name（图像版本）';
+  }
+
+  @override
   String metadataImport_fixedPrefix(Object text) {
     return '前缀: $text';
   }
@@ -8196,10 +8223,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get drop_addedToCharacterRef => '已添加到精准参考';
 
   @override
-  String get drop_extractMetadata => '提取元数据';
+  String get drop_extractMetadata => '发送到文生图';
 
   @override
-  String get drop_extractMetadataSubtitle => '读取图片中的 Prompt、Seed 等参数';
+  String get drop_extractMetadataSubtitle => '选择要套用的提示词、固定词和生成参数';
 
   @override
   String get drop_addToQueue => '加入队列';
@@ -21606,6 +21633,33 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get metadataImport_fixedTags => '固定詞';
 
   @override
+  String get metadataImport_fixedSourceStructured => '來源：圖片明確記錄';
+
+  @override
+  String get metadataImport_fixedSourceLegacy => '來源：舊版圖片欄位';
+
+  @override
+  String get metadataImport_fixedSourceLibrary => '來源：根據目前固定詞庫嚴格匹配';
+
+  @override
+  String get metadataImport_fixedSourceUnknown => '來源：圖片未記錄，無法確認';
+
+  @override
+  String get metadataImport_unknownFixedTagsHint =>
+      '圖片沒有記錄固定詞。請選擇如何處理目前已啟用的固定詞。';
+
+  @override
+  String get metadataImport_disableCurrentFixedTags => '關閉目前固定詞（推薦）';
+
+  @override
+  String get metadataImport_keepCurrentFixedTags => '保留並與圖片提示詞疊加';
+
+  @override
+  String metadataImport_imageVersionName(Object name) {
+    return '$name（圖片版本）';
+  }
+
+  @override
   String metadataImport_fixedPrefix(Object text) {
     return '字首: $text';
   }
@@ -22013,10 +22067,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get drop_addedToCharacterRef => '已新增到精準參考';
 
   @override
-  String get drop_extractMetadata => '提取後設資料';
+  String get drop_extractMetadata => '傳送到文生圖';
 
   @override
-  String get drop_extractMetadataSubtitle => '讀取圖片中的 Prompt、Seed 等引數';
+  String get drop_extractMetadataSubtitle => '選擇要套用的提示詞、固定詞和生成引數';
 
   @override
   String get drop_addToQueue => '加入佇列';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1880,8 +1880,8 @@
     }
   },
   "drop_addedToCharacterRef": "已添加到精准参考",
-  "drop_extractMetadata": "提取元数据",
-  "drop_extractMetadataSubtitle": "读取图片中的 Prompt、Seed 等参数",
+  "drop_extractMetadata": "发送到文生图",
+  "drop_extractMetadataSubtitle": "选择要套用的提示词、固定词和生成参数",
   "drop_addToQueue": "加入队列",
   "drop_addToQueueSubtitle": "提取正面提示词并加入生成队列",
   "drop_vibeDetected": "检测到预编码 Vibe（可节省 2 Anlas）",
@@ -3756,6 +3756,15 @@
   "metadataImport_clear": "清空",
   "metadataImport_mainPrompt": "主提示词",
   "metadataImport_fixedTags": "固定词",
+  "metadataImport_fixedSourceStructured": "来源：图片明确记录",
+  "metadataImport_fixedSourceLegacy": "来源：旧版图片字段",
+  "metadataImport_fixedSourceLibrary": "来源：根据当前固定词库严格匹配",
+  "metadataImport_fixedSourceUnknown": "来源：图片未记录，无法确认",
+  "metadataImport_unknownFixedTagsHint": "图片没有记录固定词。请选择如何处理当前已启用的固定词。",
+  "metadataImport_disableCurrentFixedTags": "关闭当前固定词（推荐）",
+  "metadataImport_keepCurrentFixedTags": "保留并与图片提示词叠加",
+  "metadataImport_imageVersionName": "{name}（图像版本）",
+  "@metadataImport_imageVersionName": {"placeholders": {"name": {}}},
   "metadataImport_fixedPrefix": "前缀: {text}",
   "@metadataImport_fixedPrefix": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1909,8 +1909,8 @@
     }
   },
   "drop_addedToCharacterRef": "已新增到精準參考",
-  "drop_extractMetadata": "提取後設資料",
-  "drop_extractMetadataSubtitle": "讀取圖片中的 Prompt、Seed 等引數",
+  "drop_extractMetadata": "傳送到文生圖",
+  "drop_extractMetadataSubtitle": "選擇要套用的提示詞、固定詞和生成引數",
   "drop_addToQueue": "加入佇列",
   "drop_addToQueueSubtitle": "提取正面提示詞並加入生成佇列",
   "drop_vibeDetected": "檢測到預編碼 Vibe（可節省 2 Anlas）",
@@ -3751,6 +3751,15 @@
   "metadataImport_clear": "清空",
   "metadataImport_mainPrompt": "主提示詞",
   "metadataImport_fixedTags": "固定詞",
+  "metadataImport_fixedSourceStructured": "來源：圖片明確記錄",
+  "metadataImport_fixedSourceLegacy": "來源：舊版圖片欄位",
+  "metadataImport_fixedSourceLibrary": "來源：根據目前固定詞庫嚴格匹配",
+  "metadataImport_fixedSourceUnknown": "來源：圖片未記錄，無法確認",
+  "metadataImport_unknownFixedTagsHint": "圖片沒有記錄固定詞。請選擇如何處理目前已啟用的固定詞。",
+  "metadataImport_disableCurrentFixedTags": "關閉目前固定詞（推薦）",
+  "metadataImport_keepCurrentFixedTags": "保留並與圖片提示詞疊加",
+  "metadataImport_imageVersionName": "{name}（圖片版本）",
+  "@metadataImport_imageVersionName": {"placeholders": {"name": {}}},
   "metadataImport_fixedPrefix": "字首: {text}",
   "@metadataImport_fixedPrefix": {
     "placeholders": {

--- a/lib/presentation/providers/fixed_tags_provider.dart
+++ b/lib/presentation/providers/fixed_tags_provider.dart
@@ -6,6 +6,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../core/storage/local_storage_service.dart';
 import '../../core/utils/app_logger.dart';
 import '../../data/models/fixed_tag/fixed_tag_entry.dart';
+import '../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../../data/models/fixed_tag/fixed_tag_link.dart';
 import '../../data/models/fixed_tag/fixed_tag_prompt_type.dart';
 import '../../data/models/tag_library/tag_library_entry.dart';
@@ -620,6 +621,84 @@ class FixedTagsNotifier extends _$FixedTagsNotifier {
 
     AppLogger.d('Added fixed tag: ${entry.displayName}', 'FixedTagsProvider');
     return entry;
+  }
+
+  /// Atomically restores the enabled entries for the selected prompt scopes.
+  Future<void> restoreUsageSnapshot({
+    required FixedTagUsageSnapshot snapshot,
+    required Set<FixedTagScope> scopes,
+    required String Function(String name) buildImageVersionName,
+  }) async {
+    if (scopes.isEmpty) return;
+
+    final now = DateTime.now();
+    final fingerprint = snapshot.fingerprint;
+    final nextEntries = [
+      for (final entry in state.entries)
+        if (scopes.contains(FixedTagScope(entry.promptType, entry.position)) &&
+            entry.enabled)
+          entry.copyWith(enabled: false, updatedAt: now)
+        else
+          entry,
+    ];
+
+    for (final usage in snapshot.entries) {
+      final scope = FixedTagScope(usage.promptType, usage.position);
+      if (!scopes.contains(scope) || usage.content.trim().isEmpty) continue;
+
+      final originalIndex = usage.fixedTagId == null
+          ? -1
+          : nextEntries.indexWhere((entry) => entry.id == usage.fixedTagId);
+      final hasChangedOriginal =
+          originalIndex >= 0 &&
+          !_matchesUsage(nextEntries[originalIndex], usage);
+      var index = hasChangedOriginal ? -1 : originalIndex;
+      if (hasChangedOriginal) {
+        index = nextEntries.indexWhere(
+          (entry) =>
+              entry.importedFromFixedTagId == usage.fixedTagId &&
+              entry.importedSnapshotFingerprint == fingerprint &&
+              _matchesUsage(entry, usage),
+        );
+      }
+      if (index < 0 && !hasChangedOriginal) {
+        index = nextEntries.indexWhere((entry) => _matchesUsage(entry, usage));
+      }
+
+      if (index >= 0) {
+        nextEntries[index] = nextEntries[index].copyWith(
+          enabled: true,
+          updatedAt: now,
+        );
+        continue;
+      }
+
+      nextEntries.add(
+        FixedTagEntry.create(
+          name: hasChangedOriginal
+              ? buildImageVersionName(usage.name)
+              : usage.name,
+          content: usage.content,
+          weight: usage.weight,
+          position: usage.position,
+          promptType: usage.promptType,
+          enabled: true,
+          importedFromFixedTagId: hasChangedOriginal ? usage.fixedTagId : null,
+          importedSnapshotFingerprint: hasChangedOriginal ? fingerprint : null,
+          sortOrder: nextEntries.length,
+        ),
+      );
+    }
+
+    _commitState(state.copyWith(entries: nextEntries));
+    await _saveEntries();
+  }
+
+  static bool _matchesUsage(FixedTagEntry entry, FixedTagUsageEntry usage) {
+    return entry.promptType == usage.promptType &&
+        entry.position == usage.position &&
+        entry.content.trim() == usage.content.trim() &&
+        (entry.weight - usage.weight).abs() < 0.000001;
   }
 
   /// 更新固定词

--- a/lib/presentation/providers/generation/generation_models.dart
+++ b/lib/presentation/providers/generation/generation_models.dart
@@ -6,6 +6,7 @@ import 'package:uuid/uuid.dart';
 import '../../../core/constants/api_constants.dart';
 import '../../../core/utils/nai_resolution_adapter.dart';
 import '../../../data/models/gallery/nai_image_metadata.dart';
+import '../../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../../../data/models/image/image_stream_chunk.dart';
 
 enum GeneratedImageKind { completed, failedStreamSnapshot }
@@ -86,6 +87,7 @@ class GeneratedImage {
   final int height;
   final GeneratedImageKind kind;
   final NaiImageMetadata? metadata;
+  final FixedTagUsageSnapshot? fixedTagUsageSnapshot;
 
   /// Source captured for a supported current-session transformation.
   ///
@@ -107,6 +109,7 @@ class GeneratedImage {
     DateTime? createdAt,
     this.kind = GeneratedImageKind.completed,
     this.metadata,
+    this.fixedTagUsageSnapshot,
     this.comparisonSource,
     this.preserveOriginalBytesOnSave = false,
     this.filePath,
@@ -119,6 +122,7 @@ class GeneratedImage {
     required int height,
     GeneratedImageKind kind = GeneratedImageKind.completed,
     NaiImageMetadata? metadata,
+    FixedTagUsageSnapshot? fixedTagUsageSnapshot,
     ImageComparisonSource? comparisonSource,
     bool preserveOriginalBytesOnSave = false,
   }) {
@@ -130,6 +134,7 @@ class GeneratedImage {
       height: encodedSize?.$2 ?? height,
       kind: kind,
       metadata: metadata,
+      fixedTagUsageSnapshot: fixedTagUsageSnapshot,
       comparisonSource: comparisonSource,
       preserveOriginalBytesOnSave: preserveOriginalBytesOnSave,
     );
@@ -145,6 +150,7 @@ class GeneratedImage {
       createdAt: createdAt,
       kind: kind,
       metadata: metadata,
+      fixedTagUsageSnapshot: fixedTagUsageSnapshot,
       comparisonSource: comparisonSource,
       preserveOriginalBytesOnSave: preserveOriginalBytesOnSave,
       filePath: path,

--- a/lib/presentation/providers/generation/generation_request_preparation_service.dart
+++ b/lib/presentation/providers/generation/generation_request_preparation_service.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import '../../../core/utils/character_prompt_block_parser.dart';
 import '../../../core/utils/prompt_preset_resolution.dart';
 import '../../../data/models/image/image_params.dart';
+import '../../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 
 class GenerationPromptPreparation {
   const GenerationPromptPreparation({
@@ -13,6 +14,7 @@ class GenerationPromptPreparation {
     required this.applyFixedPositiveTags,
     required this.applyFixedNegativeTags,
     required this.resolvePresets,
+    required this.fixedTagUsageSnapshot,
   });
 
   final bool randomModeEnabled;
@@ -22,6 +24,7 @@ class GenerationPromptPreparation {
   final String Function(String prompt) applyFixedPositiveTags;
   final String Function(String prompt) applyFixedNegativeTags;
   final PromptPresetResolution Function(ImageParams params) resolvePresets;
+  final FixedTagUsageSnapshot fixedTagUsageSnapshot;
 
   bool get randomModeActive => randomModeEnabled && !queueExecuting;
 }
@@ -85,11 +88,13 @@ class GenerationPreparationResult {
     required this.params,
     required this.randomModeActive,
     required this.focusedSnapshot,
+    required this.fixedTagUsageSnapshot,
   });
 
   final ImageParams params;
   final bool randomModeActive;
   final GenerationFocusedSnapshot focusedSnapshot;
+  final FixedTagUsageSnapshot fixedTagUsageSnapshot;
 }
 
 /// Produces request snapshots without reading Riverpod or writing UI state.
@@ -151,6 +156,7 @@ class GenerationRequestPreparationService {
       params: effective,
       randomModeActive: promptPreparation.randomModeActive,
       focusedSnapshot: dependencies.focused.read(),
+      fixedTagUsageSnapshot: promptPreparation.fixedTagUsageSnapshot,
     );
   }
 

--- a/lib/presentation/providers/generation/generation_result_lifecycle_service.dart
+++ b/lib/presentation/providers/generation/generation_result_lifecycle_service.dart
@@ -8,6 +8,7 @@ import '../../../core/utils/app_logger.dart';
 import '../../../core/utils/image_save_utils.dart';
 import '../../../core/utils/nai_resolution_adapter.dart';
 import '../../../data/models/image/image_params.dart';
+import '../../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../../../data/services/image_metadata_service.dart';
 import '../../services/generation_history_storage_service.dart';
 import 'generation_models.dart';
@@ -37,6 +38,7 @@ class GenerationSaveSnapshot {
     this.fixedSuffixTags = const [],
     this.fixedNegativePrefixTags = const [],
     this.fixedNegativeSuffixTags = const [],
+    this.fixedTagUsageSnapshot,
     this.useCoords = false,
   });
 
@@ -44,6 +46,7 @@ class GenerationSaveSnapshot {
   final List<String> fixedSuffixTags;
   final List<String> fixedNegativePrefixTags;
   final List<String> fixedNegativeSuffixTags;
+  final FixedTagUsageSnapshot? fixedTagUsageSnapshot;
   final bool useCoords;
 }
 
@@ -197,8 +200,15 @@ class GenerationResultLifecycleService {
             actualSeed = Random().nextInt(4294967295);
           }
         }
-        final bytes = image.preserveOriginalBytesOnSave || hasMetadata
+        final fixedTagUsageSnapshot =
+            image.fixedTagUsageSnapshot ?? snapshot.fixedTagUsageSnapshot;
+        final bytes = image.preserveOriginalBytesOnSave
             ? image.bytes
+            : hasMetadata && fixedTagUsageSnapshot != null
+            ? await ImageSaveUtils.mergeFixedTagUsageMetadata(
+                imageBytes: image.bytes,
+                snapshot: fixedTagUsageSnapshot,
+              )
             : await ImageSaveUtils.rebuildImageBytesWithMetadata(
                 imageBytes: image.bytes,
                 params: params.copyWith(
@@ -210,6 +220,7 @@ class GenerationResultLifecycleService {
                 fixedSuffixTags: snapshot.fixedSuffixTags,
                 fixedNegativePrefixTags: snapshot.fixedNegativePrefixTags,
                 fixedNegativeSuffixTags: snapshot.fixedNegativeSuffixTags,
+                fixedTagUsageSnapshot: fixedTagUsageSnapshot,
                 charCaptions: charCaptions,
                 charNegCaptions: charNegCaptions,
                 useCoords: snapshot.useCoords,

--- a/lib/presentation/providers/image_generation_provider.dart
+++ b/lib/presentation/providers/image_generation_provider.dart
@@ -24,6 +24,8 @@ import '../../core/utils/prompt_preset_resolution.dart';
 import '../../data/datasources/remote/nai_image_generation_api_service.dart';
 import '../../data/models/character/character_prompt.dart' as ui_character;
 import '../../data/models/fixed_tag/fixed_tag_entry.dart';
+import '../../data/models/fixed_tag/fixed_tag_prompt_type.dart';
+import '../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../../data/models/gallery/nai_image_metadata.dart';
 import '../../data/models/image/image_params.dart';
 import '../../data/models/image/image_stream_chunk.dart';
@@ -98,6 +100,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
   final Map<String, _RememberedStreamPreview> _streamPreviews = {};
   final Set<String> _failedSnapshotKeys = {};
   ImageComparisonSource? _activeComparisonSource;
+  FixedTagUsageSnapshot? _activeFixedTagUsageSnapshot;
   bool _isDisposed = false;
   int _lifecycleEpoch = 0;
 
@@ -371,6 +374,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
       }
       final runId = ++_runCounter;
       _activeRunId = runId;
+      _activeFixedTagUsageSnapshot = prepared.fixedTagUsageSnapshot;
       _streamPreviews.clear();
       _failedSnapshotKeys.clear();
       final coordinator = ImageGenerationCoordinator(
@@ -403,6 +407,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         _activeInvocationId = 0;
         _generationInvocationStarting = false;
         _activeComparisonSource = null;
+        _activeFixedTagUsageSnapshot = null;
       }
       if (!invocationSettled.isCompleted) {
         invocationSettled.complete();
@@ -463,6 +468,9 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
           applyFixedPositiveTags: fixedTags.applyToPrompt,
           applyFixedNegativeTags: fixedTags.applyToNegativePrompt,
           resolvePresets: _resolvePromptPresets,
+          fixedTagUsageSnapshot: FixedTagUsageSnapshot.capture(
+            fixedTags.entries,
+          ),
         ),
         characters: GenerationCharacterPreparation(
           read: (_) {
@@ -589,6 +597,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
                 width: params.width,
                 height: params.height,
                 comparisonSource: _activeComparisonSource,
+                fixedTagUsageSnapshot: _activeFixedTagUsageSnapshot,
               ),
             )
             .toList();
@@ -718,6 +727,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         width: size.$1,
         height: size.$2,
         kind: GeneratedImageKind.failedStreamSnapshot,
+        fixedTagUsageSnapshot: _activeFixedTagUsageSnapshot,
         metadata: _metadataFromParams(
           preview.params,
           outputWidth: size.$1,
@@ -921,32 +931,45 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     if (!_isCurrentLifecycle(epoch)) {
       return GenerationSaveResult(images, const []);
     }
-    final fixed = ref.read(fixedTagsNotifierProvider);
+    final fixedTagUsageSnapshot =
+        (images.isEmpty ? null : images.first.fixedTagUsageSnapshot) ??
+        FixedTagUsageSnapshot.capture(
+          ref.read(fixedTagsNotifierProvider).entries,
+        );
     final lifecycle = _lifecycle();
     final result = await lifecycle.saveImages(
       images,
       params,
       snapshot: GenerationSaveSnapshot(
-        fixedPrefixTags: fixed.enabledPrefixes
-            .sortedByOrder()
-            .map((entry) => entry.weightedContent)
-            .where((content) => content.isNotEmpty)
+        fixedPrefixTags: fixedTagUsageSnapshot
+            .entriesFor(
+              promptType: FixedTagPromptType.positive,
+              position: FixedTagPosition.prefix,
+            )
+            .map((entry) => entry.renderedContent)
             .toList(),
-        fixedSuffixTags: fixed.enabledSuffixes
-            .sortedByOrder()
-            .map((entry) => entry.weightedContent)
-            .where((content) => content.isNotEmpty)
+        fixedSuffixTags: fixedTagUsageSnapshot
+            .entriesFor(
+              promptType: FixedTagPromptType.positive,
+              position: FixedTagPosition.suffix,
+            )
+            .map((entry) => entry.renderedContent)
             .toList(),
-        fixedNegativePrefixTags: fixed.negativeEnabledPrefixes
-            .sortedByOrder()
-            .map((entry) => entry.weightedContent)
-            .where((content) => content.isNotEmpty)
+        fixedNegativePrefixTags: fixedTagUsageSnapshot
+            .entriesFor(
+              promptType: FixedTagPromptType.negative,
+              position: FixedTagPosition.prefix,
+            )
+            .map((entry) => entry.renderedContent)
             .toList(),
-        fixedNegativeSuffixTags: fixed.negativeEnabledSuffixes
-            .sortedByOrder()
-            .map((entry) => entry.weightedContent)
-            .where((content) => content.isNotEmpty)
+        fixedNegativeSuffixTags: fixedTagUsageSnapshot
+            .entriesFor(
+              promptType: FixedTagPromptType.negative,
+              position: FixedTagPosition.suffix,
+            )
+            .map((entry) => entry.renderedContent)
             .toList(),
+        fixedTagUsageSnapshot: fixedTagUsageSnapshot,
         useCoords: params.useCoords,
       ),
       directoryPath: directoryPath,
@@ -1120,6 +1143,35 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     final comment = ImageSaveUtils.buildCommentJson(
       params: effective,
       actualSeed: effective.seed,
+      fixedTagUsageSnapshot: _activeFixedTagUsageSnapshot,
+      fixedPrefixTags: _activeFixedTagUsageSnapshot
+          ?.entriesFor(
+            promptType: FixedTagPromptType.positive,
+            position: FixedTagPosition.prefix,
+          )
+          .map((entry) => entry.renderedContent)
+          .toList(),
+      fixedSuffixTags: _activeFixedTagUsageSnapshot
+          ?.entriesFor(
+            promptType: FixedTagPromptType.positive,
+            position: FixedTagPosition.suffix,
+          )
+          .map((entry) => entry.renderedContent)
+          .toList(),
+      fixedNegativePrefixTags: _activeFixedTagUsageSnapshot
+          ?.entriesFor(
+            promptType: FixedTagPromptType.negative,
+            position: FixedTagPosition.prefix,
+          )
+          .map((entry) => entry.renderedContent)
+          .toList(),
+      fixedNegativeSuffixTags: _activeFixedTagUsageSnapshot
+          ?.entriesFor(
+            promptType: FixedTagPromptType.negative,
+            position: FixedTagPosition.suffix,
+          )
+          .map((entry) => entry.renderedContent)
+          .toList(),
       charCaptions: charCaptions,
       charNegCaptions: charNegCaptions,
       useCoords: effective.useCoords,

--- a/lib/presentation/screens/generation/services/generation_save_service.dart
+++ b/lib/presentation/screens/generation/services/generation_save_service.dart
@@ -9,6 +9,7 @@ import '../../../../core/services/android_media_store_service.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../core/utils/image_save_utils.dart';
 import '../../../../data/models/gallery/nai_image_metadata.dart';
+import '../../../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../../../../data/repositories/gallery_folder_repository.dart';
 import '../../../../data/services/image_metadata_service.dart';
 import '../../../providers/generation/generation_models.dart';
@@ -65,6 +66,7 @@ class GenerationSaveService {
         showSaveButton: img.canSave,
         showCopyButton: img.canSave,
         preserveOriginalBytesOnSave: img.preserveOriginalBytesOnSave,
+        fixedTagUsageSnapshot: img.fixedTagUsageSnapshot,
       );
     }).toList();
 
@@ -100,11 +102,24 @@ class GenerationSaveService {
 
       // 获取已有元数据（如果图像已包含）
       final existingMetadata = image.metadata;
+      final fixedTagUsageSnapshot = image is GeneratedImageDetailData
+          ? image.fixedTagUsageSnapshot
+          : existingMetadata?.fixedTagUsageSnapshot;
       // 构建最终字节：明确要求保留原始字节的外部结果不做补写；
       // 其他图像优先保留已有 NAI 元数据，缺失时再用已解析数据重建。
       var finalBytes = imageBytes;
+      final hasEmbeddedMetadata = ImageSaveUtils.hasEmbeddedNovelAiMetadata(
+        imageBytes,
+      );
       if (!image.preserveOriginalBytesOnSave &&
-          !ImageSaveUtils.hasEmbeddedNovelAiMetadata(imageBytes) &&
+          hasEmbeddedMetadata &&
+          fixedTagUsageSnapshot != null) {
+        finalBytes = await ImageSaveUtils.mergeFixedTagUsageMetadata(
+          imageBytes: imageBytes,
+          snapshot: fixedTagUsageSnapshot,
+        );
+      } else if (!image.preserveOriginalBytesOnSave &&
+          !hasEmbeddedMetadata &&
           existingMetadata != null) {
         finalBytes = await ImageSaveUtils.buildPrebuiltMetadataBytes(
           imageBytes: imageBytes,
@@ -113,7 +128,10 @@ class GenerationSaveService {
             'Software': 'NovelAI',
             'Source': existingMetadata.source ?? 'NovelAI Diffusion',
             'Comment': jsonEncode(
-              buildCommentJsonFromMetadata(existingMetadata),
+              buildCommentJsonFromMetadata(
+                existingMetadata,
+                fixedTagUsageSnapshot: fixedTagUsageSnapshot,
+              ),
             ),
           },
         );
@@ -167,8 +185,9 @@ class GenerationSaveService {
 
   /// 从元数据构建 Comment JSON
   static Map<String, dynamic> buildCommentJsonFromMetadata(
-    NaiImageMetadata metadata,
-  ) {
+    NaiImageMetadata metadata, {
+    FixedTagUsageSnapshot? fixedTagUsageSnapshot,
+  }) {
     final commentJson = <String, dynamic>{
       'prompt': metadata.prompt,
       'uc': metadata.negativePrompt,
@@ -184,6 +203,15 @@ class GenerationSaveService {
       'sampler': metadata.sampler ?? 'k_euler_ancestral',
       'sm': metadata.smea ?? false,
       'sm_dyn': metadata.smeaDyn ?? false,
+      if (fixedTagUsageSnapshot != null)
+        'aaalice_fixed_tags': fixedTagUsageSnapshot.toJson(),
+      if (fixedTagUsageSnapshot != null ||
+          metadata.hasRecordedFixedTagFields) ...{
+        'fixed_prefix': metadata.fixedPrefixTags,
+        'fixed_suffix': metadata.fixedSuffixTags,
+        'fixed_negative_prefix': metadata.fixedNegativePrefixTags,
+        'fixed_negative_suffix': metadata.fixedNegativeSuffixTags,
+      },
     };
 
     // 添加 Vibe 数据

--- a/lib/presentation/screens/generation/widgets/history_panel.dart
+++ b/lib/presentation/screens/generation/widgets/history_panel.dart
@@ -1814,6 +1814,7 @@ class _HistoryPanelState extends ConsumerState<HistoryPanel> {
       showSaveButton: image.canSave,
       showCopyButton: image.canSave,
       preserveOriginalBytesOnSave: image.preserveOriginalBytesOnSave,
+      fixedTagUsageSnapshot: image.fixedTagUsageSnapshot,
     );
   }
 

--- a/lib/presentation/screens/generation/widgets/image_preview.dart
+++ b/lib/presentation/screens/generation/widgets/image_preview.dart
@@ -23,6 +23,9 @@ import '../../../../core/utils/nai_resolution_adapter.dart';
 import '../../../../core/utils/prompt_preset_resolution.dart';
 import '../../../../core/utils/vibe_file_parser.dart';
 import '../../../../data/models/gallery/nai_image_metadata.dart';
+import '../../../../data/models/fixed_tag/fixed_tag_entry.dart';
+import '../../../../data/models/fixed_tag/fixed_tag_prompt_type.dart';
+import '../../../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../../../../data/models/image/image_stream_chunk.dart';
 import '../../../../data/repositories/gallery_folder_repository.dart';
 import '../../../../data/services/alias_resolver_service.dart';
@@ -1070,6 +1073,7 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
         showSaveButton: img.canSave,
         showCopyButton: img.canSave,
         preserveOriginalBytesOnSave: img.preserveOriginalBytesOnSave,
+        fixedTagUsageSnapshot: img.fixedTagUsageSnapshot,
       );
     }).toList();
 
@@ -1119,6 +1123,9 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
       final actualSeed = finalSeed < 0
           ? Random().nextInt(4294967295)
           : finalSeed;
+      final capturedFixedTags = image is GeneratedImageDetailData
+          ? image.fixedTagUsageSnapshot
+          : null;
 
       // 构建最终字节：外部结果可要求保留原始字节；其他图像缺少 NAI
       // 元数据时仍按当前参数重建。
@@ -1126,10 +1133,18 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
       if (image.preserveOriginalBytesOnSave) {
         finalBytes = imageBytes;
       } else if (ImageSaveUtils.hasEmbeddedNovelAiMetadata(imageBytes)) {
-        finalBytes = imageBytes;
+        finalBytes = capturedFixedTags == null
+            ? imageBytes
+            : await ImageSaveUtils.mergeFixedTagUsageMetadata(
+                imageBytes: imageBytes,
+                snapshot: capturedFixedTags,
+              );
       } else {
         final characterConfig = ref.read(characterPromptNotifierProvider);
         final fixedTagsState = ref.read(fixedTagsNotifierProvider);
+        final fixedTagUsageSnapshot =
+            capturedFixedTags ??
+            FixedTagUsageSnapshot.capture(fixedTagsState.entries);
 
         // 解析别名
         final aliasResolver = ref.read(aliasResolverServiceProvider.notifier);
@@ -1197,22 +1212,35 @@ class _ImagePreviewWidgetState extends ConsumerState<ImagePreviewWidget> {
           imageBytes: imageBytes,
           params: paramsForSave,
           actualSeed: actualSeed,
-          fixedPrefixTags: fixedTagsState.enabledPrefixes
-              .map((entry) => entry.weightedContent)
-              .where((content) => content.isNotEmpty)
-              .toList(growable: false),
-          fixedSuffixTags: fixedTagsState.enabledSuffixes
-              .map((entry) => entry.weightedContent)
-              .where((content) => content.isNotEmpty)
-              .toList(growable: false),
-          fixedNegativePrefixTags: fixedTagsState.negativeEnabledPrefixes
-              .map((entry) => entry.weightedContent)
-              .where((content) => content.isNotEmpty)
-              .toList(growable: false),
-          fixedNegativeSuffixTags: fixedTagsState.negativeEnabledSuffixes
-              .map((entry) => entry.weightedContent)
-              .where((content) => content.isNotEmpty)
-              .toList(growable: false),
+          fixedPrefixTags: fixedTagUsageSnapshot
+              .entriesFor(
+                promptType: FixedTagPromptType.positive,
+                position: FixedTagPosition.prefix,
+              )
+              .map((entry) => entry.renderedContent)
+              .toList(),
+          fixedSuffixTags: fixedTagUsageSnapshot
+              .entriesFor(
+                promptType: FixedTagPromptType.positive,
+                position: FixedTagPosition.suffix,
+              )
+              .map((entry) => entry.renderedContent)
+              .toList(),
+          fixedNegativePrefixTags: fixedTagUsageSnapshot
+              .entriesFor(
+                promptType: FixedTagPromptType.negative,
+                position: FixedTagPosition.prefix,
+              )
+              .map((entry) => entry.renderedContent)
+              .toList(),
+          fixedNegativeSuffixTags: fixedTagUsageSnapshot
+              .entriesFor(
+                promptType: FixedTagPromptType.negative,
+                position: FixedTagPosition.suffix,
+              )
+              .map((entry) => entry.renderedContent)
+              .toList(),
+          fixedTagUsageSnapshot: fixedTagUsageSnapshot,
           charCaptions: charCaptions,
           charNegCaptions: charNegCaptions,
           useCoords: !characterConfig.globalAiChoice,

--- a/lib/presentation/screens/local_gallery/local_gallery_action_coordinator.dart
+++ b/lib/presentation/screens/local_gallery/local_gallery_action_coordinator.dart
@@ -36,12 +36,12 @@ import '../../router/app_routes.dart';
 import '../watermark/watermark_editor_launcher.dart';
 import 'local_gallery_move_target.dart';
 import '../../services/image_workflow_launcher.dart';
+import '../../services/image_metadata_import_workflow.dart';
 import '../../utils/asset_protection_guard.dart';
 import '../../utils/fixed_tag_metadata_matcher.dart';
 import '../../utils/krita_send_helper.dart';
 import '../../utils/local_gallery_metadata_resolver.dart';
 import '../../utils/local_gallery_reference_factory.dart';
-import '../../utils/metadata_import_coordinator.dart';
 import '../../utils/precise_ref_library_import_helper.dart';
 import '../../adaptive/adaptive_presenter.dart';
 import '../../widgets/bulk_metadata_edit_dialog.dart';
@@ -53,7 +53,6 @@ import '../../widgets/common/themed_confirm_dialog.dart';
 import '../../widgets/discord_share/discord_share_dialog.dart';
 import '../../widgets/gallery/local_image_context_menu.dart';
 import '../../widgets/gallery/zip_export_metadata_dialog.dart';
-import '../../widgets/metadata/metadata_import_dialog.dart';
 
 Future<void> showLocalGalleryZipFailureDetails(
   BuildContext context,
@@ -709,30 +708,11 @@ class LocalGalleryActionCoordinator {
         );
         return;
       }
-      final options = await MetadataImportDialog.show(
-        _context(),
-        metadata: metadata,
-      );
-      if (options == null || !_mounted()) return;
-      final appliedCount = await MetadataImportCoordinator.apply(
+      await ImageMetadataImportWorkflow.shared.run(
+        context: _context(),
         read: _ref.read,
         metadata: metadata,
-        options: options,
-        l10n: _context().l10n,
       );
-      if (!_mounted()) return;
-      if (appliedCount == 0) {
-        AppToast.warning(
-          _context(),
-          _context().l10n.metadataImport_noParamsSelected,
-        );
-        return;
-      }
-      AppToast.success(
-        _context(),
-        _context().l10n.metadataImport_appliedCount(appliedCount),
-      );
-      _context().go(AppRoutes.home);
     } catch (error, stackTrace) {
       AppLogger.e('导入图片元数据失败', error, stackTrace, 'LocalGallery');
       if (_mounted()) {

--- a/lib/presentation/services/generation_history_storage_service.dart
+++ b/lib/presentation/services/generation_history_storage_service.dart
@@ -8,6 +8,7 @@ import 'package:hive/hive.dart';
 import '../../core/constants/storage_keys.dart';
 import '../../core/utils/app_logger.dart';
 import '../../data/models/gallery/nai_image_metadata.dart';
+import '../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../providers/generation/generation_models.dart';
 
 /// Tests and embedders opt in explicitly so independently-created provider
@@ -159,6 +160,9 @@ class GenerationHistoryStorageService {
       'metadata': image.metadata == null
           ? null
           : jsonEncode(image.metadata!.toJson()),
+      'fixedTagUsageSnapshot': image.fixedTagUsageSnapshot == null
+          ? null
+          : jsonEncode(image.fixedTagUsageSnapshot!.toJson()),
       'preserveOriginalBytesOnSave': image.preserveOriginalBytesOnSave,
       'filePath': image.filePath,
     };
@@ -200,6 +204,17 @@ class GenerationHistoryStorageService {
       }
     }
 
+    FixedTagUsageSnapshot? fixedTagUsageSnapshot;
+    final fixedTagUsageJson = raw['fixedTagUsageSnapshot'];
+    if (fixedTagUsageJson is String && fixedTagUsageJson.isNotEmpty) {
+      final decoded = jsonDecode(fixedTagUsageJson);
+      if (decoded is Map) {
+        fixedTagUsageSnapshot = FixedTagUsageSnapshot.fromJson(
+          Map<String, dynamic>.from(decoded),
+        );
+      }
+    }
+
     return GeneratedImage(
       id: id,
       bytes: bytes,
@@ -208,6 +223,7 @@ class GenerationHistoryStorageService {
       createdAt: createdAt,
       kind: kind,
       metadata: metadata,
+      fixedTagUsageSnapshot: fixedTagUsageSnapshot,
       preserveOriginalBytesOnSave:
           raw['preserveOriginalBytesOnSave'] as bool? ?? false,
       filePath: raw['filePath'] as String?,

--- a/lib/presentation/services/image_metadata_import_workflow.dart
+++ b/lib/presentation/services/image_metadata_import_workflow.dart
@@ -9,6 +9,8 @@ import '../../data/models/metadata/metadata_import_options.dart';
 import '../../data/services/image_metadata_service.dart';
 import '../../l10n/app_localizations.dart';
 import '../router/app_routes.dart';
+import '../providers/fixed_tags_provider.dart';
+import '../utils/fixed_tag_import_resolution.dart';
 import '../utils/metadata_import_coordinator.dart';
 import '../utils/prompt_preset_import_utils.dart' show ProviderReader;
 import '../widgets/common/app_toast.dart';
@@ -53,18 +55,8 @@ class ImageMetadataImportWorkflow {
     GenerationPageOpener? generationPageOpener,
   }) : _metadataReader =
            metadataReader ?? ImageMetadataService().getMetadataFromBytes,
-       _optionsPicker =
-           optionsPicker ??
-           ((context, metadata) =>
-               MetadataImportDialog.show(context, metadata: metadata)),
-       _metadataApplier =
-           metadataApplier ??
-           ((read, metadata, options, l10n) => MetadataImportCoordinator.apply(
-             read: read,
-             metadata: metadata,
-             options: options,
-             l10n: l10n,
-           )),
+       _optionsPicker = optionsPicker,
+       _metadataApplier = metadataApplier,
        _resultReporter = resultReporter ?? _reportResult,
        _generationPageOpener =
            generationPageOpener ?? ((context) => context.go(AppRoutes.home));
@@ -73,35 +65,52 @@ class ImageMetadataImportWorkflow {
       ImageMetadataImportWorkflow();
 
   final ImageMetadataReader _metadataReader;
-  final MetadataImportOptionsPicker _optionsPicker;
-  final MetadataImportApplier _metadataApplier;
+  final MetadataImportOptionsPicker? _optionsPicker;
+  final MetadataImportApplier? _metadataApplier;
   final MetadataImportResultReporter _resultReporter;
   final GenerationPageOpener _generationPageOpener;
 
   Future<ImageMetadataImportResult> run({
     required BuildContext context,
     required ProviderReader read,
-    required Uint8List bytes,
+    Uint8List? bytes,
+    NaiImageMetadata? metadata,
+    bool openGenerationPage = true,
   }) async {
-    final metadata = await _metadataReader(bytes);
+    assert(bytes != null || metadata != null);
+    final parsedMetadata = metadata ?? await _metadataReader(bytes!);
     if (!context.mounted) return ImageMetadataImportResult.cancelled;
 
-    if (metadata == null || !metadata.hasData) {
+    if (parsedMetadata == null || !parsedMetadata.hasData) {
       _resultReporter(context, ImageMetadataImportResult.noMetadata, 0);
       return ImageMetadataImportResult.noMetadata;
     }
 
-    final options = await _optionsPicker(context, metadata);
+    final resolution = resolveFixedTagImport(
+      metadata: parsedMetadata,
+      entries: read(fixedTagsNotifierProvider).entries,
+    );
+    final resolvedMetadata = resolution.metadata;
+    final options = _optionsPicker == null
+        ? await MetadataImportDialog.show(
+            context,
+            metadata: resolvedMetadata,
+            fixedTagResolution: resolution,
+          )
+        : await _optionsPicker(context, resolvedMetadata);
     if (options == null || !context.mounted) {
       return ImageMetadataImportResult.cancelled;
     }
 
-    final appliedCount = await _metadataApplier(
-      read,
-      metadata,
-      options,
-      context.l10n,
-    );
+    final appliedCount = _metadataApplier == null
+        ? await MetadataImportCoordinator.apply(
+            read: read,
+            metadata: resolvedMetadata,
+            options: options,
+            l10n: context.l10n,
+            fixedTagResolution: resolution,
+          )
+        : await _metadataApplier(read, resolvedMetadata, options, context.l10n);
     if (!context.mounted) return ImageMetadataImportResult.cancelled;
 
     if (appliedCount == 0) {
@@ -114,7 +123,7 @@ class ImageMetadataImportWorkflow {
     }
 
     _resultReporter(context, ImageMetadataImportResult.applied, appliedCount);
-    _generationPageOpener(context);
+    if (openGenerationPage) _generationPageOpener(context);
     return ImageMetadataImportResult.applied;
   }
 

--- a/lib/presentation/utils/fixed_tag_import_resolution.dart
+++ b/lib/presentation/utils/fixed_tag_import_resolution.dart
@@ -1,0 +1,172 @@
+import '../../data/models/fixed_tag/fixed_tag_entry.dart';
+import '../../data/models/fixed_tag/fixed_tag_prompt_type.dart';
+import '../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
+import '../../data/models/gallery/nai_image_metadata.dart';
+import 'fixed_tag_metadata_matcher.dart';
+
+enum FixedTagImportSource { structured, legacyFields, currentLibrary, unknown }
+
+class FixedTagImportResolution {
+  const FixedTagImportResolution({
+    required this.metadata,
+    required this.source,
+    this.snapshot,
+  });
+
+  final NaiImageMetadata metadata;
+  final FixedTagImportSource source;
+  final FixedTagUsageSnapshot? snapshot;
+
+  bool get isUnknown => source == FixedTagImportSource.unknown;
+}
+
+FixedTagImportResolution resolveFixedTagImport({
+  required NaiImageMetadata metadata,
+  required Iterable<FixedTagEntry> entries,
+}) {
+  final structured = metadata.fixedTagUsageSnapshot;
+  if (structured != null) {
+    return FixedTagImportResolution(
+      metadata: metadata,
+      source: FixedTagImportSource.structured,
+      snapshot: structured,
+    );
+  }
+
+  if (metadata.hasRecordedFixedTagFields || _hasRecordedTags(metadata)) {
+    return FixedTagImportResolution(
+      metadata: metadata,
+      source: FixedTagImportSource.legacyFields,
+      snapshot: _legacySnapshot(metadata),
+    );
+  }
+
+  final positive = entries
+      .where((entry) => entry.promptType == FixedTagPromptType.positive)
+      .toList(growable: false);
+  final negative = entries
+      .where((entry) => entry.promptType == FixedTagPromptType.negative)
+      .toList(growable: false);
+  final inferred = matchMetadataFixedTags(
+    metadata: metadata,
+    positiveEntries: positive,
+    negativeEntries: negative,
+  );
+  if (_hasRecordedTags(inferred)) {
+    return FixedTagImportResolution(
+      metadata: inferred,
+      source: FixedTagImportSource.currentLibrary,
+      snapshot: _snapshotFromMatches(inferred, entries),
+    );
+  }
+  return FixedTagImportResolution(
+    metadata: metadata,
+    source: FixedTagImportSource.unknown,
+  );
+}
+
+bool _hasRecordedTags(NaiImageMetadata metadata) =>
+    metadata.fixedPrefixTags.isNotEmpty ||
+    metadata.fixedSuffixTags.isNotEmpty ||
+    metadata.fixedNegativePrefixTags.isNotEmpty ||
+    metadata.fixedNegativeSuffixTags.isNotEmpty;
+
+FixedTagUsageSnapshot _legacySnapshot(NaiImageMetadata metadata) {
+  final result = <FixedTagUsageEntry>[];
+  void add(
+    Iterable<String> values,
+    FixedTagPromptType promptType,
+    FixedTagPosition position,
+  ) {
+    for (final value in values) {
+      final content = value.trim();
+      if (content.isEmpty) continue;
+      result.add(
+        FixedTagUsageEntry.legacy(
+          renderedContent: content,
+          position: position,
+          promptType: promptType,
+          order: result.length,
+        ),
+      );
+    }
+  }
+
+  add(
+    metadata.fixedPrefixTags,
+    FixedTagPromptType.positive,
+    FixedTagPosition.prefix,
+  );
+  add(
+    metadata.fixedSuffixTags,
+    FixedTagPromptType.positive,
+    FixedTagPosition.suffix,
+  );
+  add(
+    metadata.fixedNegativePrefixTags,
+    FixedTagPromptType.negative,
+    FixedTagPosition.prefix,
+  );
+  add(
+    metadata.fixedNegativeSuffixTags,
+    FixedTagPromptType.negative,
+    FixedTagPosition.suffix,
+  );
+  return FixedTagUsageSnapshot(entries: result);
+}
+
+FixedTagUsageSnapshot _snapshotFromMatches(
+  NaiImageMetadata metadata,
+  Iterable<FixedTagEntry> entries,
+) {
+  final matched = <FixedTagUsageEntry>[];
+  void add(
+    List<String> values,
+    FixedTagPromptType promptType,
+    FixedTagPosition position,
+  ) {
+    for (final value in values) {
+      final normalized = normalizeFixedTagMetadataEntry(value);
+      final entry = entries.cast<FixedTagEntry?>().firstWhere(
+        (candidate) =>
+            candidate!.promptType == promptType &&
+            candidate.position == position &&
+            normalizeFixedTagMetadataEntry(candidate.weightedContent) ==
+                normalized,
+        orElse: () => null,
+      );
+      matched.add(
+        entry == null
+            ? FixedTagUsageEntry.legacy(
+                renderedContent: value,
+                position: position,
+                promptType: promptType,
+                order: matched.length,
+              )
+            : FixedTagUsageEntry.fromFixedTag(entry, order: matched.length),
+      );
+    }
+  }
+
+  add(
+    metadata.fixedPrefixTags,
+    FixedTagPromptType.positive,
+    FixedTagPosition.prefix,
+  );
+  add(
+    metadata.fixedSuffixTags,
+    FixedTagPromptType.positive,
+    FixedTagPosition.suffix,
+  );
+  add(
+    metadata.fixedNegativePrefixTags,
+    FixedTagPromptType.negative,
+    FixedTagPosition.prefix,
+  );
+  add(
+    metadata.fixedNegativeSuffixTags,
+    FixedTagPromptType.negative,
+    FixedTagPosition.suffix,
+  );
+  return FixedTagUsageSnapshot(entries: matched);
+}

--- a/lib/presentation/utils/fixed_tag_metadata_matcher.dart
+++ b/lib/presentation/utils/fixed_tag_metadata_matcher.dart
@@ -7,6 +7,13 @@ NaiImageMetadata matchMetadataFixedTags({
   required Iterable<FixedTagEntry> positiveEntries,
   required Iterable<FixedTagEntry> negativeEntries,
 }) {
+  if (metadata.hasExplicitFixedTagMetadata ||
+      metadata.fixedPrefixTags.isNotEmpty ||
+      metadata.fixedSuffixTags.isNotEmpty ||
+      metadata.fixedNegativePrefixTags.isNotEmpty ||
+      metadata.fixedNegativeSuffixTags.isNotEmpty) {
+    return metadata;
+  }
   final positiveMatches = _inferMatches(
     metadata.prompt,
     positiveEntries,
@@ -42,14 +49,16 @@ NaiImageMetadata matchMetadataFixedTags({
 
 List<String> _mergeMatches(List<String> recorded, List<String> inferred) {
   final result = <String>[...recorded];
-  final normalized = recorded.map(_normalizeEntry).toSet();
+  final normalized = recorded.map(normalizeFixedTagMetadataEntry).toSet();
   for (final match in inferred) {
-    if (normalized.add(_normalizeEntry(match))) result.add(match);
+    if (normalized.add(normalizeFixedTagMetadataEntry(match))) {
+      result.add(match);
+    }
   }
   return result;
 }
 
-String _normalizeEntry(String entry) =>
+String normalizeFixedTagMetadataEntry(String entry) =>
     _extractTags(entry).map(_normalizeTag).join(',');
 
 ({List<String> prefix, List<String> suffix}) _inferMatches(

--- a/lib/presentation/utils/metadata_import_coordinator.dart
+++ b/lib/presentation/utils/metadata_import_coordinator.dart
@@ -1,7 +1,7 @@
-import '../../core/utils/nai_prompt_parser.dart';
 import '../../data/models/character/character_prompt.dart' as char;
 import '../../data/models/fixed_tag/fixed_tag_entry.dart';
 import '../../data/models/fixed_tag/fixed_tag_prompt_type.dart';
+import '../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../../data/models/gallery/nai_image_metadata.dart';
 import '../../data/models/metadata/metadata_import_options.dart';
 import '../../l10n/app_localizations.dart';
@@ -10,6 +10,7 @@ import '../providers/fixed_tags_provider.dart';
 import '../providers/image_generation_provider.dart';
 import '../providers/quality_preset_provider.dart';
 import 'metadata_import_applier.dart';
+import 'fixed_tag_import_resolution.dart';
 import 'prompt_preset_import_utils.dart';
 
 class MetadataImportCoordinator {
@@ -20,9 +21,17 @@ class MetadataImportCoordinator {
     required NaiImageMetadata metadata,
     required MetadataImportOptions options,
     required AppLocalizations l10n,
+    FixedTagImportResolution? fixedTagResolution,
   }) async {
+    final resolution =
+        fixedTagResolution ??
+        resolveFixedTagImport(
+          metadata: metadata,
+          entries: read(fixedTagsNotifierProvider).entries,
+        );
+    final resolvedMetadata = resolution.metadata;
     final notifier = read(generationParamsNotifierProvider.notifier);
-    final characterPrompts = metadata.characterPrompts;
+    final characterPrompts = resolvedMetadata.characterPrompts;
 
     if (options.importCharacterPrompts && characterPrompts.isNotEmpty) {
       read(characterPromptNotifierProvider.notifier).clearAllCharacters();
@@ -30,7 +39,7 @@ class MetadataImportCoordinator {
 
     final currentModel = read(generationParamsNotifierProvider).model;
     var appliedCount = MetadataImportApplier.applyPromptAndGenerationParams(
-      metadata: metadata,
+      metadata: resolvedMetadata,
       options: options,
       currentModel: currentModel,
       target: MetadataImportTarget(
@@ -64,12 +73,18 @@ class MetadataImportCoordinator {
     );
 
     if (options.importCharacterPrompts && characterPrompts.isNotEmpty) {
-      _applyCharacterPrompts(read, metadata);
+      _applyCharacterPrompts(read, resolvedMetadata);
       appliedCount++;
     }
 
-    appliedCount += _applyReferenceParams(read, metadata, options);
-    appliedCount += await _applyFixedTags(read, metadata, options, l10n);
+    appliedCount += _applyReferenceParams(read, resolvedMetadata, options);
+    appliedCount += await _applyFixedTags(
+      read,
+      resolvedMetadata,
+      options,
+      l10n,
+      resolution,
+    );
 
     return appliedCount;
   }
@@ -79,88 +94,52 @@ class MetadataImportCoordinator {
     NaiImageMetadata metadata,
     MetadataImportOptions options,
     AppLocalizations l10n,
+    FixedTagImportResolution resolution,
   ) async {
     if (!options.importFixedTags) {
       return 0;
     }
 
-    final fixedTagsNotifier = read(fixedTagsNotifierProvider.notifier);
-    var added = 0;
-
-    Future<void> addTags(
-      List<String> tags, {
-      required FixedTagPosition position,
-      required FixedTagPromptType promptType,
-      required String Function(String content) buildName,
-    }) async {
-      for (final tag in tags) {
-        final content = tag.trim();
-        if (content.isEmpty) {
-          continue;
-        }
-
-        final normalizedContent = NaiPromptParser.normalizeSegment(content);
-        final matchingEntries = read(fixedTagsNotifierProvider).entries
-            .where((entry) {
-              return entry.position == position &&
-                  entry.promptType == promptType &&
-                  NaiPromptParser.normalizeSegment(entry.content) ==
-                      normalizedContent;
-            })
-            .toList(growable: false);
-        final existing = matchingEntries.isEmpty ? null : matchingEntries.first;
-        if (existing != null) {
-          if (!existing.enabled) {
-            await fixedTagsNotifier.updateEntry(
-              existing.copyWith(enabled: true, updatedAt: DateTime.now()),
-            );
-            added++;
-          }
-          continue;
-        }
-
-        await fixedTagsNotifier.addEntry(
-          name: buildName(content),
-          content: content,
-          position: position,
-          promptType: promptType,
-          enabled: true,
-        );
-        added++;
+    final scopes = <FixedTagScope>{};
+    void addSelectedScopes(FixedTagPromptType promptType) {
+      final isPositive = promptType == FixedTagPromptType.positive;
+      if (isPositive
+          ? options.importFixedPrefix
+          : options.importFixedNegativePrefix) {
+        scopes.add(FixedTagScope(promptType, FixedTagPosition.prefix));
+      }
+      if (isPositive
+          ? options.importFixedSuffix
+          : options.importFixedNegativeSuffix) {
+        scopes.add(FixedTagScope(promptType, FixedTagPosition.suffix));
       }
     }
 
-    if (options.importFixedPrefix) {
-      await addTags(
-        metadata.fixedPrefixTags,
-        position: FixedTagPosition.prefix,
-        promptType: FixedTagPromptType.positive,
-        buildName: l10n.metadataImport_fixedPrefix,
-      );
-      await addTags(
-        metadata.fixedNegativePrefixTags,
-        position: FixedTagPosition.prefix,
-        promptType: FixedTagPromptType.negative,
-        buildName: l10n.metadataImport_negativeFixedPrefix,
-      );
+    FixedTagUsageSnapshot snapshot;
+    if (resolution.isUnknown) {
+      if (options.unknownFixedTagPolicy == UnknownFixedTagPolicy.keepCurrent) {
+        return 0;
+      }
+      if (options.importPrompt && metadata.prompt.isNotEmpty) {
+        addSelectedScopes(FixedTagPromptType.positive);
+      }
+      if (options.importNegativePrompt && metadata.negativePrompt.isNotEmpty) {
+        addSelectedScopes(FixedTagPromptType.negative);
+      }
+      snapshot = const FixedTagUsageSnapshot();
+    } else {
+      addSelectedScopes(FixedTagPromptType.positive);
+      addSelectedScopes(FixedTagPromptType.negative);
+      snapshot = resolution.snapshot ?? const FixedTagUsageSnapshot();
     }
+    if (scopes.isEmpty) return 0;
 
-    if (options.importFixedSuffix) {
-      await addTags(
-        metadata.fixedSuffixTags,
-        position: FixedTagPosition.suffix,
-        promptType: FixedTagPromptType.positive,
-        buildName: l10n.metadataImport_fixedSuffix,
-      );
-      await addTags(
-        metadata.fixedNegativeSuffixTags,
-        position: FixedTagPosition.suffix,
-        promptType: FixedTagPromptType.negative,
-        buildName: l10n.metadataImport_negativeFixedSuffix,
-      );
-    }
-
-    return added > 0 ? 1 : 0;
+    await read(fixedTagsNotifierProvider.notifier).restoreUsageSnapshot(
+      snapshot: snapshot,
+      scopes: scopes,
+      buildImageVersionName: l10n.metadataImport_imageVersionName,
+    );
+    return 1;
   }
 
   static void _applyCharacterPrompts(

--- a/lib/presentation/widgets/common/image_detail/image_detail_data.dart
+++ b/lib/presentation/widgets/common/image_detail/image_detail_data.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 
 import '../../../../data/models/gallery/local_image_record.dart';
 import '../../../../data/models/gallery/nai_image_metadata.dart';
+import '../../../../data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import '../../../../data/services/image_metadata_service.dart';
 import '../../../../data/services/metadata/isolate_metadata_service.dart';
 
@@ -180,6 +181,7 @@ class GeneratedImageDetailData implements ImageDetailData {
   final String _id;
   final bool _showSaveButton;
   final bool _showCopyButton;
+  final FixedTagUsageSnapshot? fixedTagUsageSnapshot;
   @override
   final bool preserveOriginalBytesOnSave;
 
@@ -190,6 +192,7 @@ class GeneratedImageDetailData implements ImageDetailData {
     bool showSaveButton = true,
     bool showCopyButton = true,
     this.preserveOriginalBytesOnSave = false,
+    this.fixedTagUsageSnapshot,
   }) : _metadata = metadata,
        _id = id ?? imageBytes.hashCode.toString(),
        _showSaveButton = showSaveButton,

--- a/lib/presentation/widgets/common/image_detail/image_detail_viewer.dart
+++ b/lib/presentation/widgets/common/image_detail/image_detail_viewer.dart
@@ -10,7 +10,6 @@ import '../../../../core/utils/app_logger.dart';
 import '../../../../core/utils/image_share_sanitizer.dart';
 import '../../../../core/utils/window_focus_tracker.dart';
 import '../../../../core/windowing/workspace_side_panel_contract.dart';
-import '../../../../data/models/metadata/metadata_import_options.dart';
 import '../../../adaptive/adaptive_presenter.dart';
 import '../../../providers/share_image_settings_provider.dart';
 import '../../../screens/watermark/watermark_editor_launcher.dart';
@@ -19,7 +18,6 @@ import '../../shortcuts/shortcuts.dart';
 import '../app_toast.dart';
 import '../horizontal_resize_handle.dart';
 import '../resizable_pane.dart';
-import '../../metadata/metadata_import_dialog.dart';
 import 'components/detail_image_page.dart';
 import 'components/detail_metadata_panel.dart';
 import 'components/prompt_copy_dialog.dart';
@@ -33,9 +31,7 @@ class ImageDetailCallbacks {
   final void Function(ImageDetailData image)? onFavoriteToggle;
 
   /// 复用元数据回调
-  /// 接收图像数据和用户选择的导入选项
-  final void Function(ImageDetailData image, MetadataImportOptions options)?
-  onReuseMetadata;
+  final Future<void> Function(ImageDetailData image)? onReuseMetadata;
 
   /// 保存回调
   final Future<void> Function(ImageDetailData image)? onSave;
@@ -762,16 +758,8 @@ class _ImageDetailViewerState extends ConsumerState<ImageDetailViewer> {
       return;
     }
 
-    // 显示参数选择对话框
-    final options = await MetadataImportDialog.show(
-      context,
-      metadata: metadata,
-    );
-
-    if (options == null || !context.mounted) return; // 用户取消
-
-    // 调用回调并传递选项
-    widget.callbacks?.onReuseMetadata?.call(_currentImage, options);
+    await widget.callbacks?.onReuseMetadata?.call(_currentImage);
+    if (!context.mounted) return;
 
     // 关闭图像详情页
     if (context.mounted) {

--- a/lib/presentation/widgets/drop/global_drop_action_coordinator.dart
+++ b/lib/presentation/widgets/drop/global_drop_action_coordinator.dart
@@ -28,10 +28,9 @@ import '../../providers/vibe_library_provider.dart';
 import '../../router/app_routes.dart';
 import '../../utils/dropped_file_reader.dart';
 import '../../utils/internal_drag_protocol.dart';
-import '../../utils/metadata_import_coordinator.dart';
+import '../../services/image_metadata_import_workflow.dart';
 import '../../utils/precise_ref_library_import_helper.dart';
 import '../common/app_toast.dart';
-import '../metadata/metadata_import_dialog.dart';
 import 'dropped_image_inspector.dart';
 import 'image_destination_dialog.dart';
 import 'tag_library_drop_handler.dart';
@@ -317,8 +316,9 @@ class GlobalDropActionCoordinator {
       ImageDestination.vibeTransfer ||
       ImageDestination.vibeTransferReuse ||
       ImageDestination.vibeTransferRaw ||
-      ImageDestination.characterReference ||
-      ImageDestination.extractMetadata => true,
+      ImageDestination.characterReference => true,
+      // The shared metadata workflow owns navigation after its second dialog.
+      ImageDestination.extractMetadata ||
       ImageDestination.saveToVibeLibrary ||
       ImageDestination.addToQueue => false,
     };
@@ -569,27 +569,12 @@ class GlobalDropActionCoordinator {
         return false;
       }
       if (!context.mounted) return false;
-      final options = await MetadataImportDialog.show(
-        context,
-        metadata: metadata,
-      );
-      if (options == null || !context.mounted) return false;
-      final appliedCount = await MetadataImportCoordinator.apply(
+      final result = await ImageMetadataImportWorkflow.shared.run(
+        context: context,
         read: ref.read,
         metadata: metadata,
-        options: options,
-        l10n: context.l10n,
       );
-      if (!context.mounted) return false;
-      if (appliedCount > 0) {
-        AppToast.success(
-          context,
-          l10n.metadataImport_appliedCount(appliedCount),
-        );
-        return true;
-      }
-      AppToast.warning(context, l10n.metadataImport_noParamsSelected);
-      return false;
+      return result == ImageMetadataImportResult.applied;
     } catch (error) {
       if (kDebugMode) {
         AppLogger.d('Error extracting metadata: $error', 'DropHandler');

--- a/lib/presentation/widgets/gallery/gallery_content_view.dart
+++ b/lib/presentation/widgets/gallery/gallery_content_view.dart
@@ -596,7 +596,7 @@ class LocalGalleryContentView extends ConsumerWidget {
         showThumbnails: images.length > 1,
         callbacks: ImageDetailCallbacks(
           onReuseMetadata: onReuseMetadata != null
-              ? (data, _) =>
+              ? (data) async =>
                     onReuseMetadata?.call((data as LocalImageDetailData).record)
               : null,
           onFavoriteToggle: (data) => ref

--- a/lib/presentation/widgets/metadata/metadata_import_dialog.dart
+++ b/lib/presentation/widgets/metadata/metadata_import_dialog.dart
@@ -4,6 +4,7 @@ import '../../../../core/enums/precise_ref_type.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../data/models/gallery/nai_image_metadata.dart';
 import '../../../../data/models/metadata/metadata_import_options.dart';
+import '../../utils/fixed_tag_import_resolution.dart';
 import '../../adaptive/adaptive_presenter.dart';
 import '../common/adaptive_dialog_frame.dart';
 import '../common/translated_tag_text.dart';
@@ -15,17 +16,20 @@ import '../common/translated_tag_text.dart';
 class MetadataImportDialog extends StatefulWidget {
   final NaiImageMetadata metadata;
   final ScrollController? scrollController;
+  final FixedTagImportResolution? fixedTagResolution;
 
   const MetadataImportDialog({
     super.key,
     required this.metadata,
     this.scrollController,
+    this.fixedTagResolution,
   });
 
   /// 显示对话框并返回用户选择的导入选项
   static Future<MetadataImportOptions?> show(
     BuildContext context, {
     required NaiImageMetadata metadata,
+    FixedTagImportResolution? fixedTagResolution,
   }) {
     return AdaptivePresenter.showForm<MetadataImportOptions>(
       context: context,
@@ -52,6 +56,7 @@ class MetadataImportDialog extends StatefulWidget {
       },
       builder: (context, scrollController) => MetadataImportDialog(
         metadata: metadata,
+        fixedTagResolution: fixedTagResolution,
         scrollController: scrollController,
       ),
     );
@@ -276,7 +281,8 @@ class _MetadataImportDialogState extends State<MetadataImportDialog> {
               setState(() => _options = _options.copyWith(importPrompt: v)),
         ),
         // 固定词（带子选项）
-        if (metadata.hasSeparatedFields) ...[
+        if (metadata.hasSeparatedFields ||
+            widget.fixedTagResolution != null) ...[
           _buildParentCheckboxTile(
             title: l10n.metadataImport_fixedTags,
             value: _options.importFixedTags,
@@ -284,11 +290,17 @@ class _MetadataImportDialogState extends State<MetadataImportDialog> {
                 metadata.fixedPrefixTags.isNotEmpty ||
                 metadata.fixedSuffixTags.isNotEmpty ||
                 metadata.fixedNegativePrefixTags.isNotEmpty ||
-                metadata.fixedNegativeSuffixTags.isNotEmpty,
+                metadata.fixedNegativeSuffixTags.isNotEmpty ||
+                metadata.hasExplicitFixedTagMetadata ||
+                widget.fixedTagResolution?.isUnknown == true,
             onChanged: (v) => setState(
               () => _options = _options.copyWith(importFixedTags: v),
             ),
             children: [
+              if (widget.fixedTagResolution != null)
+                _buildFixedTagSource(widget.fixedTagResolution!),
+              if (widget.fixedTagResolution?.isUnknown == true)
+                _buildUnknownFixedTagPolicy(),
               if (metadata.fixedPrefixTags.isNotEmpty)
                 _buildChildCheckboxTile(
                   title: l10n.metadataImport_fixedPrefix(
@@ -352,11 +364,11 @@ class _MetadataImportDialogState extends State<MetadataImportDialog> {
                     selectable: false,
                     maxLines: 1,
                   ),
-                  value: _options.importFixedPrefix,
+                  value: _options.importFixedNegativePrefix,
                   onChanged: _options.importFixedTags
                       ? (v) => setState(
                           () => _options = _options.copyWith(
-                            importFixedPrefix: v,
+                            importFixedNegativePrefix: v,
                           ),
                         )
                       : null,
@@ -380,11 +392,11 @@ class _MetadataImportDialogState extends State<MetadataImportDialog> {
                     selectable: false,
                     maxLines: 1,
                   ),
-                  value: _options.importFixedSuffix,
+                  value: _options.importFixedNegativeSuffix,
                   onChanged: _options.importFixedTags
                       ? (v) => setState(
                           () => _options = _options.copyWith(
-                            importFixedSuffix: v,
+                            importFixedNegativeSuffix: v,
                           ),
                         )
                       : null,
@@ -504,6 +516,68 @@ class _MetadataImportDialogState extends State<MetadataImportDialog> {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildFixedTagSource(FixedTagImportResolution resolution) {
+    final l10n = context.l10n;
+    final text = switch (resolution.source) {
+      FixedTagImportSource.structured =>
+        l10n.metadataImport_fixedSourceStructured,
+      FixedTagImportSource.legacyFields =>
+        l10n.metadataImport_fixedSourceLegacy,
+      FixedTagImportSource.currentLibrary =>
+        l10n.metadataImport_fixedSourceLibrary,
+      FixedTagImportSource.unknown => l10n.metadataImport_fixedSourceUnknown,
+    };
+    return Padding(
+      padding: const EdgeInsets.only(left: 24, right: 8, bottom: 6),
+      child: Text(text, style: Theme.of(context).textTheme.bodySmall),
+    );
+  }
+
+  Widget _buildUnknownFixedTagPolicy() {
+    final l10n = context.l10n;
+    return Padding(
+      padding: const EdgeInsets.only(left: 12, bottom: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              l10n.metadataImport_unknownFixedTagsHint,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+          RadioGroup<UnknownFixedTagPolicy>(
+            groupValue: _options.unknownFixedTagPolicy,
+            onChanged: _options.importFixedTags
+                ? (value) => setState(
+                    () => _options = _options.copyWith(
+                      unknownFixedTagPolicy: value!,
+                    ),
+                  )
+                : (_) {},
+            child: Column(
+              children: [
+                RadioListTile<UnknownFixedTagPolicy>(
+                  dense: true,
+                  title: Text(l10n.metadataImport_disableCurrentFixedTags),
+                  value: UnknownFixedTagPolicy.disableCurrent,
+                  enabled: _options.importFixedTags,
+                ),
+                RadioListTile<UnknownFixedTagPolicy>(
+                  dense: true,
+                  title: Text(l10n.metadataImport_keepCurrentFixedTags),
+                  value: UnknownFixedTagPolicy.keepCurrent,
+                  enabled: _options.importFixedTags,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/test/core/utils/image_save_utils_test.dart
+++ b/test/core/utils/image_save_utils_test.dart
@@ -8,6 +8,9 @@ import 'package:nai_launcher/core/constants/api_constants.dart';
 import 'package:nai_launcher/core/utils/comfyui_prompt_parser.dart';
 import 'package:nai_launcher/core/utils/image_save_utils.dart';
 import 'package:nai_launcher/data/models/character/character_prompt.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_entry.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_prompt_type.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
 import 'package:nai_launcher/data/models/image/image_params.dart';
 import 'package:nai_launcher/data/services/metadata/unified_metadata_parser.dart';
@@ -466,6 +469,69 @@ void main() {
         expect(commentJson['fixed_suffix'], equals(['cinematic lighting']));
         expect(commentJson['fixed_negative_prefix'], equals(['lowres']));
         expect(commentJson['fixed_negative_suffix'], equals(['text']));
+      },
+    );
+
+    test('writes an explicit empty fixed-tag snapshot', () {
+      final commentJson = ImageSaveUtils.buildCommentJson(
+        params: const ImageParams(prompt: 'subject'),
+        actualSeed: 12,
+        fixedTagUsageSnapshot: const FixedTagUsageSnapshot(),
+      );
+
+      expect(commentJson['aaalice_fixed_tags'], {
+        'version': 1,
+        'entries': <dynamic>[],
+      });
+      expect(commentJson['fixed_prefix'], isEmpty);
+      expect(commentJson['fixed_suffix'], isEmpty);
+      expect(commentJson['fixed_negative_prefix'], isEmpty);
+      expect(commentJson['fixed_negative_suffix'], isEmpty);
+    });
+
+    test(
+      'merges fixed-tag provenance without replacing official fields',
+      () async {
+        final png = img.Image(width: 2, height: 2);
+        final base = await ImageSaveUtils.rebuildImageBytesWithMetadata(
+          imageBytes: Uint8List.fromList(img.encodePng(png)),
+          params: const ImageParams(
+            prompt: 'original prompt',
+            negativePrompt: 'original negative',
+            width: 2,
+            height: 2,
+          ),
+          actualSeed: 777,
+        );
+        const snapshot = FixedTagUsageSnapshot(
+          entries: [
+            FixedTagUsageEntry(
+              fixedTagId: 'fixed-a',
+              name: 'A',
+              content: 'masterpiece',
+              weight: 1,
+              renderedContent: 'masterpiece',
+              position: FixedTagPosition.prefix,
+              promptType: FixedTagPromptType.positive,
+              order: 0,
+            ),
+          ],
+        );
+
+        final merged = await ImageSaveUtils.mergeFixedTagUsageMetadata(
+          imageBytes: base,
+          snapshot: snapshot,
+        );
+        final metadata = UnifiedMetadataParser.parseFromPng(merged).metadata!;
+
+        expect(metadata.prompt, 'original prompt');
+        expect(metadata.negativePrompt, 'original negative');
+        expect(metadata.seed, 777);
+        expect(metadata.fixedPrefixTags, ['masterpiece']);
+        expect(
+          metadata.fixedTagUsageSnapshot?.entries.single.fixedTagId,
+          'fixed-a',
+        );
       },
     );
   });

--- a/test/data/models/gallery/nai_image_metadata_test.dart
+++ b/test/data/models/gallery/nai_image_metadata_test.dart
@@ -403,6 +403,42 @@ void main() {
       },
     );
 
+    test(
+      'metadata should not classify markup-wrapped main prompt as fixed tags',
+      () {
+        const prompt = '''<quality>
+2::best quality::,masterpiece,very aesthetic, highres, absurdres, highly finished
+</quality>''';
+        final metadata = NaiImageMetadata.fromNaiComment({
+          'Comment': jsonEncode({
+            'prompt': prompt,
+            'v4_prompt': {
+              'caption': {'base_caption': prompt, 'char_captions': []},
+            },
+          }),
+          'Software': 'NovelAI',
+          'Source': 'NovelAI Diffusion V4.5 4BDE2A90',
+        });
+
+        expect(metadata.fixedPrefixTags, isEmpty);
+        expect(metadata.fixedSuffixTags, isEmpty);
+        expect(metadata.qualityTags, isEmpty);
+        expect(metadata.mainPrompt, prompt);
+      },
+    );
+
+    test('metadata should not infer fixed tags from common prompt words', () {
+      const prompt = '2::best quality::, masterpiece, 1girl';
+      final metadata = NaiImageMetadata.fromNaiComment({
+        'Comment': jsonEncode({'prompt': prompt}),
+        'Software': 'NovelAI',
+      });
+
+      expect(metadata.fixedPrefixTags, isEmpty);
+      expect(metadata.fixedSuffixTags, isEmpty);
+      expect(metadata.mainPrompt, prompt);
+    });
+
     test('V5 metadata should restore the Light tier and transparent suffix', () {
       const prompt =
           '1girl, transparent background, very aesthetic, amazing quality, no text';

--- a/test/data/models/gallery/nai_image_metadata_test.dart
+++ b/test/data/models/gallery/nai_image_metadata_test.dart
@@ -49,6 +49,45 @@ void main() {
       expect(NaiImageMetadata.fromJson(metadata.toJson()), metadata);
     });
 
+    test('fromNaiComment preserves an explicit empty fixed-tag record', () {
+      final metadata = NaiImageMetadata.fromNaiComment({
+        'prompt': 'subject',
+        'fixed_prefix': <String>[],
+        'fixed_suffix': <String>[],
+        'fixed_negative_prefix': <String>[],
+        'fixed_negative_suffix': <String>[],
+      });
+
+      expect(metadata.hasRecordedFixedTagFields, isTrue);
+      expect(metadata.hasExplicitFixedTagMetadata, isTrue);
+    });
+
+    test('fromNaiComment parses the structured fixed-tag snapshot', () {
+      final metadata = NaiImageMetadata.fromNaiComment({
+        'prompt': 'masterpiece, subject',
+        'aaalice_fixed_tags': {
+          'version': 1,
+          'entries': [
+            {
+              'fixed_tag_id': 'tag-a',
+              'name': 'A',
+              'content': 'masterpiece',
+              'weight': 1,
+              'rendered_content': 'masterpiece',
+              'position': 'prefix',
+              'prompt_type': 'positive',
+              'order': 0,
+            },
+          ],
+        },
+      });
+
+      expect(
+        metadata.fixedTagUsageSnapshot?.entries.single.fixedTagId,
+        'tag-a',
+      );
+    });
+
     test('displayNegativePrompt should mirror embedded raw uc text', () {
       final preset = UcPresets.getPresetContent(
         ImageModels.animeDiffusionV45Full,

--- a/test/presentation/providers/generation/generation_request_preparation_service_test.dart
+++ b/test/presentation/providers/generation/generation_request_preparation_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/core/utils/prompt_preset_resolution.dart';
 import 'package:nai_launcher/data/models/image/image_params.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import 'package:nai_launcher/presentation/providers/generation/generation_request_preparation_service.dart';
 
 void main() {
@@ -19,6 +20,7 @@ void main() {
             applyFixedPositiveTags: (prompt) =>
                 '$prompt, negative(fixed literal)',
             applyFixedNegativeTags: (prompt) => prompt,
+            fixedTagUsageSnapshot: const FixedTagUsageSnapshot(),
             resolvePresets: (params) => PromptPresetResolution(
               prompt: params.prompt,
               negativePrompt: params.negativePrompt,

--- a/test/presentation/providers/generation/generation_result_lifecycle_service_test.dart
+++ b/test/presentation/providers/generation/generation_result_lifecycle_service_test.dart
@@ -4,6 +4,11 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as image_lib;
 import 'package:nai_launcher/data/models/image/image_params.dart';
+import 'package:nai_launcher/core/utils/image_save_utils.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_entry.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_prompt_type.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
+import 'package:nai_launcher/data/services/metadata/unified_metadata_parser.dart';
 import 'package:nai_launcher/presentation/providers/generation/generation_models.dart';
 import 'package:nai_launcher/presentation/providers/generation/generation_result_lifecycle_service.dart';
 import 'package:nai_launcher/presentation/services/generation_history_storage_service.dart';
@@ -104,5 +109,69 @@ void main() {
     expect(indexedCount, 1);
     expect(await File(result.savedPaths.single).exists(), isTrue);
     expect(result.images.single.filePath, result.savedPaths.single);
+  });
+
+  test('自动保存给已有 NAI 元数据补写生成时固定词快照', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'nai_generation_fixed_snapshot_',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final plain = Uint8List.fromList(
+      image_lib.encodePng(image_lib.Image(width: 2, height: 2)),
+    );
+    final bytes = await ImageSaveUtils.rebuildImageBytesWithMetadata(
+      imageBytes: plain,
+      params: const ImageParams(
+        prompt: 'masterpiece, subject',
+        width: 2,
+        height: 2,
+      ),
+      actualSeed: 321,
+    );
+    const generatedSnapshot = FixedTagUsageSnapshot(
+      entries: [
+        FixedTagUsageEntry(
+          fixedTagId: 'a',
+          name: 'A',
+          content: 'masterpiece',
+          weight: 1,
+          renderedContent: 'masterpiece',
+          position: FixedTagPosition.prefix,
+          promptType: FixedTagPromptType.positive,
+          order: 0,
+        ),
+      ],
+    );
+    final service = GenerationResultLifecycleService(
+      GenerationResultLifecycleDependencies(
+        historyStorage: GenerationHistoryStorageService(enabled: false),
+        resolveGalleryRootPath: () async => directory.path,
+        addGalleryImages: (paths) async => paths.length,
+        refreshGallery: () async {},
+        incrementStatistics: (_) async {},
+      ),
+    );
+
+    final result = await service.saveImages(
+      [
+        GeneratedImage.create(
+          bytes,
+          width: 2,
+          height: 2,
+          fixedTagUsageSnapshot: generatedSnapshot,
+        ),
+      ],
+      const ImageParams(prompt: 'changed later', seed: 999),
+      snapshot: const GenerationSaveSnapshot(
+        fixedTagUsageSnapshot: FixedTagUsageSnapshot(),
+      ),
+    );
+    final saved = await File(result.savedPaths.single).readAsBytes();
+    final metadata = UnifiedMetadataParser.parseFromPng(saved).metadata!;
+
+    expect(metadata.prompt, 'masterpiece, subject');
+    expect(metadata.seed, 321);
+    expect(metadata.fixedPrefixTags, ['masterpiece']);
+    expect(metadata.fixedTagUsageSnapshot?.entries.single.fixedTagId, 'a');
   });
 }

--- a/test/presentation/services/generation_history_storage_service_test.dart
+++ b/test/presentation/services/generation_history_storage_service_test.dart
@@ -5,6 +5,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:image/image.dart' as img;
 import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_entry.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_prompt_type.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import 'package:nai_launcher/presentation/providers/generation/generation_models.dart';
 import 'package:nai_launcher/presentation/services/generation_history_storage_service.dart';
 
@@ -38,6 +41,20 @@ void main() {
       createdAt: DateTime.utc(2026, 8, 26, 12, byte),
       filePath: '/images/$id.png',
       preserveOriginalBytesOnSave: true,
+      fixedTagUsageSnapshot: const FixedTagUsageSnapshot(
+        entries: [
+          FixedTagUsageEntry(
+            fixedTagId: 'fixed-a',
+            name: 'A',
+            content: 'masterpiece',
+            weight: 1,
+            renderedContent: 'masterpiece',
+            position: FixedTagPosition.prefix,
+            promptType: FixedTagPromptType.positive,
+            order: 0,
+          ),
+        ],
+      ),
     );
   }
 
@@ -62,6 +79,10 @@ void main() {
       expect(restored.first.createdAt, second.createdAt);
       expect(restored.first.filePath, second.filePath);
       expect(restored.first.preserveOriginalBytesOnSave, isTrue);
+      expect(
+        restored.first.fixedTagUsageSnapshot?.entries.single.fixedTagId,
+        'fixed-a',
+      );
     },
   );
 

--- a/test/presentation/utils/fixed_tag_import_resolution_test.dart
+++ b/test/presentation/utils/fixed_tag_import_resolution_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_entry.dart';
+import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
+import 'package:nai_launcher/presentation/utils/fixed_tag_import_resolution.dart';
+
+void main() {
+  test('structured empty snapshot is authoritative', () {
+    final resolution = resolveFixedTagImport(
+      metadata: const NaiImageMetadata(
+        prompt: 'masterpiece, subject',
+        fixedTagUsageData: {'version': 1, 'entries': <dynamic>[]},
+      ),
+      entries: [FixedTagEntry.create(name: 'A', content: 'masterpiece')],
+    );
+
+    expect(resolution.source, FixedTagImportSource.structured);
+    expect(resolution.snapshot?.entries, isEmpty);
+    expect(resolution.metadata.fixedPrefixTags, isEmpty);
+  });
+
+  test('legacy fields are authoritative and block extra inference', () {
+    final resolution = resolveFixedTagImport(
+      metadata: const NaiImageMetadata(
+        prompt: 'recorded, current, subject',
+        fixedPrefixTags: ['recorded'],
+        hasRecordedFixedTagFields: true,
+      ),
+      entries: [FixedTagEntry.create(name: 'current', content: 'current')],
+    );
+
+    expect(resolution.source, FixedTagImportSource.legacyFields);
+    expect(resolution.metadata.fixedPrefixTags, ['recorded']);
+    expect(resolution.snapshot?.entries.single.renderedContent, 'recorded');
+  });
+
+  test('old image can match exact boundaries from the current library', () {
+    final entry = FixedTagEntry.create(
+      name: 'A',
+      content: 'masterpiece, best quality',
+    );
+    final resolution = resolveFixedTagImport(
+      metadata: const NaiImageMetadata(
+        prompt: 'masterpiece, best quality, 1girl',
+      ),
+      entries: [entry],
+    );
+
+    expect(resolution.source, FixedTagImportSource.currentLibrary);
+    expect(resolution.metadata.mainPrompt, '1girl');
+    expect(resolution.snapshot?.entries.single.fixedTagId, entry.id);
+  });
+
+  test('issue 219 prompt remains intact when no user-library entry matches', () {
+    const prompt =
+        '<quality>\n2::best quality::,masterpiece,very aesthetic, highres, absurdres, highly finished\n</quality>';
+    final resolution = resolveFixedTagImport(
+      metadata: const NaiImageMetadata(prompt: prompt),
+      entries: const [],
+    );
+
+    expect(resolution.source, FixedTagImportSource.unknown);
+    expect(resolution.metadata.mainPrompt, prompt);
+    expect(resolution.metadata.fixedPrefixTags, isEmpty);
+  });
+}

--- a/test/presentation/utils/fixed_tag_metadata_matcher_test.dart
+++ b/test/presentation/utils/fixed_tag_metadata_matcher_test.dart
@@ -61,7 +61,7 @@ void main() {
     expect(result.fixedSuffixTags, [fragment]);
   });
 
-  test('keeps recorded fields and supplements additional current matches', () {
+  test('explicit recorded fields prevent additional inference', () {
     final libraryEntry = FixedTagEntry.create(
       name: 'new',
       content: 'new library value',
@@ -76,10 +76,7 @@ void main() {
       negativeEntries: const [],
     );
 
-    expect(
-      result.fixedPrefixTags,
-      equals(['recorded value', 'new library value']),
-    );
+    expect(result.fixedPrefixTags, equals(['recorded value']));
   });
 
   test('does not infer fixed tags from the middle of a negative prompt', () {

--- a/test/presentation/utils/metadata_import_coordinator_test.dart
+++ b/test/presentation/utils/metadata_import_coordinator_test.dart
@@ -9,6 +9,9 @@ import 'package:nai_launcher/core/constants/api_constants.dart';
 import 'package:nai_launcher/core/constants/storage_keys.dart';
 import 'package:nai_launcher/core/enums/precise_ref_type.dart';
 import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_entry.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_prompt_type.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_usage_snapshot.dart';
 import 'package:nai_launcher/data/models/metadata/metadata_import_options.dart';
 import 'package:nai_launcher/data/models/vibe/vibe_reference.dart';
 import 'package:nai_launcher/l10n/app_localizations_en.dart';
@@ -231,5 +234,220 @@ void main() {
     expect(appliedCount, 2);
     expect(params.model, ImageModels.animeDiffusionV45Full);
     expect(params.scale, 5.5);
+  });
+
+  test('structured fixed tags replace the enabled scope', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(fixedTagsNotifierProvider.notifier);
+    final old = await notifier.addEntry(
+      name: 'current',
+      content: 'current tag',
+    );
+    final target = await notifier.addEntry(
+      name: 'recorded',
+      content: 'recorded tag',
+      enabled: false,
+    );
+    final snapshot = FixedTagUsageSnapshot(
+      entries: [FixedTagUsageEntry.fromFixedTag(target, order: 0)],
+    );
+    final metadata = NaiImageMetadata(
+      prompt: 'recorded tag, subject',
+      fixedPrefixTags: const ['recorded tag'],
+      fixedTagUsageData: snapshot.toJson(),
+    );
+
+    await MetadataImportCoordinator.apply(
+      read: container.read,
+      metadata: metadata,
+      options: const MetadataImportOptions(
+        importNegativePrompt: false,
+        importFixedSuffix: false,
+        importQualityTags: false,
+        importCharacterPrompts: false,
+        importVibeReferences: false,
+        importPreciseReferences: false,
+      ),
+      l10n: AppLocalizationsEn(),
+    );
+
+    final entries = container.read(fixedTagsNotifierProvider).entries;
+    expect(entries.singleWhere((entry) => entry.id == old.id).enabled, isFalse);
+    expect(
+      entries.singleWhere((entry) => entry.id == target.id).enabled,
+      isTrue,
+    );
+  });
+
+  test('fixed-tag restoration changes only the four selected scopes', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(fixedTagsNotifierProvider.notifier);
+    final positivePrefix = await notifier.addEntry(
+      name: 'positive prefix',
+      content: 'old positive prefix',
+    );
+    final positiveSuffix = await notifier.addEntry(
+      name: 'positive suffix',
+      content: 'old positive suffix',
+      position: FixedTagPosition.suffix,
+    );
+    final negativePrefix = await notifier.addEntry(
+      name: 'negative prefix',
+      content: 'old negative prefix',
+      promptType: FixedTagPromptType.negative,
+    );
+    final negativeSuffix = await notifier.addEntry(
+      name: 'negative suffix',
+      content: 'old negative suffix',
+      position: FixedTagPosition.suffix,
+      promptType: FixedTagPromptType.negative,
+    );
+    const snapshot = FixedTagUsageSnapshot(
+      entries: [
+        FixedTagUsageEntry(
+          name: 'image prefix',
+          content: 'image positive prefix',
+          weight: 1,
+          renderedContent: 'image positive prefix',
+          position: FixedTagPosition.prefix,
+          promptType: FixedTagPromptType.positive,
+          order: 0,
+        ),
+      ],
+    );
+
+    await MetadataImportCoordinator.apply(
+      read: container.read,
+      metadata: NaiImageMetadata(
+        prompt: 'image positive prefix, subject',
+        fixedPrefixTags: const ['image positive prefix'],
+        fixedTagUsageData: snapshot.toJson(),
+      ),
+      options: const MetadataImportOptions(
+        importPrompt: false,
+        importNegativePrompt: false,
+        importFixedPrefix: true,
+        importFixedSuffix: false,
+        importFixedNegativePrefix: false,
+        importFixedNegativeSuffix: true,
+        importQualityTags: false,
+        importCharacterPrompts: false,
+        importVibeReferences: false,
+        importPreciseReferences: false,
+      ),
+      l10n: AppLocalizationsEn(),
+    );
+
+    final entries = container.read(fixedTagsNotifierProvider).entries;
+    bool enabled(String id) =>
+        entries.singleWhere((entry) => entry.id == id).enabled;
+    expect(enabled(positivePrefix.id), isFalse);
+    expect(enabled(positiveSuffix.id), isTrue);
+    expect(enabled(negativePrefix.id), isTrue);
+    expect(enabled(negativeSuffix.id), isFalse);
+    expect(
+      entries
+          .singleWhere((entry) => entry.content == 'image positive prefix')
+          .enabled,
+      isTrue,
+    );
+  });
+
+  test('changed fixed tag id creates and reuses an image version', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(fixedTagsNotifierProvider.notifier);
+    final current = await notifier.addEntry(name: 'A', content: 'best quality');
+    final sameContentEntry = await notifier.addEntry(
+      name: 'B',
+      content: 'masterpiece',
+      enabled: false,
+    );
+    final snapshot = FixedTagUsageSnapshot(
+      entries: [
+        FixedTagUsageEntry(
+          fixedTagId: current.id,
+          name: 'A',
+          content: 'masterpiece',
+          weight: 1,
+          renderedContent: 'masterpiece',
+          position: FixedTagPosition.prefix,
+          promptType: FixedTagPromptType.positive,
+          order: 0,
+        ),
+      ],
+    );
+    final metadata = NaiImageMetadata(
+      prompt: 'masterpiece, subject',
+      fixedPrefixTags: const ['masterpiece'],
+      fixedTagUsageData: snapshot.toJson(),
+    );
+    const options = MetadataImportOptions(
+      importNegativePrompt: false,
+      importFixedSuffix: false,
+      importQualityTags: false,
+      importCharacterPrompts: false,
+      importVibeReferences: false,
+      importPreciseReferences: false,
+    );
+
+    for (var i = 0; i < 2; i++) {
+      await MetadataImportCoordinator.apply(
+        read: container.read,
+        metadata: metadata,
+        options: options,
+        l10n: AppLocalizationsEn(),
+      );
+    }
+
+    final entries = container.read(fixedTagsNotifierProvider).entries;
+    expect(entries, hasLength(3));
+    expect(
+      entries.singleWhere((entry) => entry.id == current.id).content,
+      'best quality',
+    );
+    final historical = entries.singleWhere(
+      (entry) => entry.importedFromFixedTagId == current.id,
+    );
+    expect(historical.content, 'masterpiece');
+    expect(historical.enabled, isTrue);
+    expect(
+      entries.singleWhere((entry) => entry.id == sameContentEntry.id).enabled,
+      isFalse,
+    );
+  });
+
+  test('unknown legacy prompt asks policy through options', () async {
+    Future<bool> apply(UnknownFixedTagPolicy policy) async {
+      await Hive.box(StorageKeys.settingsBox).clear();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final entry = await container
+          .read(fixedTagsNotifierProvider.notifier)
+          .addEntry(name: 'current', content: 'current tag');
+      await MetadataImportCoordinator.apply(
+        read: container.read,
+        metadata: const NaiImageMetadata(prompt: 'shared subject'),
+        options: MetadataImportOptions(
+          importNegativePrompt: false,
+          importQualityTags: false,
+          importCharacterPrompts: false,
+          importVibeReferences: false,
+          importPreciseReferences: false,
+          unknownFixedTagPolicy: policy,
+        ),
+        l10n: AppLocalizationsEn(),
+      );
+      return container
+          .read(fixedTagsNotifierProvider)
+          .entries
+          .singleWhere((candidate) => candidate.id == entry.id)
+          .enabled;
+    }
+
+    expect(await apply(UnknownFixedTagPolicy.disableCurrent), isFalse);
+    expect(await apply(UnknownFixedTagPolicy.keepCurrent), isTrue);
   });
 }

--- a/test/presentation/widgets/drop/image_destination_dialog_test.dart
+++ b/test/presentation/widgets/drop/image_destination_dialog_test.dart
@@ -239,7 +239,7 @@ void main() {
 
     expect(find.text('Metadata could not be parsed'), findsOneWidget);
     expect(find.text('View error details'), findsOneWidget);
-    expect(find.text('Extract Metadata'), findsNothing);
+    expect(find.text('Send to Text to Image'), findsNothing);
     expect(find.text('Image2Image'), findsOneWidget);
   });
 
@@ -394,10 +394,10 @@ void main() {
           findsOne,
         );
         expect(find.text('Actions'), findsOneWidget);
-        expect(find.text('Extract Metadata'), findsOneWidget);
+        expect(find.text('Send to Text to Image'), findsOneWidget);
         expect(find.text('Reverse Prompt'), findsOneWidget);
         expect(
-          tester.getTopLeft(find.text('Extract Metadata')).dy,
+          tester.getTopLeft(find.text('Send to Text to Image')).dy,
           lessThan(tester.getTopLeft(find.text('Reverse Prompt')).dy),
         );
         expect(tester.takeException(), isNull, reason: 'width=$width');
@@ -460,7 +460,7 @@ void main() {
       onResult: (result) => selected = result,
     );
 
-    final extract = find.text('Extract Metadata');
+    final extract = find.text('Send to Text to Image');
     await tester.ensureVisible(extract);
     await tester.tap(extract);
     await tester.pumpAndSettle();

--- a/test/presentation/widgets/metadata/metadata_import_dialog_test.dart
+++ b/test/presentation/widgets/metadata/metadata_import_dialog_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
 import 'package:nai_launcher/data/models/metadata/metadata_import_options.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/utils/fixed_tag_import_resolution.dart';
 import 'package:nai_launcher/presentation/widgets/metadata/metadata_import_dialog.dart';
 
 void main() {
@@ -13,6 +14,7 @@ void main() {
     EdgeInsets padding = EdgeInsets.zero,
     EdgeInsets viewInsets = EdgeInsets.zero,
     NaiImageMetadata metadata = const NaiImageMetadata(steps: 28, scale: 5),
+    FixedTagImportResolution? fixedTagResolution,
   }) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = size;
@@ -43,6 +45,7 @@ void main() {
                 result = await MetadataImportDialog.show(
                   context,
                   metadata: metadata,
+                  fixedTagResolution: fixedTagResolution,
                 );
               },
               child: const Text('Open'),
@@ -206,5 +209,24 @@ void main() {
     expect(find.text('步数'), findsOneWidget);
     expect(find.text('CFG 强度'), findsOneWidget);
     expect(find.text('CFG 强度：'), findsNothing);
+  });
+
+  testWidgets('unknown fixed tags require an explicit stacking policy', (
+    tester,
+  ) async {
+    const metadata = NaiImageMetadata(prompt: 'shared prompt');
+    await pumpAndOpenDialog(
+      tester,
+      size: const Size(700, 800),
+      metadata: metadata,
+      fixedTagResolution: const FixedTagImportResolution(
+        metadata: metadata,
+        source: FixedTagImportSource.unknown,
+      ),
+    );
+
+    expect(find.text('Source: not recorded; cannot be determined'), findsOne);
+    expect(find.text('Disable current fixed tags (recommended)'), findsOne);
+    expect(find.text('Keep and stack with the image prompt'), findsOne);
   });
 }


### PR DESCRIPTION
## 改动内容

- 生成请求确定时记录版本化 `aaalice_fixed_tags` 快照，并继续写入旧版 `fixed_*` 字段；自动保存、手动保存和图库保存都会补写该快照，同时保留原有 NovelAI 元数据
- 导入固定词按“新版快照 → 旧版字段 → 用户当前固定词库严格边界匹配 → 无法确认”处理，不再使用内置常见词猜测，避免 Issue #219 的 `<quality>` 内容被误拆
- 固定词恢复改为按正面/负面、前置/后置范围批量替换启用组合；同 ID 内容已变化时保留当前条目，并创建或复用“图像版本”
- 本地图库、图片详情、图片菜单、移动端选择和全局拖入统一走 `ImageMetadataImportWorkflow`；外部拖入仍先选用途，再选具体导入内容
- 无法确认固定词的老图片可选择关闭对应范围当前固定词（默认推荐）或保留并叠加

Fixes #219

## 验证结果

- 16 个相关测试文件：170 项通过，1 项因本地缺少官方 PNG 样本按既有逻辑跳过
- 使用本地图库 570 张 PNG 做只读实图回归：569 张元数据解析成功，固定词识别阶段未改写原始 prompt；1 张水印图本身无可解析生成元数据
- 在真实 PNG 副本字节上补写固定词快照后，原提示词、负面提示词、seed、Source 和未知 Comment 字段均保持不变
- `dart analyze`：通过
- `dart run build_runner build --delete-conflicting-outputs`：通过
- `scripts/verify_flutter_sources.ps1`：通过
- `git diff --check`：通过

## 注意事项

- 未执行会消耗 Anlas 的真实生成
- 未执行 Windows/Android 运行时自动化；导入窗口和拖入流程已由相关 Widget tests 覆盖