### PR TITLE
feat(library): 统一拖拽与触屏分类交互

### DIFF
--- a/lib/presentation/screens/local_gallery/local_gallery_action_coordinator.dart
+++ b/lib/presentation/screens/local_gallery/local_gallery_action_coordinator.dart
@@ -504,6 +504,8 @@ class LocalGalleryActionCoordinator {
     switch (request.action) {
       case LocalImageContextAction.addToAgent:
         await _addToAgent(record);
+      case LocalImageContextAction.moveToCategory:
+        await _moveImageToCategory(record);
       case LocalImageContextAction.sendToTextToImage:
       case LocalImageContextAction.importMetadata:
         await importImageMetadata(record);
@@ -570,6 +572,50 @@ class LocalGalleryActionCoordinator {
           _context().l10n.agentChat_addResourceFailed('$error'),
         );
       }
+    }
+  }
+
+  Future<void> _moveImageToCategory(LocalImageRecord record) async {
+    final categories = _ref.read(galleryCategoryNotifierProvider).categories;
+    final targets = buildLocalGalleryMoveTargets(categories);
+    if (targets.isEmpty) {
+      AppToast.info(
+        _context(),
+        _context().l10n.localGallery_noCategoriesAvailable,
+      );
+      return;
+    }
+    final targetId = await showLocalGalleryMoveTargetDialog(
+      context: _context(),
+      targets: targets,
+    );
+    if (targetId == null || !_mounted()) return;
+    final protected = await AssetProtectionGuard.confirmDangerousAction(
+      context: _context(),
+      ref: _ref,
+      title: _context().l10n.localGallery_confirmMoveImageTitle,
+      content: _context().l10n.localGallery_confirmMoveImageContent,
+      confirmText: _context().l10n.localGallery_confirmMove,
+      icon: Icons.drive_file_move_outline,
+    );
+    if (!protected || !_mounted()) return;
+    final newPath = await _ref
+        .read(galleryCategoryNotifierProvider.notifier)
+        .moveImageToCategory(record.path, targetId);
+    if (newPath == null) return;
+    await _watermarkRegistry.relocatePath(
+      oldPath: record.path,
+      newPath: newPath,
+    );
+    await _ref.read(localGalleryNotifierProvider.notifier).refresh(scan: false);
+    unawaited(
+      _ref.read(galleryAlbumNotifierProvider.notifier).exportSidecarNow(),
+    );
+    if (_mounted()) {
+      AppToast.success(
+        _context(),
+        _context().l10n.localGallery_imageMovedToCategory,
+      );
     }
   }
 

--- a/lib/presentation/screens/local_gallery/local_gallery_category_panel.dart
+++ b/lib/presentation/screens/local_gallery/local_gallery_category_panel.dart
@@ -38,6 +38,7 @@ class LocalGalleryCategoryPanel extends StatefulWidget {
     required this.onAlbumMoveToSlot,
     required this.onCategoryMoveToSlot,
     required this.onImageDropToAlbum,
+    this.onImageFavoriteDrop,
     this.modal = false,
     this.scrollController,
     this.afterSelection,
@@ -77,6 +78,7 @@ class LocalGalleryCategoryPanel extends StatefulWidget {
   onCategoryMoveToSlot;
   final Future<void> Function(String imagePath, String albumId)
   onImageDropToAlbum;
+  final Future<void> Function(String imagePath)? onImageFavoriteDrop;
   final bool modal;
   final ScrollController? scrollController;
   final VoidCallback? afterSelection;
@@ -147,6 +149,7 @@ class _LocalGalleryCategoryPanelState extends State<LocalGalleryCategoryPanel> {
                       onAlbumMove: widget.onAlbumMove,
                       onAlbumMoveToSlot: widget.onAlbumMoveToSlot,
                       onImageDrop: widget.onImageDropToAlbum,
+                      onImageFavoriteDrop: widget.onImageFavoriteDrop,
                       onCreateAlbumRequest: () => widget.onCreateAlbum(null),
                     ),
                   ),

--- a/lib/presentation/screens/local_gallery/local_gallery_screen_controller.dart
+++ b/lib/presentation/screens/local_gallery/local_gallery_screen_controller.dart
@@ -314,6 +314,7 @@ class LocalGalleryScreenController extends ChangeNotifier {
           .read(galleryAlbumNotifierProvider.notifier)
           .moveAlbumToSlot(id, targetId, slot),
       onImageDropToAlbum: handleImageDropToAlbum,
+      onImageFavoriteDrop: handleImageFavoriteDrop,
     );
   }
 
@@ -486,6 +487,16 @@ class LocalGalleryScreenController extends ChangeNotifier {
         _context().l10n.localGallery_imageMovedToCategory,
       );
     }
+  }
+
+  Future<void> handleImageFavoriteDrop(String imagePath) async {
+    final images = _ref.read(localGalleryNotifierProvider).currentImages;
+    final index = images.indexWhere((item) => item.path == imagePath);
+    final image = index < 0 ? null : images[index];
+    if (image == null || image.isFavorite) return;
+    await _ref
+        .read(localGalleryNotifierProvider.notifier)
+        .toggleFavorite(imagePath);
   }
 
   Future<void> handleSyncWithFileSystem() async {

--- a/lib/presentation/screens/precise_ref_library/precise_ref_library_screen.dart
+++ b/lib/presentation/screens/precise_ref_library/precise_ref_library_screen.dart
@@ -25,6 +25,8 @@ import '../../utils/dropped_file_reader.dart';
 import '../../widgets/common/app_toast.dart';
 import '../../widgets/common/input_surface_container.dart';
 import '../../widgets/common/pagination_bar.dart';
+import '../../widgets/common/library_classification_drag.dart';
+import '../../widgets/common/precise_reference_type_dialog.dart';
 import '../../widgets/gallery/gallery_sidebar.dart';
 import '../../agent_chat/widgets/agent_resource_drop_region.dart';
 import 'widgets/precise_ref_card.dart';
@@ -342,6 +344,8 @@ class _PreciseRefLibraryScreenState
                   ? PreciseRefLibrarySidebar(
                       state: state,
                       onFilterChanged: _selectSidebarFilter,
+                      onEntryTypeDrop: _setEntryType,
+                      onFavoriteDrop: _favoriteEntry,
                     )
                   : null,
               body: state.isLoading
@@ -421,6 +425,8 @@ class _PreciseRefLibraryScreenState
           _selectSidebarFilter(favoritesOnly: favoritesOnly, type: type);
           Navigator.of(panelContext).pop();
         },
+        onEntryTypeDrop: _setEntryType,
+        onFavoriteDrop: _favoriteEntry,
       ),
     );
   }
@@ -771,21 +777,49 @@ class _PreciseRefLibraryScreenState
             resourceId: entry.id,
             display: {'name': entry.name},
           ),
-          child: PreciseRefCard(
-            entry: entry,
-            onSendToPreciseRef: () => _sendToPreciseRef(entry),
-            onSendToImg2Img: () => _sendToImg2Img(entry),
-            onEdit: () => _editEntry(entry),
-            onDelete: () => _deleteEntry(entry),
-            onToggleFavorite: () {
-              ref
-                  .read(preciseRefLibraryNotifierProvider.notifier)
-                  .toggleFavorite(entry.id);
-            },
+          child: LibraryClassificationDragSource<PreciseRefLibraryEntry>(
+            data: entry,
+            label: entry.name,
+            child: PreciseRefCard(
+              entry: entry,
+              onSendToPreciseRef: () => _sendToPreciseRef(entry),
+              onSendToImg2Img: () => _sendToImg2Img(entry),
+              onEdit: () => _editEntry(entry),
+              onDelete: () => _deleteEntry(entry),
+              onToggleFavorite: () {
+                ref
+                    .read(preciseRefLibraryNotifierProvider.notifier)
+                    .toggleFavorite(entry.id);
+              },
+              onClassify: () => _classifyEntry(entry),
+            ),
           ),
         );
       },
     );
+  }
+
+  Future<void> _classifyEntry(PreciseRefLibraryEntry entry) async {
+    final type = await PreciseReferenceTypeDialog.show(context);
+    if (type == null || !mounted) return;
+    await _setEntryType(entry, type);
+  }
+
+  Future<void> _setEntryType(
+    PreciseRefLibraryEntry entry,
+    PreciseRefType type,
+  ) async {
+    if (entry.type == type) return;
+    await ref
+        .read(preciseRefLibraryNotifierProvider.notifier)
+        .updateEntry(entry.id, type: type);
+  }
+
+  Future<void> _favoriteEntry(PreciseRefLibraryEntry entry) async {
+    if (entry.isFavorite) return;
+    await ref
+        .read(preciseRefLibraryNotifierProvider.notifier)
+        .toggleFavorite(entry.id);
   }
 
   Widget _buildPagination(PreciseRefLibraryState state, double contentWidth) {

--- a/lib/presentation/screens/precise_ref_library/widgets/precise_ref_card.dart
+++ b/lib/presentation/screens/precise_ref_library/widgets/precise_ref_card.dart
@@ -18,6 +18,7 @@ enum _PreciseRefCardAction {
   sendToPreciseRef,
   sendToImg2Img,
   edit,
+  classify,
   delete,
 }
 
@@ -34,6 +35,7 @@ class PreciseRefCard extends ConsumerStatefulWidget {
     this.onEdit,
     this.onDelete,
     this.onToggleFavorite,
+    this.onClassify,
   });
 
   final PreciseRefLibraryEntry entry;
