### PR TITLE
feat(library): 补齐卡片分类收藏标识与悬浮预览

### DIFF
--- a/lib/presentation/screens/precise_ref_library/widgets/precise_ref_card.dart
+++ b/lib/presentation/screens/precise_ref_library/widgets/precise_ref_card.dart
@@ -10,8 +10,11 @@ import '../../../../data/services/precise_ref_library_storage_service.dart';
 import '../../../adaptive/interaction_policy.dart';
 import '../../../widgets/app_branch_visibility.dart';
 import '../../../widgets/common/card_action_buttons.dart';
+import '../../../widgets/common/card_hover_preview_controller.dart';
 import '../../../widgets/common/image_card_actions.dart';
 import '../../../widgets/common/image_card_hover_motion.dart';
+import '../../../widgets/common/library_card_badges.dart';
+import 'precise_ref_hover_preview.dart';
 
 enum _PreciseRefCardAction {
   addToAgent,
@@ -55,6 +58,10 @@ class _PreciseRefCardState extends ConsumerState<PreciseRefCard> {
   bool _thumbnailRequested = false;
   bool _hovering = false;
   bool _isBranchVisible = true;
+  Future<Uint8List?>? _hoverImageFuture;
+  final CardHoverPreviewController _hoverController =
+      CardHoverPreviewController();
+  final LayerLink _layerLink = LayerLink();
 
   @override
   void didChangeDependencies() {
@@ -70,9 +77,18 @@ class _PreciseRefCardState extends ConsumerState<PreciseRefCard> {
   void didUpdateWidget(covariant PreciseRefCard oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.entry.id != widget.entry.id) {
+      _hoverController.dismissFor(oldWidget.entry.id);
       _thumbnail = null;
       _thumbnailRequested = false;
+      _hoverImageFuture = null;
+      _hovering = false;
     }
+  }
+
+  @override
+  void dispose() {
+    _hoverController.dispose();
+    super.dispose();
   }
 
   void _loadThumbnailIfNeeded() {
@@ -112,6 +128,41 @@ class _PreciseRefCardState extends ConsumerState<PreciseRefCard> {
     );
   }
 
+  void _onHoverEnter(PointerEvent event) {
+    setState(() => _hovering = true);
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) return;
+    final previewSize = computePreciseRefHoverPreviewBounds(
+      MediaQuery.sizeOf(context),
+    );
+    if (previewSize.isEmpty) return;
+
+    _hoverImageFuture ??= ref
+        .read(preciseRefLibraryStorageServiceProvider)
+        .readImageBytes(widget.entry.id);
+    final targetRect =
+        renderObject.localToGlobal(Offset.zero) & renderObject.size;
+    _hoverController.schedule(
+      context: context,
+      stableKey: widget.entry.id,
+      layerLink: _layerLink,
+      targetRect: targetRect,
+      previewSize: previewSize,
+      builder: (_) => PreciseRefHoverPreview(
+        entry: widget.entry,
+        imageFuture: _hoverImageFuture!,
+        fallbackImage: _thumbnail,
+        maxWidth: previewSize.width,
+        maxHeight: previewSize.height,
+      ),
+    );
+  }
+
+  void _onHoverExit(PointerEvent event) {
+    setState(() => _hovering = false);
+    _hoverController.dismissFor(widget.entry.id);
+  }
+
   @override
   Widget build(BuildContext context) {
     _loadThumbnailIfNeeded();
@@ -119,62 +170,76 @@ class _PreciseRefCardState extends ConsumerState<PreciseRefCard> {
     final isTouch = context.interactionPolicy.shouldExposeTouchAlternatives;
     final reducedMotion = MediaQuery.disableAnimationsOf(context);
 
-    return MouseRegion(
-      onEnter: (_) => setState(() => _hovering = true),
-      onExit: (_) => setState(() => _hovering = false),
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        onTap: widget.onSendToPreciseRef,
-        child: ImageCardHoverMotion(
-          hovered: _hovering,
-          enabled: !isTouch,
-          child: AnimatedContainer(
-            duration: reducedMotion
-                ? Duration.zero
-                : const Duration(milliseconds: 150),
-            curve: Curves.easeOutCubic,
-            transform: Matrix4.identity()
-              ..translateByDouble(0, _hovering && !isTouch ? -2 : 0, 0, 1),
-            transformAlignment: Alignment.center,
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceContainerLow,
-              borderRadius: BorderRadius.circular(12),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withValues(
-                    alpha: _hovering ? 0.18 : 0.08,
+    return CompositedTransformTarget(
+      link: _layerLink,
+      child: MouseRegion(
+        onEnter: _onHoverEnter,
+        onExit: _onHoverExit,
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: widget.onSendToPreciseRef,
+          child: ImageCardHoverMotion(
+            hovered: _hovering,
+            enabled: !isTouch,
+            child: AnimatedContainer(
+              duration: reducedMotion
+                  ? Duration.zero
+                  : const Duration(milliseconds: 150),
+              curve: Curves.easeOutCubic,
+              transform: Matrix4.identity()
+                ..translateByDouble(0, _hovering && !isTouch ? -2 : 0, 0, 1),
+              transformAlignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerLow,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(
+                      alpha: _hovering ? 0.18 : 0.08,
+                    ),
+                    blurRadius: _hovering ? 16 : 6,
+                    offset: Offset(0, _hovering ? 7 : 2),
                   ),
-                  blurRadius: _hovering ? 16 : 6,
-                  offset: Offset(0, _hovering ? 7 : 2),
-                ),
-              ],
-            ),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(12),
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  _buildThumbnail(theme),
-                  _buildInfoOverlay(theme),
-                  if (isTouch || !_hovering) _buildTypeBadge(theme),
-                  if (isTouch) ...[
-                    Positioned(
-                      top: 6,
-                      right: 54,
-                      child: _buildFavoriteButton(theme),
-                    ),
-                    Positioned(
-                      top: 6,
-                      right: 6,
-                      child: _buildTouchActions(theme),
-                    ),
-                  ] else if (_hovering)
-                    Positioned(
-                      top: 6,
-                      right: 6,
-                      child: _buildDesktopActions(theme),
-                    ),
                 ],
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    _buildThumbnail(theme),
+                    _buildInfoOverlay(theme),
+                    if (isTouch || !_hovering) _buildTypeBadge(),
+                    if (!isTouch && !_hovering && widget.entry.isFavorite)
+                      Positioned(
+                        top: 8,
+                        right: 8,
+                        child: LibraryCardFavoriteBadge(
+                          key: Key(
+                            'precise-ref-card-favorite-badge-${widget.entry.id}',
+                          ),
+                          semanticLabel: context.l10n.common_favorite,
+                        ),
+                      ),
+                    if (isTouch) ...[
+                      Positioned(
+                        top: 6,
+                        right: 54,
+                        child: _buildFavoriteButton(theme),
+                      ),
+                      Positioned(
+                        top: 6,
+                        right: 6,
+                        child: _buildTouchActions(theme),
+                      ),
+                    ] else if (_hovering)
+                      Positioned(
+                        top: 6,
+                        right: 6,
+                        child: _buildDesktopActions(theme),
+                      ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -201,41 +266,14 @@ class _PreciseRefCardState extends ConsumerState<PreciseRefCard> {
     );
   }
 
-  Widget _buildTypeBadge(ThemeData theme) {
+  Widget _buildTypeBadge() {
     final entry = widget.entry;
     return Positioned(
       top: 8,
       left: 8,
-      child: Container(
-        constraints: const BoxConstraints(maxWidth: 140),
-        padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
-        decoration: BoxDecoration(
-          color: theme.colorScheme.inverseSurface.withValues(alpha: 0.82),
-          borderRadius: BorderRadius.circular(999),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              entry.type.icon,
-              size: 12,
-              semanticLabel: _typeDisplayName(context),
-              color: theme.colorScheme.onInverseSurface,
-            ),
-            const SizedBox(width: 4),
-            Flexible(
-              child: Text(
-                _typeDisplayName(context),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onInverseSurface,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-          ],
-        ),
+      child: LibraryCardCategoryBadge(
+        icon: entry.type.icon,
+        label: _typeDisplayName(context),
       ),
     );
   }

--- a/lib/presentation/screens/precise_ref_library/widgets/precise_ref_hover_preview.dart
+++ b/lib/presentation/screens/precise_ref_library/widgets/precise_ref_hover_preview.dart
@@ -1,0 +1,317 @@
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../core/extensions/precise_ref_type_extensions.dart';
+import '../../../../core/utils/localization_extension.dart';
+import '../../../../data/models/precise_ref/precise_ref_library_entry.dart';
+import '../../../widgets/common/library_card_badges.dart';
+
+/// 精准参考卡片的桌面悬浮预览。
+///
+/// 原图异步读取期间先展示已有缩略图，避免把磁盘 IO 阻塞在 hover 事件中。
+class PreciseRefHoverPreview extends StatefulWidget {
+  const PreciseRefHoverPreview({
+    super.key,
+    required this.entry,
+    required this.imageFuture,
+    required this.fallbackImage,
+    required this.maxWidth,
+    required this.maxHeight,
+  });
+
+  final PreciseRefLibraryEntry entry;
+  final Future<Uint8List?> imageFuture;
+  final Uint8List? fallbackImage;
+  final double maxWidth;
+  final double maxHeight;
+
+  @override
+  State<PreciseRefHoverPreview> createState() => _PreciseRefHoverPreviewState();
+}
+
+class _PreciseRefHoverPreviewState extends State<PreciseRefHoverPreview> {
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Uint8List?>(
+      future: widget.imageFuture,
+      builder: (context, snapshot) {
+        final image = snapshot.data ?? widget.fallbackImage;
+        return _PreciseRefHoverPreviewContent(
+          entry: widget.entry,
+          image: image,
+          maxWidth: widget.maxWidth,
+          maxHeight: widget.maxHeight,
+          isLoading: snapshot.connectionState != ConnectionState.done,
+        );
+      },
+    );
+  }
+}
+
+class _PreciseRefHoverPreviewContent extends StatefulWidget {
+  const _PreciseRefHoverPreviewContent({
+    required this.entry,
+    required this.image,
+    required this.maxWidth,
+    required this.maxHeight,
+    required this.isLoading,
+  });
+
+  final PreciseRefLibraryEntry entry;
+  final Uint8List? image;
+  final double maxWidth;
+  final double maxHeight;
+  final bool isLoading;
+
+  @override
+  State<_PreciseRefHoverPreviewContent> createState() =>
+      _PreciseRefHoverPreviewContentState();
+}
+
+class _PreciseRefHoverPreviewContentState
+    extends State<_PreciseRefHoverPreviewContent> {
+  Future<double>? _aspectRatioFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveAspectRatio();
+  }
+
+  @override
+  void didUpdateWidget(covariant _PreciseRefHoverPreviewContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.image, widget.image)) _resolveAspectRatio();
+  }
+
+  void _resolveAspectRatio() {
+    final image = widget.image;
+    _aspectRatioFuture = image == null ? Future.value(1) : _decodeRatio(image);
+  }
+
+  Future<double> _decodeRatio(Uint8List bytes) async {
+    ui.Codec? codec;
+    ui.FrameInfo? frame;
+    try {
+      codec = await ui.instantiateImageCodec(bytes);
+      frame = await codec.getNextFrame();
+      final width = frame.image.width;
+      final height = frame.image.height;
+      return width > 0 && height > 0 ? width / height : 1;
+    } catch (_) {
+      return 1;
+    } finally {
+      frame?.image.dispose();
+      codec?.dispose();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<double>(
+      future: _aspectRatioFuture,
+      initialData: 1,
+      builder: (context, snapshot) =>
+          _buildCard((snapshot.data ?? 1).clamp(0.1, 10).toDouble()),
+    );
+  }
+
+  Widget _buildCard(double aspectRatio) {
+    final theme = Theme.of(context);
+    const metadataHeight = 118.0;
+    final imageSize = computePreciseRefHoverImageSize(
+      aspectRatio: aspectRatio,
+      maxWidth: widget.maxWidth,
+      maxHeight: math.max(80, widget.maxHeight - metadataHeight),
+    );
+    final pixelRatio = MediaQuery.devicePixelRatioOf(context);
+    final typeLabel = widget.entry.type.getDisplayName(
+      character: context.l10n.preciseRef_typeCharacter,
+      style: context.l10n.preciseRef_typeStyle,
+      characterAndStyle: context.l10n.preciseRef_typeCharacterAndStyle,
+    );
+
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        key: const ValueKey('precise-ref-hover-preview'),
+        width: imageSize.width,
+        constraints: BoxConstraints(maxHeight: widget.maxHeight),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.32),
+              blurRadius: 28,
+              offset: const Offset(0, 14),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(10),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                key: const ValueKey('precise-ref-hover-media'),
+                width: imageSize.width,
+                height: imageSize.height,
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    ColoredBox(color: theme.colorScheme.surfaceContainerLowest),
+                    if (widget.image != null)
+                      Image.memory(
+                        widget.image!,
+                        fit: BoxFit.contain,
+                        cacheWidth: (imageSize.width * pixelRatio).round(),
+                        gaplessPlayback: true,
+                        errorBuilder: (_, __, ___) => _imageFallback(theme),
+                      )
+                    else
+                      _imageFallback(theme),
+                    Positioned(
+                      left: 10,
+                      top: 10,
+                      child: LibraryCardCategoryBadge(
+                        icon: widget.entry.type.icon,
+                        label: typeLabel,
+                      ),
+                    ),
+                    if (widget.entry.isFavorite)
+                      Positioned(
+                        right: 10,
+                        top: 10,
+                        child: LibraryCardFavoriteBadge(
+                          semanticLabel: context.l10n.common_favorite,
+                        ),
+                      ),
+                    if (widget.isLoading)
+                      Positioned(
+                        right: 10,
+                        bottom: 10,
+                        child: SizedBox.square(
+                          dimension: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white.withValues(alpha: 0.9),
+                            value: MediaQuery.disableAnimationsOf(context)
+                                ? 0.5
+                                : null,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(14, 12, 14, 14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      widget.entry.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: _PreviewStat(
+                            label: context.l10n.preciseRef_strength,
+                            value: _formatParam(widget.entry.strength),
+                          ),
+                        ),
+                        Expanded(
+                          child: _PreviewStat(
+                            label: context.l10n.preciseRef_fidelity,
+                            value: _formatParam(widget.entry.fidelity),
+                          ),
+                        ),
+                        Expanded(
+                          child: _PreviewStat(
+                            label: context.l10n.vibeDetail_usageCount,
+                            value: '${widget.entry.usedCount}',
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _imageFallback(ThemeData theme) {
+    return ColoredBox(
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: Center(
+        child: Icon(
+          Icons.image_outlined,
+          size: 46,
+          color: theme.colorScheme.outline,
+        ),
+      ),
+    );
+  }
+
+  static String _formatParam(double value) {
+    final text = value.toStringAsFixed(2);
+    return text.endsWith('0') ? value.toStringAsFixed(1) : text;
+  }
+}
+
+class _PreviewStat extends StatelessWidget {
+  const _PreviewStat({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      '$label $value',
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+        fontFeatures: const [ui.FontFeature.tabularFigures()],
+      ),
+    );
+  }
+}
+
+Size computePreciseRefHoverPreviewBounds(Size viewport) {
+  return Size(
+    math.min(380.0, math.max(0.0, viewport.width - 20)),
+    math.min(680.0, math.max(0.0, viewport.height - 20)),
+  );
+}
+
+@visibleForTesting
+Size computePreciseRefHoverImageSize({
+  required double aspectRatio,
+  required double maxWidth,
+  required double maxHeight,
+}) {
+  final safeRatio = aspectRatio > 0 ? aspectRatio : 1.0;
+  final width = safeRatio >= 1
+      ? maxWidth
+      : math.min(maxWidth, math.max(240.0, maxHeight * safeRatio));
+  final naturalHeight = width / safeRatio;
+  final height = math.min(maxHeight, math.max(120.0, naturalHeight));
+  return Size(width, height);
+}

--- a/lib/presentation/screens/tag_library_page/widgets/entry_card.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_card.dart
@@ -6,6 +6,7 @@ import '../../../../data/models/tag_library/tag_library_entry.dart';
 import '../../../adaptive/interaction_policy.dart';
 import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/library_classification_drag.dart';
+import '../../../widgets/common/library_card_badges.dart';
 import '../../../widgets/common/thumbnail_display.dart';
 import '../../../widgets/tag_library/tag_library_entry_hover_preview.dart';
 
@@ -125,10 +126,12 @@ class _EntryCardState extends State<EntryCard> {
                       !widget.isSelectionMode &&
                       !_isHovering &&
                       widget.entry.isFavorite)
-                    const Positioned(
+                    Positioned(
                       top: 8,
                       right: 8,
-                      child: _FavoriteIndicator(),
+                      child: LibraryCardFavoriteBadge(
+                        semanticLabel: context.l10n.common_favorite,
+                      ),
                     ),
 
                   if (isTouch && !widget.isSelectionMode)
@@ -503,31 +506,6 @@ class _ActionIconState extends State<_ActionIcon> {
           ),
         ),
       ),
-    );
-  }
-}
-
-/// 收藏指示器（常驻小红心）
-class _FavoriteIndicator extends StatelessWidget {
-  const _FavoriteIndicator();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 20,
-      height: 20,
-      decoration: BoxDecoration(
-        color: Colors.redAccent,
-        shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.3),
-            blurRadius: 4,
-            offset: const Offset(0, 1),
-          ),
-        ],
-      ),
-      child: const Icon(Icons.favorite, size: 12, color: Colors.white),
     );
   }
 }

