### PR TITLE
fix(prompt): 修复固定词网格翻译溢出

### DIFF
--- a/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
+++ b/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
@@ -23,6 +23,28 @@ const _uncategorizedSectionId = '__uncategorized__';
 const _linkDetachDistance = 36.0;
 const _linkEndpointHitSize = 30.0;
 
+double _gridCardHeight(
+  BuildContext context, {
+  required double cardWidth,
+  required bool hasCategory,
+}) {
+  final scaledLabelSize = MediaQuery.textScalerOf(context).scale(14);
+  final usesActionMenu =
+      context.interactionPolicy.shouldExposeTouchAlternatives ||
+      scaledLabelSize >= 20;
+  final needsTallBase = !hasCategory || cardWidth < 180 || usesActionMenu;
+
+  // Grid previews can contain up to five scaled text lines. Grow the fixed
+  // extent with the text scaler so asynchronous translations cannot outgrow it.
+  final scaledTextGrowth = (scaledLabelSize - 14).clamp(0.0, double.infinity);
+  final baseHeight = usesActionMenu
+      ? 210.0
+      : needsTallBase
+      ? 180.0
+      : 150.0;
+  return baseHeight + scaledTextGrowth * 6;
+}
+
 /// 桌面端固定词侧边栏。
 class FixedTagsSidebar extends ConsumerStatefulWidget {
   const FixedTagsSidebar({super.key, this.isResizing = false});
@@ -462,11 +484,11 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
                   (constraints.crossAxisExtent -
                       spacing * (crossAxisCount - 1)) /
                   crossAxisCount;
-              final mainAxisExtent = largeText
-                  ? 230.0
-                  : cardWidth < 180
-                  ? 180.0
-                  : 150.0;
+              final mainAxisExtent = _gridCardHeight(
+                context,
+                cardWidth: cardWidth,
+                hasCategory: true,
+              );
               return SliverGrid.builder(
                 key: ValueKey('positive-grid-${section.id}'),
                 gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
@@ -660,7 +682,11 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
                 .clamp(1, 3);
         final itemWidth =
             (availableWidth - spacing * (columnCount - 1)) / columnCount;
-        final itemHeight = textScale >= 2 ? 220.0 : 150.0;
+        final itemHeight = _gridCardHeight(
+          context,
+          cardWidth: itemWidth,
+          hasCategory: categoryName != null,
+        );
         return Wrap(
           spacing: spacing,
           runSpacing: spacing,

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
@@ -1963,6 +1963,50 @@ void main() {
     },
   );
 
+  testWidgets(
+    'grid cards reserve enough height for translated text and touch actions',
+    (tester) async {
+      final category = TagLibraryCategory.create(name: 'Quality');
+      final positive = FixedTagEntry.create(
+        name: 'positive',
+        content: 'masterpiece, best quality, detailed background',
+        enabled: false,
+        categoryId: category.id,
+      );
+      final negative = FixedTagEntry.create(
+        name: 'negative',
+        content: 'bad hands, low quality, blurry, watermark',
+        enabled: false,
+        promptType: FixedTagPromptType.negative,
+      );
+      final storage = _SidebarTestStorage(
+        fixedEntries: [positive, negative],
+        categories: [category],
+        libraryEntries: const [],
+      )..fixedSidebarViewMode = 'grid';
+      final lookup = TagTranslationLookup.fromResolver((tags) async {
+        return {for (final tag in tags) tag: '译文$tag'};
+      });
+
+      await _pumpSidebar(
+        tester,
+        storage,
+        interactionPolicy: const InteractionPolicy(
+          modality: InteractionModality.touch,
+          touchAvailable: true,
+          precisePointerAvailable: false,
+        ),
+        translationLookup: lookup,
+      );
+
+      expect(
+        find.byKey(const ValueKey('translated-prompt-translation')),
+        findsNWidgets(2),
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets('negative list keeps exact scroll metrics while scrolling', (
     tester,
   ) async {
@@ -2531,10 +2575,15 @@ Future<void> _pumpSidebar(
   _SidebarTestStorage storage, {
   double textScale = 1,
   InteractionPolicy? interactionPolicy,
+  TagTranslationLookup? translationLookup,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+      overrides: [
+        localStorageServiceProvider.overrideWith((ref) => storage),
+        if (translationLookup != null)
+          tagTranslationLookupProvider.overrideWithValue(translationLookup),
+      ],
       child: MaterialApp(
         locale: const Locale('zh'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
## 改动内容

- 统一正向与负向固定词网格卡片的高度计算
- 根据卡片宽度、触屏操作入口和文本缩放预留内容空间
- 新增异步翻译加载后正负卡片不发生 RenderFlex overflow 的回归测试

## 验证结果

- `flutter test test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart`：41 项通过
- `flutter analyze lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart`：通过
- `scripts/verify_flutter_sources.ps1`：通过
- `git diff --check`：通过

## 注意事项

- 未执行热重载；已有运行实例需后续手动执行 `R` 或重新启动以加载修复。