@@ -42,6 +44,7 @@ class PreciseRefCard extends ConsumerStatefulWidget {
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
   final VoidCallback? onToggleFavorite;
+  final VoidCallback? onClassify;
 
   @override
   ConsumerState<PreciseRefCard> createState() => _PreciseRefCardState();
@@ -377,6 +380,8 @@ class _PreciseRefCardState extends ConsumerState<PreciseRefCard> {
             widget.onSendToImg2Img?.call();
           case _PreciseRefCardAction.edit:
             widget.onEdit?.call();
+          case _PreciseRefCardAction.classify:
+            widget.onClassify?.call();
           case _PreciseRefCardAction.delete:
             widget.onDelete?.call();
         }
@@ -413,6 +418,14 @@ class _PreciseRefCardState extends ConsumerState<PreciseRefCard> {
             contentPadding: EdgeInsets.zero,
             leading: const Icon(Icons.edit_outlined),
             title: Text(l10n.preciseRefLib_editEntry),
+          ),
+        ),
+        PopupMenuItem(
+          value: _PreciseRefCardAction.classify,
+          child: ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: const Icon(Icons.category_outlined),
+            title: Text(l10n.preciseRef_referenceType),
           ),
         ),
         PopupMenuItem(

--- a/lib/presentation/screens/precise_ref_library/widgets/precise_ref_library_sidebar.dart
+++ b/lib/presentation/screens/precise_ref_library/widgets/precise_ref_library_sidebar.dart
@@ -6,6 +6,8 @@ import '../../../../core/extensions/precise_ref_type_extensions.dart';
 import '../../../providers/precise_ref_library_provider.dart';
 import '../../../widgets/gallery/gallery_album_tree_view.dart';
 import '../../../widgets/gallery/gallery_sidebar.dart';
+import '../../../widgets/common/library_classification_drag.dart';
+import '../../../../data/models/precise_ref/precise_ref_library_entry.dart';
 
 class PreciseRefLibrarySidebar extends StatefulWidget {
   const PreciseRefLibrarySidebar({
@@ -13,12 +15,17 @@ class PreciseRefLibrarySidebar extends StatefulWidget {
     required this.state,
     required this.onFilterChanged,
     this.modal = false,
+    this.onEntryTypeDrop,
+    this.onFavoriteDrop,
   });
 
   final PreciseRefLibraryState state;
   final void Function({required bool favoritesOnly, PreciseRefType? type})
   onFilterChanged;
   final bool modal;
+  final void Function(PreciseRefLibraryEntry entry, PreciseRefType type)?
+  onEntryTypeDrop;
+  final ValueChanged<PreciseRefLibraryEntry>? onFavoriteDrop;
 
   @override
   State<PreciseRefLibrarySidebar> createState() =>
@@ -61,34 +68,45 @@ class _PreciseRefLibrarySidebarState extends State<PreciseRefLibrarySidebar> {
               child: ListView(
                 padding: const EdgeInsets.only(bottom: 8),
                 children: [
-                  GallerySidebarFavoritesItem(
-                    key: const Key('precise-ref-sidebar-favorites'),
-                    label: l10n.tagLibrary_favorites,
-                    count: state.entries
-                        .where((entry) => entry.isFavorite)
-                        .length,
-                    isSelected: state.favoritesOnly,
-                    onTap: () => widget.onFilterChanged(favoritesOnly: true),
+                  LibraryClassificationDropTarget<PreciseRefLibraryEntry>(
+                    enabled: widget.onFavoriteDrop != null,
+                    canAccept: (entry) => !entry.isFavorite,
+                    onAccept: (entry) => widget.onFavoriteDrop?.call(entry),
+                    child: GallerySidebarFavoritesItem(
+                      key: const Key('precise-ref-sidebar-favorites'),
+                      label: l10n.tagLibrary_favorites,
+                      count: state.entries
+                          .where((entry) => entry.isFavorite)
+                          .length,
+                      isSelected: state.favoritesOnly,
+                      onTap: () => widget.onFilterChanged(favoritesOnly: true),
+                    ),
                   ),
                   for (final type in PreciseRefType.values)
-                    GallerySidebarNavigationItem(
-                      key: Key('precise-ref-sidebar-type-${type.name}'),
-                      icon: type.icon,
-                      selectedIcon: type.icon,
-                      label: type.getDisplayName(
-                        character: l10n.preciseRef_typeCharacter,
-                        style: l10n.preciseRef_typeStyle,
-                        characterAndStyle:
-                            l10n.preciseRef_typeCharacterAndStyle,
-                      ),
-                      count: state.entries
-                          .where((entry) => entry.type == type)
-                          .length,
-                      isSelected:
-                          !state.favoritesOnly && state.typeFilter == type,
-                      onTap: () => widget.onFilterChanged(
-                        favoritesOnly: false,
-                        type: type,
+                    LibraryClassificationDropTarget<PreciseRefLibraryEntry>(
+                      enabled: widget.onEntryTypeDrop != null,
+                      canAccept: (entry) => entry.type != type,
+                      onAccept: (entry) =>
+                          widget.onEntryTypeDrop?.call(entry, type),
+                      child: GallerySidebarNavigationItem(
+                        key: Key('precise-ref-sidebar-type-${type.name}'),
+                        icon: type.icon,
+                        selectedIcon: type.icon,
+                        label: type.getDisplayName(
+                          character: l10n.preciseRef_typeCharacter,
+                          style: l10n.preciseRef_typeStyle,
+                          characterAndStyle:
+                              l10n.preciseRef_typeCharacterAndStyle,
+                        ),
+                        count: state.entries
+                            .where((entry) => entry.type == type)
+                            .length,
+                        isSelected:
+                            !state.favoritesOnly && state.typeFilter == type,
+                        onTap: () => widget.onFilterChanged(
+                          favoritesOnly: false,
+                          type: type,
+                        ),
                       ),
                     ),
                 ],

--- a/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
+++ b/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
@@ -345,6 +345,16 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
                       context.l10n.tagLibrary_entryMoved,
                     );
                   },
+                  onEntryFavoriteDrop: (entryId) {
+                    final index = state.entries.indexWhere(
+                      (candidate) => candidate.id == entryId,
+                    );
+                    if (index >= 0 && !state.entries[index].isFavorite) {
+                      ref
+                          .read(tagLibraryPageNotifierProvider.notifier)
+                          .toggleFavorite(entryId);
+                    }
+                  },
                 ),
               ),
             )
@@ -523,6 +533,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
           onDelete: commonProps.onDelete,
           onEdit: commonProps.onEdit,
           onSend: () => _showEntryDetail(entry),
+          onClassify: () => _classifyEntry(entry),
           onToggleFavorite: commonProps.onToggleFavorite,
         ),
       );
@@ -541,6 +552,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
         onTap: () => _showEntryDetail(entry),
         onDelete: commonProps.onDelete,
         onEdit: commonProps.onEdit,
+        onClassify: () => _classifyEntry(entry),
         onToggleFavorite: commonProps.onToggleFavorite,
       ),
     );
@@ -559,6 +571,19 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
       ),
       child: child,
     );
+  }
+
+  Future<void> _classifyEntry(TagLibraryEntry entry) async {
+    final state = ref.read(tagLibraryPageNotifierProvider);
+    final target = await BulkMoveCategoryDialog.show(
+      context,
+      categories: state.categories,
+      currentCategoryId: entry.categoryId,
+    );
+    if (target == null || !mounted) return;
+    await ref
+        .read(tagLibraryPageNotifierProvider.notifier)
+        .moveEntryToCategory(entry.id, target.isEmpty ? null : target);
   }
 
   /// 获取分类名称
@@ -629,7 +654,10 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
     for (final entryId in selectedIds) {
       await ref
           .read(tagLibraryPageNotifierProvider.notifier)
-          .moveEntryToCategory(entryId, targetCategoryId);
+          .moveEntryToCategory(
+            entryId,
+            targetCategoryId.isEmpty ? null : targetCategoryId,
+          );
     }
 
     ref.read(tagLibrarySelectionNotifierProvider.notifier).exit();