--- a/lib/presentation/screens/vibe_library/widgets/vibe_card.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_card.dart
@@ -13,6 +13,7 @@ import '../../../widgets/app_branch_visibility.dart';
 import '../../../widgets/common/card_action_buttons.dart';
 import '../../../widgets/common/card_hover_preview_controller.dart';
 import '../../../widgets/common/image_card_actions.dart';
+import '../../../widgets/common/library_card_badges.dart';
 import '../../../widgets/common/translated_tag_text.dart';
 
 /// Vibe 图像卡片统一采用 4:5 纵向比例，为缩略图和底部参数保留稳定空间。
@@ -46,6 +47,7 @@ class VibeCard extends ConsumerStatefulWidget {
   final void Function(TapUpDetails)? onSecondaryTapUp;
   final bool isSelected;
   final bool showFavoriteIndicator;
+  final String? categoryLabel;
   final VoidCallback? onFavoriteToggle;
   final VoidCallback? onSendToGeneration;
   final VoidCallback? onExport;
@@ -64,6 +66,7 @@ class VibeCard extends ConsumerStatefulWidget {
     this.onSecondaryTapUp,
     this.isSelected = false,
     this.showFavoriteIndicator = true,
+    this.categoryLabel,
     this.onFavoriteToggle,
     this.onSendToGeneration,
     this.onExport,
@@ -307,6 +310,38 @@ class _VibeCardState extends ConsumerState<VibeCard>
 
                   // Bundle 数量标识
                   if (widget.entry.isBundle) _buildBundleBadge(),
+
+                  if (widget.categoryLabel case final categoryLabel?)
+                    Positioned(
+                      top: 8,
+                      left: 8,
+                      child: LibraryCardCategoryBadge(
+                        key: ValueKey('vibe-card-category-${widget.entry.id}'),
+                        icon: Icons.category_outlined,
+                        label: categoryLabel,
+                        maxWidth: math.max(
+                          80,
+                          widget.width -
+                              (widget.entry.isFavorite && !isTouch ? 48 : 16),
+                        ),
+                      ),
+                    ),
+
+                  if (!isTouch &&
+                      !_isHovered &&
+                      !widget.isSelected &&
+                      widget.showFavoriteIndicator &&
+                      widget.entry.isFavorite)
+                    Positioned(
+                      top: 8,
+                      right: 8,
+                      child: LibraryCardFavoriteBadge(
+                        key: ValueKey(
+                          'vibe-card-favorite-badge-${widget.entry.id}',
+                        ),
+                        semanticLabel: context.l10n.common_favorite,
+                      ),
+                    ),
 
                   // 选中状态
                   if (widget.isSelected) _buildSelectionOverlay(colorScheme),
@@ -656,7 +691,7 @@ class _VibeCardState extends ConsumerState<VibeCard>
 
   Widget _buildBundleBadge() {
     return Positioned(
-      top: 8,
+      top: widget.categoryLabel == null ? 8 : 38,
       left: 8,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),

--- a/lib/presentation/screens/vibe_library/widgets/vibe_library_content_view.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_library_content_view.dart
@@ -14,6 +14,7 @@ import '../../../../core/utils/localization_extension.dart';
 import '../../../../core/utils/vibe_file_parser.dart';
 import '../../../../core/utils/vibe_performance_diagnostics.dart';
 import '../../../../data/models/vibe/vibe_empty_state_info.dart';
+import '../../../../data/models/vibe/vibe_library_category.dart';
 import '../../../../data/models/vibe/vibe_library_entry.dart';
 import '../../../../data/models/vibe/vibe_reference.dart';
 import '../../../../data/services/vibe_library_storage_service.dart';
@@ -38,6 +39,15 @@ import 'vibe_export_dialog.dart';
 import 'vibe_library_empty_view.dart';
 
 const vibeLibraryGridSpacing = 16.0;
+
+Map<String, String> buildVibeCategoryLabels(
+  List<VibeLibraryCategory> categories,
+) {
+  return {
+    for (final category in categories)
+      category.id: categories.getPathString(category.id),
+  };
+}
 
 /// Vibe 库内容视图
 ///
@@ -75,15 +85,20 @@ class _VibeLibraryContentViewState
   Widget build(BuildContext context) {
     final state = ref.watch(vibeLibraryNotifierProvider);
     final selectionState = ref.watch(vibeLibrarySelectionNotifierProvider);
+    final categories = ref.watch(
+      vibeLibraryCategoryNotifierProvider.select((state) => state.categories),
+    );
+    final categoryLabels = buildVibeCategoryLabels(categories);
 
     // 使用 3D 卡片视图模式
-    return _build3DCardView(state, selectionState);
+    return _build3DCardView(state, selectionState, categoryLabels);
   }
 
   /// 构建 3D 卡片视图
   Widget _build3DCardView(
     VibeLibraryState state,
     SelectionModeState selectionState,
+    Map<String, String> categoryLabels,
   ) {
     final entries = state.currentEntries;
 
@@ -167,6 +182,7 @@ class _VibeLibraryContentViewState
                 height: computeVibeCardHeight(widget.itemWidth),
                 isSelected: isSelected,
                 showFavoriteIndicator: true,
+                categoryLabel: categoryLabels[entry.categoryId],
                 onTap: () {
                   if (selectionState.isActive) {
                     ref

--- a/lib/presentation/widgets/common/library_card_badges.dart
+++ b/lib/presentation/widgets/common/library_card_badges.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+/// 资源库图片卡片左上角的紧凑分类标签。
+///
+/// 调用方负责定位，避免这个共享视觉组件耦合不同卡片的 Stack 布局。
+class LibraryCardCategoryBadge extends StatelessWidget {
+  const LibraryCardCategoryBadge({
+    super.key,
+    required this.icon,
+    required this.label,
+    this.maxWidth = 140,
+  });
+
+  final IconData icon;
+  final String label;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.inverseSurface.withValues(alpha: 0.82),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            icon,
+            size: 12,
+            semanticLabel: label,
+            color: theme.colorScheme.onInverseSurface,
+          ),
+          const SizedBox(width: 4),
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onInverseSurface,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 已收藏资源的常驻状态徽章；收藏操作仍由卡片自己的操作区承载。
+class LibraryCardFavoriteBadge extends StatelessWidget {
+  const LibraryCardFavoriteBadge({super.key, required this.semanticLabel});
+
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticLabel,
+      image: true,
+      child: Container(
+        width: 20,
+        height: 20,
+        decoration: BoxDecoration(
+          color: Colors.redAccent,
+          shape: BoxShape.circle,
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.3),
+              blurRadius: 4,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        child: const Icon(Icons.favorite, size: 12, color: Colors.white),
+      ),
+    );
+  }
+}

--- a/test/presentation/screens/precise_ref_library/precise_ref_card_test.dart
+++ b/test/presentation/screens/precise_ref_library/precise_ref_card_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/gestures.dart';
@@ -10,15 +11,24 @@ import 'package:nai_launcher/data/services/precise_ref_library_storage_service.d
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
 import 'package:nai_launcher/presentation/screens/precise_ref_library/widgets/precise_ref_card.dart';
+import 'package:nai_launcher/presentation/screens/precise_ref_library/widgets/precise_ref_hover_preview.dart';
 import 'package:nai_launcher/presentation/widgets/common/image_card_actions.dart';
 import 'package:nai_launcher/presentation/widgets/common/image_card_hover_motion.dart';
+import 'package:nai_launcher/presentation/widgets/common/library_card_badges.dart';
 
 class _FakeStorage extends PreciseRefLibraryStorageService {
+  _FakeStorage({this.imageBytes});
+
+  final Uint8List? imageBytes;
+
   @override
   Future<Uint8List?> getDisplayThumbnail(
     String id, {
     bool Function()? isCancelled,
-  }) async => null;
+  }) async => imageBytes;
+
+  @override
+  Future<Uint8List?> readImageBytes(String id) async => imageBytes;
 }
 
 void main() {
@@ -99,8 +109,11 @@ void main() {
       ),
       findsOneWidget,
     );
-    // 精确指针下操作只在悬浮时出现，避免常驻按钮遮挡图像。
-    expect(find.byIcon(Icons.favorite_rounded), findsNothing);
+    expect(
+      find.byKey(const Key('precise-ref-card-favorite-badge-entry-1')),
+      findsOneWidget,
+    );
+    expect(find.byType(LibraryCardFavoriteBadge), findsOneWidget);
     final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
     addTearDown(mouse.removePointer);
     await mouse.addPointer(
@@ -113,6 +126,93 @@ void main() {
           .widget<ImageCardHoverMotion>(find.byType(ImageCardHoverMotion))
           .hovered,
       isTrue,
+    );
+  });
+
+  testWidgets('悬浮预览读取原图、展示参数并避让窗口边缘', (tester) async {
+    tester.view.physicalSize = const Size(700, 520);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final imageBytes = Uint8List.fromList(_onePixelPng);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          preciseRefLibraryStorageServiceProvider.overrideWithValue(
+            _FakeStorage(imageBytes: imageBytes),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Stack(
+              children: [
+                Positioned(
+                  right: 4,
+                  bottom: 4,
+                  width: 160,
+                  height: 200,
+                  child: PreciseRefCard(entry: entry),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(find.byType(PreciseRefCard)));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 281));
+    await tester.pump();
+
+    const previewKey = ValueKey('precise-ref-hover-preview');
+    expect(find.byKey(previewKey), findsOneWidget);
+    final previewRect = tester.getRect(find.byKey(previewKey));
+    expect(previewRect.left, greaterThanOrEqualTo(10));
+    expect(previewRect.top, greaterThanOrEqualTo(10));
+    expect(previewRect.right, lessThanOrEqualTo(690));
+    expect(previewRect.bottom, lessThanOrEqualTo(510));
+    expect(find.text('银发少女'), findsWidgets);
+    expect(find.text('角色'), findsOneWidget);
+    expect(find.text('参考强度 1.0'), findsOneWidget);
+    expect(find.text('保真度 0.85'), findsOneWidget);
+    expect(find.text('使用次数 0'), findsOneWidget);
+
+    final image = tester.widget<Image>(
+      find.descendant(
+        of: find.byKey(const ValueKey('precise-ref-hover-media')),
+        matching: find.byType(Image),
+      ),
+    );
+    final resized = image.image as ResizeImage;
+    expect((resized.imageProvider as MemoryImage).bytes, same(imageBytes));
+    expect(tester.takeException(), isNull);
+  });
+
+  test('悬浮预览按比例适配且有最大尺寸', () {
+    expect(
+      computePreciseRefHoverPreviewBounds(const Size(700, 520)),
+      const Size(380, 500),
+    );
+    expect(
+      computePreciseRefHoverPreviewBounds(const Size(1200, 1000)),
+      const Size(380, 680),
+    );
+    expect(
+      computePreciseRefHoverImageSize(
+        aspectRatio: 2,
+        maxWidth: 380,
+        maxHeight: 500,
+      ),
+      const Size(380, 190),
     );
   });
 
@@ -301,3 +401,7 @@ void main() {
     expect(addCount, 2);
   });
 }
