### PR TITLE
fix(prompt): 修正组成条点击高亮圆角

### DIFF
--- a/lib/presentation/screens/generation/widgets/prompt_tooltip_components.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_tooltip_components.dart
@@ -259,6 +259,7 @@ class _TooltipCompositionCardState extends State<_TooltipCompositionCard> {
             child: InkWell(
               onTap: () => setState(() => _expanded = !_expanded),
               mouseCursor: SystemMouseCursors.click,
+              borderRadius: BorderRadius.circular(8),
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(9, 7, 8, 7),
                 child: Row(

--- a/test/presentation/screens/generation/prompt_tooltip_components_test.dart
+++ b/test/presentation/screens/generation/prompt_tooltip_components_test.dart
@@ -81,6 +81,13 @@ void main() {
         expect(stepDecoration.color, isNotNull);
         expect(stepDecoration.border, isNull);
         expect(stepDecoration.borderRadius, BorderRadius.circular(8));
+        final stepInkWell = tester.widget<InkWell>(
+          find.descendant(
+            of: find.byKey(const ValueKey('step')),
+            matching: find.byType(InkWell),
+          ),
+        );
+        expect(stepInkWell.borderRadius, BorderRadius.circular(8));
         final stepPrompt = tester.widget<TranslatedPromptText>(
           find.descendant(
             of: find.byKey(const ValueKey('step')),


### PR DESCRIPTION
## 改动内容

- 为正负面提示词悬浮预览中的组成条点击态补充与容器一致的 8px 圆角
- 新增 Widget 回归断言，防止 InkWell 点击高亮退回方形

## 验证结果

- `flutter test test/presentation/screens/generation/prompt_tooltip_components_test.dart`（12/12 通过）
- `flutter analyze lib/presentation/screens/generation/widgets/prompt_tooltip_components.dart test/presentation/screens/generation/prompt_tooltip_components_test.dart`（无问题）
- `scripts/verify_flutter_sources.ps1`（通过）
- `git diff --check`（通过）

## 注意事项

- 无