--- a/lib/presentation/screens/tag_library_page/widgets/bulk_move_category_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/bulk_move_category_dialog.dart
@@ -142,7 +142,7 @@ class _BulkMoveCategoryContent extends StatelessWidget {
                     id: null,
                     name: context.l10n.tagLibrary_rootCategory,
                     isSelected: currentCategoryId == null,
-                    onTap: () => Navigator.of(context).pop(null),
+                    onTap: () => Navigator.of(context).pop(''),
                     depth: 0,
                   ),
                   const Divider(height: 1, indent: 8, endIndent: 8),

--- a/lib/presentation/screens/tag_library_page/widgets/category_tree_view.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/category_tree_view.dart
@@ -8,6 +8,7 @@ import '../../../../data/models/tag_library/tag_library_category.dart';
 import '../../../../data/models/tag_library/tag_library_entry.dart';
 import '../../../adaptive/interaction_policy.dart';
 import '../../../widgets/common/context_menu_anchor.dart';
+import '../../../widgets/common/library_classification_drag.dart';
 import '../../../widgets/gallery/gallery_album_tree_view.dart';
 import '../../../widgets/gallery/gallery_sidebar.dart';
 import 'package:nai_launcher/presentation/widgets/common/themed_input.dart';
@@ -33,6 +34,7 @@ class CategoryTreeView extends StatefulWidget {
 
   /// 词条拖拽到分类
   final void Function(String entryId, String? categoryId)? onEntryDrop;
+  final ValueChanged<String>? onEntryFavoriteDrop;
   final bool includeAllEntries;
 
   const CategoryTreeView({
@@ -49,6 +51,7 @@ class CategoryTreeView extends StatefulWidget {
     this.onCategoryMove,
     this.onCategoryReorder,
     this.onEntryDrop,
+    this.onEntryFavoriteDrop,
     this.includeAllEntries = true,
   });
 
@@ -118,13 +121,17 @@ class _CategoryTreeViewState extends State<CategoryTreeView> {
               ),
             ),
 
-          // 收藏 - 不接收拖拽
-          GallerySidebarFavoritesItem(
-            key: const ValueKey('tag-library-favorites'),
-            label: context.l10n.tagLibrary_favorites,
-            count: widget.entries.where((e) => e.isFavorite).length,
-            isSelected: widget.selectedCategoryId == 'favorites',
-            onTap: () => widget.onCategorySelected('favorites'),
+          LibraryClassificationDropTarget<TagLibraryEntry>(
+            enabled: widget.onEntryFavoriteDrop != null,
+            canAccept: (entry) => !entry.isFavorite,
+            onAccept: (entry) => widget.onEntryFavoriteDrop?.call(entry.id),
+            child: GallerySidebarFavoritesItem(
+              key: const ValueKey('tag-library-favorites'),
+              label: context.l10n.tagLibrary_favorites,
+              count: widget.entries.where((e) => e.isFavorite).length,
+              isSelected: widget.selectedCategoryId == 'favorites',
+              onTap: () => widget.onCategorySelected('favorites'),
+            ),
           ),
 
           // 分类树

--- a/lib/presentation/screens/tag_library_page/widgets/entry_card.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_card.dart
@@ -5,10 +5,11 @@ import '../../../../core/utils/localization_extension.dart';
 import '../../../../data/models/tag_library/tag_library_entry.dart';
 import '../../../adaptive/interaction_policy.dart';
 import '../../../widgets/common/app_toast.dart';
+import '../../../widgets/common/library_classification_drag.dart';
 import '../../../widgets/common/thumbnail_display.dart';
 import '../../../widgets/tag_library/tag_library_entry_hover_preview.dart';
 
-enum _EntryAction { select, edit, favorite, copy, delete }
+enum _EntryAction { select, edit, favorite, classify, copy, delete }
 
 /// 词库条目卡片 - 名称居中 + 互斥显示
 ///
@@ -22,6 +23,7 @@ class EntryCard extends StatefulWidget {
   final VoidCallback onToggleFavorite;
   final VoidCallback? onEdit;
   final VoidCallback? onSend;
+  final VoidCallback? onClassify;
 
   /// 所属分类名称
   final String? categoryName;
@@ -47,6 +49,7 @@ class EntryCard extends StatefulWidget {
     required this.onToggleFavorite,
     this.onEdit,
     this.onSend,
+    this.onClassify,
     this.categoryName,
     this.enableDrag = false,
     this.isSelectionMode = false,
@@ -214,25 +217,18 @@ class _EntryCardState extends State<EntryCard> {
       child: cardVisual,
     );
 
-    // 保持根节点稳定，避免切换多选模式时重建缩略图子树。
-    return Draggable<TagLibraryEntry>(
+    return LibraryClassificationDragSource<TagLibraryEntry>(
       data: entry,
-      maxSimultaneousDrags: widget.enableDrag && !isTouch ? null : 0,
-      feedback: widget.enableDrag && !isTouch
-          ? _buildDragFeedback(theme, entry)
-          : const SizedBox.shrink(),
-      childWhenDragging: Opacity(opacity: 0.4, child: cardContent),
+      label: entry.displayName,
+      enabled: widget.enableDrag,
       onDragStarted: () {
-        HapticFeedback.mediumImpact();
         setState(() {
           _isDragging = true;
           _isHovering = false;
         });
       },
-      onDragEnd: (_) {
-        setState(() {
-          _isDragging = false;
-        });
+      onDragEnded: () {
+        if (mounted) setState(() => _isDragging = false);
       },
       child: cardContent,
     );
@@ -330,6 +326,8 @@ class _EntryCardState extends State<EntryCard> {
               widget.onEdit?.call();
             case _EntryAction.favorite:
               widget.onToggleFavorite();
+            case _EntryAction.classify:
+              widget.onClassify?.call();
             case _EntryAction.copy:
               _copyToClipboard(entry.content);
             case _EntryAction.delete:
@@ -370,6 +368,15 @@ class _EntryCardState extends State<EntryCard> {
               ),
             ),
           ),
+          if (widget.onClassify != null)
+            PopupMenuItem(
+              value: _EntryAction.classify,
+              child: ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: const Icon(Icons.drive_file_move_outline),
+                title: Text(l10n.tagLibrary_moveToCategoryTitle),
+              ),
+            ),
           PopupMenuItem(
             value: _EntryAction.copy,
             child: ListTile(
@@ -430,116 +437,6 @@ class _EntryCardState extends State<EntryCard> {
             onTap: () => _copyToClipboard(entry.content),
           ),
         ],
-      ),
-    );
-  }
-
-  /// 构建拖拽反馈UI
-  Widget _buildDragFeedback(ThemeData theme, TagLibraryEntry entry) {
-    return Material(
-      elevation: 16,
-      borderRadius: BorderRadius.circular(16),
-      color: Colors.transparent,
-      shadowColor: Colors.black54,
-      child: Container(
-        width: 200,
-        height: 80,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: theme.colorScheme.primary.withValues(alpha: 0.75),
-          ),
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(16),
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              // 背景图
-              if (entry.hasThumbnail && entry.thumbnail != null)
-                ThumbnailDisplay(
-                  imagePath: entry.thumbnail!,
-                  offsetX: entry.thumbnailOffsetX,
-                  offsetY: entry.thumbnailOffsetY,
-                  scale: entry.thumbnailScale,
-                  width: 200,
-                  height: 80,
-                )
-              else
-                _buildPlaceholder(),
-              // 轻微暗化
-              _buildDarkenOverlay(),
-              // 拖拽提示
-              Positioned(
-                top: 8,
-                left: 8,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
-                  ),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.primary,
-                    borderRadius: BorderRadius.circular(6),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.35),
-                        blurRadius: 4,
-                      ),
-                    ],
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Icons.drive_file_move_outline,
-                        size: 12,
-                        color: theme.colorScheme.onPrimary,
-                      ),
-                      const SizedBox(width: 4),
-                      Text(
-                        context.l10n.tagLibrary_moveToCategoryTitle,
-                        style: TextStyle(
-                          fontSize: 11,
-                          color: theme.colorScheme.onPrimary,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              // 名称（靠左）
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 12,
-                ),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    entry.displayName,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                      fontSize: 20,
-                      shadows: [
-                        Shadow(
-                          color: Colors.black,
-                          blurRadius: 8,
-                          offset: Offset(0, 1),
-                        ),
-                      ],
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    textAlign: TextAlign.left,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/presentation/screens/tag_library_page/widgets/entry_list_item.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_list_item.dart
@@ -5,10 +5,11 @@ import '../../../../core/utils/localization_extension.dart';
 import '../../../../data/models/tag_library/tag_library_entry.dart';
 import '../../../adaptive/interaction_policy.dart';
 import '../../../widgets/common/app_toast.dart';
+import '../../../widgets/common/library_classification_drag.dart';
 import '../../../widgets/common/thumbnail_display.dart';
 import '../../../widgets/common/translated_tag_text.dart';
 
-enum _EntryListAction { select, edit, favorite, copy, delete }
+enum _EntryListAction { select, edit, favorite, classify, copy, delete }
 
 /// 词库条目列表项
 class EntryListItem extends StatefulWidget {
@@ -17,6 +18,7 @@ class EntryListItem extends StatefulWidget {
   final VoidCallback onDelete;
   final VoidCallback onToggleFavorite;
   final VoidCallback? onEdit;
+  final VoidCallback? onClassify;
 
   /// 所属分类名称
   final String? categoryName;
@@ -41,6 +43,7 @@ class EntryListItem extends StatefulWidget {
     required this.onDelete,
     required this.onToggleFavorite,
     this.onEdit,
+    this.onClassify,
     this.categoryName,
     this.enableDrag = false,
     this.isSelectionMode = false,
@@ -134,113 +137,20 @@ class _EntryListItemState extends State<EntryListItem> {
       ),
     );
 
-    // 保持根节点稳定，避免切换多选模式时重建缩略图子树。
-    return Draggable<TagLibraryEntry>(
+    return LibraryClassificationDragSource<TagLibraryEntry>(
       data: entry,
-      maxSimultaneousDrags: widget.enableDrag && !isTouch ? null : 0,
-      feedback: widget.enableDrag && !isTouch
-          ? _buildDragFeedback(theme, entry)
-          : const SizedBox.shrink(),
-      childWhenDragging: Opacity(opacity: 0.4, child: itemContent),
+      label: entry.displayName,
+      enabled: widget.enableDrag,
       onDragStarted: () {
-        HapticFeedback.mediumImpact();
         setState(() {
           _isDragging = true;
           _isHovering = false;
         });
       },
-      onDragEnd: (_) {
-        setState(() {
-          _isDragging = false;
-        });
+      onDragEnded: () {
+        if (mounted) setState(() => _isDragging = false);
       },
       child: itemContent,
-    );
-  }
-
-  /// 构建拖拽反馈UI
-  Widget _buildDragFeedback(ThemeData theme, TagLibraryEntry entry) {
-    return Material(
-      elevation: 12,
-      borderRadius: BorderRadius.circular(10),
-      color: theme.colorScheme.surfaceContainerHigh,
-      shadowColor: Colors.black54,
-      child: Container(
-        width: 280,
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(
-            color: theme.colorScheme.primary.withValues(alpha: 0.5),
-            width: 2,
-          ),
-        ),
-        child: Row(
-          children: [
-            // 缩略图
-            if (entry.hasThumbnail && entry.thumbnail != null)
-              ThumbnailDisplay(
-                imagePath: entry.thumbnail!,
-                offsetX: entry.thumbnailOffsetX,
-                offsetY: entry.thumbnailOffsetY,
-                scale: entry.thumbnailScale,
-                width: 48,
-                height: 48,
-                borderRadius: BorderRadius.circular(6),
-              )
-            else
-              Container(
-                width: 48,
-                height: 48,
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.surfaceContainerHighest,
-                  borderRadius: BorderRadius.circular(6),
-                ),
-                child: Icon(
-                  Icons.library_books,
-                  size: 20,
-                  color: theme.colorScheme.primary,
-                ),
-              ),
-            const SizedBox(width: 12),
-            // 信息
-            Expanded(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    entry.displayName,
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 4),
-                  Row(
-                    children: [
-                      Icon(
-                        Icons.drive_file_move_outline,
-                        size: 12,
-                        color: theme.colorScheme.outline,
-                      ),
-                      const SizedBox(width: 4),
-                      Text(
-                        context.l10n.tagLibrary_dragToCategoryHint,
-                        style: TextStyle(
-                          fontSize: 10,
-                          color: theme.colorScheme.outline,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 
@@ -416,6 +326,9 @@ class _EntryListItemState extends State<EntryListItem> {
             case _EntryListAction.favorite:
               widget.onToggleFavorite();
               break;
+            case _EntryListAction.classify:
+              widget.onClassify?.call();
+              break;
             case _EntryListAction.copy:
               _copyToClipboard(widget.entry.content);
               break;
@@ -460,6 +373,15 @@ class _EntryListItemState extends State<EntryListItem> {
               ),
             ),
           ),
+          if (widget.onClassify != null)
+            PopupMenuItem(
+              value: _EntryListAction.classify,
+              child: ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: const Icon(Icons.drive_file_move_outline),
+                title: Text(l10n.tagLibrary_moveToCategoryTitle),
+              ),
+            ),
           PopupMenuItem(
             value: _EntryListAction.copy,
             child: ListTile(

--- a/lib/presentation/screens/vibe_library/vibe_library_commands.dart
+++ b/lib/presentation/screens/vibe_library/vibe_library_commands.dart
@@ -8,6 +8,17 @@ sealed class VibeLibraryCommand {
   const VibeLibraryCommand();
 }
 
+final class ClassifyVibeEntryCommand extends VibeLibraryCommand {
+  const ClassifyVibeEntryCommand(this.entryId, this.categoryId);
+  final String entryId;
+  final String? categoryId;
+}
+
+final class FavoriteVibeEntryCommand extends VibeLibraryCommand {
+  const FavoriteVibeEntryCommand(this.entryId);
+  final String entryId;
+}
+
 final class ImportVibesCommand extends VibeLibraryCommand {
   const ImportVibesCommand();
 }

--- a/lib/presentation/screens/vibe_library/vibe_library_screen.dart
+++ b/lib/presentation/screens/vibe_library/vibe_library_screen.dart
@@ -14,7 +14,6 @@ import '../../../core/utils/file_explorer_utils.dart';
 import '../../../core/utils/localization_extension.dart';
 import '../../../core/utils/novelai_vibe_codec.dart';
 import '../../../core/utils/vibe_library_path_helper.dart';
-import '../../../data/models/vibe/vibe_library_category.dart';
 import '../../../data/models/vibe/vibe_library_entry.dart';
 import '../../adaptive/adaptive_presenter.dart';
 import '../../providers/generation/generation_params_notifier.dart';
@@ -31,6 +30,8 @@ import 'vibe_library_commands.dart';
 import 'vibe_library_screen_controller.dart';
 import 'vibe_library_workspace.dart';
 import 'widgets/category/vibe_category_tree_view.dart';
+import 'widgets/category/vibe_category_destination_panel.dart';
+export 'widgets/category/vibe_category_destination_panel.dart';
 import 'widgets/menus/vibe_import_menu.dart';
 import 'widgets/vibe_export_dialog_advanced.dart';
 
@@ -201,6 +202,17 @@ class _VibeLibraryScreenState extends ConsumerState<VibeLibraryScreen> {
         unawaited(_markEncodingModel());
       case DeleteSelectionCommand():
         unawaited(_deleteSelection());
+      case ClassifyVibeEntryCommand(:final entryId, :final categoryId):
+        unawaited(library.updateEntryCategory(entryId, categoryId));
+      case FavoriteVibeEntryCommand(:final entryId):
+        final entry = ref
+            .read(vibeLibraryNotifierProvider)
+            .entries
+            .cast<VibeLibraryEntry?>()
+            .firstWhere((item) => item?.id == entryId, orElse: () => null);
+        if (entry != null && !entry.isFavorite) {
+          unawaited(library.toggleFavorite(entryId));
+        }
     }
   }
 
@@ -506,58 +518,6 @@ class _VibeLibraryScreenState extends ConsumerState<VibeLibraryScreen> {
     if (selected.isEmpty || !mounted) return;
     await _controller.runDialogLocked(
       () => VibeExportDialogAdvanced.show(context, entries: selected),
-    );
-  }
-}
-
-/// 自适应的 Vibe 批量移动目标分类列表。
-///
-/// 空字符串表示“未分类”，null 仅表示用户取消，以保留既有返回值契约。
-class VibeCategoryDestinationPanel extends StatelessWidget {
-  const VibeCategoryDestinationPanel({
-    super.key,
-    required this.categories,
-    this.scrollController,
-  });
-
-  final List<VibeLibraryCategory> categories;
-  final ScrollController? scrollController;
-
-  static Future<String?> show(
-    BuildContext context, {
-    required List<VibeLibraryCategory> categories,
-  }) {
-    return AdaptivePresenter.showForm<String>(
-      context: context,
-      title: context.l10n.vibeLibrary_moveToCategory,
-      sideSheetWidth: 440,
-      builder: (panelContext, scrollController) => VibeCategoryDestinationPanel(
-        categories: categories,
-        scrollController: scrollController,
-      ),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return ListView(
-      key: const ValueKey('vibe-category-destination-list'),
-      controller: scrollController,
-      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      children: [
-        ListTile(
-          leading: const Icon(Icons.folder_off_outlined),
-          title: Text(context.l10n.vibeLibrary_uncategorized),
-          onTap: () => Navigator.of(context).pop(''),
-        ),
-        for (final category in categories)
-          ListTile(
-            leading: const Icon(Icons.folder_outlined),
-            title: Text(category.name),
-            onTap: () => Navigator.of(context).pop(category.id),
-          ),
-      ],
     );
   }
 }

--- a/lib/presentation/screens/vibe_library/vibe_library_workspace.dart
+++ b/lib/presentation/screens/vibe_library/vibe_library_workspace.dart
@@ -229,6 +229,11 @@ class _CategoryPanelState extends State<_CategoryPanel> {
                     widget.onCommand(DeleteCategoryCommand(id)),
                 onCreateCategory: () =>
                     widget.onCommand(const CreateCategoryCommand()),
+                onEntryDrop: (entry, categoryId) => widget.onCommand(
+                  ClassifyVibeEntryCommand(entry.id, categoryId),
+                ),
+                onFavoriteDrop: (entry) =>
+                    widget.onCommand(FavoriteVibeEntryCommand(entry.id)),
               ),
             ),
         ],

--- a/lib/presentation/screens/vibe_library/widgets/category/vibe_category_destination_panel.dart
+++ b/lib/presentation/screens/vibe_library/widgets/category/vibe_category_destination_panel.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/utils/localization_extension.dart';
+import '../../../../../data/models/vibe/vibe_library_category.dart';
+import '../../../../adaptive/adaptive_presenter.dart';
+
+/// Empty string means uncategorized; null means the picker was cancelled.
+class VibeCategoryDestinationPanel extends StatelessWidget {
+  const VibeCategoryDestinationPanel({
+    super.key,
+    required this.categories,
+    this.scrollController,
+  });
+
+  final List<VibeLibraryCategory> categories;
+  final ScrollController? scrollController;
+
+  static Future<String?> show(
+    BuildContext context, {
+    required List<VibeLibraryCategory> categories,
+  }) => AdaptivePresenter.showForm<String>(
+    context: context,
+    title: context.l10n.vibeLibrary_moveToCategory,
+    sideSheetWidth: 440,
+    builder: (panelContext, scrollController) => VibeCategoryDestinationPanel(
+      categories: categories,
+      scrollController: scrollController,
+    ),
+  );
+
+  @override
+  Widget build(BuildContext context) => ListView(
+    key: const ValueKey('vibe-category-destination-list'),
+    controller: scrollController,
+    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+    children: [
+      ListTile(
+        leading: const Icon(Icons.folder_off_outlined),
+        title: Text(context.l10n.vibeLibrary_uncategorized),
+        onTap: () => Navigator.of(context).pop(''),
+      ),
+      for (final category in categories)
+        ListTile(
+          leading: const Icon(Icons.folder_outlined),
+          title: Text(category.name),
+          onTap: () => Navigator.of(context).pop(category.id),
+        ),
+    ],
+  );
+}

--- a/lib/presentation/screens/vibe_library/widgets/category/vibe_category_tree_view.dart
+++ b/lib/presentation/screens/vibe_library/widgets/category/vibe_category_tree_view.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../../../../../core/utils/localization_extension.dart';
 import '../../../../../data/models/vibe/vibe_library_category.dart';
+import '../../../../../data/models/vibe/vibe_library_entry.dart';
+import '../../../../widgets/common/library_classification_drag.dart';
 import '../../../../widgets/common/context_menu_anchor.dart';
 import '../../../../widgets/gallery/gallery_album_tree_view.dart';
 import '../../../../widgets/gallery/gallery_sidebar.dart';
@@ -24,6 +26,8 @@ class VibeCategoryTreeView extends StatelessWidget {
     this.onCategoryRename,
     this.onCategoryDelete,
     this.onCreateCategory,
+    this.onEntryDrop,
+    this.onFavoriteDrop,
   });
 
   final List<VibeLibraryCategory> categories;
@@ -36,6 +40,8 @@ class VibeCategoryTreeView extends StatelessWidget {
   final void Function(String id, String newName)? onCategoryRename;
   final ValueChanged<String>? onCategoryDelete;
   final VoidCallback? onCreateCategory;
+  final void Function(VibeLibraryEntry entry, String? categoryId)? onEntryDrop;
+  final ValueChanged<VibeLibraryEntry>? onFavoriteDrop;
 
   @override
   Widget build(BuildContext context) {
@@ -50,36 +56,51 @@ class VibeCategoryTreeView extends StatelessWidget {
         padding: const EdgeInsets.only(top: 4, bottom: 8),
         children: [
           if (includeAll)
-            GalleryAllImagesItem(
-              key: const ValueKey('vibe-library-all'),
-              label: context.l10n.vibeLibrary_allVibes,
-              icon: Icons.auto_awesome_outlined,
-              selectedIcon: Icons.auto_awesome_rounded,
-              count: totalEntryCount,
-              isSelected: selectedCategoryId == null,
-              onTap: () => onCategorySelected(null),
+            LibraryClassificationDropTarget<VibeLibraryEntry>(
+              enabled: onEntryDrop != null,
+              canAccept: (entry) => entry.categoryId != null,
+              onAccept: (entry) => onEntryDrop?.call(entry, null),
+              child: GalleryAllImagesItem(
+                key: const ValueKey('vibe-library-all'),
+                label: context.l10n.vibeLibrary_allVibes,
+                icon: Icons.auto_awesome_outlined,
+                selectedIcon: Icons.auto_awesome_rounded,
+                count: totalEntryCount,
+                isSelected: selectedCategoryId == null,
+                onTap: () => onCategorySelected(null),
+              ),
             ),
-          GallerySidebarFavoritesItem(
-            key: const ValueKey('vibe-library-favorites'),
-            label: context.l10n.vibeLibrary_favorites,
-            count: favoriteCount,
-            isSelected: selectedCategoryId == 'favorites',
-            onTap: () => onCategorySelected('favorites'),
+          LibraryClassificationDropTarget<VibeLibraryEntry>(
+            enabled: onFavoriteDrop != null,
+            canAccept: (entry) => !entry.isFavorite,
+            onAccept: (entry) => onFavoriteDrop?.call(entry),
+            child: GallerySidebarFavoritesItem(
+              key: const ValueKey('vibe-library-favorites'),
+              label: context.l10n.vibeLibrary_favorites,
+              count: favoriteCount,
+              isSelected: selectedCategoryId == 'favorites',
+              onTap: () => onCategorySelected('favorites'),
+            ),
           ),
           for (final category in sortedCategories)
-            VibeCategoryItem(
-              key: ValueKey('vibe-library-category-${category.id}'),
-              icon: Icons.label_outline_rounded,
-              label: category.displayName,
-              count: categoryEntryCounts[category.id] ?? 0,
-              isSelected: selectedCategoryId == category.id,
-              onTap: () => onCategorySelected(category.id),
-              onRename: onCategoryRename == null
-                  ? null
-                  : (name) => onCategoryRename!(category.id, name),
-              onDelete: onCategoryDelete == null
-                  ? null
-                  : () => onCategoryDelete!(category.id),
+            LibraryClassificationDropTarget<VibeLibraryEntry>(
+              enabled: onEntryDrop != null,
+              canAccept: (entry) => entry.categoryId != category.id,
+              onAccept: (entry) => onEntryDrop?.call(entry, category.id),
+              child: VibeCategoryItem(
+                key: ValueKey('vibe-library-category-${category.id}'),
+                icon: Icons.label_outline_rounded,
+                label: category.displayName,
+                count: categoryEntryCounts[category.id] ?? 0,
+                isSelected: selectedCategoryId == category.id,
+                onTap: () => onCategorySelected(category.id),
+                onRename: onCategoryRename == null
+                    ? null
+                    : (name) => onCategoryRename!(category.id, name),
+                onDelete: onCategoryDelete == null
+                    ? null
+                    : () => onCategoryDelete!(category.id),
+              ),
             ),
         ],
       ),

--- a/lib/presentation/screens/vibe_library/widgets/vibe_card.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_card.dart
@@ -27,6 +27,7 @@ enum _VibeCardAction {
   send,
   export,
   edit,
+  classify,
   delete,
 }
 
@@ -49,6 +50,7 @@ class VibeCard extends ConsumerStatefulWidget {
   final VoidCallback? onSendToGeneration;
   final VoidCallback? onExport;
   final VoidCallback? onEdit;
+  final VoidCallback? onClassify;
   final VoidCallback? onDelete;
 
   const VibeCard({
@@ -66,6 +68,7 @@ class VibeCard extends ConsumerStatefulWidget {
     this.onSendToGeneration,
     this.onExport,
     this.onEdit,
+    this.onClassify,
     this.onDelete,
   });
 
@@ -318,6 +321,7 @@ class _VibeCardState extends ConsumerState<VibeCard>
                           widget.onSendToGeneration != null ||
                           widget.onExport != null ||
                           widget.onEdit != null ||
+                          widget.onClassify != null ||
                           widget.onDelete != null))
                     _buildTouchActionMenu()
                   else if (_isHovered && !widget.isSelected)
@@ -740,6 +744,8 @@ class _VibeCardState extends ConsumerState<VibeCard>
                 widget.onExport?.call();
               case _VibeCardAction.edit:
                 widget.onEdit?.call();
+              case _VibeCardAction.classify:
+                widget.onClassify?.call();
               case _VibeCardAction.delete:
                 widget.onDelete?.call();
             }
@@ -806,6 +812,15 @@ class _VibeCardState extends ConsumerState<VibeCard>
                   contentPadding: EdgeInsets.zero,
                   leading: const Icon(Icons.edit),
                   title: Text(l10n.common_edit),
+                ),
+              ),
+            if (widget.onClassify != null)
+              PopupMenuItem(
+                value: _VibeCardAction.classify,
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: const Icon(Icons.drive_file_move_outline),
+                  title: Text(l10n.vibeLibrary_moveToCategory),
                 ),
               ),
             if (widget.onDelete != null)

--- a/lib/presentation/screens/vibe_library/widgets/vibe_library_content_view.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_library_content_view.dart
@@ -28,8 +28,10 @@ import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/frame_staggered_builder.dart';
 import '../../../widgets/common/pro_context_menu.dart';
 import '../../../widgets/common/themed_confirm_dialog.dart';
+import '../../../widgets/common/library_classification_drag.dart';
 import '../../../agent_chat/widgets/agent_resource_drop_region.dart';
 import 'vibe_card.dart';
+import 'category/vibe_category_destination_panel.dart';
 import '../../../widgets/common/context_menu_anchor.dart';
 import 'vibe_detail_viewer.dart';
 import 'vibe_export_dialog.dart';
@@ -155,52 +157,73 @@ class _VibeLibraryContentViewState
               resourceId: entry.id,
               display: {'name': entry.displayName},
             ),
-            child: VibeCard(
-              entry: entry,
-              width: widget.itemWidth,
-              height: computeVibeCardHeight(widget.itemWidth),
-              isSelected: isSelected,
-              showFavoriteIndicator: true,
-              onTap: () {
-                if (selectionState.isActive) {
+            child: LibraryClassificationDragSource<VibeLibraryEntry>(
+              data: entry,
+              label: entry.displayName,
+              enabled: !selectionState.isActive,
+              child: VibeCard(
+                entry: entry,
+                width: widget.itemWidth,
+                height: computeVibeCardHeight(widget.itemWidth),
+                isSelected: isSelected,
+                showFavoriteIndicator: true,
+                onTap: () {
+                  if (selectionState.isActive) {
+                    ref
+                        .read(vibeLibrarySelectionNotifierProvider.notifier)
+                        .toggle(entry.id);
+                  } else {
+                    _showVibeDetail(context, entry);
+                  }
+                },
+                onLongPress: () {
+                  if (!selectionState.isActive) {
+                    ref
+                        .read(vibeLibrarySelectionNotifierProvider.notifier)
+                        .enterAndSelect(entry.id);
+                  }
+                },
+                onSecondaryTapUp: (details) {
+                  _showContextMenu(context, entry, details.globalPosition);
+                },
+                onFavoriteToggle: () {
                   ref
-                      .read(vibeLibrarySelectionNotifierProvider.notifier)
-                      .toggle(entry.id);
-                } else {
-                  _showVibeDetail(context, entry);
-                }
-              },
-              onLongPress: () {
-                if (!selectionState.isActive) {
-                  ref
-                      .read(vibeLibrarySelectionNotifierProvider.notifier)
-                      .enterAndSelect(entry.id);
-                }
-              },
-              onSecondaryTapUp: (details) {
-                _showContextMenu(context, entry, details.globalPosition);
-              },
-              onFavoriteToggle: () {
-                ref
-                    .read(vibeLibraryNotifierProvider.notifier)
-                    .toggleFavorite(entry.id);
-              },
-              onSendToGeneration: () async {
-                final physicalKeys =
-                    HardwareKeyboard.instance.physicalKeysPressed;
-                final isShiftPressed =
-                    physicalKeys.contains(PhysicalKeyboardKey.shiftLeft) ||
-                    physicalKeys.contains(PhysicalKeyboardKey.shiftRight);
-                await _sendEntryToGeneration(context, entry, isShiftPressed);
-              },
-              onExport: () => unawaited(_exportSingleEntry(context, entry)),
-              onEdit: () => _showVibeDetail(context, entry),
-              onDelete: () => _deleteSingleEntry(context, entry),
+                      .read(vibeLibraryNotifierProvider.notifier)
+                      .toggleFavorite(entry.id);
+                },
+                onSendToGeneration: () async {
+                  final physicalKeys =
+                      HardwareKeyboard.instance.physicalKeysPressed;
+                  final isShiftPressed =
+                      physicalKeys.contains(PhysicalKeyboardKey.shiftLeft) ||
+                      physicalKeys.contains(PhysicalKeyboardKey.shiftRight);
+                  await _sendEntryToGeneration(context, entry, isShiftPressed);
+                },
+                onExport: () => unawaited(_exportSingleEntry(context, entry)),
+                onEdit: () => _showVibeDetail(context, entry),
+                onClassify: () => _classifyEntry(entry),
+                onDelete: () => _deleteSingleEntry(context, entry),
+              ),
             ),
           ),
         );
       },
     );
+  }
+
+  Future<void> _classifyEntry(VibeLibraryEntry entry) async {
+    final categories = ref.read(vibeLibraryCategoryNotifierProvider).categories;
+    final destination = await VibeCategoryDestinationPanel.show(
+      context,
+      categories: categories,
+    );
+    if (destination == null || !mounted) return;
+    await ref
+        .read(vibeLibraryNotifierProvider.notifier)
+        .updateEntryCategory(
+          entry.id,
+          destination.isEmpty ? null : destination,
+        );
   }
 
   /// 显示 Vibe 详情

--- a/lib/presentation/services/image_send_action_dispatcher.dart
+++ b/lib/presentation/services/image_send_action_dispatcher.dart
@@ -44,6 +44,7 @@ class ImageSendActionDispatcher {
 
       switch (action) {
         case LocalImageContextAction.addToAgent:
+        case LocalImageContextAction.moveToCategory:
           return;
         case LocalImageContextAction.sendToTextToImage:
         case LocalImageContextAction.importMetadata:

--- a/lib/presentation/widgets/common/library_classification_drag.dart
+++ b/lib/presentation/widgets/common/library_classification_drag.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../adaptive/interaction_policy.dart';
+
+/// Shared in-app drag behavior for assigning library entries to sidebar
+/// destinations. Touch layouts use explicit card actions instead.
+class LibraryClassificationDragSource<T extends Object>
+    extends StatelessWidget {
+  const LibraryClassificationDragSource({
+    super.key,
+    required this.data,
+    required this.label,
+    required this.child,
+    this.icon = Icons.drive_file_move_outline,
+    this.enabled = true,
+    this.onDragStarted,
+    this.onDragEnded,
+  });
+
+  final T data;
+  final String label;
+  final Widget child;
+  final IconData icon;
+  final bool enabled;
+  final VoidCallback? onDragStarted;
+  final VoidCallback? onDragEnded;
+
+  @override
+  Widget build(BuildContext context) {
+    final dragEnabled = enabled && context.interactionPolicy.usesAnchoredMenus;
+    final theme = Theme.of(context);
+    return Draggable<T>(
+      data: data,
+      maxSimultaneousDrags: dragEnabled ? null : 0,
+      onDragStarted: () {
+        HapticFeedback.mediumImpact();
+        onDragStarted?.call();
+      },
+      onDragEnd: (_) => onDragEnded?.call(),
+      feedback: dragEnabled
+          ? Material(
+              elevation: 8,
+              borderRadius: BorderRadius.circular(8),
+              color: theme.colorScheme.surfaceContainerHigh,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 220),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 10,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(icon, size: 18, color: theme.colorScheme.primary),
+                      const SizedBox(width: 8),
+                      Flexible(
+                        child: Text(label, overflow: TextOverflow.ellipsis),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            )
+          : const SizedBox.shrink(),
+      childWhenDragging: Opacity(opacity: 0.4, child: child),
+      child: child,
+    );
+  }
+}
+
+/// Shared visual and haptic response for Favorites and category/type targets.
+class LibraryClassificationDropTarget<T extends Object>
+    extends StatelessWidget {
+  const LibraryClassificationDropTarget({
+    super.key,
+    required this.child,
+    required this.onAccept,
+    this.canAccept,
+    this.enabled = true,
+  });
+
+  final Widget child;
+  final ValueChanged<T> onAccept;
+  final bool Function(T data)? canAccept;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) return child;
+    final theme = Theme.of(context);
+    return DragTarget<T>(
+      onWillAcceptWithDetails: (details) =>
+          canAccept?.call(details.data) ?? true,
+      onAcceptWithDetails: (details) {
+        HapticFeedback.heavyImpact();
+        onAccept(details.data);
+      },
+      builder: (context, candidates, rejected) => AnimatedContainer(
+        duration: MediaQuery.disableAnimationsOf(context)
+            ? Duration.zero
+            : const Duration(milliseconds: 150),
+        decoration: candidates.isEmpty
+            ? null
+            : BoxDecoration(
+                color: theme.colorScheme.primary.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(8),
+              ),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/gallery/gallery_album_tree_view.dart
+++ b/lib/presentation/widgets/gallery/gallery_album_tree_view.dart
@@ -40,6 +40,7 @@ class GalleryAlbumTreeView extends StatefulWidget {
   )?
   onAlbumMoveToSlot;
   final void Function(String imagePath, String albumId)? onImageDrop;
+  final void Function(String imagePath)? onImageFavoriteDrop;
   final VoidCallback? onCreateAlbumRequest;
 
   const GalleryAlbumTreeView({
@@ -57,6 +58,7 @@ class GalleryAlbumTreeView extends StatefulWidget {
     this.onAlbumMove,
     this.onAlbumMoveToSlot,
     this.onImageDrop,
+    this.onImageFavoriteDrop,
     this.onCreateAlbumRequest,
   });
 
@@ -70,6 +72,7 @@ class _GalleryAlbumTreeViewState extends State<GalleryAlbumTreeView> {
   String? _hoveredAlbumId;
   final Map<String, GalleryTreeDropSlot> _slotStates = {};
   Timer? _autoExpandTimer;
+  bool _favoriteDropActive = false;
 
   @override
   void dispose() {
@@ -122,17 +125,64 @@ class _GalleryAlbumTreeViewState extends State<GalleryAlbumTreeView> {
             isSelected: widget.selectedAlbumId == null,
             onTap: () => widget.onAlbumSelected(null),
           ),
-        GallerySidebarFavoritesItem(
-          key: const ValueKey('local-gallery-favorites'),
-          label: context.l10n.common_favorite,
-          count: widget.favoriteCount,
-          isSelected: widget.selectedAlbumId == 'favorites',
-          onTap: () => widget.onAlbumSelected('favorites'),
+        _wrapFavoriteDropTarget(
+          GallerySidebarFavoritesItem(
+            key: const ValueKey('local-gallery-favorites'),
+            label: context.l10n.common_favorite,
+            count: widget.favoriteCount,
+            isSelected: widget.selectedAlbumId == 'favorites',
+            onTap: () => widget.onAlbumSelected('favorites'),
+          ),
         ),
         if (widget.albums.isEmpty)
           _EmptyAlbumHint(onCreate: widget.onCreateAlbumRequest),
         ..._buildRootNodes(),
       ],
+    );
+  }
+
+  Widget _wrapFavoriteDropTarget(Widget child) {
+    final onDrop = widget.onImageFavoriteDrop;
+    if (onDrop == null) return child;
+    return DropRegion(
+      formats: const [Formats.fileUri],
+      onDropOver: (event) {
+        final accepts = event.session.items.any(
+          (item) =>
+              galleryInternalDragPathFromLocalData(item.localData) != null,
+        );
+        if (_favoriteDropActive != accepts) {
+          setState(() => _favoriteDropActive = accepts);
+        }
+        return accepts ? DropOperation.copy : DropOperation.none;
+      },
+      onDropLeave: (_) {
+        if (_favoriteDropActive) setState(() => _favoriteDropActive = false);
+      },
+      onPerformDrop: (event) async {
+        if (_favoriteDropActive) setState(() => _favoriteDropActive = false);
+        for (final item in event.session.items) {
+          final path = galleryInternalDragPathFromLocalData(item.localData);
+          if (path != null) {
+            HapticFeedback.heavyImpact();
+            onDrop(path);
+          }
+        }
+      },
+      child: AnimatedContainer(
+        duration: MediaQuery.disableAnimationsOf(context)
+            ? Duration.zero
+            : const Duration(milliseconds: 150),
+        decoration: _favoriteDropActive
+            ? BoxDecoration(
+                color: Theme.of(
+                  context,
+                ).colorScheme.primary.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(8),
+              )
+            : null,
+        child: child,
+      ),
     );
   }
 

--- a/lib/presentation/widgets/gallery/local_image_card_3d.dart
+++ b/lib/presentation/widgets/gallery/local_image_card_3d.dart
@@ -535,6 +535,12 @@ class _LocalImageCard3DState extends ConsumerState<LocalImageCard3D> {
                 icon: Icons.auto_awesome_outlined,
                 label: context.l10n.agentChat_addResource,
               ),
+            if (widget.onSendAction != null)
+              item(
+                value: LocalImageContextAction.moveToCategory,
+                icon: Icons.drive_file_move_outline,
+                label: context.l10n.localGallery_moveToCategory,
+              ),
             if (watermarkEnabled)
               item(
                 value: LocalImageContextAction.createWatermark,

--- a/lib/presentation/widgets/gallery/local_image_context_menu.dart
+++ b/lib/presentation/widgets/gallery/local_image_context_menu.dart
@@ -6,6 +6,7 @@ import '../common/context_menu_anchor.dart';
 
 enum LocalImageContextAction {
   addToAgent,
+  moveToCategory,
   sendToTextToImage,
   sendToImg2Img,
   sendToReversePrompt,
@@ -106,6 +107,12 @@ class LocalImageContextMenu {
         value: LocalImageContextAction.addToAgent,
         icon: Icons.auto_awesome_outlined,
         label: context.l10n.agentChat_addResource,
+      ),
+      _item(
+        context,
+        value: LocalImageContextAction.moveToCategory,
+        icon: Icons.drive_file_move_outline,
+        label: context.l10n.localGallery_moveToCategory,
       ),
       const PopupMenuDivider(),
       ...buildSendEntries(context, isKritaConnected: isKritaConnected),

--- a/test/presentation/screens/precise_ref_library/precise_ref_card_test.dart
+++ b/test/presentation/screens/precise_ref_library/precise_ref_card_test.dart
@@ -41,6 +41,7 @@ void main() {
     VoidCallback? onEdit,
     VoidCallback? onDelete,
     VoidCallback? onToggleFavorite,
+    VoidCallback? onClassify,
     VoidCallback? onAddToAgent,
   }) async {
     final card = PreciseRefCard(
@@ -50,6 +51,7 @@ void main() {
       onEdit: onEdit,
       onDelete: onDelete,
       onToggleFavorite: onToggleFavorite,
+      onClassify: onClassify,
     );
     await tester.pumpWidget(
       ProviderScope(
@@ -144,6 +146,7 @@ void main() {
     var editCount = 0;
     var deleteCount = 0;
     var favoriteCount = 0;
+    var classifyCount = 0;
     await pumpCard(
       tester,
       initialPolicy: const InteractionPolicy(
@@ -156,6 +159,7 @@ void main() {
       onEdit: () => editCount++,
       onDelete: () => deleteCount++,
       onToggleFavorite: () => favoriteCount++,
+      onClassify: () => classifyCount++,
     );
 
     await tester.tap(
@@ -185,11 +189,13 @@ void main() {
     await selectAction('发送到精准参考');
     await selectAction('发送到图生图');
     await selectAction('编辑参数');
+    await selectAction('参考类型');
     await selectAction('删除');
 
     expect(sendCount, 1);
     expect(img2imgCount, 1);
     expect(editCount, 1);
+    expect(classifyCount, 1);
     expect(deleteCount, 1);
   });
 

--- a/test/presentation/screens/tag_library_page/widgets/entry_card_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/entry_card_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/screens/tag_library_page/widgets/entry_card.dart';
+import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
 import 'package:nai_launcher/presentation/widgets/common/thumbnail_display.dart';
 
 void main() {
@@ -150,5 +151,44 @@ void main() {
     await tester.pump();
     expect(find.byKey(previewKey), findsNothing);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('触屏更多菜单可以点击移动到分类', (tester) async {
+    var classifyCount = 0;
+    final entry = TagLibraryEntry(
+      id: 'touch-entry',
+      name: '触屏词条',
+      content: '1girl',
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: InteractionPolicyScope(
+          initialPolicy: const InteractionPolicy(
+            modality: InteractionModality.touch,
+            touchAvailable: true,
+            precisePointerAvailable: false,
+          ),
+          child: Scaffold(
+            body: EntryCard(
+              entry: entry,
+              onTap: () {},
+              onDelete: () {},
+              onToggleFavorite: () {},
+              onClassify: () => classifyCount++,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.more_vert_rounded));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('移动到分类'));
+    expect(classifyCount, 1);
   });
 }

--- a/test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart
+++ b/test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart
@@ -216,6 +216,7 @@ void main() {
 
   testWidgets('Vibe 卡片桌面与触屏操作均可发送到智能体', (tester) async {
     var addCount = 0;
+    var classifyCount = 0;
     final entry = _entry(rawImageData: _onePixelPng);
     final storage = _HoverStorage(entry, _onePixelPng);
 
@@ -233,7 +234,11 @@ void main() {
             home: Scaffold(
               body: ImageCardActionScope(
                 onAddToAgent: () => addCount++,
-                child: VibeCard(entry: entry.toDisplayEntry(), width: 180),
+                child: VibeCard(
+                  entry: entry.toDisplayEntry(),
+                  width: 180,
+                  onClassify: () => classifyCount++,
+                ),
               ),
             ),
           ),
@@ -269,7 +274,16 @@ void main() {
     );
     await tester.pumpAndSettle();
     await tester.tap(find.text('发送到智能体'), kind: PointerDeviceKind.touch);
+    await tester.pumpAndSettle();
     expect(addCount, 2);
+
+    await tester.tap(
+      find.byIcon(Icons.more_vert_rounded),
+      kind: PointerDeviceKind.touch,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('移动到分类'), kind: PointerDeviceKind.touch);
+    expect(classifyCount, 1);
   });
 }
 

--- a/test/presentation/widgets/common/library_classification_drag_test.dart
+++ b/test/presentation/widgets/common/library_classification_drag_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
+import 'package:nai_launcher/presentation/widgets/common/library_classification_drag.dart';
+
+void main() {
+  testWidgets(
+    'desktop entry can be dragged to an enabled classification target',
+    (tester) async {
+      String? accepted;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: InteractionPolicyScope(
+            initialPolicy: const InteractionPolicy(
+              modality: InteractionModality.pointer,
+              touchAvailable: false,
+              precisePointerAvailable: true,
+            ),
+            child: Scaffold(
+              body: Column(
+                children: [
+                  const LibraryClassificationDragSource<String>(
+                    data: 'entry-1',
+                    label: 'Entry',
+                    child: ColoredBox(
+                      key: ValueKey('source'),
+                      color: Colors.transparent,
+                      child: SizedBox(width: 100, height: 60),
+                    ),
+                  ),
+                  LibraryClassificationDropTarget<String>(
+                    onAccept: (value) => accepted = value,
+                    child: const SizedBox(
+                      key: ValueKey('target'),
+                      width: 100,
+                      height: 60,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.drag(
+        find.byKey(const ValueKey('source')),
+        const Offset(0, 70),
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pumpAndSettle();
+
+      expect(accepted, 'entry-1');
+    },
+  );
+
+  testWidgets(
+    'touch uses explicit actions instead of a competing drag gesture',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: InteractionPolicyScope(
+            initialPolicy: InteractionPolicy(
+              modality: InteractionModality.touch,
+              touchAvailable: true,
+              precisePointerAvailable: false,
+            ),
+            child: LibraryClassificationDragSource<String>(
+              data: 'entry-1',
+              label: 'Entry',
+              child: SizedBox(width: 100, height: 60),
+            ),
+          ),
+        ),
+      );
+
+      final draggable = tester.widget<Draggable<String>>(
+        find.byType(Draggable<String>),
+      );
+      expect(draggable.maxSimultaneousDrags, 0);
+    },
+  );
+}

--- a/test/presentation/widgets/gallery/gallery_album_tree_view_test.dart
+++ b/test/presentation/widgets/gallery/gallery_album_tree_view_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:super_drag_and_drop/super_drag_and_drop.dart';
 
 import 'package:nai_launcher/data/models/gallery/gallery_album.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
@@ -28,6 +29,28 @@ Widget _host(Widget child) {
 /// 相簿树交互回归：桌面右键菜单执行动作、就地重命名、新相簿自动展开。
 /// （此前桌面右键菜单漏注册选择回调，四个操作全部无效。）
 void main() {
+  testWidgets('收藏项注册为本地图像拖拽目标', (tester) async {
+    await tester.pumpWidget(
+      _host(
+        GalleryAlbumTreeView(
+          albums: const [],
+          totalImageCount: 1,
+          favoriteCount: 0,
+          onAlbumSelected: (_) {},
+          onImageFavoriteDrop: (_) {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final favorite = find.byKey(const ValueKey('local-gallery-favorites'));
+    expect(favorite, findsOneWidget);
+    expect(
+      find.ancestor(of: favorite, matching: find.byType(DropRegion)),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('右键菜单的四个操作各自执行对应回调', (tester) async {
     String? renamedId;
     String? renamedNewName;
@@ -114,9 +137,8 @@ void main() {
                 const SizedBox(width: 200),
                 Expanded(
                   child: Navigator(
-                    onGenerateRoute: (_) => PageRouteBuilder(
-                      pageBuilder: (_, __, ___) => child,
-                    ),
+                    onGenerateRoute: (_) =>
+                        PageRouteBuilder(pageBuilder: (_, __, ___) => child),
                   ),
                 ),
               ],
@@ -152,10 +174,12 @@ void main() {
     await tester.pumpAndSettle();
 
     // 用菜单面板（菜单项最近的 Material 祖先）断言面板原点贴合点击点
-    final menuPanel = find.ancestor(
-      of: find.byWidgetPredicate((widget) => widget is PopupMenuItem),
-      matching: find.byType(Material),
-    ).first;
+    final menuPanel = find
+        .ancestor(
+          of: find.byWidgetPredicate((widget) => widget is PopupMenuItem),
+          matching: find.byType(Material),
+        )
+        .first;
     expect(menuPanel, findsOneWidget);
     final panelTopLeft = tester.getTopLeft(menuPanel);
     expect(panelTopLeft.dx, closeTo(tapPosition.dx, 0.01));

--- a/test/presentation/widgets/gallery/local_image_card_thumbnail_test.dart
+++ b/test/presentation/widgets/gallery/local_image_card_thumbnail_test.dart
@@ -438,7 +438,7 @@ void main() {
     await tester.pump();
   });
 
-  testWidgets('Android 卡片更多操作可保存到系统相册', (tester) async {
+  testWidgets('Android 卡片更多操作可点击移动到分类', (tester) async {
     final tempDirectory = (await tester.runAsync(
       () => Directory.systemTemp.createTemp('nai_local_card_menu_'),
     ))!;
@@ -492,17 +492,17 @@ void main() {
     await tester.tap(find.byIcon(Icons.more_vert_rounded));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 200));
-    expect(find.text('保存到系统相册'), findsOneWidget);
-    final saveItem = find.byWidgetPredicate(
+    expect(find.text('移动到分类'), findsOneWidget);
+    final classifyItem = find.byWidgetPredicate(
       (widget) =>
           widget is PopupMenuItem<Object> &&
-          widget.value == LocalImageContextAction.saveToSystemGallery,
+          widget.value == LocalImageContextAction.moveToCategory,
     );
-    expect(saveItem, findsOneWidget);
+    expect(classifyItem, findsOneWidget);
 
-    await tester.tap(saveItem);
+    await tester.tap(classifyItem);
     await tester.pump();
-    expect(selected, LocalImageContextAction.saveToSystemGallery);
+    expect(selected, LocalImageContextAction.moveToCategory);
   });
 }
 

--- a/test/presentation/widgets/gallery/local_image_context_menu_test.dart
+++ b/test/presentation/widgets/gallery/local_image_context_menu_test.dart
@@ -36,6 +36,7 @@ void main() {
 
     expect(items.map((item) => item.value).toList(), const [
       LocalImageContextAction.addToAgent,
+      LocalImageContextAction.moveToCategory,
       LocalImageContextAction.sendToTextToImage,
       LocalImageContextAction.sendToImg2Img,
       LocalImageContextAction.sendToReversePrompt,
@@ -148,7 +149,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final items = find.byType(PopupMenuItem<LocalImageContextAction>);
-      expect(items, findsNWidgets(15));
+      expect(items, findsNWidgets(16));
       for (final element in items.evaluate()) {
         final rect = tester.getRect(
           find.byElementPredicate((candidate) => candidate == element),


### PR DESCRIPTION
## 改动内容

- 新增统一的图库分类拖拽源与投放目标，统一拖拽反馈、高亮、触觉反馈和触屏策略。
- 修复本地图库卡片无法拖入“收藏”的问题，并为单张图片补充“移动到分类”入口。
- 为 Vibe、精准参考和词库补齐拖拽到分类/类型/收藏的能力；Vibe 支持拖回未分类。
- 为移动端卡片菜单补充点击分类入口，分类选择面板复用现有自适应呈现与业务更新逻辑。
- 补充拖放、收藏目标、触屏菜单和 320/600/840/1180/1600 宽度回归测试。

## 验证结果

- `flutter test --no-pub`：13 个相关测试文件，共 62 项测试通过。
- `flutter analyze --no-pub lib`：通过，无问题。
- `scripts/verify_flutter_sources.ps1`：通过。
- `git diff --check origin/main...HEAD`：通过。

## 注意事项

- 未修改 assets、LFS 数据库或生成文件。
- 全仓库 analyze 仍有 1 个既有测试文件 unused import 警告，位于 `test/data/services/random_prompt_generator_preset_test.dart`，与本次改动无关。