### PR TITLE
fix(library): 消除分类拖拽双重悬浮

### DIFF
--- a/lib/presentation/screens/vibe_library/widgets/category/vibe_category_item.dart
+++ b/lib/presentation/screens/vibe_library/widgets/category/vibe_category_item.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import '../../../../../core/utils/localization_extension.dart';
 import '../../../../widgets/common/context_menu_anchor.dart';
+import '../../../../widgets/common/library_classification_drag.dart';
 import '../../../../adaptive/interaction_policy.dart';
 
 enum _VibeCategoryAction { rename, addSubCategory, delete }
@@ -90,6 +91,9 @@ class _VibeCategoryItemState extends State<VibeCategoryItem> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final isAcceptingDrop = LibraryClassificationDropTargetStatus.isAcceptingOf(
+      context,
+    );
     final isTouch = context.interactionPolicy.shouldExposeTouchAlternatives;
     const controlExtent = 48.0;
     // Preserve a usable label/action area for deeply nested imported trees.
@@ -113,6 +117,8 @@ class _VibeCategoryItemState extends State<VibeCategoryItem> {
           decoration: BoxDecoration(
             color: widget.isSelected
                 ? theme.colorScheme.primaryContainer
+                : isAcceptingDrop
+                ? theme.colorScheme.primary.withValues(alpha: 0.12)
                 : (_isHovering
                       ? theme.colorScheme.surfaceContainerHighest
                       : Colors.transparent),

--- a/lib/presentation/widgets/common/library_classification_drag.dart
+++ b/lib/presentation/widgets/common/library_classification_drag.dart
@@ -3,6 +3,33 @@ import 'package:flutter/services.dart';
 
 import '../../adaptive/interaction_policy.dart';
 
+/// Exposes the active drop state to the classification row that owns the
+/// visual surface. Keeping the feedback on that row avoids stacking a second
+/// rounded highlight around its built-in pointer hover state.
+class LibraryClassificationDropTargetStatus extends InheritedWidget {
+  const LibraryClassificationDropTargetStatus({
+    super.key,
+    required this.isAccepting,
+    required super.child,
+  });
+
+  final bool isAccepting;
+
+  static bool isAcceptingOf(BuildContext context) {
+    return context
+            .dependOnInheritedWidgetOfExactType<
+              LibraryClassificationDropTargetStatus
+            >()
+            ?.isAccepting ??
+        false;
+  }
+
+  @override
+  bool updateShouldNotify(LibraryClassificationDropTargetStatus oldWidget) {
+    return isAccepting != oldWidget.isAccepting;
+  }
+}
+
 /// Shared in-app drag behavior for assigning library entries to sidebar
 /// destinations. Touch layouts use explicit card actions instead.
 class LibraryClassificationDragSource<T extends Object>
@@ -89,7 +116,6 @@ class LibraryClassificationDropTarget<T extends Object>
   @override
   Widget build(BuildContext context) {
     if (!enabled) return child;
-    final theme = Theme.of(context);
     return DragTarget<T>(
       onWillAcceptWithDetails: (details) =>
           canAccept?.call(details.data) ?? true,
@@ -97,18 +123,11 @@ class LibraryClassificationDropTarget<T extends Object>
         HapticFeedback.heavyImpact();
         onAccept(details.data);
       },
-      builder: (context, candidates, rejected) => AnimatedContainer(
-        duration: MediaQuery.disableAnimationsOf(context)
-            ? Duration.zero
-            : const Duration(milliseconds: 150),
-        decoration: candidates.isEmpty
-            ? null
-            : BoxDecoration(
-                color: theme.colorScheme.primary.withValues(alpha: 0.12),
-                borderRadius: BorderRadius.circular(8),
-              ),
-        child: child,
-      ),
+      builder: (context, candidates, rejected) =>
+          LibraryClassificationDropTargetStatus(
+            isAccepting: candidates.isNotEmpty,
+            child: child,
+          ),
     );
   }
 }

--- a/lib/presentation/widgets/gallery/gallery_sidebar.dart
+++ b/lib/presentation/widgets/gallery/gallery_sidebar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/utils/localization_extension.dart';
 import '../../adaptive/interaction_policy.dart';
+import '../common/library_classification_drag.dart';
 import '../../themes/core/layered_surface_style.dart';
 
 /// Shared geometry for collection pages that pair a navigation sidebar with a
@@ -305,6 +306,9 @@ class _GallerySidebarNavigationItemState
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
+    final isAcceptingDrop = LibraryClassificationDropTargetStatus.isAcceptingOf(
+      context,
+    );
     const controlExtent = 48.0;
     final indent = (12.0 + widget.depth * 16.0).clamp(12.0, 44.0);
 
@@ -323,6 +327,8 @@ class _GallerySidebarNavigationItemState
           decoration: BoxDecoration(
             color: widget.isSelected
                 ? colors.primaryContainer
+                : isAcceptingDrop
+                ? colors.primary.withValues(alpha: 0.12)
                 : _isHovered
                 ? colors.surfaceContainerHighest
                 : Colors.transparent,

--- a/test/presentation/widgets/common/library_classification_drag_test.dart
+++ b/test/presentation/widgets/common/library_classification_drag_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
 import 'package:nai_launcher/presentation/widgets/common/library_classification_drag.dart';
+import 'package:nai_launcher/presentation/widgets/gallery/gallery_sidebar.dart';
 
 void main() {
   testWidgets(
@@ -52,6 +53,65 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(accepted, 'entry-1');
+    },
+  );
+
+  testWidgets(
+    'active drop uses the classification row single highlight surface',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: InteractionPolicyScope(
+            initialPolicy: const InteractionPolicy(
+              modality: InteractionModality.pointer,
+              touchAvailable: false,
+              precisePointerAvailable: true,
+            ),
+            child: Scaffold(
+              body: Column(
+                children: [
+                  LibraryClassificationDropTarget<String>(
+                    onAccept: (_) {},
+                    child: LibraryClassificationDropTargetStatus(
+                      isAccepting: true,
+                      child: GallerySidebarNavigationItem(
+                        key: const ValueKey('single-highlight-target'),
+                        icon: Icons.folder_outlined,
+                        label: 'Category',
+                        count: 1,
+                        isSelected: false,
+                        onTap: () {},
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final rowSurface = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byKey(const ValueKey('single-highlight-target')),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      final decoration = rowSurface.decoration! as BoxDecoration;
+      final theme = Theme.of(
+        tester.element(find.byKey(const ValueKey('single-highlight-target'))),
+      );
+      expect(
+        decoration.color,
+        theme.colorScheme.primary.withValues(alpha: 0.12),
+      );
+      expect(
+        find.ancestor(
+          of: find.text('Category'),
+          matching: find.byType(AnimatedContainer),
+        ),
+        findsOneWidget,
+      );
     },
   );
 


### PR DESCRIPTION
## 改动内容
- 将分类拖放命中状态下沉到分类条目自身的视觉表面
- 统一 Vibe 库、精准参考库与标签库收藏入口的拖拽悬浮反馈
- 增加回归测试，确保拖拽时只存在一层高亮容器

## 验证结果
- `flutter test`：8 个相关测试文件，共 72 项通过
- `flutter analyze`：相关 4 个文件无问题
- `scripts/verify_flutter_sources.ps1`：通过
- `git diff --check`：通过

## 注意事项
- 未执行真机或桌面运行时自动化验收；本次通过 Widget 回归测试覆盖视觉状态结构