### PR TITLE
style(slider): 移除所有滑条间隔点

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -257,6 +257,10 @@ Compact/Medium 下没有持久侧栏时，页面名称保留在主工具栏，�
 - **Hierarchy**：大面积 Prompt 编辑器优先保障正文面积，工具操作放在框外 footer；只读内容无需编辑能力时直接使用文本。
 - **Behavior**：prefix/suffix 保持次级权重；软键盘打开后当前字段必须可见。
 
+### Sliders
+
+- 滑条可以使用 `divisions` 保留离散取值、键盘步进和语义行为，但所有主题与局部 `SliderTheme` 均隐藏轨道间隔点，只显示轨道、进度和滑块。
+
 ### Chips
 
 - **Style**：默认无 side，普通背景使用 `surfaceContainerHighest`，selected 使用 `primaryContainer`；短标签采用 4px 圆角与 8×4px padding。

--- a/lib/presentation/screens/generation/widgets/generation_param_sections.dart
+++ b/lib/presentation/screens/generation/widgets/generation_param_sections.dart
@@ -278,7 +278,6 @@ class StepsSection extends ConsumerWidget {
           min: 1,
           max: 50,
           divisions: 49,
-          hideTickMarks: true,
           onChanged: (value) {
             ref
                 .read(generationParamsNotifierProvider.notifier)

--- a/lib/presentation/themes/core/theme_composer.dart
+++ b/lib/presentation/themes/core/theme_composer.dart
@@ -79,6 +79,9 @@ class ThemeComposer {
         ),
       ),
       materialTapTargetSize: MaterialTapTargetSize.padded,
+      sliderTheme: SliderThemeData(
+        tickMarkShape: SliderTickMarkShape.noTickMark,
+      ),
 
       // Apply divider module colors to Flutter's built-in divider
       dividerColor: colorScheme.onSurface.withValues(alpha: 0.08),

--- a/lib/presentation/widgets/common/themed_slider.dart
+++ b/lib/presentation/widgets/common/themed_slider.dart
@@ -15,7 +15,6 @@ class ThemedSlider extends StatelessWidget {
     this.divisions,
     this.label,
     this.enabled = true,
-    this.hideTickMarks = false,
     this.activeColor,
     this.inactiveColor,
     this.thumbColor,
@@ -32,7 +31,6 @@ class ThemedSlider extends StatelessWidget {
   final int? divisions;
   final String? label;
   final bool enabled;
-  final bool hideTickMarks;
   final Color? activeColor;
   final Color? inactiveColor;
   final Color? thumbColor;
@@ -51,7 +49,7 @@ class ThemedSlider extends StatelessWidget {
         inactiveTrackColor: inactiveColor ?? colors.surfaceContainerHighest,
         thumbColor: thumbColor ?? activeColor ?? colors.primary,
         overlayColor: (activeColor ?? colors.primary).withValues(alpha: 0.12),
-        tickMarkShape: hideTickMarks ? SliderTickMarkShape.noTickMark : null,
+        tickMarkShape: SliderTickMarkShape.noTickMark,
         thumbShape: RoundSliderThumbShape(
           enabledThumbRadius: thumbSize / 2,
           disabledThumbRadius: thumbSize / 2,

--- a/lib/presentation/widgets/online_gallery/video_player_widget.dart
+++ b/lib/presentation/widgets/online_gallery/video_player_widget.dart
@@ -328,6 +328,7 @@ class OnlineGalleryVideoControls extends StatelessWidget {
                         child: SliderTheme(
                           data: SliderThemeData(
                             trackHeight: 3,
+                            tickMarkShape: SliderTickMarkShape.noTickMark,
                             thumbShape: const RoundSliderThumbShape(
                               enabledThumbRadius: 5,
                             ),

--- a/lib/presentation/widgets/prompt/components/tag_action_menu/bottom_action_sheet.dart
+++ b/lib/presentation/widgets/prompt/components/tag_action_menu/bottom_action_sheet.dart
@@ -305,6 +305,7 @@ class _TagBottomActionSheetState extends State<TagBottomActionSheet> {
           SliderTheme(
             data: SliderThemeData(
               trackHeight: 6,
+              tickMarkShape: SliderTickMarkShape.noTickMark,
               activeTrackColor: isIncrease
                   ? PromptTagColors.weightIncrease
                   : isDecrease

--- a/lib/presentation/widgets/prompt/random_manager/category_card_widgets.dart
+++ b/lib/presentation/widgets/prompt/random_manager/category_card_widgets.dart
@@ -236,6 +236,7 @@ class ColorfulProbabilitySlider extends StatelessWidget {
           child: SliderTheme(
             data: SliderThemeData(
               trackHeight: 6,
+              tickMarkShape: SliderTickMarkShape.noTickMark,
               // 隐藏默认轨道，使用自定义背景
               activeTrackColor: Colors.transparent,
               inactiveTrackColor: Colors.transparent,

--- a/test/presentation/screens/generation/widgets/parameter_panel_test.dart
+++ b/test/presentation/screens/generation/widgets/parameter_panel_test.dart
@@ -166,7 +166,7 @@ void main() {
       expect(cfgSliders, hasLength(1));
       expect(cfgSliders.single.divisions, equals(190));
       expect(stepsSliders, hasLength(1));
-      expect(stepsSliders.single.hideTickMarks, isTrue);
+      expect(stepsSliders.single.divisions, equals(49));
     });
 
     testWidgets('高级选项在侧栏色面内使用独立 Material', (tester) async {

--- a/test/presentation/themes/slider_theme_test.dart
+++ b/test/presentation/themes/slider_theme_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:nai_launcher/presentation/themes/app_theme.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
+
+  test('all app themes hide slider tick marks', () {
+    for (final style in AppStyle.values) {
+      for (final brightness in Brightness.values) {
+        final theme = AppTheme.getTheme(style, brightness);
+
+        expect(
+          theme.sliderTheme.tickMarkShape,
+          SliderTickMarkShape.noTickMark,
+          reason: '${style.name} ${brightness.name}',
+        );
+      }
+    }
+  });
+}

--- a/test/presentation/widgets/common/themed_slider_test.dart
+++ b/test/presentation/widgets/common/themed_slider_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/presentation/widgets/common/themed_slider.dart';
 
 void main() {
-  testWidgets('can hide tick marks without removing discrete divisions', (
+  testWidgets('hides tick marks without removing discrete divisions', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -14,7 +14,6 @@ void main() {
             min: 1,
             max: 50,
             divisions: 49,
-            hideTickMarks: true,
             onChanged: (_) {},
           ),
         ),


### PR DESCRIPTION
## 改动内容
- 在全局主题与公共 `ThemedSlider` 中统一隐藏滑条间隔点
- 为三个独立 `SliderTheme` 补充无间隔点配置
- 保留 `divisions` 的离散取值、键盘步进和语义行为
- 在 `DESIGN.md` 记录滑条视觉规范

## 验证结果
- `flutter test test/presentation/widgets/common/themed_slider_test.dart test/presentation/themes/slider_theme_test.dart test/presentation/screens/generation/widgets/parameter_panel_test.dart`
- `flutter analyze`（9 个受影响文件）
- `scripts/verify_flutter_sources.ps1`

## 注意事项
- 未执行运行时截图验收；改动仅影响 Slider tick mark 绘制，不改变取值逻辑