+
+final Uint8List _onePixelPng = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+);

--- a/test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart
+++ b/test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart
@@ -13,6 +13,7 @@ import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
 import 'package:nai_launcher/presentation/screens/vibe_library/widgets/vibe_card.dart';
 import 'package:nai_launcher/presentation/widgets/common/card_action_buttons.dart';
 import 'package:nai_launcher/presentation/widgets/common/image_card_actions.dart';
+import 'package:nai_launcher/presentation/widgets/common/library_card_badges.dart';
 
 void main() {
   test('悬浮大图按比例适配且不会随高窗口无限增高', () {
@@ -111,6 +112,57 @@ void main() {
       (resized.imageProvider as MemoryImage).bytes,
       same(highResolutionImage),
     );
+  });
+
+  testWidgets('Vibe 卡片仅在有分类时显示类别，并为收藏条目显示常驻徽章', (tester) async {
+    final favoriteEntry = _entry(
+      rawImageData: _onePixelPng,
+    ).copyWith(isFavorite: true);
+
+    Future<void> pumpCard({String? categoryLabel}) => tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          vibeLibraryStorageServiceProvider.overrideWithValue(
+            _HoverStorage(favoriteEntry, _onePixelPng),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: VibeCard(
+                entry: favoriteEntry.toDisplayEntry(),
+                width: 180,
+                categoryLabel: categoryLabel,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await pumpCard(categoryLabel: '人物 / 女性角色');
+    expect(find.text('人物 / 女性角色'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('vibe-card-category-hover-vibe')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('vibe-card-favorite-badge-hover-vibe')),
+      findsOneWidget,
+    );
+    expect(find.byType(LibraryCardFavoriteBadge), findsOneWidget);
+
+    await pumpCard();
+    expect(find.text('人物 / 女性角色'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('vibe-card-category-hover-vibe')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('Vibe 卡片悬浮操作复用图片卡片双列操作轨', (tester) async {

--- a/test/presentation/screens/vibe_library/widgets/vibe_library_content_view_test.dart
+++ b/test/presentation/screens/vibe_library/widgets/vibe_library_content_view_test.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/vibe/vibe_library_entry.dart';
+import 'package:nai_launcher/data/models/vibe/vibe_library_category.dart';
 import 'package:nai_launcher/data/models/vibe/vibe_reference.dart';
 import 'package:nai_launcher/data/services/vibe_library_storage_service.dart';
 import 'package:nai_launcher/presentation/screens/vibe_library/widgets/vibe_card.dart';
@@ -20,6 +21,25 @@ void main() {
   test('Vibe 库与选择器共用 4:5 图像卡片比例', () {
     expect(vibeCardAspectRatio, 0.8);
     expect(computeVibeCardHeight(200), 250);
+  });
+
+  test('分类标签保留完整层级路径，未分类条目不会得到标签', () {
+    final categories = [
+      VibeLibraryCategory(id: 'people', name: '人物', createdAt: DateTime(2026)),
+      VibeLibraryCategory(
+        id: 'female',
+        name: '女性角色',
+        parentId: 'people',
+        createdAt: DateTime(2026),
+      ),
+    ];
+
+    final labels = buildVibeCategoryLabels(categories);
+
+    expect(labels['people'], '人物');
+    expect(labels['female'], '人物 / 女性角色');
+    expect(labels[null], isNull);
+    expect(labels['missing'], isNull);
   });
 
   test('打开详情前应优先回读真实条目参数，而不是继续使用列表旧快照', () async {


### PR DESCRIPTION
## 改动内容

- Vibe 库卡片显示所属分类层级，未分类时不显示分类徽章
- Vibe 与精准参考库的收藏卡片显示统一的常驻爱心徽章
- 精准参考卡片增加按需读取原图的桌面悬浮预览
- 提取共享分类与收藏徽章组件，并补充相关回归测试

## 验证结果

- 相关 4 个测试文件共 26 项测试通过
- 受影响的 9 个源码及测试文件执行 `flutter analyze`：No issues found
- `scripts/verify_flutter_sources.ps1` 通过
- `git diff --check` 通过

## 注意事项

- 未执行 Windows 或 Android 运行时验收
- 按要求不等待 CI