### PR TITLE
fix(reverse-prompt): 支持新版本地 ONNX Tagger

### DIFF
--- a/lib/data/services/local_onnx_model_service.dart
+++ b/lib/data/services/local_onnx_model_service.dart
@@ -9,7 +9,13 @@ import '../../core/constants/storage_keys.dart';
 import '../../core/storage/local_storage_service.dart';
 import '../../core/utils/app_logger.dart';
 
-enum LocalOnnxModelKind { wd14Tagger, clTagger, unknown }
+enum LocalOnnxModelKind {
+  wd14Tagger,
+  clTagger,
+  clTaggerV2,
+  animeTimmEva02,
+  unknown,
+}
 
 class LocalOnnxImportSource {
   const LocalOnnxImportSource({required this.name, required this.path});
@@ -322,6 +328,8 @@ class LocalOnnxModelService {
       allowedKinds: const {
         LocalOnnxModelKind.wd14Tagger,
         LocalOnnxModelKind.clTagger,
+        LocalOnnxModelKind.clTaggerV2,
+        LocalOnnxModelKind.animeTimmEva02,
         LocalOnnxModelKind.unknown,
       },
     );
@@ -346,7 +354,8 @@ class LocalOnnxModelService {
       if (entity is! File) continue;
       if (p.extension(entity.path).toLowerCase() != '.onnx') continue;
 
-      final kind = _inferKind(entity.path);
+      final labelsPath = await _findLabelsFile(entity.path);
+      final kind = _inferKind(entity.path, labelsPath);
       if (!allowedKinds.contains(kind)) continue;
 
       result.add(
@@ -354,7 +363,7 @@ class LocalOnnxModelService {
           name: p.basename(entity.path),
           path: entity.path,
           kind: kind,
-          labelsPath: await _findLabelsFile(entity.path),
+          labelsPath: labelsPath,
         ),
       );
     }
@@ -392,8 +401,18 @@ class LocalOnnxModelService {
     return false;
   }
 
-  LocalOnnxModelKind _inferKind(String filePath) {
+  LocalOnnxModelKind _inferKind(String filePath, String? labelsPath) {
+    final lowerPath = filePath.toLowerCase();
     final lower = p.basenameWithoutExtension(filePath).toLowerCase();
+    final lowerLabels = labelsPath?.toLowerCase() ?? '';
+    if (lowerPath.contains('cl_tagger_v2') ||
+        lowerPath.contains('cl-tagger-v2') ||
+        lowerLabels.endsWith('model_vocabulary.json')) {
+      return LocalOnnxModelKind.clTaggerV2;
+    }
+    if (lowerPath.contains('eva02_large_patch14')) {
+      return LocalOnnxModelKind.animeTimmEva02;
+    }
     if (lower.contains('wd14') ||
         lower.contains('wd-v1-4') ||
         lower.contains('wd-v1-5') ||
@@ -434,6 +453,7 @@ class LocalOnnxModelService {
       'labels.txt',
       'classes.txt',
       'tag_mapping.json',
+      'model_vocabulary.json',
     ]) {
       final candidate = p.join(directory, name);
       if (await File(candidate).exists()) {

--- a/lib/data/services/local_onnx_tagger_preprocessor.dart
+++ b/lib/data/services/local_onnx_tagger_preprocessor.dart
@@ -1,0 +1,251 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+import 'local_onnx_model_service.dart';
+
+enum OnnxTaggerPreprocessing { wd14, clTagger, clTaggerV2, animeTimm }
+
+enum OnnxTaggerOutputActivation { auto, sigmoid }
+
+class OnnxTaggerPreprocessProfile {
+  const OnnxTaggerPreprocessProfile({
+    required this.preprocessing,
+    required this.inputSize,
+    required this.outputActivation,
+  });
+
+  final OnnxTaggerPreprocessing preprocessing;
+  final int inputSize;
+  final OnnxTaggerOutputActivation outputActivation;
+
+  List<double> normalizeScores(List<double> scores) {
+    if (outputActivation == OnnxTaggerOutputActivation.sigmoid ||
+        scores.any((score) => score < 0 || score > 1)) {
+      return scores.map((score) => 1 / (1 + math.exp(-score))).toList();
+    }
+    return scores;
+  }
+}
+
+class OnnxImageInput {
+  const OnnxImageInput({required this.data, required this.shape});
+
+  final Float32List data;
+  final List<int> shape;
+}
+
+class OnnxLetterboxLayout {
+  const OnnxLetterboxLayout({
+    required this.canvasWidth,
+    required this.canvasHeight,
+    required this.resizedWidth,
+    required this.resizedHeight,
+    required this.offsetX,
+    required this.offsetY,
+  });
+
+  final int canvasWidth;
+  final int canvasHeight;
+  final int resizedWidth;
+  final int resizedHeight;
+  final int offsetX;
+  final int offsetY;
+
+  int get canvasPixels => canvasWidth * canvasHeight;
+}
+
+class LocalOnnxTaggerPreprocessor {
+  const LocalOnnxTaggerPreprocessor._();
+
+  static const int defaultInputSize = 448;
+  static const List<double> _animeTimmMean = [
+    0.48145466,
+    0.4578275,
+    0.40821073,
+  ];
+  static const List<double> _animeTimmStd = [0.26862954, 0.2613026, 0.2757771];
+
+  static OnnxTaggerPreprocessProfile profileFor(
+    LocalOnnxModelDescriptor model,
+  ) {
+    return switch (model.kind) {
+      LocalOnnxModelKind.clTaggerV2 => const OnnxTaggerPreprocessProfile(
+        preprocessing: OnnxTaggerPreprocessing.clTaggerV2,
+        inputSize: 384,
+        outputActivation: OnnxTaggerOutputActivation.sigmoid,
+      ),
+      LocalOnnxModelKind.clTagger => const OnnxTaggerPreprocessProfile(
+        preprocessing: OnnxTaggerPreprocessing.clTagger,
+        inputSize: 448,
+        outputActivation: OnnxTaggerOutputActivation.auto,
+      ),
+      LocalOnnxModelKind.animeTimmEva02 => const OnnxTaggerPreprocessProfile(
+        preprocessing: OnnxTaggerPreprocessing.animeTimm,
+        inputSize: 448,
+        outputActivation: OnnxTaggerOutputActivation.sigmoid,
+      ),
+      LocalOnnxModelKind.wd14Tagger ||
+      LocalOnnxModelKind.unknown => OnnxTaggerPreprocessProfile(
+        preprocessing: OnnxTaggerPreprocessing.wd14,
+        inputSize: _inputSizeFromName(model.name),
+        outputActivation: OnnxTaggerOutputActivation.auto,
+      ),
+    };
+  }
+
+  static OnnxImageInput preprocess(
+    img.Image source,
+    LocalOnnxModelDescriptor model,
+  ) {
+    final profile = profileFor(model);
+    if (profile.preprocessing == OnnxTaggerPreprocessing.animeTimm) {
+      return _preprocessAnimeTimm(source, profile.inputSize);
+    }
+
+    final resized = _letterbox(
+      source,
+      profile.inputSize,
+      interpolation: img.Interpolation.cubic,
+    );
+    return switch (profile.preprocessing) {
+      OnnxTaggerPreprocessing.clTaggerV2 => _nchwInput(
+        resized,
+        channelOrder: const [0, 1, 2],
+        normalize: (value, _) => value / 127.5 - 1.0,
+      ),
+      OnnxTaggerPreprocessing.clTagger => _nchwInput(
+        resized,
+        channelOrder: const [2, 1, 0],
+        normalize: (value, _) => value / 255.0,
+      ),
+      OnnxTaggerPreprocessing.wd14 => _nhwcBgrInput(resized),
+      OnnxTaggerPreprocessing.animeTimm => throw StateError(
+        'AnimeTimm preprocessing must use its official resize pipeline',
+      ),
+    };
+  }
+
+  static OnnxImageInput _preprocessAnimeTimm(img.Image source, int inputSize) {
+    // AnimeTimm's published pipeline first fits onto a 512px white canvas
+    // with bilinear interpolation, then resizes that canvas to 448px bicubic.
+    final padded = _letterbox(
+      source,
+      512,
+      interpolation: img.Interpolation.linear,
+    );
+    final resized = img.copyResize(
+      padded,
+      width: inputSize,
+      height: inputSize,
+      interpolation: img.Interpolation.cubic,
+    );
+    return _nchwInput(
+      resized,
+      channelOrder: const [0, 1, 2],
+      normalize: (value, channel) =>
+          (value / 255.0 - _animeTimmMean[channel]) / _animeTimmStd[channel],
+    );
+  }
+
+  static img.Image _letterbox(
+    img.Image source,
+    int inputSize, {
+    required img.Interpolation interpolation,
+  }) {
+    final layout = computeLetterboxLayout(
+      sourceWidth: source.width,
+      sourceHeight: source.height,
+      inputSize: inputSize,
+    );
+    final resizedSource = img.copyResize(
+      source,
+      width: layout.resizedWidth,
+      height: layout.resizedHeight,
+      interpolation: interpolation,
+    );
+    final canvas = img.Image(
+      width: layout.canvasWidth,
+      height: layout.canvasHeight,
+    );
+    img.fill(canvas, color: img.ColorRgb8(255, 255, 255));
+    img.compositeImage(
+      canvas,
+      resizedSource,
+      dstX: layout.offsetX,
+      dstY: layout.offsetY,
+    );
+    return canvas;
+  }
+
+  static OnnxImageInput _nchwInput(
+    img.Image image, {
+    required List<int> channelOrder,
+    required double Function(double value, int channel) normalize,
+  }) {
+    final planeSize = image.width * image.height;
+    final data = Float32List(planeSize * 3);
+    for (
+      var outputChannel = 0;
+      outputChannel < channelOrder.length;
+      outputChannel++
+    ) {
+      var offset = outputChannel * planeSize;
+      final sourceChannel = channelOrder[outputChannel];
+      for (var y = 0; y < image.height; y++) {
+        for (var x = 0; x < image.width; x++) {
+          final pixel = image.getPixel(x, y);
+          final value = switch (sourceChannel) {
+            0 => pixel.r.toDouble(),
+            1 => pixel.g.toDouble(),
+            2 => pixel.b.toDouble(),
+            _ => throw RangeError.index(sourceChannel, channelOrder),
+          };
+          data[offset++] = normalize(value, sourceChannel);
+        }
+      }
+    }
+    return OnnxImageInput(data: data, shape: [1, 3, image.height, image.width]);
+  }
+
+  static OnnxImageInput _nhwcBgrInput(img.Image image) {
+    final data = Float32List(image.width * image.height * 3);
+    var offset = 0;
+    for (var y = 0; y < image.height; y++) {
+      for (var x = 0; x < image.width; x++) {
+        final pixel = image.getPixel(x, y);
+        data[offset++] = pixel.b.toDouble();
+        data[offset++] = pixel.g.toDouble();
+        data[offset++] = pixel.r.toDouble();
+      }
+    }
+    return OnnxImageInput(data: data, shape: [1, image.height, image.width, 3]);
+  }
+
+  static int _inputSizeFromName(String modelName) {
+    final match = RegExp(
+      r'(?:^|[^0-9])(224|256|384|448|512)(?:[^0-9]|$)',
+    ).firstMatch(modelName.toLowerCase());
+    return match == null ? defaultInputSize : int.parse(match.group(1)!);
+  }
+
+  static OnnxLetterboxLayout computeLetterboxLayout({
+    required int sourceWidth,
+    required int sourceHeight,
+    required int inputSize,
+  }) {
+    final longestSide = math.max(1, math.max(sourceWidth, sourceHeight));
+    final scale = inputSize / longestSide;
+    final resizedWidth = math.max(1, (sourceWidth * scale).round());
+    final resizedHeight = math.max(1, (sourceHeight * scale).round());
+    return OnnxLetterboxLayout(
+      canvasWidth: inputSize,
+      canvasHeight: inputSize,
+      resizedWidth: math.min(inputSize, resizedWidth),
+      resizedHeight: math.min(inputSize, resizedHeight),
+      offsetX: (inputSize - resizedWidth) ~/ 2,
+      offsetY: (inputSize - resizedHeight) ~/ 2,
+    );
+  }
+}

--- a/lib/data/services/local_onnx_tagger_service.dart
+++ b/lib/data/services/local_onnx_tagger_service.dart
@@ -18,6 +18,7 @@ import 'package:onnxruntime_v2/src/bindings/onnxruntime_bindings_generated.dart'
 
 import '../../core/utils/isolate_pool.dart';
 import 'local_onnx_model_service.dart';
+import 'local_onnx_tagger_preprocessor.dart';
 
 final localOnnxTaggerServiceProvider = Provider<LocalOnnxTaggerService>((ref) {
   return const LocalOnnxTaggerService();
@@ -78,39 +79,11 @@ class OnnxTaggerResult {
   String get prompt => tags.map((tag) => tag.name).join(', ');
 }
 
-class _OnnxImageInput {
-  const _OnnxImageInput({required this.data, required this.shape});
-
-  final Float32List data;
-  final List<int> shape;
-}
-
 enum OnnxSessionLoadMode { externalDataFile, patchedSingleFile }
-
-class OnnxLetterboxLayout {
-  const OnnxLetterboxLayout({
-    required this.canvasWidth,
-    required this.canvasHeight,
-    required this.resizedWidth,
-    required this.resizedHeight,
-    required this.offsetX,
-    required this.offsetY,
-  });
-
-  final int canvasWidth;
-  final int canvasHeight;
-  final int resizedWidth;
-  final int resizedHeight;
-  final int offsetX;
-  final int offsetY;
-
-  int get canvasPixels => canvasWidth * canvasHeight;
-}
 
 class LocalOnnxTaggerService {
   const LocalOnnxTaggerService();
 
-  static const int defaultInputSize = 448;
   static const int _opsetPatchTailBytes = 4096;
 
   static OnnxLetterboxLayout debugLetterboxLayoutForTesting({
@@ -118,7 +91,7 @@ class LocalOnnxTaggerService {
     required int sourceHeight,
     required int inputSize,
   }) {
-    return _computeLetterboxLayout(
+    return LocalOnnxTaggerPreprocessor.computeLetterboxLayout(
       sourceWidth: sourceWidth,
       sourceHeight: sourceHeight,
       inputSize: inputSize,
@@ -175,8 +148,7 @@ class LocalOnnxTaggerService {
       throw StateError('无法解码图片');
     }
 
-    final inputSize = _resolveInputSize(model);
-    final input = _preprocessImage(decoded, inputSize, model);
+    final input = LocalOnnxTaggerPreprocessor.preprocess(decoded, model);
     final options = OrtSessionOptions()
       ..setInterOpNumThreads(1)
       ..setIntraOpNumThreads(1)
@@ -196,7 +168,7 @@ class LocalOnnxTaggerService {
       final inputs = {inputName: inputOrt};
       outputs = session.run(runOptions, inputs, outputNames);
       final scores = outputs.isNotEmpty
-          ? _normalizeScores(_flattenScores(outputs.first?.value))
+          ? _normalizeScores(_flattenScores(outputs.first?.value), model)
           : <double>[];
       return OnnxTaggerResult(
         model: model,
@@ -420,7 +392,8 @@ class LocalOnnxTaggerService {
   }
 
   String _resolveInputName(OrtSession session, LocalOnnxModelDescriptor model) {
-    if (_isClTaggerV2(model) && session.inputNames.contains('pixel_values')) {
+    if (model.kind == LocalOnnxModelKind.clTaggerV2 &&
+        session.inputNames.contains('pixel_values')) {
       return 'pixel_values';
     }
     return session.inputNames.isNotEmpty ? session.inputNames.first : 'input';
@@ -430,136 +403,11 @@ class LocalOnnxTaggerService {
     OrtSession session,
     LocalOnnxModelDescriptor model,
   ) {
-    if (_isClTaggerV2(model) && session.outputNames.contains('logits')) {
+    if (model.kind == LocalOnnxModelKind.clTaggerV2 &&
+        session.outputNames.contains('logits')) {
       return const ['logits'];
     }
     return null;
-  }
-
-  int _resolveInputSize(LocalOnnxModelDescriptor model) {
-    final lower = model.name.toLowerCase();
-    if (_isClTaggerV2(model)) {
-      return 384;
-    }
-    if (_isClTagger(model)) {
-      return 448;
-    }
-    final match = RegExp(
-      r'(?:^|[^0-9])(224|256|384|448|512)(?:[^0-9]|$)',
-    ).firstMatch(lower);
-    if (match != null) {
-      return int.parse(match.group(1)!);
-    }
-    return defaultInputSize;
-  }
-
-  bool _isClTaggerV2(LocalOnnxModelDescriptor model) {
-    final lowerName = model.name.toLowerCase();
-    final lowerPath = model.path.toLowerCase();
-    final lowerLabels = model.labelsPath?.toLowerCase() ?? '';
-    return lowerName.contains('cl_tagger_v2') ||
-        lowerName.contains('cl-tagger-v2') ||
-        lowerPath.contains('cl_tagger_v2') ||
-        lowerPath.contains('cl-tagger-v2') ||
-        lowerLabels.endsWith('model_vocabulary.json');
-  }
-
-  bool _isClTagger(LocalOnnxModelDescriptor model) {
-    final lowerName = model.name.toLowerCase();
-    return model.kind == LocalOnnxModelKind.clTagger ||
-        lowerName.contains('cl_tagger');
-  }
-
-  _OnnxImageInput _preprocessImage(
-    img.Image source,
-    int inputSize,
-    LocalOnnxModelDescriptor model,
-  ) {
-    final layout = _computeLetterboxLayout(
-      sourceWidth: source.width,
-      sourceHeight: source.height,
-      inputSize: inputSize,
-    );
-    final resizedSource = img.copyResize(
-      source,
-      width: layout.resizedWidth,
-      height: layout.resizedHeight,
-      interpolation: img.Interpolation.cubic,
-    );
-    final resized = img.Image(
-      width: layout.canvasWidth,
-      height: layout.canvasHeight,
-    );
-    img.fill(resized, color: img.ColorRgb8(255, 255, 255));
-    img.compositeImage(
-      resized,
-      resizedSource,
-      dstX: layout.offsetX,
-      dstY: layout.offsetY,
-    );
-
-    final data = Float32List(inputSize * inputSize * 3);
-    if (_isClTaggerV2(model)) {
-      final planeSize = inputSize * inputSize;
-      var rOffset = 0;
-      var gOffset = planeSize;
-      var bOffset = planeSize * 2;
-      for (var y = 0; y < inputSize; y++) {
-        for (var x = 0; x < inputSize; x++) {
-          final pixel = resized.getPixel(x, y);
-          data[rOffset++] = pixel.r.toDouble() / 127.5 - 1.0;
-          data[gOffset++] = pixel.g.toDouble() / 127.5 - 1.0;
-          data[bOffset++] = pixel.b.toDouble() / 127.5 - 1.0;
-        }
-      }
-      return _OnnxImageInput(data: data, shape: [1, 3, inputSize, inputSize]);
-    }
-
-    if (_isClTagger(model)) {
-      final planeSize = inputSize * inputSize;
-      var bOffset = 0;
-      var gOffset = planeSize;
-      var rOffset = planeSize * 2;
-      for (var y = 0; y < inputSize; y++) {
-        for (var x = 0; x < inputSize; x++) {
-          final pixel = resized.getPixel(x, y);
-          data[bOffset++] = pixel.b.toDouble() / 255.0;
-          data[gOffset++] = pixel.g.toDouble() / 255.0;
-          data[rOffset++] = pixel.r.toDouble() / 255.0;
-        }
-      }
-      return _OnnxImageInput(data: data, shape: [1, 3, inputSize, inputSize]);
-    }
-
-    var offset = 0;
-    for (var y = 0; y < inputSize; y++) {
-      for (var x = 0; x < inputSize; x++) {
-        final pixel = resized.getPixel(x, y);
-        data[offset++] = pixel.b.toDouble();
-        data[offset++] = pixel.g.toDouble();
-        data[offset++] = pixel.r.toDouble();
-      }
-    }
-    return _OnnxImageInput(data: data, shape: [1, inputSize, inputSize, 3]);
-  }
-
-  static OnnxLetterboxLayout _computeLetterboxLayout({
-    required int sourceWidth,
-    required int sourceHeight,
-    required int inputSize,
-  }) {
-    final longestSide = math.max(1, math.max(sourceWidth, sourceHeight));
-    final scale = inputSize / longestSide;
-    final resizedWidth = math.max(1, (sourceWidth * scale).round());
-    final resizedHeight = math.max(1, (sourceHeight * scale).round());
-    return OnnxLetterboxLayout(
-      canvasWidth: inputSize,
-      canvasHeight: inputSize,
-      resizedWidth: math.min(inputSize, resizedWidth),
-      resizedHeight: math.min(inputSize, resizedHeight),
-      offsetX: (inputSize - resizedWidth) ~/ 2,
-      offsetY: (inputSize - resizedHeight) ~/ 2,
-    );
   }
 
   List<double> _flattenScores(Object? value) {
@@ -581,11 +429,13 @@ class LocalOnnxTaggerService {
     return scores;
   }
 
-  List<double> _normalizeScores(List<double> scores) {
-    if (scores.any((score) => score < 0 || score > 1)) {
-      return scores.map((score) => 1 / (1 + math.exp(-score))).toList();
-    }
-    return scores;
+  List<double> _normalizeScores(
+    List<double> scores,
+    LocalOnnxModelDescriptor model,
+  ) {
+    return LocalOnnxTaggerPreprocessor.profileFor(
+      model,
+    ).normalizeScores(scores);
   }
 
   Uint8List _patchUnsupportedOpsetImports(Uint8List bytes) {

--- a/test/data/services/local_onnx_model_service_test.dart
+++ b/test/data/services/local_onnx_model_service_test.dart
@@ -150,6 +150,63 @@ void main() {
       expect(service.taggerDirectory, isEmpty);
     },
   );
+
+  test(
+    'discovers CL Tagger v2 vocabulary beside an external-data model',
+    () async {
+      final modelDirectory = await Directory(
+        p.join(tempDirectory.path, 'cl_tagger_v2', 'v2_01a'),
+      ).create(recursive: true);
+      final model = await File(
+        p.join(modelDirectory.path, 'model.onnx'),
+      ).writeAsBytes([1]);
+      await File('${model.path}.data').writeAsBytes([2]);
+      final vocabulary = await File(
+        p.join(modelDirectory.path, 'model_vocabulary.json'),
+      ).writeAsString('{"idx_to_tag":{"0":"1girl"}}');
+      await service.setTaggerDirectory(modelDirectory.path);
+
+      final models = await service.scanTaggerModels();
+
+      expect(models, hasLength(1));
+      expect(models.single.path, model.path);
+      expect(models.single.kind, LocalOnnxModelKind.clTaggerV2);
+      expect(models.single.labelsPath, vocabulary.path);
+    },
+  );
+
+  test('recognizes the AnimeTimm EVA02 model family', () async {
+    for (final layout in const [
+      (
+        directory: 'reported_names',
+        model: 'eva02_large_patch14.onnx',
+        labels: 'eva02_large_patch14.csv',
+      ),
+      (
+        directory: 'eva02_large_patch14_448.dbv4-full',
+        model: 'model.onnx',
+        labels: 'selected_tags.csv',
+      ),
+    ]) {
+      final modelDirectory = await Directory(
+        p.join(tempDirectory.path, 'animetimm', layout.directory),
+      ).create(recursive: true);
+      final model = await File(
+        p.join(modelDirectory.path, layout.model),
+      ).writeAsBytes([1]);
+      final labels = await File(
+        p.join(modelDirectory.path, layout.labels),
+      ).writeAsString('name,category,best_threshold\n1girl,0,0.4\n');
+      await service.setTaggerDirectory(modelDirectory.path);
+
+      final models = await service.scanTaggerModels();
+
+      expect(models, hasLength(1));
+      expect(models.single.path, model.path);
+      expect(models.single.kind, LocalOnnxModelKind.animeTimmEva02);
+      expect(models.single.labelsPath, labels.path);
+    }
+  });
 }
 
 class _TestPathProviderPlatform extends PathProviderPlatform {

--- a/test/data/services/local_onnx_tagger_service_test.dart
+++ b/test/data/services/local_onnx_tagger_service_test.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
 import 'package:nai_launcher/core/utils/isolate_pool.dart';
 import 'package:nai_launcher/data/services/local_onnx_model_service.dart';
+import 'package:nai_launcher/data/services/local_onnx_tagger_preprocessor.dart';
 import 'package:nai_launcher/data/services/local_onnx_tagger_service.dart';
 
 void main() {
@@ -25,6 +27,29 @@ void main() {
         expect(layout.canvasPixels, 448 * 448);
       },
     );
+
+    test('uses AnimeTimm official RGB NCHW normalization profile', () {
+      const descriptor = LocalOnnxModelDescriptor(
+        name: 'eva02_large_patch14.onnx',
+        path: 'eva02_large_patch14.onnx',
+        kind: LocalOnnxModelKind.animeTimmEva02,
+      );
+      final source = img.Image(width: 2, height: 1);
+      img.fill(source, color: img.ColorRgb8(255, 0, 0));
+
+      final input = LocalOnnxTaggerPreprocessor.preprocess(source, descriptor);
+      final profile = LocalOnnxTaggerPreprocessor.profileFor(descriptor);
+      const planeSize = 448 * 448;
+      const centerPixel = 224 * 448 + 224;
+
+      expect(input.shape, [1, 3, 448, 448]);
+      expect(input.data[centerPixel], closeTo(1.9303, 0.001));
+      expect(input.data[planeSize + centerPixel], closeTo(-1.7521, 0.001));
+      expect(input.data[planeSize * 2 + centerPixel], closeTo(-1.4802, 0.001));
+      expect(input.data[planeSize], closeTo(2.0749, 0.001));
+      expect(input.data[planeSize * 2], closeTo(2.1459, 0.001));
+      expect(profile.normalizeScores([0]).single, closeTo(0.5, 0.000001));
+    });
   });
 
   group('LocalOnnxTaggerService session loading', () {
@@ -54,7 +79,7 @@ void main() {
         final descriptor = LocalOnnxModelDescriptor(
           name: 'cl_tagger_v2',
           path: modelPath,
-          kind: LocalOnnxModelKind.clTagger,
+          kind: LocalOnnxModelKind.clTaggerV2,
           labelsPath:
               '${directory.path}${Platform.pathSeparator}model_vocabulary.json',
         );


### PR DESCRIPTION
## 改动内容

- 修复 CL Tagger v2 无法识别 `model_vocabulary.json` 的问题，并保留 `model.onnx.data` external-data 加载方式
- 增加 AnimeTimm EVA02 模型识别，按官方要求生成 RGB NCHW 输入、执行白底补齐与归一化，并对 logits 应用 sigmoid
- 将各类 ONNX Tagger 的预处理配置拆分到独立模块，降低后续扩展新模型的维护成本
- 补充 CL Tagger v2 与 AnimeTimm EVA02 的模型扫描和预处理回归测试

## 验证结果

- `scripts/test_affected.ps1`：受影响的 4 个测试文件共 91 项测试通过
- `scripts/run_flutter_tests.ps1`：ONNX 模型服务与 Tagger 服务共 10 项测试通过
- `flutter analyze`：5 个相关文件无问题
- `git diff --check`：通过

## 注意事项

- AnimeTimm 官方模型需要授权访问且约 1.27 GB，本次未使用真实权重执行完整推理；模型输入形状、预处理参数与输出激活已按官方文档实现并由纯逻辑测试覆盖

Closes #217
