### PR TITLE
fix(cloud-sync): 移除图像与大文件备份

### DIFF
--- a/lib/data/cloud_sync/user_tag_library_cloud_sync_adapter.dart
+++ b/lib/data/cloud_sync/user_tag_library_cloud_sync_adapter.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'package:path/path.dart' as p;
-
 import '../../core/storage/local_storage_service.dart';
 import '../services/tag_library_io_service.dart';
 import '../services/tag_library_portable_thumbnail_store.dart';
@@ -24,26 +22,12 @@ class UserTagLibraryCloudSyncAdapter extends ValidatingCloudSyncDataAdapter {
   Stream<PortableSyncRecord> exportRecords() async* {
     for (final original in _decodeList(_storage.getTagLibraryEntriesJson())) {
       final entry = Map<String, dynamic>.from(original);
-      final thumbnail = entry.remove('thumbnail') as String?;
-      final length = await _io.thumbnailLength(thumbnail);
-      final extension = thumbnail == null
-          ? ''
-          : p.extension(thumbnail).toLowerCase();
+      entry.remove('thumbnail');
       yield PortableSyncRecord(
         adapterId: id,
         id: 'entry:${entry['id']}',
         kind: 'entry',
-        data: {
-          'entry': entry,
-          'thumbnailExtension': length == null ? null : extension,
-        },
-        resource: length == null
-            ? null
-            : PortableSyncResource(
-                relativePath: 'tag-library/${entry['id']}/thumbnail$extension',
-                length: length,
-                openRead: () => _io.openThumbnail(thumbnail!),
-              ),
+        data: {'entry': entry},
       );
     }
     for (final category in _decodeList(
@@ -80,11 +64,13 @@ class UserTagLibraryCloudSyncAdapter extends ValidatingCloudSyncDataAdapter {
     final extension = record.data['thumbnailExtension'];
     if (record.kind == 'category' && resource != null ||
         record.kind == 'entry' &&
-            ((resource == null) != (extension == null) ||
-                resource != null &&
-                    (!resource.relativePath.endsWith('/thumbnail$extension') ||
-                        resource.relativePath.contains('..')))) {
-      throw const CloudSyncPreflightException('Invalid tag thumbnail');
+            resource != null &&
+            (extension is! String ||
+                resource.relativePath !=
+                    'tag-library/$stableId/thumbnail$extension')) {
+      throw const CloudSyncPreflightException(
+        'Invalid legacy tag thumbnail resource',
+      );
     }
   }
 
@@ -125,15 +111,8 @@ class UserTagLibraryCloudSyncAdapter extends ValidatingCloudSyncDataAdapter {
         final value = Map<String, dynamic>.from(
           record.data[record.kind]! as Map,
         );
-        if (record.kind == 'entry') {
-          final mutation = await _io.stagePortableThumbnail(
-            stableId,
-            extension: record.data['thumbnailExtension'] as String?,
-            bytes: record.resource?.openRead(),
-            existingPath: existingThumbnail,
-          );
-          mutations.add(mutation);
-          value['thumbnail'] = mutation.path;
+        if (record.kind == 'entry' && existingThumbnail != null) {
+          value['thumbnail'] = existingThumbnail;
         }
         target[stableId] = value;
       }

--- a/lib/presentation/providers/cloud_sync/cloud_sync_connection_store.dart
+++ b/lib/presentation/providers/cloud_sync/cloud_sync_connection_store.dart
@@ -88,7 +88,10 @@ class CloudSyncConnectionStore {
         'allowInsecureHttp': draft.allowInsecureHttp,
         'accountId': draft.accountId,
         'accountLabel': draft.accountLabel,
-        'dataKinds': dataKinds.map((value) => value.name).toList(),
+        'dataKinds': dataKinds
+            .where(cloudSyncSelectableDataKinds.contains)
+            .map((value) => value.name)
+            .toList(),
         'contentSelection': contentSelection.toJson(),
         'remoteRevision': remoteRevision,
         'lastSync': lastSync?.toUtc().toIso8601String(),
@@ -143,9 +146,15 @@ class CloudSyncConnectionStore {
       public['version'] = _configurationVersion;
       await _localStorage.setSetting(configurationKey, jsonEncode(public));
     }
-    final scope = (public['dataKinds'] as List? ?? const [])
+    final storedKinds = public['dataKinds'] as List?;
+    final scope = (storedKinds ?? const [])
         .whereType<String>()
-        .map(CloudSyncDataKind.values.byName)
+        .map(
+          (name) => CloudSyncDataKind.values.where((kind) => kind.name == name),
+        )
+        .where((matches) => matches.isNotEmpty)
+        .map((matches) => matches.single)
+        .where(cloudSyncSelectableDataKinds.contains)
         .toSet();
     return PersistedCloudSyncConnection(
       draft: CloudSyncConnectionDraft(
@@ -163,7 +172,9 @@ class CloudSyncConnectionStore {
         accountId: public['accountId'] as String? ?? '',
         accountLabel: public['accountLabel'] as String? ?? '',
       ),
-      dataKinds: scope.isEmpty ? CloudSyncDataKind.values.toSet() : scope,
+      dataKinds: storedKinds == null
+          ? cloudSyncSelectableDataKinds
+          : Set.unmodifiable(scope),
       contentSelection: public['contentSelection'] == null
           ? const CloudSyncContentSelection()
           : CloudSyncContentSelection.decode(

--- a/lib/presentation/providers/cloud_sync/cloud_sync_provider_wiring.dart
+++ b/lib/presentation/providers/cloud_sync/cloud_sync_provider_wiring.dart
@@ -212,9 +212,7 @@ bool isCloudSyncAdapterInScope(
     return contentSelection.includeAgentSystemPrompt;
   }
   if (id == 'agent-skills') return contentSelection.includeSkills;
-  if (id == 'vibe-library' || id == 'precise-ref-library') {
-    return scope.contains(CloudSyncDataKind.largeBinary);
-  }
+  if (id == 'vibe-library' || id == 'precise-ref-library') return false;
   if (id.contains('gallery') || id == 'online-favorites') {
     return scope.contains(CloudSyncDataKind.galleries);
   }

--- a/lib/presentation/providers/cloud_sync/cloud_sync_ui_provider.dart
+++ b/lib/presentation/providers/cloud_sync/cloud_sync_ui_provider.dart
@@ -30,6 +30,12 @@ enum CloudSyncConflictChoice { local, remote, keepBoth }
 
 enum CloudSyncDataKind { settings, prompts, galleries, largeBinary }
 
+const cloudSyncSelectableDataKinds = <CloudSyncDataKind>{
+  CloudSyncDataKind.settings,
+  CloudSyncDataKind.prompts,
+  CloudSyncDataKind.galleries,
+};
+
 enum CloudSyncChangeKind { added, modified, deleted }
 
 @immutable

--- a/lib/presentation/screens/cloud_sync/cloud_sync_setup.dart
+++ b/lib/presentation/screens/cloud_sync/cloud_sync_setup.dart
@@ -396,10 +396,6 @@ class _CloudSyncSetupState extends ConsumerState<CloudSyncSetup> {
               CloudSyncDataKind.galleries,
               context.l10n.cloudSync_kindGalleries,
             ),
-            _filter(
-              CloudSyncDataKind.largeBinary,
-              context.l10n.cloudSync_kindLargeFiles,
-            ),
           ],
         ),
         const SizedBox(height: 16),

--- a/test/data/cloud_sync/user_tag_library_cloud_sync_adapter_test.dart
+++ b/test/data/cloud_sync/user_tag_library_cloud_sync_adapter_test.dart
@@ -7,6 +7,60 @@ import 'package:nai_launcher/data/services/tag_library_io_service.dart';
 import 'package:nai_launcher/data/services/tag_library_portable_thumbnail_store.dart';
 
 void main() {
+  test('exports tag entries without thumbnail image resources', () async {
+    final storage = _FailingStorage(
+      entries: jsonEncode([
+        {'id': 'tag-1', 'name': 'Portrait', 'thumbnail': 'portrait.png'},
+      ]),
+      categories: '[]',
+    );
+    final io = _TrackingIo(_TrackingMutation());
+    final records = await UserTagLibraryCloudSyncAdapter(
+      storage,
+      io,
+    ).exportRecords().toList();
+
+    expect(records, hasLength(1));
+    expect(records.single.resource, isNull);
+    expect(records.single.data, {
+      'entry': {'id': 'tag-1', 'name': 'Portrait'},
+    });
+    expect(io.thumbnailReads, 0);
+  });
+
+  test('restoring tag metadata preserves the device-local thumbnail', () async {
+    final storage = _FailingStorage(
+      entries: jsonEncode([
+        {'id': 'tag-1', 'name': 'Old', 'thumbnail': 'local.png'},
+      ]),
+      categories: '[]',
+    )..failNextCategoryWrite = false;
+    final io = _TrackingIo(_TrackingMutation());
+    final adapter = UserTagLibraryCloudSyncAdapter(storage, io);
+
+    await adapter.apply([
+      PortableSyncRecord(
+        adapterId: adapter.id,
+        id: 'entry:tag-1',
+        kind: 'entry',
+        data: {
+          'entry': {'id': 'tag-1', 'name': 'Updated'},
+          'thumbnailExtension': '.png',
+        },
+        resource: PortableSyncResource(
+          relativePath: 'tag-library/tag-1/thumbnail.png',
+          length: 3,
+          openRead: () => Stream.value([1, 2, 3]),
+        ),
+      ),
+    ]);
+
+    expect(jsonDecode(storage.entries), [
+      {'id': 'tag-1', 'name': 'Updated', 'thumbnail': 'local.png'},
+    ]);
+    expect(io.stageCalls, 0);
+  });
+
   test('metadata failure rolls back a tombstoned thumbnail', () async {
     final storage = _FailingStorage(
       entries: jsonEncode([
@@ -66,6 +120,14 @@ class _TrackingIo extends TagLibraryIOService {
 
   final PortableThumbnailMutation mutation;
   String? existingPath;
+  var stageCalls = 0;
+  var thumbnailReads = 0;
+
+  @override
+  Future<int?> thumbnailLength(String? filePath) async {
+    thumbnailReads++;
+    return 3;
+  }
 
   @override
   Future<PortableThumbnailMutation> stagePortableThumbnail(
@@ -74,6 +136,7 @@ class _TrackingIo extends TagLibraryIOService {
     required Stream<List<int>>? bytes,
     String? existingPath,
   }) async {
+    stageCalls++;
     this.existingPath = existingPath;
     return mutation;
   }

--- a/test/presentation/providers/cloud_sync_connection_store_test.dart
+++ b/test/presentation/providers/cloud_sync_connection_store_test.dart
@@ -160,6 +160,32 @@ void main() {
     expect(restored.contentSelection.includeSkills, isFalse);
     expect(restored.contentSelection.selectedSkillIds, isEmpty);
   });
+
+  test(
+    'legacy large-file scope is removed when restoring a connection',
+    () async {
+      final local = _MemoryLocalStorage();
+      final secure = _MemorySecureStorage()
+        ..credentials = jsonEncode({'username': 'user', 'secret': 'secret'});
+      local.values[StorageKeys.cloudSyncConfiguration] = jsonEncode({
+        'version': 3,
+        'backend': CloudSyncBackendKind.webDav.name,
+        'serverUrl': 'https://dav.test/root',
+        'dataKinds': [
+          CloudSyncDataKind.prompts.name,
+          CloudSyncDataKind.largeBinary.name,
+        ],
+      });
+      final store = CloudSyncConnectionStore(
+        localStorage: local,
+        secureStorage: secure,
+      );
+
+      final restored = await store.load();
+
+      expect(restored!.dataKinds, {CloudSyncDataKind.prompts});
+    },
+  );
 }
 
 class _MemoryLocalStorage extends LocalStorageService {

--- a/test/presentation/providers/cloud_sync_provider_wiring_test.dart
+++ b/test/presentation/providers/cloud_sync_provider_wiring_test.dart
@@ -48,4 +48,18 @@ void main() {
       isNot(contains('prompt-assistant')),
     );
   });
+
+  test('large-file libraries are never included in cloud backup', () {
+    const scope = {CloudSyncDataKind.largeBinary};
+    const selection = CloudSyncContentSelection();
+
+    expect(
+      isCloudSyncAdapterInScope('precise-ref-library', scope, selection),
+      isFalse,
+    );
+    expect(
+      isCloudSyncAdapterInScope('vibe-library', scope, selection),
+      isFalse,
+    );
+  });
 }

--- a/test/presentation/screens/cloud_sync/cloud_sync_screen_test.dart
+++ b/test/presentation/screens/cloud_sync/cloud_sync_screen_test.dart
@@ -59,7 +59,7 @@ void main() {
     );
     expect(tester.widget<TextField>(passwordField).obscureText, isTrue);
     expect(find.text('选择要保存的内容'), findsOneWidget);
-    expect(find.text('图片与其他大文件'), findsOneWidget);
+    expect(find.text('图片与其他大文件'), findsNothing);
     expect(find.textContaining('快照'), findsNothing);
     expect(find.textContaining('后端'), findsNothing);
     expect(find.text('设置加密密码'), findsNothing);


### PR DESCRIPTION
## 改动内容

- 移除云备份设置中的“图片与其他大文件”选项，不再同步精准参考与 Vibe 文件
- 词库仍同步条目与分类，但不再读取、上传或恢复缩略图；恢复时保留当前设备已有缩略图
- 自动过滤旧连接中已保存的 `largeBinary` 范围，避免升级后继续备份大文件

## 验证结果

- `scripts/test_affected.ps1`：7 个相关测试文件、42 项测试全部通过
- 针对 9 个改动文件执行 `flutter analyze`：无问题
- `scripts/verify_flutter_sources.ps1`：通过
- `git diff --check`：通过

## 注意事项

- 已存在于旧云端快照中的大文件不会被新版本继续扫描或新增；本次改动不会主动删除用户已有的历史备份