### PR TITLE
fix(dialog): 统一桌面弹窗尺寸与内容高度

### DIFF
--- a/lib/presentation/adaptive/adaptive_presenter.dart
+++ b/lib/presentation/adaptive/adaptive_presenter.dart
@@ -2,7 +2,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
-import '../../core/windowing/workspace_side_panel_contract.dart';
 import '../themes/theme_extension.dart';
 import 'window_size_class.dart';
 
@@ -18,6 +17,8 @@ typedef AdaptivePanelBuilder =
 class AdaptivePresenter {
   AdaptivePresenter._();
 
+  static const _defaultCenteredWidth = 560.0;
+
   /// Presents dialog-style editing flows full-screen on compact panes and in
   /// a bounded, centered surface at every larger width.
   static Future<T?> showForm<T>({
@@ -25,7 +26,7 @@ class AdaptivePresenter {
     String? title,
     WidgetBuilder? titleBuilder,
     required AdaptivePanelBuilder builder,
-    double? sideSheetWidth,
+    double? width,
     double? maxCenteredHeight,
     bool barrierDismissible = true,
     bool requestFocus = true,
@@ -46,7 +47,7 @@ class AdaptivePresenter {
         context: context,
         titleBuilder: resolvedTitleBuilder,
         builder: builder,
-        width: sideSheetWidth ?? WorkspaceSidePanelContract.preferredFormWidth,
+        width: width ?? _defaultCenteredWidth,
         maxHeight: maxCenteredHeight,
         barrierDismissible: barrierDismissible,
         requestFocus: requestFocus,
@@ -117,7 +118,7 @@ class AdaptivePresenter {
         initialChildSize: initialChildSize,
         minChildSize: minChildSize,
         maxChildSize: maxChildSize,
-        sideSheetWidth: width,
+        width: width,
         barrierDismissible: barrierDismissible,
         requestFocus: requestFocus,
         restoreFocus: restoreFocus,
@@ -138,7 +139,7 @@ class AdaptivePresenter {
       context: context,
       titleBuilder: (_) => const SizedBox.shrink(),
       builder: builder,
-      width: width ?? WorkspaceSidePanelContract.preferredFormWidth,
+      width: width ?? _defaultCenteredWidth,
       maxHeight: maxCenteredHeight,
       barrierDismissible: barrierDismissible,
       requestFocus: requestFocus,
@@ -154,6 +155,8 @@ class AdaptivePresenter {
     return result;
   }
 
+  /// Presents auxiliary content as a bottom sheet on compact panes and as an
+  /// independent, centered dialog everywhere else.
   static Future<T?> showPanel<T>({
     required BuildContext context,
     String? title,
@@ -162,7 +165,8 @@ class AdaptivePresenter {
     double initialChildSize = 0.72,
     double minChildSize = 0.38,
     double maxChildSize = 0.94,
-    double? sideSheetWidth,
+    double? width,
+    double? maxCenteredHeight,
     bool barrierDismissible = true,
     bool allowDragDismissal = true,
     bool requestFocus = true,
@@ -180,15 +184,13 @@ class AdaptivePresenter {
         ? FocusManager.instance.primaryFocus
         : null;
     final Future<T?> presentation;
-    if (metrics.isExpandedOrWider) {
-      presentation = _showSideSheet<T>(
+    if (!metrics.isCompact) {
+      presentation = _showCenteredForm<T>(
         context: context,
         titleBuilder: resolvedTitleBuilder,
         builder: builder,
-        width: WorkspaceSidePanelContract.overlayWidth(
-          metrics.safeUsableSize.width,
-          preferredWidth: sideSheetWidth,
-        ),
+        width: width ?? _defaultCenteredWidth,
+        maxHeight: maxCenteredHeight,
         barrierDismissible: barrierDismissible,
         requestFocus: requestFocus,
         showHeader: showHeader,
@@ -281,46 +283,6 @@ class AdaptivePresenter {
       },
     );
   }
-
-  static Future<T?> _showSideSheet<T>({
-    required BuildContext context,
-    required WidgetBuilder titleBuilder,
-    required AdaptivePanelBuilder builder,
-    required double width,
-    required bool barrierDismissible,
-    required bool requestFocus,
-    required bool showHeader,
-  }) {
-    final reduceMotion = MediaQuery.disableAnimationsOf(context);
-    final motion = Theme.of(context).appTheme;
-    return showGeneralDialog<T>(
-      context: context,
-      anchorPoint: Offset(MediaQuery.sizeOf(context).width - 1, 0),
-      barrierDismissible: barrierDismissible,
-      barrierLabel: barrierDismissible
-          ? MaterialLocalizations.of(context).modalBarrierDismissLabel
-          : null,
-      requestFocus: requestFocus,
-      barrierColor: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.32),
-      transitionDuration: reduceMotion ? Duration.zero : motion.normalDuration,
-      pageBuilder: (dialogContext, _, __) => _SideSheetPanel(
-        width: width,
-        titleBuilder: titleBuilder,
-        builder: builder,
-        showHeader: showHeader,
-      ),
-      transitionBuilder: (context, animation, _, child) {
-        if (reduceMotion) return child;
-        return SlideTransition(
-          position: Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero)
-              .animate(
-                CurvedAnimation(parent: animation, curve: motion.enterCurve),
-              ),
-          child: child,
-        );
-      },
-    );
-  }
 }
 
 class _FullScreenPanel extends StatefulWidget {
@@ -394,8 +356,6 @@ class _CenteredFormPanel extends StatefulWidget {
 }
 
 class _CenteredFormPanelState extends State<_CenteredFormPanel> {
-  static const _minimumCenteredHeight = 560.0;
-
   final ScrollController _scrollController = ScrollController();
 
   @override
@@ -417,8 +377,6 @@ class _CenteredFormPanelState extends State<_CenteredFormPanel> {
       child: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final useFullScreen =
-                constraints.maxHeight < _minimumCenteredHeight;
             final maxPanelHeight = math.min(
               constraints.maxHeight * 0.9,
               widget.maxHeight ?? double.infinity,
@@ -426,83 +384,20 @@ class _CenteredFormPanelState extends State<_CenteredFormPanel> {
             final panel = _PanelSurface(
               titleBuilder: widget.titleBuilder,
               scrollController: _scrollController,
-              fullScreen: useFullScreen,
-              centered: !useFullScreen,
+              centered: true,
               showHeader: widget.showHeader,
               child: widget.builder(context, _scrollController),
             );
             return Center(
               child: SizedBox(
-                width: useFullScreen
-                    ? double.infinity
-                    : widget.width.clamp(320, size.width * 0.9).toDouble(),
-                height: useFullScreen ? double.infinity : null,
-                child: useFullScreen
-                    ? panel
-                    : ConstrainedBox(
-                        constraints: BoxConstraints(maxHeight: maxPanelHeight),
-                        child: panel,
-                      ),
+                width: widget.width.clamp(320, size.width * 0.9).toDouble(),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(maxHeight: maxPanelHeight),
+                  child: panel,
+                ),
               ),
             );
           },
-        ),
-      ),
-    );
-  }
-}
-
-class _SideSheetPanel extends StatefulWidget {
-  const _SideSheetPanel({
-    required this.width,
-    required this.titleBuilder,
-    required this.builder,
-    required this.showHeader,
-  });
-
-  final double width;
-  final WidgetBuilder titleBuilder;
-  final AdaptivePanelBuilder builder;
-  final bool showHeader;
-
-  @override
-  State<_SideSheetPanel> createState() => _SideSheetPanelState();
-}
-
-class _SideSheetPanelState extends State<_SideSheetPanel> {
-  final ScrollController _scrollController = ScrollController();
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final motion = Theme.of(context).appTheme;
-    return AnimatedPadding(
-      duration: MediaQuery.disableAnimationsOf(context)
-          ? Duration.zero
-          : motion.fastDuration,
-      curve: motion.standardCurve,
-      padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
-      child: SafeArea(
-        child: Align(
-          alignment: Alignment.centerRight,
-          child: SizedBox(
-            width: widget.width
-                .clamp(320, MediaQuery.sizeOf(context).width * 0.9)
-                .toDouble(),
-            height: double.infinity,
-            child: _PanelSurface(
-              titleBuilder: widget.titleBuilder,
-              scrollController: _scrollController,
-              sideSheet: true,
-              showHeader: widget.showHeader,
-              child: widget.builder(context, _scrollController),
-            ),
-          ),
         ),
       ),
     );
@@ -514,7 +409,6 @@ class _PanelSurface extends StatelessWidget {
     required this.titleBuilder,
     required this.scrollController,
     required this.child,
-    this.sideSheet = false,
     this.fullScreen = false,
     this.centered = false,
     this.showHeader = true,
@@ -523,7 +417,6 @@ class _PanelSurface extends StatelessWidget {
   final WidgetBuilder titleBuilder;
   final ScrollController scrollController;
   final Widget child;
-  final bool sideSheet;
   final bool fullScreen;
   final bool centered;
   final bool showHeader;
@@ -542,8 +435,6 @@ class _PanelSurface extends StatelessWidget {
                 ? 'adaptive-full-screen-form'
                 : centered
                 ? 'adaptive-centered-form'
-                : sideSheet
-                ? 'adaptive-side-sheet'
                 : 'adaptive-bottom-sheet',
           ),
           color: theme.colorScheme.surface,
@@ -553,14 +444,12 @@ class _PanelSurface extends StatelessWidget {
                 ? BorderRadius.zero
                 : centered
                 ? BorderRadius.circular(24)
-                : sideSheet
-                ? const BorderRadius.horizontal(left: Radius.circular(24))
                 : const BorderRadius.vertical(top: Radius.circular(24)),
           ),
           child: Column(
             mainAxisSize: centered ? MainAxisSize.min : MainAxisSize.max,
             children: [
-              if (!sideSheet && !fullScreen && !centered)
+              if (!fullScreen && !centered)
                 Padding(
                   padding: const EdgeInsets.only(top: 10),
                   child: Container(
@@ -616,7 +505,7 @@ class _PanelSurface extends StatelessWidget {
                   top: false,
                   left: false,
                   right: false,
-                  bottom: !sideSheet,
+                  bottom: true,
                   child: PrimaryScrollController(
                     controller: scrollController,
                     child: child,

--- a/lib/presentation/agent_chat/widgets/agent_chat_resource_widgets.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_resource_widgets.dart
@@ -395,7 +395,7 @@ abstract final class AgentChatResourcePicker {
       initialChildSize: 0.9,
       minChildSize: 0.5,
       maxChildSize: 0.96,
-      sideSheetWidth: 720,
+      width: 720,
       builder: (_, __) => _AgentChatResourcePickerBody(
         mode: _PickerMode.gallery,
         onSelected: onSelected,
@@ -419,7 +419,7 @@ abstract final class AgentChatResourcePicker {
       initialChildSize: 0.9,
       minChildSize: 0.5,
       maxChildSize: 0.96,
-      sideSheetWidth: 720,
+      width: 720,
       builder: (_, __) => _AgentChatResourcePickerBody(
         mode: _PickerMode.library,
         onSelected: onSelected,

--- a/lib/presentation/prompt_assistant/widgets/prompt_assistant_custom_dialog.dart
+++ b/lib/presentation/prompt_assistant/widgets/prompt_assistant_custom_dialog.dart
@@ -43,7 +43,7 @@ class PromptAssistantCustomDialog extends StatefulWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(context).textTheme.titleLarge,
       ),
-      sideSheetWidth: 600,
+      width: 600,
       builder: (context, scrollController) => PromptAssistantCustomDialog(
         currentPrompt: currentPrompt,
         allowImages: allowImages,

--- a/lib/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart
+++ b/lib/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart
@@ -645,6 +645,7 @@ class _PromptAssistantOverlayState
       ),
       builder: (sheetContext, scrollController) => ListView(
         controller: scrollController,
+        shrinkWrap: true,
         children: [
           ListTile(
             leading: const Icon(Icons.history),

--- a/lib/presentation/prompt_assistant/widgets/prompt_assistant_quick_settings.dart
+++ b/lib/presentation/prompt_assistant/widgets/prompt_assistant_quick_settings.dart
@@ -14,13 +14,14 @@ class PromptAssistantQuickSettings {
       title: context.l10n.promptAssistant_assistantSettings,
       initialChildSize: 0.42,
       minChildSize: 0.32,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (context, scrollController) => Consumer(
         builder: (context, ref, _) {
           final config = ref.watch(promptAssistantConfigProvider);
           final notifier = ref.read(promptAssistantConfigProvider.notifier);
           return ListView(
             controller: scrollController,
+            shrinkWrap: true,
             padding: const EdgeInsets.symmetric(vertical: 8),
             children: [
               SwitchListTile(

--- a/lib/presentation/screens/auth/login_screen.dart
+++ b/lib/presentation/screens/auth/login_screen.dart
@@ -396,6 +396,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       minChildSize: 0.62,
       builder: (panelContext, scrollController) => ListView(
         controller: scrollController,
+        shrinkWrap: true,
         padding: const EdgeInsets.fromLTRB(8, 16, 8, 32),
         children: [
           LoginFormContainer(onLoginSuccess: () => Navigator.pop(panelContext)),
@@ -417,6 +418,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       maxChildSize: 0.62,
       builder: (panelContext, scrollController) => ListView(
         controller: scrollController,
+        shrinkWrap: true,
         padding: const EdgeInsets.only(bottom: 24),
         children: [
           ListTile(

--- a/lib/presentation/screens/generation/handlers/vibe_export_handler.dart
+++ b/lib/presentation/screens/generation/handlers/vibe_export_handler.dart
@@ -376,7 +376,7 @@ Future<List<VibeReference>> showVibeEmbedSelectionForm({
   final result = await AdaptivePresenter.showForm<List<VibeReference>>(
     context: context,
     title: context.l10n.vibe_export_selectToEmbed,
-    sideSheetWidth: 480,
+    width: 480,
     builder: (panelContext, scrollController) => StatefulBuilder(
       builder: (panelContext, setState) => Column(
         children: [

--- a/lib/presentation/screens/generation/handlers/vibe_import_handler.dart
+++ b/lib/presentation/screens/generation/handlers/vibe_import_handler.dart
@@ -510,7 +510,7 @@ Future<VibeLibrarySaveFormResult?> showVibeLibrarySaveForm({
   return AdaptivePresenter.showForm<VibeLibrarySaveFormResult>(
     context: context,
     title: context.l10n.vibe_saveToLibrary_title,
-    sideSheetWidth: 440,
+    width: 440,
     builder: (panelContext, scrollController) => StatefulBuilder(
       builder: (panelContext, setState) => Column(
         children: [

--- a/lib/presentation/screens/generation/widgets/comfyui_workflow_dialog.dart
+++ b/lib/presentation/screens/generation/widgets/comfyui_workflow_dialog.dart
@@ -39,7 +39,7 @@ class ComfyUIWorkflowDialog extends ConsumerStatefulWidget {
   }) {
     return AdaptivePresenter.showForm<List<Uint8List>>(
       context: context,
-      sideSheetWidth: 560,
+      width: 560,
       titleBuilder: (panelContext) {
         final theme = Theme.of(panelContext);
         return Row(

--- a/lib/presentation/screens/generation/widgets/generation_controls/batch_settings_button.dart
+++ b/lib/presentation/screens/generation/widgets/generation_controls/batch_settings_button.dart
@@ -92,7 +92,7 @@ class BatchSettingsButton extends ConsumerWidget {
           Flexible(child: Text(l10n.batchSize_title)),
         ],
       ),
-      sideSheetWidth: 440,
+      width: 440,
       builder: (context, scrollController) => StatefulBuilder(
         builder: (context, setState) {
           final totalImages = batchCount * currentBatchSize;

--- a/lib/presentation/screens/generation/widgets/prompt_input_coordinator.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_input_coordinator.dart
@@ -265,7 +265,7 @@ class PromptInputCoordinator {
     await AdaptivePresenter.showForm<void>(
       context: context,
       title: context.l10n.prompt_characterPrompts,
-      sideSheetWidth: 560,
+      width: 560,
       builder: (context, scrollController) =>
           MobileCharacterManagerSheet(scrollController: scrollController),
     );

--- a/lib/presentation/screens/local_gallery/local_gallery_action_coordinator.dart
+++ b/lib/presentation/screens/local_gallery/local_gallery_action_coordinator.dart
@@ -73,7 +73,7 @@ Future<void> showLocalGalleryZipFailureDetails(
     ),
     initialChildSize: 0.78,
     minChildSize: 0.5,
-    sideSheetWidth: 600,
+    width: 600,
     builder: (panelContext, scrollController) => ListView.builder(
       key: const ValueKey('local-gallery-zip-failure-list'),
       controller: scrollController,

--- a/lib/presentation/screens/local_gallery/local_gallery_move_target.dart
+++ b/lib/presentation/screens/local_gallery/local_gallery_move_target.dart
@@ -45,7 +45,7 @@ Future<String?> showLocalGalleryMoveTargetDialog({
   return AdaptivePresenter.showForm<String>(
     context: context,
     title: l10n.localGallery_moveToCategory,
-    sideSheetWidth: 440,
+    width: 440,
     builder: (panelContext, scrollController) => ListView.builder(
       key: const ValueKey('local-gallery-move-target-list'),
       controller: scrollController,

--- a/lib/presentation/screens/online_gallery/online_gallery_content.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_content.dart
@@ -88,7 +88,7 @@ class _OnlineGalleryContentPresenter {
       initialChildSize: 0.86,
       minChildSize: 0.58,
       maxChildSize: 0.96,
-      sideSheetWidth: 480,
+      width: 480,
       builder: (_, scrollController) => GelbooruCredentialsDialog(
         embedded: true,
         scrollController: scrollController,

--- a/lib/presentation/screens/online_gallery/online_gallery_detail_launcher.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_detail_launcher.dart
@@ -93,7 +93,7 @@ class OnlineGalleryDetailLauncher {
       await AdaptivePresenter.showForm<void>(
         context: context,
         showHeader: false,
-        sideSheetWidth: 960,
+        width: 960,
         builder: (dialogContext, _) => GalleryDetailDialog(
           embedded: true,
           item: item,

--- a/lib/presentation/screens/online_gallery/online_gallery_selection_actions.dart
+++ b/lib/presentation/screens/online_gallery/online_gallery_selection_actions.dart
@@ -356,7 +356,7 @@ class OnlineGallerySelectionActions {
         barrierDismissible: false,
         allowDragDismissal: false,
         showHeader: false,
-        sideSheetWidth: 480,
+        width: 480,
         initialChildSize: 0.42,
         minChildSize: 0.32,
         maxChildSize: 0.72,

--- a/lib/presentation/screens/online_gallery/widgets/online_gallery_toolbar/online_gallery_auth_dialogs.dart
+++ b/lib/presentation/screens/online_gallery/widgets/online_gallery_toolbar/online_gallery_auth_dialogs.dart
@@ -20,7 +20,7 @@ class OnlineGalleryAuthDialogs {
       initialChildSize: 0.82,
       minChildSize: 0.58,
       maxChildSize: 0.96,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (_, scrollController) => DanbooruLoginDialog(
         embedded: true,
         scrollController: scrollController,
@@ -41,7 +41,7 @@ class OnlineGalleryAuthDialogs {
       initialChildSize: 0.86,
       minChildSize: 0.58,
       maxChildSize: 0.96,
-      sideSheetWidth: 480,
+      width: 480,
       builder: (_, scrollController) => GelbooruCredentialsDialog(
         embedded: true,
         scrollController: scrollController,

--- a/lib/presentation/screens/online_gallery/widgets/online_gallery_toolbar/online_gallery_toolbar_dialogs.dart
+++ b/lib/presentation/screens/online_gallery/widgets/online_gallery_toolbar/online_gallery_toolbar_dialogs.dart
@@ -41,7 +41,7 @@ class OnlineGalleryToolbarDialogs {
       initialChildSize: 0.58,
       minChildSize: 0.36,
       maxChildSize: 0.92,
-      sideSheetWidth: 480,
+      width: 480,
       titleBuilder: (panelContext) => Row(
         children: [
           const Icon(Icons.tune_rounded, size: 20),

--- a/lib/presentation/screens/precise_ref_library/widgets/precise_ref_entry_edit_dialog.dart
+++ b/lib/presentation/screens/precise_ref_library/widgets/precise_ref_entry_edit_dialog.dart
@@ -52,7 +52,7 @@ class PreciseRefEntryEditDialog extends StatefulWidget {
         panelContext.l10n.preciseRefLib_editEntry,
         style: Theme.of(panelContext).textTheme.titleLarge,
       ),
-      sideSheetWidth: 440,
+      width: 440,
       builder: (panelContext, scrollController) =>
           PreciseRefEntryEditDialog._presented(
             entry: entry,

--- a/lib/presentation/screens/precise_ref_library/widgets/precise_ref_selector_dialog.dart
+++ b/lib/presentation/screens/precise_ref_library/widgets/precise_ref_selector_dialog.dart
@@ -40,7 +40,7 @@ class PreciseRefSelectorDialog extends ConsumerStatefulWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(panelContext).textTheme.titleLarge,
       ),
-      sideSheetWidth: 720,
+      width: 720,
       builder: (panelContext, scrollController) => PreciseRefSelectorDialog(
         multiSelect: multiSelect,
         scrollController: scrollController,

--- a/lib/presentation/screens/prompt_config/prompt_config_screen.dart
+++ b/lib/presentation/screens/prompt_config/prompt_config_screen.dart
@@ -166,6 +166,7 @@ class _PromptConfigScreenState extends ConsumerState<PromptConfigScreen> {
       maxChildSize: 0.62,
       builder: (context, scrollController) => ListView(
         controller: scrollController,
+        shrinkWrap: true,
         padding: const EdgeInsets.all(16),
         children: [
           _ImportExportActionCard(

--- a/lib/presentation/screens/settings/sections/agent/agent_profile_actions.dart
+++ b/lib/presentation/screens/settings/sections/agent/agent_profile_actions.dart
@@ -86,7 +86,7 @@ class _AgentProfileActionsState extends ConsumerState<AgentProfileActions> {
       if (!mounted) return;
       final confirmed = await AdaptivePresenter.showForm<bool>(
         context: context,
-        sideSheetWidth: 568,
+        width: 568,
         title: context.l10n.agentSettings_confirmProfileImport,
         builder: (context, scrollController) => LayoutBuilder(
           builder: (context, constraints) => Column(

--- a/lib/presentation/screens/settings/sections/agent/skill_management_panel.dart
+++ b/lib/presentation/screens/settings/sections/agent/skill_management_panel.dart
@@ -196,7 +196,7 @@ class _SkillManagementPanelState extends ConsumerState<SkillManagementPanel> {
     final confirmed = await AdaptivePresenter.showForm<bool>(
       context: context,
       title: context.l10n.agentSettings_exportSkillsTitle,
-      sideSheetWidth: 560,
+      width: 560,
       builder: (context, scrollController) => StatefulBuilder(
         builder: (context, setFormState) => Padding(
           padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
@@ -332,7 +332,7 @@ class SkillImportConflictForm {
     return AdaptivePresenter.showForm<Set<String>>(
       context: context,
       title: context.l10n.agentSettings_confirmSkillsImport,
-      sideSheetWidth: 600,
+      width: 600,
       builder: (context, scrollController) => StatefulBuilder(
         builder: (context, setFormState) => Padding(
           padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),

--- a/lib/presentation/screens/settings/sections/appearance_settings_section.dart
+++ b/lib/presentation/screens/settings/sections/appearance_settings_section.dart
@@ -177,7 +177,7 @@ class _AppearanceSettingsSectionState
     return AdaptivePresenter.showForm<void>(
       context: context,
       title: context.l10n.settings_selectFont,
-      sideSheetWidth: 560,
+      width: 560,
       builder: (panelContext, scrollController) => _FontPickerContent(
         currentFont: currentFont,
         scrollController: scrollController,
@@ -397,7 +397,7 @@ class _AppearanceSettingsSectionState
     return AdaptivePresenter.showForm<void>(
       context: context,
       title: context.l10n.settings_fontScale,
-      sideSheetWidth: 420,
+      width: 420,
       builder: (panelContext, scrollController) => _FontScaleEditor(
         initialScale: currentScale,
         scrollController: scrollController,

--- a/lib/presentation/screens/settings/sections/privacy_settings_section.dart
+++ b/lib/presentation/screens/settings/sections/privacy_settings_section.dart
@@ -41,7 +41,7 @@ class _PrivacySettingsSectionState
         overflow: TextOverflow.ellipsis,
         style: Theme.of(panelContext).textTheme.titleMedium,
       ),
-      sideSheetWidth: 420,
+      width: 420,
       builder: (panelContext, scrollController) => _NumberEditorForm(
         initialValue: initialValue,
         label: label,

--- a/lib/presentation/screens/settings/sections/prompt_assistant_settings_section.dart
+++ b/lib/presentation/screens/settings/sections/prompt_assistant_settings_section.dart
@@ -532,7 +532,7 @@ class PromptAssistantSettingsSection extends ConsumerWidget {
     final result =
         await AdaptivePresenter.showForm<PromptAssistantProviderFormResult>(
           context: context,
-          sideSheetWidth: 520,
+          width: 520,
           title: provider == null
               ? context.l10n.promptAssistant_addProvider
               : context.l10n.promptAssistant_editProviderTitle,
@@ -622,7 +622,7 @@ class PromptAssistantSettingsSection extends ConsumerWidget {
     final result =
         await AdaptivePresenter.showForm<PromptAssistantConnectionFormResult>(
           context: context,
-          sideSheetWidth: 520,
+          width: 520,
           title: context.l10n.promptAssistant_connectionTitle(provider.name),
           builder: (context, scrollController) => PromptAssistantConnectionForm(
             provider: provider,
@@ -657,7 +657,7 @@ class PromptAssistantSettingsSection extends ConsumerWidget {
     final result =
         await AdaptivePresenter.showForm<PromptAssistantRuleFormResult>(
           context: context,
-          sideSheetWidth: 560,
+          width: 560,
           title: rule == null
               ? context.l10n.promptAssistant_addRuleTitle
               : context.l10n.promptAssistant_editRuleTitle,

--- a/lib/presentation/screens/settings/sections/web_access_settings.dart
+++ b/lib/presentation/screens/settings/sections/web_access_settings.dart
@@ -309,7 +309,7 @@ class _WebAccessSettingsState extends ConsumerState<WebAccessSettings> {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(panelContext).textTheme.titleMedium,
       ),
-      sideSheetWidth: 420,
+      width: 420,
       builder: (panelContext, scrollController) =>
           _ApiKeyEditorForm(hasKey: hasKey, scrollController: scrollController),
     );

--- a/lib/presentation/screens/settings/widgets/shortcut_settings_panel.dart
+++ b/lib/presentation/screens/settings/widgets/shortcut_settings_panel.dart
@@ -42,7 +42,7 @@ class ShortcutSettingsPanel extends ConsumerStatefulWidget {
           ],
         );
       },
-      sideSheetWidth: 720,
+      width: 720,
       builder: (context, scrollController) =>
           const ShortcutSettingsPanel(presented: true),
     );

--- a/lib/presentation/screens/settings/widgets/workflow_import_wizard.dart
+++ b/lib/presentation/screens/settings/widgets/workflow_import_wizard.dart
@@ -27,7 +27,7 @@ class WorkflowImportWizard extends ConsumerStatefulWidget {
   static Future<void> show(BuildContext context) {
     return AdaptivePresenter.showForm<void>(
       context: context,
-      sideSheetWidth: 600,
+      width: 600,
       barrierDismissible: false,
       titleBuilder: (panelContext) => Row(
         children: [

--- a/lib/presentation/screens/statistics/widgets/dashboard/anlas_cost_card.dart
+++ b/lib/presentation/screens/statistics/widgets/dashboard/anlas_cost_card.dart
@@ -69,7 +69,7 @@ class _AnlasCostCardState extends ConsumerState<AnlasCostCard> {
       final selectedDays = await AdaptivePresenter.showForm<int>(
         context: context,
         title: AppLocalizations.of(context)!.statistics_customPeriodTitle,
-        sideSheetWidth: 420,
+        width: 420,
         builder: (context, scrollController) => _CustomDaysForm(
           initialDays: _customDays,
           maxDays: _maxCustomDays,

--- a/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
+++ b/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
@@ -763,7 +763,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
     await AdaptivePresenter.showForm<void>(
       context: context,
       title: context.l10n.tagLibrary_newCategory,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (panelContext, scrollController) => _AddCategoryForm(
         scrollController: scrollController,
         onCreate: (name) async {

--- a/lib/presentation/screens/tag_library_page/widgets/bulk_move_category_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/bulk_move_category_dialog.dart
@@ -26,7 +26,7 @@ class BulkMoveCategoryDialog extends StatelessWidget {
     return AdaptivePresenter.showForm<String>(
       context: context,
       titleBuilder: _buildTitle,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (panelContext, scrollController) => _BulkMoveCategoryContent(
         categories: categories,
         currentCategoryId: currentCategoryId,

--- a/lib/presentation/screens/tag_library_page/widgets/category_tree_view.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/category_tree_view.dart
@@ -489,7 +489,7 @@ class _CategoryItemState extends State<_CategoryItem> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     // Deep imported hierarchies must retain room for the label and action menu
-    // instead of pushing the row beyond a compact side sheet.
+    // instead of pushing the row beyond a compact modal surface.
     final indent = (12.0 + widget.depth * 16.0).clamp(12.0, 44.0).toDouble();
     final showActions =
         widget.onRename != null &&

--- a/lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart
@@ -71,7 +71,7 @@ class EntryAddDialog extends ConsumerStatefulWidget {
     return AdaptivePresenter.showForm<void>(
       context: context,
       titleBuilder: title,
-      sideSheetWidth: 700,
+      width: 700,
       maxCenteredHeight: 680,
       builder: (dialogContext, scrollController) => EntryAddDialog._(
         categories: categories,

--- a/lib/presentation/screens/tag_library_page/widgets/entry_selector_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_selector_dialog.dart
@@ -52,7 +52,7 @@ class EntrySelectorDialog extends ConsumerStatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 500,
+      width: 500,
       builder: (panelContext, scrollController) => EntrySelectorDialog(
         entries: entries,
         categories: categories,

--- a/lib/presentation/screens/tag_library_page/widgets/export_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/export_dialog.dart
@@ -52,7 +52,7 @@ class ExportDialog extends ConsumerStatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 600,
+      width: 600,
       builder: (context, _) =>
           ExportDialog._(entries: entries, categories: categories),
     );

--- a/lib/presentation/screens/tag_library_page/widgets/import_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/import_dialog.dart
@@ -39,7 +39,7 @@ class ImportDialog extends ConsumerStatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 700,
+      width: 700,
       builder: (context, _) => const ImportDialog._(),
     );
   }

--- a/lib/presentation/screens/tag_library_page/widgets/send_to_home_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/send_to_home_dialog.dart
@@ -60,7 +60,7 @@ class SendToHomeDialog extends ConsumerStatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 480,
+      width: 480,
       builder: (panelContext, scrollController) =>
           SendToHomeDialog(entry: entry, scrollController: scrollController),
     );

--- a/lib/presentation/screens/tag_library_page/widgets/tag_library_drop_menu.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/tag_library_drop_menu.dart
@@ -44,7 +44,7 @@ class TagLibraryDropMenu extends StatelessWidget {
     final displayFileName = _displayFileName(fileName);
     return AdaptivePresenter.showForm<TagLibraryDropAction>(
       context: context,
-      sideSheetWidth: 400,
+      width: 400,
       titleBuilder: (panelContext) => Row(
         children: [
           Icon(

--- a/lib/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog.dart
@@ -573,7 +573,7 @@ Future<void> showThumbnailCropDialog({
         ),
       ],
     ),
-    sideSheetWidth: 720,
+    width: 720,
     builder: (_, __) => ThumbnailCropDialog(
       imagePath: imagePath,
       initialOffsetX: initialOffsetX,

--- a/lib/presentation/screens/vibe_library/widgets/category/vibe_category_destination_panel.dart
+++ b/lib/presentation/screens/vibe_library/widgets/category/vibe_category_destination_panel.dart
@@ -21,7 +21,7 @@ class VibeCategoryDestinationPanel extends StatelessWidget {
   }) => AdaptivePresenter.showForm<String>(
     context: context,
     title: context.l10n.vibeLibrary_moveToCategory,
-    sideSheetWidth: 440,
+    width: 440,
     builder: (panelContext, scrollController) => VibeCategoryDestinationPanel(
       categories: categories,
       scrollController: scrollController,

--- a/lib/presentation/screens/vibe_library/widgets/menus/vibe_import_menu.dart
+++ b/lib/presentation/screens/vibe_library/widgets/menus/vibe_import_menu.dart
@@ -122,6 +122,7 @@ extension ImportMenuExtension on BuildContext {
       maxChildSize: 0.72,
       builder: (panelContext, scrollController) => ListView(
         controller: scrollController,
+        shrinkWrap: true,
         padding: const EdgeInsets.only(bottom: 24),
         children: [
           for (final item in items)

--- a/lib/presentation/screens/vibe_library/widgets/vibe_bundle_import_dialog.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_bundle_import_dialog.dart
@@ -81,7 +81,7 @@ class VibeBundleImportDialog extends StatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 500,
+      width: 500,
       builder: (dialogContext, scrollController) =>
           VibeBundleImportDialog._presented(
             bundleName: bundleName,

--- a/lib/presentation/screens/vibe_library/widgets/vibe_detail_viewer.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_detail_viewer.dart
@@ -76,7 +76,7 @@ class _VibeRenameForm extends StatefulWidget {
     return AdaptivePresenter.showForm<String>(
       context: context,
       title: context.l10n.shortcut_action_vibe_detail_rename,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (panelContext, scrollController) => _VibeRenameForm(
         initialValue: initialValue,
         scrollController: scrollController,
@@ -210,7 +210,7 @@ class VibeDetailViewer extends ConsumerStatefulWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(panelContext).textTheme.titleLarge,
       ),
-      sideSheetWidth: 960,
+      width: 960,
       builder: (panelContext, _) => VibeDetailViewer(
         entry: entry,
         detailDataFuture: detailDataFuture,

--- a/lib/presentation/screens/vibe_library/widgets/vibe_export_dialog.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_export_dialog.dart
@@ -112,7 +112,7 @@ class VibeExportDialog extends ConsumerStatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 650,
+      width: 650,
       builder: (_, __) =>
           VibeExportDialog(entries: entries, categories: categories),
     );

--- a/lib/presentation/screens/vibe_library/widgets/vibe_export_dialog_advanced.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_export_dialog_advanced.dart
@@ -61,7 +61,7 @@ class VibeExportDialogAdvanced extends ConsumerStatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 520,
+      width: 520,
       builder: (_, __) => VibeExportDialogAdvanced(entries: entries),
     );
   }

--- a/lib/presentation/screens/vibe_library/widgets/vibe_image_encode_dialog.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_image_encode_dialog.dart
@@ -92,7 +92,7 @@ class VibeImageEncodeDialog extends StatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 400,
+      width: 400,
       builder: (panelContext, scrollController) =>
           VibeImageEncodeDialog._presented(
             thumbnail: imageBytes,
@@ -620,7 +620,7 @@ class VibeImageEncodeErrorDialog extends StatelessWidget {
           ),
         ],
       ),
-      sideSheetWidth: 440,
+      width: 440,
       builder: (panelContext, scrollController) => VibeImageEncodeErrorDialog(
         fileName: fileName,
         errorMessage: errorMessage,

--- a/lib/presentation/screens/vibe_library/widgets/vibe_import_naming_dialog.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_import_naming_dialog.dart
@@ -92,7 +92,7 @@ class VibeImportNamingDialog extends StatefulWidget {
             ),
         ],
       ),
-      sideSheetWidth: 400,
+      width: 400,
       builder: (dialogContext, scrollController) =>
           VibeImportNamingDialog._presented(
             suggestedName: suggestedName,

--- a/lib/presentation/screens/vibe_library/widgets/vibe_selector_dialog.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_selector_dialog.dart
@@ -184,7 +184,7 @@ class VibeSelectorDialog extends ConsumerStatefulWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(panelContext).textTheme.titleLarge,
       ),
-      sideSheetWidth: 900,
+      width: 900,
       builder: (panelContext, scrollController) {
         if (!openSpanFinished) {
           openSpanFinished = true;

--- a/lib/presentation/screens/watermark/watermark_editor_controls.dart
+++ b/lib/presentation/screens/watermark/watermark_editor_controls.dart
@@ -422,7 +422,7 @@ class WatermarkEditorControls extends StatelessWidget {
     final result = await AdaptivePresenter.showForm<Color>(
       context: context,
       title: context.l10n.editor_toolColorPicker,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (panelContext, scrollController) => _WatermarkColorForm(
         initial: initial,
         scrollController: scrollController,

--- a/lib/presentation/screens/watermark/watermark_editor_launcher.dart
+++ b/lib/presentation/screens/watermark/watermark_editor_launcher.dart
@@ -127,7 +127,7 @@ class WatermarkEditorLauncher {
     return AdaptivePresenter.showForm<String>(
       context: context,
       title: context.l10n.watermark_editorTitle,
-      sideSheetWidth: 960,
+      width: 960,
       barrierDismissible: false,
       showHeader: false,
       builder: (context, scrollController) => page,

--- a/lib/presentation/widgets/auth/network_troubleshooting_dialog.dart
+++ b/lib/presentation/widgets/auth/network_troubleshooting_dialog.dart
@@ -12,7 +12,7 @@ class NetworkTroubleshootingDialog extends StatelessWidget {
   static Future<void> show(BuildContext context) {
     return AdaptivePresenter.showPanel<void>(
       context: context,
-      sideSheetWidth: 498,
+      width: 498,
       titleBuilder: (context) {
         final theme = Theme.of(context);
         return Row(

--- a/lib/presentation/widgets/bulk_metadata_edit_dialog.dart
+++ b/lib/presentation/widgets/bulk_metadata_edit_dialog.dart
@@ -410,7 +410,7 @@ void showBulkMetadataEditDialog(BuildContext context) {
   unawaited(
     AdaptivePresenter.showForm<void>(
       context: context,
-      sideSheetWidth: 500,
+      width: 500,
       titleBuilder: (panelContext) => Consumer(
         builder: (context, ref, _) {
           final selectedCount = ref

--- a/lib/presentation/widgets/bulk_progress_dialog.dart
+++ b/lib/presentation/widgets/bulk_progress_dialog.dart
@@ -43,7 +43,7 @@ class BulkProgressDialog extends ConsumerStatefulWidget {
       barrierDismissible: false,
       allowDragDismissal: false,
       showHeader: false,
-      sideSheetWidth: 480,
+      width: 480,
       initialChildSize: 0.5,
       minChildSize: 0.38,
       maxChildSize: 0.72,

--- a/lib/presentation/widgets/character/add_to_library_dialog.dart
+++ b/lib/presentation/widgets/character/add_to_library_dialog.dart
@@ -44,7 +44,7 @@ class AddToLibraryDialog extends ConsumerStatefulWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(context).textTheme.titleLarge,
       ),
-      sideSheetWidth: 520,
+      width: 520,
       builder: (context, scrollController) => AddToLibraryDialog(
         defaultName: name,
         content: content,

--- a/lib/presentation/widgets/character/inline_character_editor.dart
+++ b/lib/presentation/widgets/character/inline_character_editor.dart
@@ -447,9 +447,10 @@ Future<void> confirmClearAllCharacters(
     title: l10n.characterEditor_clearAllTitle,
     initialChildSize: 0.46,
     minChildSize: 0.38,
-    sideSheetWidth: 440,
+    width: 440,
     builder: (panelContext, scrollController) => ListView(
       controller: scrollController,
+      shrinkWrap: true,
       padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
       children: [
         Text(l10n.characterEditor_clearAllConfirm),

--- a/lib/presentation/widgets/collection_select_dialog.dart
+++ b/lib/presentation/widgets/collection_select_dialog.dart
@@ -53,7 +53,7 @@ class CollectionSelectDialog extends ConsumerStatefulWidget {
       initialChildSize: needsTallPanel ? 0.93 : 0.72,
       minChildSize: needsTallPanel ? 0.72 : 0.46,
       maxChildSize: 0.94,
-      sideSheetWidth: 450,
+      width: 450,
       builder: (panelContext, scrollController) => CollectionSelectDialog(
         theme: theme,
         scrollController: scrollController,

--- a/lib/presentation/widgets/common/adaptive_dialog_frame.dart
+++ b/lib/presentation/widgets/common/adaptive_dialog_frame.dart
@@ -2,9 +2,9 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
-/// Gives dialog bodies a bounded viewport while preserving a preferred
-/// desktop size. The reserved space accounts for route insets, titles and
-/// action rows that live outside [child].
+/// Gives dialog bodies a bounded viewport without forcing short content to
+/// occupy the full available height. The reserved space accounts for route
+/// insets, titles and action rows that live outside [child].
 class AdaptiveDialogFrame extends StatelessWidget {
   const AdaptiveDialogFrame({
     super.key,
@@ -46,13 +46,17 @@ class AdaptiveDialogFrame extends StatelessWidget {
     );
 
     // AlertDialog measures its content intrinsically. LayoutBuilder cannot
-    // provide intrinsic dimensions, so the frame must derive its preferred
-    // bounds directly from the current viewport and let parent constraints
-    // tighten the resulting SizedBox when necessary.
+    // provide intrinsic dimensions, so derive the bounds from the viewport.
+    // Width remains stable on desktop, while height is only capped: forcing
+    // maxHeight here makes every short dialog look like a mostly empty panel.
     return SizedBox(
       width: math.min(maxWidth, viewportWidth),
-      height: math.min(maxHeight, viewportHeight),
-      child: child,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: math.min(maxHeight, viewportHeight),
+        ),
+        child: child,
+      ),
     );
   }
 }

--- a/lib/presentation/widgets/common/add_to_library_dialog.dart
+++ b/lib/presentation/widgets/common/add_to_library_dialog.dart
@@ -43,7 +43,7 @@ class AddToLibraryDialog extends ConsumerStatefulWidget {
   }) async {
     final result = await AdaptivePresenter.showForm<bool>(
       context: context,
-      sideSheetWidth: 520,
+      width: 520,
       titleBuilder: (panelContext) => Row(
         children: [
           Icon(

--- a/lib/presentation/widgets/common/emoji_picker_dialog.dart
+++ b/lib/presentation/widgets/common/emoji_picker_dialog.dart
@@ -21,7 +21,7 @@ class EmojiPickerDialog extends StatelessWidget {
     return AdaptivePresenter.showForm<String>(
       context: context,
       title: context.l10n.category_selectEmoji,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (context, scrollController) =>
           const EmojiPickerDialog(presentationManaged: true),
     );

--- a/lib/presentation/widgets/common/image_card_context_menu.dart
+++ b/lib/presentation/widgets/common/image_card_context_menu.dart
@@ -46,6 +46,7 @@ class ImageCardContextMenu {
         maxChildSize: 0.94,
         builder: (panelContext, scrollController) => ListView(
           controller: scrollController,
+          shrinkWrap: true,
           padding: const EdgeInsets.only(bottom: 24),
           children: [
             for (final item in items)

--- a/lib/presentation/widgets/common/image_detail/components/prompt_copy_dialog.dart
+++ b/lib/presentation/widgets/common/image_detail/components/prompt_copy_dialog.dart
@@ -24,7 +24,7 @@ class PromptCopyDialog extends StatefulWidget {
     required NaiImageMetadata metadata,
   }) => AdaptivePresenter.showForm<String>(
     context: context,
-    sideSheetWidth: 480,
+    width: 480,
     titleBuilder: (context) {
       final theme = Theme.of(context);
       return Row(
@@ -54,7 +54,7 @@ class PromptCopyDialog extends StatefulWidget {
     required NaiImageMetadata metadata,
   }) => AdaptivePresenter.showForm<String>(
     context: context,
-    sideSheetWidth: 480,
+    width: 480,
     titleBuilder: (context) => Text(
       context.l10n.promptCopy_exportTitle,
       maxLines: 1,

--- a/lib/presentation/widgets/common/save_as_preset_dialog.dart
+++ b/lib/presentation/widgets/common/save_as_preset_dialog.dart
@@ -32,7 +32,7 @@ class SaveAsPresetDialog extends ConsumerStatefulWidget {
   }) async {
     final result = await AdaptivePresenter.showForm<bool>(
       context: context,
-      sideSheetWidth: 460,
+      width: 460,
       titleBuilder: (panelContext) => Row(
         children: [
           Icon(

--- a/lib/presentation/widgets/common/save_vibe_dialog.dart
+++ b/lib/presentation/widgets/common/save_vibe_dialog.dart
@@ -41,7 +41,7 @@ class SaveVibeDialog extends ConsumerStatefulWidget {
   }) async {
     final result = await AdaptivePresenter.showForm<bool>(
       context: context,
-      sideSheetWidth: 440,
+      width: 440,
       titleBuilder: (panelContext) => Row(
         children: [
           Icon(

--- a/lib/presentation/widgets/common/themed_input_dialog.dart
+++ b/lib/presentation/widgets/common/themed_input_dialog.dart
@@ -83,7 +83,7 @@ class ThemedInputDialog extends StatefulWidget {
     return AdaptivePresenter.showForm<String>(
       context: context,
       title: title,
-      sideSheetWidth: multiline ? 440 : 380,
+      width: multiline ? 440 : 380,
       builder: (context, scrollController) => ThemedInputDialog(
         title: title,
         labelText: labelText,

--- a/lib/presentation/widgets/common/update_check_dialog.dart
+++ b/lib/presentation/widgets/common/update_check_dialog.dart
@@ -881,7 +881,7 @@ class UpdateCheckDialog extends ConsumerWidget {
       context: context,
       barrierDismissible: false,
       showHeader: false,
-      sideSheetWidth: 680,
+      width: 680,
       builder: (context, scrollController) =>
           const UpdateCheckDialog(presentationManaged: true),
     );

--- a/lib/presentation/widgets/discord_share/discord_share_dialog.dart
+++ b/lib/presentation/widgets/discord_share/discord_share_dialog.dart
@@ -45,7 +45,7 @@ class DiscordShareDialog extends ConsumerStatefulWidget {
     return AdaptivePresenter.showForm<bool>(
       context: context,
       barrierDismissible: false,
-      sideSheetWidth: 920,
+      width: 920,
       titleBuilder: (panelContext) => Row(
         children: [
           Container(

--- a/lib/presentation/widgets/drop/global_drop_action_coordinator.dart
+++ b/lib/presentation/widgets/drop/global_drop_action_coordinator.dart
@@ -61,7 +61,7 @@ Future<String?> showVibeLibraryNamingForm({
     title: isBundle
         ? '${l10n.vibe_saveToLibrary_saveAsBundle} (${vibes.length})'
         : l10n.vibe_saveToLibrary_title,
-    sideSheetWidth: 520,
+    width: 520,
     builder: (dialogContext, scrollController) => _VibeLibraryNamingForm(
       vibes: vibes,
       initialName: initialName,

--- a/lib/presentation/widgets/drop/image_destination_dialog.dart
+++ b/lib/presentation/widgets/drop/image_destination_dialog.dart
@@ -98,7 +98,7 @@ class ImageDestinationDialog extends ConsumerWidget {
   }) {
     return AdaptivePresenter.showForm<ImageDestination>(
       context: context,
-      sideSheetWidth: metadata == null ? 480 : 960,
+      width: metadata == null ? 480 : 960,
       titleBuilder: (panelContext) {
         final theme = Theme.of(panelContext);
         return Row(
@@ -310,7 +310,7 @@ class ImageDestinationDialog extends ConsumerWidget {
     return AdaptivePresenter.showForm<void>(
       context: context,
       title: context.l10n.drop_metadataErrorDetails,
-      sideSheetWidth: 600,
+      width: 600,
       builder: (panelContext, scrollController) => ListView(
         key: const ValueKey('metadata-error-details-scroll'),
         controller: scrollController,

--- a/lib/presentation/widgets/gallery/album_select_dialog.dart
+++ b/lib/presentation/widgets/gallery/album_select_dialog.dart
@@ -29,7 +29,7 @@ class AlbumSelectDialog extends ConsumerStatefulWidget {
     return AdaptivePresenter.showForm<AlbumSelectResult>(
       context: context,
       title: context.l10n.localGallery_albumSelectTitle,
-      sideSheetWidth: 450,
+      width: 450,
       builder: (panelContext, scrollController) =>
           AlbumSelectDialog(scrollController: scrollController),
     );

--- a/lib/presentation/widgets/gallery/zip_export_metadata_dialog.dart
+++ b/lib/presentation/widgets/gallery/zip_export_metadata_dialog.dart
@@ -13,7 +13,7 @@ class ZipExportMetadataDialog extends StatefulWidget {
     return AdaptivePresenter.showForm<bool>(
       context: context,
       title: context.l10n.localGallery_zipMetadataTitle,
-      sideSheetWidth: 520,
+      width: 520,
       builder: (panelContext, scrollController) =>
           ZipExportMetadataDialog(scrollController: scrollController),
     );

--- a/lib/presentation/widgets/gallery_filter_panel.dart
+++ b/lib/presentation/widgets/gallery_filter_panel.dart
@@ -693,7 +693,7 @@ Future<void> showGalleryFilterPanel(BuildContext context) {
   return AdaptivePresenter.showForm<void>(
     context: context,
     title: context.l10n.localGallery_advancedFilters,
-    sideSheetWidth: 460,
+    width: 460,
     builder: (context, scrollController) =>
         GalleryFilterPanel(scrollController: scrollController),
   );

--- a/lib/presentation/widgets/image_editor/effects/effects_preview_dialog.dart
+++ b/lib/presentation/widgets/image_editor/effects/effects_preview_dialog.dart
@@ -38,7 +38,7 @@ class EffectsPreviewDialog extends StatefulWidget {
     required ImageEditorProcessingService processingService,
   }) => AdaptivePresenter.showForm<EditorEffectSelection>(
     context: context,
-    sideSheetWidth: 960,
+    width: 960,
     titleBuilder: (context) => Text(
       context.l10n.editor_localEffects,
       maxLines: 2,

--- a/lib/presentation/widgets/image_editor/image_editor_workspace.dart
+++ b/lib/presentation/widgets/image_editor/image_editor_workspace.dart
@@ -2210,7 +2210,7 @@ class ImageEditorWorkspaceState extends State<ImageEditorWorkspace> {
       title: context.l10n.editor_compressionTitle,
       initialChildSize: 0.62,
       minChildSize: 0.42,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (panelContext, scrollController) => StatefulBuilder(
         builder: (panelContext, setPanelState) {
           final plan = _compressionPlan;
@@ -2220,6 +2220,7 @@ class ImageEditorWorkspaceState extends State<ImageEditorWorkspace> {
           final theme = Theme.of(panelContext);
           return ListView(
             controller: scrollController,
+            shrinkWrap: true,
             padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
             children: [
               Text(
@@ -3074,7 +3075,7 @@ class ImageEditorWorkspaceState extends State<ImageEditorWorkspace> {
     unawaited(
       AdaptivePresenter.showForm<void>(
         context: context,
-        sideSheetWidth: 440,
+        width: 440,
         titleBuilder: (panelContext) => Row(
           children: [
             const Icon(Icons.keyboard),
@@ -3091,6 +3092,7 @@ class ImageEditorWorkspaceState extends State<ImageEditorWorkspace> {
         builder: (panelContext, scrollController) => ListView(
           key: const ValueKey('image-editor-shortcut-help-scroll'),
           controller: scrollController,
+          shrinkWrap: true,
           keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
           padding: const EdgeInsets.all(20),
           children: [

--- a/lib/presentation/widgets/image_editor/widgets/panels/canvas_size_dialog.dart
+++ b/lib/presentation/widgets/image_editor/widgets/panels/canvas_size_dialog.dart
@@ -89,7 +89,7 @@ class CanvasSizeDialog extends StatefulWidget {
     final resolvedConfirmText = confirmText ?? context.l10n.common_confirm;
     return AdaptivePresenter.showForm<CanvasSizeResult>(
       context: context,
-      sideSheetWidth: 480,
+      width: 480,
       titleBuilder: (context) => Text(
         resolvedTitle,
         maxLines: 2,

--- a/lib/presentation/widgets/image_editor/widgets/panels/color_panel.dart
+++ b/lib/presentation/widgets/image_editor/widgets/panels/color_panel.dart
@@ -98,7 +98,7 @@ class ColorPanel extends StatelessWidget {
   ) {
     AdaptivePresenter.showForm<void>(
       context: context,
-      sideSheetWidth: 440,
+      width: 440,
       titleBuilder: (context) => Text(
         context.l10n.editor_colorPickerTitle,
         maxLines: 2,

--- a/lib/presentation/widgets/image_editor/widgets/panels/shift_edges_dialog.dart
+++ b/lib/presentation/widgets/image_editor/widgets/panels/shift_edges_dialog.dart
@@ -43,7 +43,7 @@ class ShiftEdgesDialog extends StatefulWidget {
   }) {
     return AdaptivePresenter.showForm<ShiftEdgesResult>(
       context: context,
-      sideSheetWidth: 480,
+      width: 480,
       titleBuilder: (context) => Text(
         context.l10n.editor_shiftEdges,
         maxLines: 2,

--- a/lib/presentation/widgets/metadata/metadata_import_dialog.dart
+++ b/lib/presentation/widgets/metadata/metadata_import_dialog.dart
@@ -33,7 +33,7 @@ class MetadataImportDialog extends StatefulWidget {
   }) {
     return AdaptivePresenter.showForm<MetadataImportOptions>(
       context: context,
-      sideSheetWidth: 560,
+      width: 560,
       titleBuilder: (context) {
         final theme = Theme.of(context);
         return Row(

--- a/lib/presentation/widgets/model3d_editor/model3d_editor_screen.dart
+++ b/lib/presentation/widgets/model3d_editor/model3d_editor_screen.dart
@@ -289,7 +289,7 @@ class _Model3dEditorScreenState extends State<Model3dEditorScreen> {
     await AdaptivePresenter.showForm<void>(
       context: context,
       title: context.l10n.model3d_light,
-      sideSheetWidth: 520,
+      width: 520,
       builder: (panelContext, scrollController) => StatefulBuilder(
         builder: (context, setFormState) {
           void updateLight(ValueChanged<double> update, double value) {

--- a/lib/presentation/widgets/navigation/main_nav_rail.dart
+++ b/lib/presentation/widgets/navigation/main_nav_rail.dart
@@ -1494,7 +1494,7 @@ class _AccountAvatarButtonState extends State<_AccountAvatarButton> {
     AdaptivePresenter.showForm<void>(
       context: context,
       title: context.l10n.auth_addAccount,
-      sideSheetWidth: 450,
+      width: 450,
       builder: (panelContext, scrollController) => ListView(
         key: const Key('main-nav-add-account-form'),
         controller: scrollController,

--- a/lib/presentation/widgets/online_gallery/blacklist_settings_panel.dart
+++ b/lib/presentation/widgets/online_gallery/blacklist_settings_panel.dart
@@ -350,7 +350,7 @@ class _OnlineGalleryBlacklistSettingsPanelState
     final text = await AdaptivePresenter.showForm<String>(
       context: context,
       title: context.l10n.onlineGallery_blacklistImportTitle,
-      sideSheetWidth: 560,
+      width: 560,
       builder: (panelContext, scrollController) =>
           _BlacklistImportForm(scrollController: scrollController),
     );
@@ -466,7 +466,7 @@ class _OnlineGalleryBlacklistSettingsPanelState
         await AdaptivePresenter.showForm<_BlacklistPushReviewResult>(
           context: context,
           title: context.l10n.onlineGallery_pushBlacklistConfirmTitle,
-          sideSheetWidth: 620,
+          width: 620,
           builder: (panelContext, scrollController) => _BlacklistPushReviewForm(
             preview: preview,
             scrollController: scrollController,
@@ -500,7 +500,7 @@ class _OnlineGalleryBlacklistSettingsPanelState
       initialChildSize: 0.82,
       minChildSize: 0.58,
       maxChildSize: 0.96,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (_, scrollController) => DanbooruLoginDialog(
         embedded: true,
         scrollController: scrollController,
@@ -713,7 +713,7 @@ Future<void> showOnlineGalleryBlacklistDialog(
   await AdaptivePresenter.showForm<void>(
     context: context,
     title: context.l10n.onlineGallery_blacklistSettingsTitle,
-    sideSheetWidth: 728,
+    width: 728,
     builder: (panelContext, scrollController) => SingleChildScrollView(
       key: const ValueKey('online-gallery-blacklist-form-scroll'),
       controller: scrollController,

--- a/lib/presentation/widgets/online_gallery/gallery_prompt_copy_dialog.dart
+++ b/lib/presentation/widgets/online_gallery/gallery_prompt_copy_dialog.dart
@@ -26,7 +26,7 @@ class GalleryPromptCopyDialog extends StatefulWidget {
       panelContext.l10n.onlineGallery_copyPrompt,
       style: Theme.of(panelContext).textTheme.titleMedium,
     ),
-    sideSheetWidth: 500,
+    width: 500,
     builder: (_, scrollController) => GalleryPromptCopyDialog._(
       projection: projection,
       initialSelection: initialSelection,

--- a/lib/presentation/widgets/online_gallery/output_filter_settings_panel.dart
+++ b/lib/presentation/widgets/online_gallery/output_filter_settings_panel.dart
@@ -124,7 +124,7 @@ Future<void> showOnlineGalleryOutputFilterDialog(BuildContext context) {
   return AdaptivePresenter.showForm<void>(
     context: context,
     title: context.l10n.onlineGallery_outputFilter,
-    sideSheetWidth: 728,
+    width: 728,
     builder: (panelContext, scrollController) => SingleChildScrollView(
       key: const ValueKey('online-gallery-output-filter-form-scroll'),
       controller: scrollController,

--- a/lib/presentation/widgets/online_gallery/quick_tag_cloud_toolbar.dart
+++ b/lib/presentation/widgets/online_gallery/quick_tag_cloud_toolbar.dart
@@ -289,7 +289,7 @@ class _QuickTagCloudToolbarState extends ConsumerState<QuickTagCloudToolbar> {
       context: context,
       title: l10n.onlineGallery_codexSelect,
       initialChildSize: 0.82,
-      sideSheetWidth: 680,
+      width: 680,
       builder: (panelContext, scrollController) => ListView(
         controller: scrollController,
         padding: const EdgeInsets.symmetric(vertical: 8),
@@ -383,7 +383,7 @@ class _QuickTagCloudToolbarState extends ConsumerState<QuickTagCloudToolbar> {
       context: context,
       title: l10n.onlineGallery_codexCategory,
       initialChildSize: 0.82,
-      sideSheetWidth: 580,
+      width: 580,
       builder: (panelContext, scrollController) => ListView(
         controller: scrollController,
         padding: const EdgeInsets.symmetric(vertical: 8),
@@ -515,7 +515,7 @@ class _QuickTagCloudToolbarState extends ConsumerState<QuickTagCloudToolbar> {
       context: context,
       title: l10n.common_filter,
       initialChildSize: 0.72,
-      sideSheetWidth: 560,
+      width: 560,
       builder: (panelContext, scrollController) => StatefulBuilder(
         builder: (panelContext, setPanelState) => SingleChildScrollView(
           controller: scrollController,
@@ -657,7 +657,7 @@ class _QuickTagCloudToolbarState extends ConsumerState<QuickTagCloudToolbar> {
       context: context,
       title: meta.title,
       initialChildSize: 0.78,
-      sideSheetWidth: 580,
+      width: 580,
       builder: (panelContext, scrollController) => ListView(
         controller: scrollController,
         padding: const EdgeInsets.all(20),

--- a/lib/presentation/widgets/prompt/comfyui_import_dialog.dart
+++ b/lib/presentation/widgets/prompt/comfyui_import_dialog.dart
@@ -55,7 +55,7 @@ class ComfyuiImportDialog extends StatefulWidget {
       ),
       initialChildSize: 0.78,
       minChildSize: 0.5,
-      sideSheetWidth: 520,
+      width: 520,
       builder: (context, scrollController) => ComfyuiImportDialog(
         parseResult: parseResult,
         scrollController: scrollController,

--- a/lib/presentation/widgets/prompt/components/tag_action_menu/bottom_action_sheet.dart
+++ b/lib/presentation/widgets/prompt/components/tag_action_menu/bottom_action_sheet.dart
@@ -113,6 +113,7 @@ class _TagBottomActionSheetState extends State<TagBottomActionSheet> {
 
     return ListView(
       controller: widget.scrollController,
+      shrinkWrap: true,
       padding: const EdgeInsets.only(top: 16, bottom: 16),
       children: [
         _buildTagPreview(theme, tagColor),

--- a/lib/presentation/widgets/prompt/diy/dialogs/conditional_branch_dialog.dart
+++ b/lib/presentation/widgets/prompt/diy/dialogs/conditional_branch_dialog.dart
@@ -26,7 +26,7 @@ class ConditionalBranchDialog extends StatefulWidget {
   }) {
     return AdaptivePresenter.showForm<ConditionalBranchConfig>(
       context: context,
-      sideSheetWidth: 600,
+      width: 600,
       titleBuilder: (context) => Row(
         children: [
           const Icon(Icons.call_split),

--- a/lib/presentation/widgets/prompt/diy/dialogs/dependency_config_dialog.dart
+++ b/lib/presentation/widgets/prompt/diy/dialogs/dependency_config_dialog.dart
@@ -53,7 +53,7 @@ class DependencyConfigDialog extends StatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 560,
+      width: 560,
       builder: (context, scrollController) => DependencyConfigDialog(
         initialConfig: initialConfig,
         availableCategories: availableCategories,

--- a/lib/presentation/widgets/prompt/diy/dialogs/diy_guide_dialog.dart
+++ b/lib/presentation/widgets/prompt/diy/dialogs/diy_guide_dialog.dart
@@ -24,7 +24,7 @@ class DiyGuideDialog extends StatelessWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(context).textTheme.titleLarge,
       ),
-      sideSheetWidth: 680,
+      width: 680,
       builder: (context, scrollController) =>
           DiyGuideDialog(scrollController: scrollController),
     );

--- a/lib/presentation/widgets/prompt/diy/dialogs/nai_rules_dialog.dart
+++ b/lib/presentation/widgets/prompt/diy/dialogs/nai_rules_dialog.dart
@@ -15,7 +15,7 @@ class NaiRulesDialog extends StatelessWidget {
   static Future<void> show(BuildContext context) {
     return AdaptivePresenter.showForm<void>(
       context: context,
-      sideSheetWidth: 600,
+      width: 600,
       titleBuilder: (context) => Row(
         children: [
           const Icon(Icons.info_outline),

--- a/lib/presentation/widgets/prompt/diy/dialogs/preset_import_dialog.dart
+++ b/lib/presentation/widgets/prompt/diy/dialogs/preset_import_dialog.dart
@@ -56,7 +56,7 @@ class PresetImportDialog extends StatefulWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(context).textTheme.titleLarge,
       ),
-      sideSheetWidth: 560,
+      width: 560,
       builder: (context, scrollController) => PresetImportDialog(
         isExport: isExport,
         presetToExport: presetToExport,

--- a/lib/presentation/widgets/prompt/diy/dialogs/time_condition_dialog.dart
+++ b/lib/presentation/widgets/prompt/diy/dialogs/time_condition_dialog.dart
@@ -26,7 +26,7 @@ class TimeConditionDialog extends StatefulWidget {
   }) {
     return AdaptivePresenter.showForm<TimeCondition>(
       context: context,
-      sideSheetWidth: 600,
+      width: 600,
       titleBuilder: (context) => Row(
         children: [
           const Icon(Icons.calendar_month),

--- a/lib/presentation/widgets/prompt/diy/panels/dependency_config_panel.dart
+++ b/lib/presentation/widgets/prompt/diy/panels/dependency_config_panel.dart
@@ -729,7 +729,7 @@ class _DependencyConfigPanelState extends State<DependencyConfigPanel> {
           ),
         ],
       ),
-      sideSheetWidth: 480,
+      width: 480,
       builder: (context, scrollController) =>
           _MappingRuleForm(scrollController: scrollController),
     );

--- a/lib/presentation/widgets/prompt/fixed_tag_edit_dialog.dart
+++ b/lib/presentation/widgets/prompt/fixed_tag_edit_dialog.dart
@@ -50,7 +50,7 @@ class FixedTagEditDialog extends ConsumerStatefulWidget {
       title: entry == null
           ? context.l10n.fixedTags_add
           : context.l10n.fixedTags_edit,
-      sideSheetWidth: 860,
+      width: 860,
       builder: (_, __) => FixedTagEditDialog(
         entry: entry,
         initialPromptType: initialPromptType,

--- a/lib/presentation/widgets/prompt/fixed_tag_library_picker_dialog.dart
+++ b/lib/presentation/widgets/prompt/fixed_tag_library_picker_dialog.dart
@@ -28,7 +28,7 @@ class FixedTagLibraryPickerDialog extends StatefulWidget {
     return AdaptivePresenter.showForm<TagLibraryEntry>(
       context: context,
       title: context.l10n.fixedTags_addFromLibrary,
-      sideSheetWidth: 460,
+      width: 460,
       builder: (_, __) => FixedTagLibraryPickerDialog(
         entries: entries,
         presentationManaged: true,

--- a/lib/presentation/widgets/prompt/fixed_tags_dialog.dart
+++ b/lib/presentation/widgets/prompt/fixed_tags_dialog.dart
@@ -24,7 +24,7 @@ class FixedTagsDialog extends ConsumerStatefulWidget {
     return AdaptivePresenter.showForm<void>(
       context: context,
       showHeader: false,
-      sideSheetWidth: 980,
+      width: 980,
       builder: (_, __) => const FixedTagsDialog(presentationManaged: true),
     );
   }

--- a/lib/presentation/widgets/prompt/fixed_tags_link_manager.dart
+++ b/lib/presentation/widgets/prompt/fixed_tags_link_manager.dart
@@ -35,7 +35,7 @@ void showFixedTagLinkManager({
     initialChildSize: 0.72,
     minChildSize: 0.38,
     maxChildSize: 0.94,
-    sideSheetWidth: 420,
+    width: 420,
     builder: (panelContext, scrollController) => Align(
       alignment: Alignment.topCenter,
       child: AdaptiveDialogFrame(

--- a/lib/presentation/widgets/prompt/global_settings_dialog.dart
+++ b/lib/presentation/widgets/prompt/global_settings_dialog.dart
@@ -32,7 +32,7 @@ class GlobalSettingsDialog extends ConsumerStatefulWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(context).textTheme.titleLarge,
       ),
-      sideSheetWidth: 720,
+      width: 720,
       builder: (context, scrollController) =>
           GlobalSettingsDialog(scrollController: scrollController),
     );
@@ -518,7 +518,7 @@ class _GlobalSettingsDialogState extends ConsumerState<GlobalSettingsDialog> {
         title: category.isMultiPersonContainer
             ? l10n.characterCountConfig_addMultiPersonCombo
             : l10n.characterCountConfig_addTagOption,
-        sideSheetWidth: 480,
+        width: 480,
         builder: (context, scrollController) => StatefulBuilder(
           builder: (context, setDialogState) {
             return Column(
@@ -719,7 +719,7 @@ class _GlobalSettingsDialogState extends ConsumerState<GlobalSettingsDialog> {
       await AdaptivePresenter.showForm<void>(
         context: context,
         title: l10n.characterCountConfig_customSlotsTitle,
-        sideSheetWidth: 480,
+        width: 480,
         builder: (context, scrollController) => StatefulBuilder(
           builder: (context, setDialogState) {
             return Column(

--- a/lib/presentation/widgets/prompt/new_preset_dialog.dart
+++ b/lib/presentation/widgets/prompt/new_preset_dialog.dart
@@ -35,7 +35,7 @@ class NewPresetDialog extends StatefulWidget {
   static Future<NewPresetResult?> show(BuildContext context) {
     return AdaptivePresenter.showForm<NewPresetResult>(
       context: context,
-      sideSheetWidth: 420,
+      width: 420,
       maxCenteredHeight: 460,
       titleBuilder: (panelContext) => Row(
         children: [

--- a/lib/presentation/widgets/prompt/random_manager/add_tag_group_dialog.dart
+++ b/lib/presentation/widgets/prompt/random_manager/add_tag_group_dialog.dart
@@ -35,7 +35,7 @@ class AddTagGroupDialog extends ConsumerStatefulWidget {
   }) {
     return AdaptivePresenter.showForm<void>(
       context: context,
-      sideSheetWidth: 580,
+      width: 580,
       titleBuilder: (panelContext) => Row(
         children: [
           Icon(

--- a/lib/presentation/widgets/prompt/random_manager/tag_group_card.dart
+++ b/lib/presentation/widgets/prompt/random_manager/tag_group_card.dart
@@ -297,7 +297,7 @@ class _TagGroupCardState extends ConsumerState<TagGroupCard> {
   void _showEditDialog(BuildContext context, {int initialTabIndex = 0}) {
     AdaptivePresenter.showForm<void>(
       context: context,
-      sideSheetWidth: 640,
+      width: 640,
       titleBuilder: (panelContext) {
         final compactTitle =
             MediaQuery.textScalerOf(panelContext).scale(1) >= 2;
@@ -1050,7 +1050,7 @@ class _TagGroupEditDialogState extends ConsumerState<_TagGroupEditDialog>
   }) {
     return AdaptivePresenter.showForm<void>(
       context: context,
-      sideSheetWidth: 620,
+      width: 620,
       titleBuilder: (panelContext) => Row(
         children: [
           Icon(

--- a/lib/presentation/widgets/prompt/regex_rules_dialog.dart
+++ b/lib/presentation/widgets/prompt/regex_rules_dialog.dart
@@ -26,7 +26,7 @@ class RegexRulesDialog extends ConsumerStatefulWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(context).textTheme.titleLarge,
       ),
-      sideSheetWidth: 600,
+      width: 600,
       builder: (context, scrollController) =>
           RegexRulesDialog(scrollController: scrollController),
     );
@@ -68,7 +68,7 @@ class _RegexRulesDialogState extends ConsumerState<RegexRulesDialog> {
       title: l10n.regexRules_deleteConfirmTitle,
       initialChildSize: 0.46,
       minChildSize: 0.36,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (dialogContext, scrollController) => Column(
         children: [
           Expanded(
@@ -437,7 +437,7 @@ class _RuleEditDialog extends StatefulWidget {
         overflow: TextOverflow.ellipsis,
         style: Theme.of(context).textTheme.titleLarge,
       ),
-      sideSheetWidth: 480,
+      width: 480,
       builder: (context, scrollController) =>
           _RuleEditDialog(rule: rule, scrollController: scrollController),
     );

--- a/lib/presentation/widgets/prompt/weight_adjust_dialog.dart
+++ b/lib/presentation/widgets/prompt/weight_adjust_dialog.dart
@@ -37,7 +37,7 @@ class WeightAdjustDialog extends StatefulWidget {
     return AdaptivePresenter.showPanel<void>(
       context: context,
       title: context.l10n.weight_title,
-      sideSheetWidth: 640,
+      width: 640,
       initialChildSize: 0.8,
       minChildSize: 0.5,
       builder: (_, scrollController) => WeightAdjustDialog(
@@ -402,7 +402,7 @@ class TagEditDialog extends StatefulWidget {
     return AdaptivePresenter.showForm<void>(
       context: context,
       title: context.l10n.weight_editTag,
-      sideSheetWidth: 440,
+      width: 440,
       builder: (_, __) => TagEditDialog(tag: tag, onTextChanged: onTextChanged),
     );
   }

--- a/lib/presentation/widgets/queue/task_edit_dialog.dart
+++ b/lib/presentation/widgets/queue/task_edit_dialog.dart
@@ -51,7 +51,7 @@ class TaskEditDialog extends ConsumerStatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 560,
+      width: 560,
       builder: (panelContext, scrollController) => TaskEditDialog(
         task: task,
         scrollController: scrollController,

--- a/lib/presentation/widgets/settings/account_profile_sheet.dart
+++ b/lib/presentation/widgets/settings/account_profile_sheet.dart
@@ -41,7 +41,7 @@ class AccountProfileBottomSheet extends ConsumerStatefulWidget {
   }) {
     return AdaptivePresenter.showForm<void>(
       context: context,
-      sideSheetWidth: 520,
+      width: 520,
       titleBuilder: (panelContext) => Row(
         children: [
           const Icon(Icons.manage_accounts_outlined, size: 21),

--- a/lib/presentation/widgets/settings/nickname_edit_dialog.dart
+++ b/lib/presentation/widgets/settings/nickname_edit_dialog.dart
@@ -49,7 +49,7 @@ class NicknameEditDialog extends StatefulWidget {
           ],
         );
       },
-      sideSheetWidth: 400,
+      width: 400,
       builder: (panelContext, scrollController) => NicknameEditDialog(
         account: account,
         scrollController: scrollController,

--- a/lib/presentation/widgets/shortcuts/shortcut_help_dialog.dart
+++ b/lib/presentation/widgets/shortcuts/shortcut_help_dialog.dart
@@ -34,7 +34,7 @@ class ShortcutHelpDialog extends ConsumerStatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 800,
+      width: 800,
       builder: (context, scrollController) =>
           ShortcutHelpDialog(scrollController: scrollController),
     );

--- a/lib/presentation/widgets/tag_library/tag_library_picker_dialog.dart
+++ b/lib/presentation/widgets/tag_library/tag_library_picker_dialog.dart
@@ -45,7 +45,7 @@ class TagLibraryPickerDialog extends ConsumerStatefulWidget {
           ),
         ],
       ),
-      sideSheetWidth: 800,
+      width: 800,
       builder: (context, scrollController) => const TagLibraryPickerDialog(),
     );
   }

--- a/test/presentation/adaptive/adaptive_presenter_test.dart
+++ b/test/presentation/adaptive/adaptive_presenter_test.dart
@@ -403,7 +403,52 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('medium short forms fill the safe area with IME and large text', (
+  testWidgets('non-compact panels use a content-sized centered dialog', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(700, 800);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => FilledButton(
+              onPressed: () {
+                unawaited(
+                  AdaptivePresenter.showPanel<void>(
+                    context: context,
+                    title: 'Short panel',
+                    width: 420,
+                    builder: (context, _) => const Padding(
+                      padding: EdgeInsets.all(20),
+                      child: Text('Short panel content'),
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Open short panel'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open short panel'));
+    await tester.pumpAndSettle();
+
+    final surface = find.byKey(const ValueKey('adaptive-centered-form'));
+    expect(surface, findsOneWidget);
+    expect(find.byType(DraggableScrollableSheet), findsNothing);
+    expect(tester.getSize(surface).width, 420);
+    expect(tester.getSize(surface).height, lessThan(140));
+    expect(tester.getRect(surface).center, const Offset(350, 400));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('medium forms remain centered with IME and large text', (
     tester,
   ) async {
     tester.view.devicePixelRatio = 1;
@@ -461,10 +506,12 @@ void main() {
     await tester.tap(find.text('Open short form'));
     await tester.pumpAndSettle();
 
-    final surface = find.byKey(const ValueKey('adaptive-full-screen-form'));
+    final surface = find.byKey(const ValueKey('adaptive-centered-form'));
     expect(surface, findsOneWidget);
-    expect(find.byKey(const Key('adaptive-centered-form')), findsNothing);
-    expect(tester.getRect(surface), const Rect.fromLTWH(0, 12, 839.9, 392));
+    final rect = tester.getRect(surface);
+    expect(rect.width, 560);
+    expect(rect.height, lessThanOrEqualTo(392 * 0.9));
+    expect(rect.center.dy, moreOrLessEquals(208));
     expect(find.byKey(const Key('bottom-action')), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
@@ -479,7 +526,7 @@ void main() {
 
     expect(find.byType(DraggableScrollableSheet), findsNothing);
     expect(find.text('Panel title'), findsOneWidget);
-    expect(tester.getSize(find.byKey(const Key('panel-content'))).width, 520);
+    expect(tester.getSize(find.byKey(const Key('panel-content'))).width, 560);
 
     await tester.tap(find.byTooltip('Close'));
     await tester.pumpAndSettle();
@@ -493,7 +540,6 @@ void main() {
 
     final surface = find.byKey(const ValueKey('adaptive-centered-form'));
     expect(surface, findsOneWidget);
-    expect(find.byKey(const ValueKey('adaptive-side-sheet')), findsNothing);
     expect(tester.getSize(find.byKey(const Key('panel-content'))).width, 560);
     final rect = tester.getRect(surface);
     expect(rect.center.dx, moreOrLessEquals(800));
@@ -550,7 +596,7 @@ void main() {
     },
   );
 
-  testWidgets('expanded side sheet supports large text without overflow', (
+  testWidgets('expanded centered dialog supports large text without overflow', (
     tester,
   ) async {
     await pumpHost(
@@ -563,7 +609,7 @@ void main() {
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
 
-    expect(tester.getSize(find.byKey(const Key('panel-content'))).width, 520);
+    expect(tester.getSize(find.byKey(const Key('panel-content'))).width, 560);
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/presentation/agent_chat/widgets/agent_chat_resource_widgets_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_resource_widgets_test.dart
@@ -47,11 +47,11 @@ void main() {
         );
         expect(
           find.byKey(const ValueKey('adaptive-bottom-sheet')),
-          width < 840 ? findsOneWidget : findsNothing,
+          width < 600 ? findsOneWidget : findsNothing,
         );
         expect(
-          find.byKey(const ValueKey('adaptive-side-sheet')),
-          width >= 840 ? findsOneWidget : findsNothing,
+          find.byKey(const ValueKey('adaptive-centered-form')),
+          width >= 600 ? findsOneWidget : findsNothing,
         );
 
         await tester.tap(find.text('本地图库'));
@@ -144,7 +144,7 @@ void main() {
     },
   );
 
-  testWidgets('both resource managers use an adaptive side sheet at 1180', (
+  testWidgets('both resource managers use a centered dialog at 1180', (
     tester,
   ) async {
     tester.view.devicePixelRatio = 1;
@@ -165,7 +165,10 @@ void main() {
 
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('adaptive-side-sheet')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('adaptive-centered-form')),
+      findsOneWidget,
+    );
     expect(find.text('生成历史'), findsOneWidget);
     expect(find.text('本地图库'), findsOneWidget);
     await tester.binding.handlePopRoute();
@@ -173,7 +176,10 @@ void main() {
 
     await tester.tap(find.text('open resource'));
     await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('adaptive-side-sheet')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('adaptive-centered-form')),
+      findsOneWidget,
+    );
     expect(find.text('标签词库'), findsOneWidget);
     expect(find.text('Vibe 库'), findsOneWidget);
     expect(find.text('精准参考库'), findsOneWidget);
@@ -182,7 +188,7 @@ void main() {
 
     expect(selected?.kind, AgentChatResourceKind.tagLibraryEntry);
     expect(selected?.resourceId, 'tag-1');
-    expect(find.byKey(const ValueKey('adaptive-side-sheet')), findsNothing);
+    expect(find.byKey(const ValueKey('adaptive-centered-form')), findsNothing);
     expect(tester.takeException(), isNull);
   });
 

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
@@ -295,7 +295,6 @@ void main() {
 
     final surface = find.byKey(const ValueKey('adaptive-centered-form'));
     expect(surface, findsOneWidget);
-    expect(find.byKey(const ValueKey('adaptive-side-sheet')), findsNothing);
     final rect = tester.getRect(surface);
     expect(rect.width, 980);
     expect(rect.center, const Offset(800, 450));

--- a/test/presentation/screens/local_gallery/local_gallery_adaptive_presentations_test.dart
+++ b/test/presentation/screens/local_gallery/local_gallery_adaptive_presentations_test.dart
@@ -66,7 +66,7 @@ void main() {
 
         final expectedSurface = size.width < 600
             ? const ValueKey('adaptive-full-screen-form')
-            : const ValueKey('adaptive-side-sheet');
+            : const ValueKey('adaptive-centered-form');
 
         await tester.tap(find.text('move'));
         await tester.pumpAndSettle();
@@ -92,9 +92,9 @@ void main() {
 
         await tester.tap(find.text('failures'));
         await tester.pumpAndSettle();
-        final failureSurface = size.width < 840
+        final failureSurface = size.width < 600
             ? const ValueKey('adaptive-bottom-sheet')
-            : const ValueKey('adaptive-side-sheet');
+            : const ValueKey('adaptive-centered-form');
         expect(find.byKey(failureSurface), findsOneWidget);
         expect(
           find.byKey(const ValueKey('local-gallery-zip-failure-list')),

--- a/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
+++ b/test/presentation/screens/online_gallery/online_gallery_source_auth_test.dart
@@ -216,7 +216,7 @@ void main() {
         expect(
           find.byKey(
             ValueKey(
-              width < 840 ? 'adaptive-bottom-sheet' : 'adaptive-side-sheet',
+              width < 600 ? 'adaptive-bottom-sheet' : 'adaptive-centered-form',
             ),
           ),
           findsOneWidget,
@@ -556,7 +556,9 @@ void main() {
         );
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
-        final filterPanel = find.byType(DraggableScrollableSheet);
+        final filterPanel = find.byKey(
+          const ValueKey('adaptive-centered-form'),
+        );
         expect(filterPanel, findsOneWidget);
         expect(
           find.descendant(

--- a/test/presentation/screens/settings/sections/privacy_settings_section_test.dart
+++ b/test/presentation/screens/settings/sections/privacy_settings_section_test.dart
@@ -146,9 +146,7 @@ void main() {
     await tester.tap(find.text('Anlas 警告阈值'));
     await tester.pumpAndSettle();
     var panel = find.byWidgetPredicate(
-      (widget) =>
-          widget.key == const ValueKey('adaptive-centered-form') ||
-          widget.key == const ValueKey('adaptive-side-sheet'),
+      (widget) => widget.key == const ValueKey('adaptive-centered-form'),
     );
     var editor = find.descendant(of: panel, matching: find.byType(TextField));
     await tester.enterText(editor, '0');
@@ -167,9 +165,7 @@ void main() {
     await tester.tap(find.text('生图间隔'));
     await tester.pumpAndSettle();
     panel = find.byWidgetPredicate(
-      (widget) =>
-          widget.key == const ValueKey('adaptive-centered-form') ||
-          widget.key == const ValueKey('adaptive-side-sheet'),
+      (widget) => widget.key == const ValueKey('adaptive-centered-form'),
     );
     editor = find.descendant(of: panel, matching: find.byType(TextField));
     await tester.enterText(editor, '3601');

--- a/test/presentation/screens/settings/settings_screen_test.dart
+++ b/test/presentation/screens/settings/settings_screen_test.dart
@@ -352,8 +352,7 @@ void main() {
       find.byWidgetPredicate(
         (widget) =>
             widget.key == const ValueKey('adaptive-full-screen-form') ||
-            widget.key == const ValueKey('adaptive-centered-form') ||
-            widget.key == const ValueKey('adaptive-side-sheet'),
+            widget.key == const ValueKey('adaptive-centered-form'),
       ),
       findsOneWidget,
     );

--- a/test/presentation/widgets/auth/network_troubleshooting_dialog_responsive_test.dart
+++ b/test/presentation/widgets/auth/network_troubleshooting_dialog_responsive_test.dart
@@ -45,8 +45,8 @@ void main() {
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
-      final surfaceKey = scenario.size.width >= 840
-          ? 'adaptive-side-sheet'
+      final surfaceKey = scenario.size.width >= 600
+          ? 'adaptive-centered-form'
           : 'adaptive-bottom-sheet';
       expect(find.byKey(ValueKey(surfaceKey)), findsOneWidget);
       final tipsList = find.byKey(

--- a/test/presentation/widgets/character/inline_character_section_test.dart
+++ b/test/presentation/widgets/character/inline_character_section_test.dart
@@ -825,7 +825,9 @@ void main() {
       expect(
         find.byKey(
           ValueKey(
-            size.width < 600 ? 'adaptive-bottom-sheet' : 'adaptive-side-sheet',
+            size.width < 600
+                ? 'adaptive-bottom-sheet'
+                : 'adaptive-centered-form',
           ),
         ),
         findsOneWidget,

--- a/test/presentation/widgets/common/adaptive_dialog_frame_test.dart
+++ b/test/presentation/widgets/common/adaptive_dialog_frame_test.dart
@@ -3,6 +3,35 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/presentation/widgets/common/adaptive_dialog_frame.dart';
 
 void main() {
+  testWidgets('short dialog content keeps its intrinsic height', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1000, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: AdaptiveDialogFrame(
+              maxWidth: 420,
+              maxHeight: 600,
+              child: SizedBox(
+                key: ValueKey('short-dialog-content'),
+                height: 72,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getSize(find.byKey(const ValueKey('short-dialog-content'))),
+      const Size(420, 72),
+    );
+  });
+
   testWidgets('bounds dialog content for landscape, large text and keyboard', (
     tester,
   ) async {
@@ -28,9 +57,9 @@ void main() {
                 maxHeight: 600,
                 reservedVerticalSpace: reservedSpace,
                 scaleReservedVerticalSpace: scaleReserve,
-                child: const ColoredBox(
+                child: const SizedBox(
                   key: ValueKey('dialog-content'),
-                  color: Colors.black,
+                  height: 500,
                 ),
               ),
             ),

--- a/test/presentation/widgets/common/adaptive_dialog_presenter_integration_test.dart
+++ b/test/presentation/widgets/common/adaptive_dialog_presenter_integration_test.dart
@@ -108,7 +108,7 @@ void main() {
       tester
           .getSize(find.byKey(const ValueKey('adaptive-centered-form')))
           .height,
-      lessThan(360),
+      lessThan(260),
     );
 
     await tester.enterText(find.byType(TextField), 'bad');

--- a/test/presentation/widgets/common/add_to_library_dialog_test.dart
+++ b/test/presentation/widgets/common/add_to_library_dialog_test.dart
@@ -59,7 +59,7 @@ void main() {
     expect(result, isFalse);
   });
 
-  testWidgets('宽屏使用有界侧边表单并保留全部字段与返回语义', (tester) async {
+  testWidgets('宽屏使用有界居中弹窗并保留全部字段与返回语义', (tester) async {
     tester.view.physicalSize = const Size(1200, 800);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);

--- a/test/presentation/widgets/gallery/collection_album_select_presenter_test.dart
+++ b/test/presentation/widgets/gallery/collection_album_select_presenter_test.dart
@@ -119,7 +119,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('desktop selectors use bounded side sheets', (tester) async {
+  testWidgets('desktop selectors use bounded centered dialogs', (tester) async {
     await _pumpHost(
       tester,
       size: const Size(1180, 800),
@@ -128,12 +128,15 @@ void main() {
 
     await tester.tap(find.text('Open collection'));
     await tester.pumpAndSettle();
-    expect(find.byKey(const ValueKey('adaptive-side-sheet')), findsOneWidget);
-    expect(find.byType(AlertDialog), findsNothing);
-    final collectionSheet = tester.getRect(
-      find.byKey(const ValueKey('adaptive-side-sheet')),
+    expect(
+      find.byKey(const ValueKey('adaptive-centered-form')),
+      findsOneWidget,
     );
-    expect(collectionSheet.width, 450);
+    expect(find.byType(AlertDialog), findsNothing);
+    final collectionDialog = tester.getRect(
+      find.byKey(const ValueKey('adaptive-centered-form')),
+    );
+    expect(collectionDialog.width, 450);
     await tester.tap(find.byTooltip('Close'));
     await tester.pumpAndSettle();
 
@@ -143,10 +146,10 @@ void main() {
       find.byKey(const ValueKey('adaptive-centered-form')),
       findsOneWidget,
     );
-    final albumSheet = tester.getRect(
+    final albumDialog = tester.getRect(
       find.byKey(const ValueKey('adaptive-centered-form')),
     );
-    expect(albumSheet.width, 450);
+    expect(albumDialog.width, 450);
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/presentation/widgets/image_editor/image_editor_workspace_responsive_test.dart
+++ b/test/presentation/widgets/image_editor/image_editor_workspace_responsive_test.dart
@@ -115,7 +115,7 @@ void main() {
             ValueKey(
               size.width < 600
                   ? 'adaptive-bottom-sheet'
-                  : 'adaptive-side-sheet',
+                  : 'adaptive-centered-form',
             ),
           ),
           findsOneWidget,

--- a/test/presentation/widgets/image_editor/widgets/panels/color_panel_test.dart
+++ b/test/presentation/widgets/image_editor/widgets/panels/color_panel_test.dart
@@ -72,7 +72,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('expanded picker is constrained to an adaptive side sheet', (
+  testWidgets('expanded picker is constrained to an adaptive centered dialog', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(1200, 800);
@@ -88,9 +88,9 @@ void main() {
     await tester.tap(find.byKey(const Key('color_panel_foreground_preview')));
     await tester.pumpAndSettle();
 
-    final sideSheet = find.byKey(const ValueKey('adaptive-centered-form'));
-    expect(sideSheet, findsOneWidget);
-    expect(tester.getSize(sideSheet).width, lessThanOrEqualTo(440));
+    final dialog = find.byKey(const ValueKey('adaptive-centered-form'));
+    expect(dialog, findsOneWidget);
+    expect(tester.getSize(dialog).width, lessThanOrEqualTo(440));
     expect(find.byKey(const Key('color_picker_confirm')), findsOneWidget);
     expect(tester.takeException(), isNull);
   });

--- a/test/presentation/widgets/online_gallery/gallery_detail_dialog_test.dart
+++ b/test/presentation/widgets/online_gallery/gallery_detail_dialog_test.dart
@@ -1016,7 +1016,7 @@ void main() {
                 onPressed: () => AdaptivePresenter.showForm<void>(
                   context: context,
                   showHeader: false,
-                  sideSheetWidth: 960,
+                  width: 960,
                   builder: (context, _) => GalleryDetailDialog(
                     embedded: true,
                     item: item,
@@ -1048,7 +1048,6 @@ void main() {
 
     final surface = find.byKey(const ValueKey('adaptive-centered-form'));
     expect(surface, findsOneWidget);
-    expect(find.byKey(const ValueKey('adaptive-side-sheet')), findsNothing);
     final rect = tester.getRect(surface);
     expect(rect.width, 960);
     expect(rect.center, const Offset(800, 450));

--- a/test/presentation/widgets/prompt/diy/dialogs/conditional_branch_dialog_test.dart
+++ b/test/presentation/widgets/prompt/diy/dialogs/conditional_branch_dialog_test.dart
@@ -45,9 +45,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('expanded keeps a bounded adaptive side sheet and all actions', (
-    tester,
-  ) async {
+  testWidgets('expanded uses a bounded centered dialog', (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(1600, 900);
     addTearDown(() {

--- a/test/presentation/widgets/prompt/diy/dialogs/time_condition_dialog_test.dart
+++ b/test/presentation/widgets/prompt/diy/dialogs/time_condition_dialog_test.dart
@@ -52,9 +52,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('expanded keeps a bounded adaptive side sheet and all actions', (
-    tester,
-  ) async {
+  testWidgets('expanded uses a bounded centered dialog', (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(1600, 900);
     addTearDown(() {

--- a/test/presentation/widgets/prompt/fixed_tags_link_manager_test.dart
+++ b/test/presentation/widgets/prompt/fixed_tags_link_manager_test.dart
@@ -23,7 +23,10 @@ void main() {
     await tester.tap(find.text('打开'));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const ValueKey('adaptive-side-sheet')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('adaptive-centered-form')),
+      findsOneWidget,
+    );
     final listFinder = find.descendant(
       of: find.byType(AdaptiveDialogFrame),
       matching: find.byType(ListView),
@@ -44,7 +47,7 @@ void main() {
     await tester.tap(lastOption);
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const ValueKey('adaptive-side-sheet')), findsNothing);
+    expect(find.byKey(const ValueKey('adaptive-centered-form')), findsNothing);
     expect(notifier.removedPair, (fixture.positive.id, lastEntry.id));
     expect(tester.takeException(), isNull);
   });
@@ -108,7 +111,10 @@ void main() {
     await tester.tap(find.text('打开'));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const ValueKey('adaptive-bottom-sheet')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('adaptive-centered-form')),
+      findsOneWidget,
+    );
     final frame = find.byType(AdaptiveDialogFrame);
     expect(frame, findsOneWidget);
     expect(tester.getSize(frame).width, lessThanOrEqualTo(420));
@@ -117,7 +123,7 @@ void main() {
     await tester.tap(find.byTooltip('关闭'));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const ValueKey('adaptive-bottom-sheet')), findsNothing);
+    expect(find.byKey(const ValueKey('adaptive-centered-form')), findsNothing);
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/presentation/widgets/prompt/weight_adjust_dialog_responsive_test.dart
+++ b/test/presentation/widgets/prompt/weight_adjust_dialog_responsive_test.dart
@@ -115,7 +115,7 @@ void main() {
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
 
-    final panel = find.byKey(const ValueKey('adaptive-side-sheet'));
+    final panel = find.byKey(const ValueKey('adaptive-centered-form'));
     expect(panel, findsOneWidget);
     expect(tester.getSize(panel).width, lessThanOrEqualTo(640));
     expect(tester.takeException(), isNull);


### PR DESCRIPTION
## 改动内容

- 移除 `AdaptivePresenter` 的桌面 side sheet 实现，Medium 及以上宽度统一使用独立居中弹窗
- 修复 `AdaptiveDialogFrame` 强制占满最大高度的问题，短内容按实际高度收缩，长内容仍受视口上限约束并可滚动
- 将短菜单、确认框和设置面板的列表改为内容高度收缩，并清理遗留的 `sideSheetWidth` API 命名
- 更新弹窗响应式测试，覆盖 Compact、Medium、Expanded、IME、大字体和内容高度场景

## 验证结果

- `scripts/verify_flutter_sources.ps1`：通过
- 相关 21 个 Widget Test 文件：237 项通过；另有 1 项既有的透明背景提示词测试失败，与本次弹窗改动无关
- 额外针对性回归测试：此前分批执行的 170 项通过
- `flutter analyze`：本次改动无错误；仓库既有 1 条未使用 import 警告位于 `test/data/services/random_prompt_generator_preset_test.dart:12`
- `git diff --check`：通过

## 注意事项

- Compact 宽度继续使用移动端底部弹窗；非 Compact 宽度不再使用 side sheet
- 按要求不等待 CI，创建后直接执行 Squash Merge