### PR TITLE
feat(library): 优化词库顶栏与词条创建

### DIFF
--- a/lib/presentation/screens/precise_ref_library/precise_ref_library_screen.dart
+++ b/lib/presentation/screens/precise_ref_library/precise_ref_library_screen.dart
@@ -16,18 +16,19 @@ import '../../../data/models/image/image_params.dart';
 import '../../../data/models/precise_ref/precise_ref_library_entry.dart';
 import '../../../data/services/precise_ref_library_storage_service.dart';
 import '../../adaptive/adaptive_presenter.dart';
-import '../../adaptive/interaction_policy.dart';
 import '../../providers/image_generation_provider.dart';
 import '../../providers/precise_ref_library_provider.dart';
 import '../../router/app_routes.dart';
 import '../../services/image_workflow_launcher.dart';
 import '../../utils/dropped_file_reader.dart';
 import '../../widgets/common/app_toast.dart';
+import '../../widgets/common/compact_icon_button.dart';
 import '../../widgets/common/input_surface_container.dart';
 import '../../widgets/common/pagination_bar.dart';
 import '../../widgets/common/library_classification_drag.dart';
 import '../../widgets/common/precise_reference_type_dialog.dart';
 import '../../widgets/gallery/gallery_sidebar.dart';
+import '../../widgets/gallery/gallery_library_toolbar.dart';
 import '../../agent_chat/widgets/agent_resource_drop_region.dart';
 import 'widgets/precise_ref_card.dart';
 import 'widgets/precise_ref_entry_edit_dialog.dart';
@@ -469,16 +470,15 @@ class _PreciseRefLibraryScreenState
   }) {
     final l10n = context.l10n;
     final theme = Theme.of(context);
-    final touchTarget = context.interactionPolicy.shouldExposeTouchAlternatives;
-
+    final textScale = MediaQuery.textScalerOf(context).scale(14) / 14;
+    final compact = MediaQuery.sizeOf(context).width < 1050 || textScale > 1.5;
     final title = GalleryCollectionPageTitle(
       key: const Key('precise-ref-library-page-title'),
       icon: Icons.center_focus_strong,
       title: l10n.preciseRefLib_title,
-      subtitle: l10n.preciseRefLib_entryCount(state.totalCount),
-      maxWidth: 210,
+      maxWidth: compact ? 180 : 220,
     );
-    final searchHeight = touchTarget ? 48.0 : 40.0;
+    final searchHeight = compact ? 48.0 : 36.0;
     final search = InputSurfaceContainer(
       key: const Key('precise-ref-library-search-surface'),
       height: searchHeight,
@@ -517,23 +517,6 @@ class _PreciseRefLibraryScreenState
         ),
       ),
     );
-    final favorites = IconButton(
-      key: const Key('precise-ref-library-favorites-toggle'),
-      tooltip: l10n.preciseRefLib_favoritesOnly,
-      icon: Icon(
-        state.favoritesOnly
-            ? Icons.favorite_rounded
-            : Icons.favorite_border_rounded,
-        color: state.favoritesOnly ? theme.colorScheme.error : null,
-      ),
-      onPressed: () {
-        setState(() => _currentPage = 0);
-        ref
-            .read(preciseRefLibraryNotifierProvider.notifier)
-            .toggleFavoritesOnly();
-      },
-      style: _toolbarIconButtonStyle(theme),
-    );
     final sort = PopupMenuButton<PreciseRefLibrarySortOrder>(
       key: const Key('precise-ref-library-sort-menu'),
       tooltip: l10n.preciseRefLib_sortBy,
@@ -566,167 +549,52 @@ class _PreciseRefLibraryScreenState
           state,
         ),
       ],
-      style: _toolbarIconButtonStyle(theme),
     );
-    final importButton = FilledButton.icon(
+    final importButton = CompactIconButton(
       key: const Key('precise-ref-library-import-button'),
       onPressed: _isPickingFile ? null : _importImages,
-      icon: const Icon(Icons.add_photo_alternate_outlined, size: 18),
-      label: Text(l10n.preciseRefLib_import),
-      style: _toolbarImportButtonStyle(
-        theme,
-        minimumHeight: touchTarget ? 48 : 40,
-      ),
+      icon: Icons.add_photo_alternate_outlined,
+      label: l10n.preciseRefLib_import,
+      tooltip: l10n.preciseRefLib_import,
+    );
+    final compactImportButton = IconButton.filledTonal(
+      key: const Key('precise-ref-library-import-button'),
+      onPressed: _isPickingFile ? null : _importImages,
+      tooltip: l10n.preciseRefLib_import,
+      icon: const Icon(Icons.add_photo_alternate_outlined),
     );
     final showToolbarImport = state.totalCount > 0 || state.hasFilters;
-    final categories = IconButton(
+    final categories = CompactIconButton(
+      key: const Key('precise-ref-library-categories-button'),
+      icon: Icons.folder_outlined,
+      label: l10n.common_categories,
+      tooltip: l10n.localGallery_showCategoryPanel,
+      onPressed: () => _showCategoryPanel(state),
+    );
+    final compactCategories = IconButton(
       key: const Key('precise-ref-library-categories-button'),
       tooltip: l10n.localGallery_showCategoryPanel,
       onPressed: () => _showCategoryPanel(state),
       icon: const Icon(Icons.folder_outlined),
-      style: _toolbarIconButtonStyle(theme),
-    );
-    final actions = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        favorites,
-        const SizedBox(width: 2),
-        sort,
-        if (showToolbarImport) ...[const SizedBox(width: 8), importButton],
-      ],
-    );
-    final utilityActions = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [favorites, const SizedBox(width: 2), sort],
     );
 
-    return GalleryCollectionToolbarSurface(
+    return GalleryLibraryToolbar(
       key: const Key('precise-ref-library-unified-toolbar'),
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final largeText = MediaQuery.textScalerOf(context).scale(14) > 18;
-          if (constraints.maxWidth >= 700 && !largeText) {
-            return Row(
-              children: [
-                if (showCategoryButton) ...[
-                  categories,
-                  const SizedBox(width: 8),
-                ],
-                if (showPageTitle) ...[
-                  title,
-                  const SizedBox(
-                    width: GalleryCollectionChrome.toolbarGroupGap,
-                  ),
-                ],
-                Expanded(
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 520),
-                    child: search,
-                  ),
-                ),
-                const SizedBox(width: 10),
-                actions,
-              ],
-            );
-          }
-
-          return Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Row(
-                children: [
-                  if (showCategoryButton) ...[
-                    categories,
-                    const SizedBox(width: 4),
-                  ],
-                  if (showPageTitle) Expanded(child: title) else const Spacer(),
-                  utilityActions,
-                ],
-              ),
-              const SizedBox(height: 10),
-              search,
-              if (showToolbarImport) ...[
-                const SizedBox(height: 10),
-                SizedBox(width: double.infinity, child: importButton),
-              ],
-            ],
-          );
-        },
+      compact: compact,
+      title: showPageTitle ? title : const SizedBox.shrink(),
+      count: GalleryLibraryCountBadge(
+        label: state.hasFilters
+            ? '${state.filteredEntries.length}/${state.totalCount}'
+            : '${state.totalCount}',
       ),
-    );
-  }
-
-  ButtonStyle _toolbarIconButtonStyle(ThemeData theme) {
-    final colors = theme.colorScheme;
-    return ButtonStyle(
-      minimumSize: WidgetStatePropertyAll(
-        Size.square(context.interactionPolicy.minimumControlExtent),
-      ),
-      foregroundColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.disabled)) {
-          return colors.onSurface.withValues(alpha: 0.38);
-        }
-        if (states.contains(WidgetState.hovered) ||
-            states.contains(WidgetState.focused)) {
-          return colors.primary;
-        }
-        return colors.onSurfaceVariant;
-      }),
-      backgroundColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.disabled)) return Colors.transparent;
-        if (states.contains(WidgetState.pressed)) {
-          return colors.primaryContainer.withValues(alpha: 0.72);
-        }
-        if (states.contains(WidgetState.hovered) ||
-            states.contains(WidgetState.focused)) {
-          return colors.primaryContainer.withValues(alpha: 0.48);
-        }
-        return Colors.transparent;
-      }),
-      overlayColor: const WidgetStatePropertyAll(Colors.transparent),
-      elevation: const WidgetStatePropertyAll(0),
-      shape: WidgetStatePropertyAll(
-        RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-      ),
-    );
-  }
-
-  ButtonStyle _toolbarImportButtonStyle(
-    ThemeData theme, {
-    required double minimumHeight,
-  }) {
-    final colors = theme.colorScheme;
-    return FilledButton.styleFrom(
-      minimumSize: Size(64, minimumHeight),
-      elevation: 0,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-    ).copyWith(
-      foregroundColor: WidgetStateProperty.resolveWith((states) {
-        return states.contains(WidgetState.disabled)
-            ? colors.onSurface.withValues(alpha: 0.38)
-            : colors.onPrimary;
-      }),
-      backgroundColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.disabled)) {
-          return colors.onSurface.withValues(alpha: 0.12);
-        }
-        if (states.contains(WidgetState.pressed)) {
-          return Color.alphaBlend(
-            colors.onPrimary.withValues(alpha: 0.14),
-            colors.primary,
-          );
-        }
-        if (states.contains(WidgetState.hovered) ||
-            states.contains(WidgetState.focused)) {
-          return Color.alphaBlend(
-            colors.onPrimary.withValues(alpha: 0.08),
-            colors.primary,
-          );
-        }
-        return colors.primary;
-      }),
-      overlayColor: const WidgetStatePropertyAll(Colors.transparent),
-      elevation: const WidgetStatePropertyAll(0),
+      search: search,
+      desktopActions: [
+        sort,
+        if (showCategoryButton) categories,
+        if (showToolbarImport) importButton,
+      ],
+      compactHeaderActions: [if (showCategoryButton) compactCategories],
+      compactSearchActions: [sort, if (showToolbarImport) compactImportButton],
     );
   }
 

--- a/lib/presentation/screens/prompt_config/prompt_config_screen.dart
+++ b/lib/presentation/screens/prompt_config/prompt_config_screen.dart
@@ -348,8 +348,8 @@ class _StudioHeader extends StatelessWidget {
           }
           return Row(
             children: [
-              SizedBox(width: 220, child: title),
-              const SizedBox(width: 24),
+              title,
+              const SizedBox(width: 12),
               Expanded(
                 child: PresetSelectorBar(onImportExport: onImportExport),
               ),

--- a/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
+++ b/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
@@ -20,6 +20,7 @@ import '../../router/app_routes.dart';
 
 import '../../agent_chat/widgets/agent_resource_drop_region.dart';
 import '../../widgets/common/app_toast.dart';
+import '../../widgets/common/context_menu_anchor.dart';
 import '../../widgets/common/owned_scroll_controller.dart';
 import '../../widgets/common/themed_confirm_dialog.dart';
 import '../../widgets/gallery/gallery_album_tree_view.dart';
@@ -27,6 +28,7 @@ import '../../widgets/gallery/gallery_sidebar.dart';
 import '../../widgets/shortcuts/shortcut_aware_widget.dart';
 import 'widgets/category_tree_view.dart';
 import 'widgets/entry_card.dart';
+import 'widgets/entry_create_card.dart';
 import 'widgets/entry_list_item.dart';
 import 'widgets/entry_add_dialog.dart';
 import 'widgets/send_to_home_dialog.dart';
@@ -174,7 +176,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
                   onAddEntry: _showAddEntryDialog,
                 ),
                 sidebar: showSidebar ? _buildCategorySidebar(state) : null,
-                body: _buildContent(theme, state),
+                body: _buildContent(theme, state, isSelectionMode),
               );
             },
           ),
@@ -259,28 +261,34 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
       isSelected: state.selectedCategoryId == null,
       onTap: () => selectCategory(null),
     );
-    final allEntries = DragTarget<TagLibraryEntry>(
-      onWillAcceptWithDetails: (details) => details.data.categoryId != null,
-      onAcceptWithDetails: (details) {
-        HapticFeedback.heavyImpact();
-        ref
-            .read(tagLibraryPageNotifierProvider.notifier)
-            .moveEntryToCategory(details.data.id, null);
-        AppToast.success(context, context.l10n.tagLibrary_entryMoved);
-      },
-      builder: (context, candidateData, _) => AnimatedContainer(
-        duration: MediaQuery.disableAnimationsOf(context)
-            ? Duration.zero
-            : const Duration(milliseconds: 150),
-        decoration: BoxDecoration(
-          color: candidateData.isEmpty
-              ? null
-              : Theme.of(
-                  context,
-                ).colorScheme.primaryContainer.withValues(alpha: 0.32),
-          borderRadius: BorderRadius.circular(8),
+    final allEntries = GestureDetector(
+      onSecondaryTapUp: (details) => _showEntryCreationContextMenu(
+        details.globalPosition,
+        initialCategoryId: null,
+      ),
+      child: DragTarget<TagLibraryEntry>(
+        onWillAcceptWithDetails: (details) => details.data.categoryId != null,
+        onAcceptWithDetails: (details) {
+          HapticFeedback.heavyImpact();
+          ref
+              .read(tagLibraryPageNotifierProvider.notifier)
+              .moveEntryToCategory(details.data.id, null);
+          AppToast.success(context, context.l10n.tagLibrary_entryMoved);
+        },
+        builder: (context, candidateData, _) => AnimatedContainer(
+          duration: MediaQuery.disableAnimationsOf(context)
+              ? Duration.zero
+              : const Duration(milliseconds: 150),
+          decoration: BoxDecoration(
+            color: candidateData.isEmpty
+                ? null
+                : Theme.of(
+                    context,
+                  ).colorScheme.primaryContainer.withValues(alpha: 0.32),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: allEntriesItem,
         ),
-        child: allEntriesItem,
       ),
     );
 
@@ -326,6 +334,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
                   onAddSubCategory: (parentId) {
                     _showAddCategoryDialog(parentId: parentId);
                   },
+                  onAddEntry: _showAddEntryDialogForCategory,
                   onCategoryMove: (categoryId, newParentId) {
                     ref
                         .read(tagLibraryPageNotifierProvider.notifier)
@@ -379,7 +388,11 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
   }
 
   /// 构建内容区域
-  Widget _buildContent(ThemeData theme, TagLibraryPageState state) {
+  Widget _buildContent(
+    ThemeData theme,
+    TagLibraryPageState state,
+    bool isSelectionMode,
+  ) {
     final entries = state.filteredEntries;
 
     if (state.isLoading) {
@@ -390,23 +403,34 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
       );
     }
 
-    if (entries.isEmpty) {
+    if (entries.isEmpty && state.viewMode != TagLibraryViewMode.card) {
       return _buildEmptyState(theme, state);
     }
 
-    switch (state.viewMode) {
-      case TagLibraryViewMode.card:
-        return _buildCardGrid(theme, entries);
-      case TagLibraryViewMode.list:
-        return _buildListView(theme, entries);
-      case TagLibraryViewMode.grouped:
-        return GroupedEntriesView(
-          scrollController: _groupedScrollController,
-          onEdit: _showEditDialog,
-          onDelete: _showDeleteEntryConfirmationForEntry,
-          onSend: _showEntryDetail,
-        );
-    }
+    final content = switch (state.viewMode) {
+      TagLibraryViewMode.card => _buildCardGrid(
+        theme,
+        entries,
+        showCreateCard: !isSelectionMode,
+      ),
+      TagLibraryViewMode.list => _buildListView(theme, entries),
+      TagLibraryViewMode.grouped => GroupedEntriesView(
+        scrollController: _groupedScrollController,
+        onEdit: _showEditDialog,
+        onDelete: _showDeleteEntryConfirmationForEntry,
+        onSend: _showEntryDetail,
+      ),
+    };
+
+    if (isSelectionMode) return content;
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onSecondaryTapUp: (details) => _showEntryCreationContextMenu(
+        details.globalPosition,
+        initialCategoryId: _selectedEntryCategoryId(state),
+      ),
+      child: content,
+    );
   }
 
   /// 构建空状态
@@ -449,7 +473,11 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
   }
 
   /// 构建卡片网格
-  Widget _buildCardGrid(ThemeData theme, List<TagLibraryEntry> entries) {
+  Widget _buildCardGrid(
+    ThemeData theme,
+    List<TagLibraryEntry> entries, {
+    required bool showCreateCard,
+  }) {
     return LayoutBuilder(
       builder: (context, constraints) {
         final textScale = MediaQuery.textScalerOf(context).scale(14) / 14;
@@ -466,9 +494,13 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
             mainAxisSpacing: 12,
             crossAxisSpacing: 12,
           ),
-          itemCount: entries.length,
-          itemBuilder: (context, index) =>
-              _buildEntryItem(entries[index], true),
+          itemCount: entries.length + (showCreateCard ? 1 : 0),
+          itemBuilder: (context, index) {
+            if (index < entries.length) {
+              return _buildEntryItem(entries[index], true);
+            }
+            return EntryCreateCard(onPressed: _showAddEntryDialog);
+          },
         );
       },
     );
@@ -752,11 +784,49 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
 
   void _showAddEntryDialog() {
     final state = ref.read(tagLibraryPageNotifierProvider);
+    _showAddEntryDialogForCategory(_selectedEntryCategoryId(state));
+  }
+
+  void _showAddEntryDialogForCategory(String? categoryId) {
+    final state = ref.read(tagLibraryPageNotifierProvider);
     EntryAddDialog.show(
       context,
       categories: state.categories,
-      initialCategoryId: state.selectedCategoryId,
+      initialCategoryId: categoryId,
     );
+  }
+
+  String? _selectedEntryCategoryId(TagLibraryPageState state) {
+    final selected = state.selectedCategoryId;
+    return state.categories.any((category) => category.id == selected)
+        ? selected
+        : null;
+  }
+
+  Future<void> _showEntryCreationContextMenu(
+    Offset position, {
+    required String? initialCategoryId,
+  }) async {
+    final create = await showMenu<bool>(
+      context: context,
+      position: contextMenuAnchorAt(context, position),
+      items: [
+        PopupMenuItem(
+          key: const Key('tag-library-context-create-entry'),
+          value: true,
+          child: Row(
+            children: [
+              const Icon(Icons.add_box_outlined, size: 18),
+              const SizedBox(width: 8),
+              Text(context.l10n.tagLibrary_addEntry),
+            ],
+          ),
+        ),
+      ],
+    );
+    if (create == true && mounted) {
+      _showAddEntryDialogForCategory(initialCategoryId);
+    }
   }
 
   Future<void> _showAddCategoryDialog({String? parentId}) async {

--- a/lib/presentation/screens/tag_library_page/widgets/category_tree_view.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/category_tree_view.dart
@@ -24,6 +24,7 @@ class CategoryTreeView extends StatefulWidget {
   final void Function(String id, String newName) onCategoryRename;
   final ValueChanged<String> onCategoryDelete;
   final ValueChanged<String?> onAddSubCategory;
+  final ValueChanged<String?>? onAddEntry;
 
   /// 分类移动到新父级（跨层级移动）
   final void Function(String categoryId, String? newParentId)? onCategoryMove;
@@ -48,6 +49,7 @@ class CategoryTreeView extends StatefulWidget {
     required this.onCategoryRename,
     required this.onCategoryDelete,
     required this.onAddSubCategory,
+    this.onAddEntry,
     this.onCategoryMove,
     this.onCategoryReorder,
     this.onEntryDrop,
@@ -149,6 +151,17 @@ class _CategoryTreeViewState extends State<CategoryTreeView> {
       context: context,
       position: contextMenuAnchorAt(context, position),
       items: [
+        if (widget.onAddEntry != null)
+          PopupMenuItem(
+            onTap: () => widget.onAddEntry?.call(null),
+            child: Row(
+              children: [
+                const Icon(Icons.add_box_outlined, size: 18),
+                const SizedBox(width: 8),
+                Text(context.l10n.tagLibrary_addEntry),
+              ],
+            ),
+          ),
         PopupMenuItem(
           onTap: () => widget.onAddSubCategory(null),
           child: Row(
@@ -191,6 +204,9 @@ class _CategoryTreeViewState extends State<CategoryTreeView> {
       onRename: (newName) => widget.onCategoryRename(category.id, newName),
       onDelete: () => widget.onCategoryDelete(category.id),
       onAddSubCategory: () => widget.onAddSubCategory(category.id),
+      onAddEntry: widget.onAddEntry == null
+          ? null
+          : () => widget.onAddEntry?.call(category.id),
       // 仅当分类不在根目录时显示"移动到根目录"选项
       onMoveToRoot: category.parentId != null && widget.onCategoryMove != null
           ? () => widget.onCategoryMove!(category.id, null)
@@ -446,6 +462,7 @@ class _CategoryItem extends StatefulWidget {
   final void Function(String)? onRename;
   final VoidCallback? onDelete;
   final VoidCallback? onAddSubCategory;
+  final VoidCallback? onAddEntry;
   final VoidCallback? onMoveToRoot;
 
   const _CategoryItem({
@@ -461,6 +478,7 @@ class _CategoryItem extends StatefulWidget {
     this.onRename,
     this.onDelete,
     this.onAddSubCategory,
+    this.onAddEntry,
     this.onMoveToRoot,
   });
 
@@ -651,6 +669,17 @@ class _CategoryItemState extends State<_CategoryItem> {
           ],
         ),
       ),
+      if (widget.onAddEntry != null)
+        PopupMenuItem(
+          value: _CategoryAction.addEntry,
+          child: Row(
+            children: [
+              const Icon(Icons.add_box_outlined, size: 18),
+              const SizedBox(width: 8),
+              Text(context.l10n.tagLibrary_addEntry),
+            ],
+          ),
+        ),
       if (widget.onAddSubCategory != null)
         PopupMenuItem(
           value: _CategoryAction.addSubCategory,
@@ -700,6 +729,8 @@ class _CategoryItemState extends State<_CategoryItem> {
         setState(() => _isEditing = true);
       case _CategoryAction.addSubCategory:
         widget.onAddSubCategory?.call();
+      case _CategoryAction.addEntry:
+        widget.onAddEntry?.call();
       case _CategoryAction.moveToRoot:
         widget.onMoveToRoot?.call();
       case _CategoryAction.delete:
@@ -708,4 +739,4 @@ class _CategoryItemState extends State<_CategoryItem> {
   }
 }
 
-enum _CategoryAction { rename, addSubCategory, moveToRoot, delete }
+enum _CategoryAction { rename, addEntry, addSubCategory, moveToRoot, delete }

--- a/lib/presentation/screens/tag_library_page/widgets/entry_create_card.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_create_card.dart
@@ -1,0 +1,112 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../../../core/utils/localization_extension.dart';
+
+class EntryCreateCard extends StatelessWidget {
+  const EntryCreateCard({super.key, required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    return Semantics(
+      button: true,
+      label: context.l10n.tagLibrary_addEntry,
+      child: Material(
+        color: colors.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(16),
+        child: InkWell(
+          key: const Key('tag-library-create-card'),
+          onTap: onPressed,
+          borderRadius: BorderRadius.circular(16),
+          child: CustomPaint(
+            foregroundPainter: _DashedRoundedBorderPainter(
+              color: colors.outline.withValues(alpha: 0.7),
+              radius: 16,
+            ),
+            child: Center(
+              child: MediaQuery.textScalerOf(context).scale(14) > 21
+                  ? Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.add_rounded,
+                          size: 30,
+                          color: colors.onSurfaceVariant,
+                        ),
+                        const SizedBox(width: 10),
+                        Flexible(
+                          child: Text(
+                            context.l10n.tagLibrary_addEntry,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.labelLarge?.copyWith(
+                              color: colors.onSurfaceVariant,
+                            ),
+                          ),
+                        ),
+                      ],
+                    )
+                  : Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.add_rounded,
+                          size: 30,
+                          color: colors.onSurfaceVariant,
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          context.l10n.tagLibrary_addEntry,
+                          style: theme.textTheme.labelLarge?.copyWith(
+                            color: colors.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DashedRoundedBorderPainter extends CustomPainter {
+  const _DashedRoundedBorderPainter({
+    required this.color,
+    required this.radius,
+  });
+
+  final Color color;
+  final double radius;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final path = Path()
+      ..addRRect(
+        RRect.fromRectAndRadius(Offset.zero & size, Radius.circular(radius)),
+      );
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5;
+    for (final metric in path.computeMetrics()) {
+      for (double start = 0; start < metric.length; start += 10) {
+        canvas.drawPath(
+          metric.extractPath(start, math.min(start + 5, metric.length)),
+          paint,
+        );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _DashedRoundedBorderPainter oldDelegate) {
+    return oldDelegate.color != color || oldDelegate.radius != radius;
+  }
+}

--- a/lib/presentation/screens/tag_library_page/widgets/entry_list_item.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_list_item.dart
@@ -56,6 +56,8 @@ class EntryListItem extends StatefulWidget {
 }
 
 class _EntryListItemState extends State<EntryListItem> {
+  static const double _desktopActionsWidth = 132;
+
   bool _isHovering = false;
   bool _isDragging = false;
 
@@ -126,10 +128,29 @@ class _EntryListItemState extends State<EntryListItem> {
               // 信息
               Expanded(child: _buildInfo(theme, entry)),
 
-              // 精确指针悬浮时显示完整操作；触屏始终显示菜单入口。
-              if (!widget.isSelectionMode && (isTouch || _isHovering)) ...[
+              // 为桌面悬浮操作保留固定几何空间，避免提示词翻译因可用宽度
+              // 改变而重新换行，造成整行高度抖动。
+              if (!widget.isSelectionMode) ...[
                 const SizedBox(width: 12),
-                _buildActions(theme),
+                if (isTouch)
+                  _buildActions(theme)
+                else
+                  SizedBox(
+                    width: _desktopActionsWidth,
+                    child: IgnorePointer(
+                      ignoring: !_isHovering,
+                      child: AnimatedOpacity(
+                        duration: MediaQuery.disableAnimationsOf(context)
+                            ? Duration.zero
+                            : const Duration(milliseconds: 120),
+                        opacity: _isHovering ? 1 : 0,
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: _buildActions(theme),
+                        ),
+                      ),
+                    ),
+                  ),
               ],
             ],
           ),
@@ -171,7 +192,12 @@ class _EntryListItemState extends State<EntryListItem> {
 
   Widget _buildPlaceholder(ThemeData theme) {
     return Container(
-      color: theme.colorScheme.surfaceContainerHighest,
+      width: 64,
+      height: 64,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
       child: Center(
         child: Icon(
           Icons.image_outlined,

--- a/lib/presentation/screens/tag_library_page/widgets/tag_library_toolbar.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/tag_library_toolbar.dart
@@ -291,11 +291,11 @@ class _TagLibraryToolbarState extends ConsumerState<TagLibraryToolbar> {
                 categoriesButton,
                 const SizedBox(width: 8),
               ],
-              addButton,
-              const SizedBox(width: 12),
               Expanded(child: _buildSearchField(theme, state)),
               const SizedBox(width: 12),
               buildActions(),
+              const SizedBox(width: 8),
+              addButton,
             ],
           );
         },

--- a/lib/presentation/screens/vibe_library/vibe_library_workspace.dart
+++ b/lib/presentation/screens/vibe_library/vibe_library_workspace.dart
@@ -16,6 +16,7 @@ import '../../widgets/common/input_surface_container.dart';
 import '../../widgets/common/pagination_bar.dart';
 import '../../widgets/gallery/gallery_state_views.dart';
 import '../../widgets/gallery/gallery_album_tree_view.dart';
+import '../../widgets/gallery/gallery_library_toolbar.dart';
 import '../../widgets/gallery/gallery_sidebar.dart';
 import 'vibe_library_commands.dart';
 import 'vibe_library_screen_controller.dart';
@@ -270,206 +271,137 @@ class _Toolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (selectionState.isActive) return _buildBulkBar(context);
-    return GalleryCollectionToolbarSurface(
-      key: const Key('vibe-library-toolbar'),
-      child: compact
-          ? _buildCompact(context)
-          : Row(
-              children: [
-                if (showPageTitle) ...[
-                  GalleryCollectionPageTitle(
-                    icon: Icons.auto_awesome_outlined,
-                    title: context.l10n.vibeLibrary_title,
-                  ),
-                  const SizedBox(width: 8),
-                ],
-                if (!libraryState.isLoading) _CountBadge(state: libraryState),
-                const SizedBox(width: GalleryCollectionChrome.toolbarGroupGap),
-                Expanded(child: _SearchField(controller: controller)),
-                const SizedBox(width: 8),
-                _SortButton(state: libraryState, onCommand: onCommand),
-                const SizedBox(width: 6),
-                CompactIconButton(
-                  icon: showCategoryPanel
-                      ? Icons.view_sidebar
-                      : Icons.view_sidebar_outlined,
-                  label: context.l10n.common_categories,
-                  tooltip: showCategoryPanel
-                      ? context.l10n.vibeLibrary_hideCategoryPanel
-                      : context.l10n.vibeLibrary_showCategoryPanel,
-                  onPressed: () => onCommand(
-                    usePersistentCategories
-                        ? const ToggleCategoryPanelCommand()
-                        : const ShowCategoryPanelCommand(),
-                  ),
-                ),
-                const SizedBox(width: 6),
-                CompactIconButton(
-                  icon: Icons.checklist,
-                  label: context.l10n.common_multiSelect,
-                  tooltip: context.l10n.vibeLibrary_enterSelectionMode,
-                  onPressed: () => onCommand(const EnterSelectionModeCommand()),
-                ),
-                if (libraryState.entries.isNotEmpty) ...[
-                  const SizedBox(width: 6),
-                  GestureDetector(
-                    onSecondaryTapUp: controller.isBusy
-                        ? null
-                        : (details) => onCommand(
-                            ShowImportMenuCommand(details.globalPosition),
-                          ),
-                    child: CompactIconButton(
-                      icon: Icons.file_download_outlined,
-                      label: context.l10n.common_import,
-                      tooltip: context.l10n.vibeLibrary_importTooltip,
-                      isLoading: controller.isPickingFile,
-                      onPressed: controller.isBusy
-                          ? null
-                          : () => _handleImportPressed(context),
-                    ),
-                  ),
-                ],
-                const SizedBox(width: 6),
-                CompactIconButton(
-                  icon: Icons.file_upload_outlined,
-                  label: context.l10n.common_export,
-                  tooltip: context.l10n.vibeLibrary_exportTooltip,
-                  onPressed: libraryState.entries.isEmpty
-                      ? null
-                      : () => onCommand(const ExportVibesCommand()),
-                ),
-                if (PlatformCapabilities.current.supportsOpenFolder) ...[
-                  const SizedBox(width: 6),
-                  CompactIconButton(
-                    icon: Icons.folder_open_outlined,
-                    label: context.l10n.common_folder,
-                    tooltip: context.l10n.vibeLibrary_openFolderTooltip,
-                    onPressed: () =>
-                        onCommand(const OpenLibraryFolderCommand()),
-                  ),
-                ],
-                const SizedBox(width: 6),
-                _RefreshButton(state: libraryState, onCommand: onCommand),
-              ],
-            ),
+    final title = GalleryCollectionPageTitle(
+      icon: Icons.auto_awesome_outlined,
+      title: context.l10n.vibeLibrary_title,
+      maxWidth: compact ? 180 : 220,
     );
-  }
+    final categoryCommand = usePersistentCategories
+        ? const ToggleCategoryPanelCommand()
+        : const ShowCategoryPanelCommand();
+    final categoryIcon = showCategoryPanel
+        ? Icons.view_sidebar
+        : Icons.view_sidebar_outlined;
+    final categoryTooltip = showCategoryPanel
+        ? context.l10n.vibeLibrary_hideCategoryPanel
+        : context.l10n.vibeLibrary_showCategoryPanel;
+    final importAction = GestureDetector(
+      onSecondaryTapUp: controller.isBusy
+          ? null
+          : (details) =>
+                onCommand(ShowImportMenuCommand(details.globalPosition)),
+      child: CompactIconButton(
+        icon: Icons.file_download_outlined,
+        label: context.l10n.common_import,
+        tooltip: context.l10n.vibeLibrary_importTooltip,
+        isLoading: controller.isPickingFile,
+        onPressed: controller.isBusy
+            ? null
+            : () => _handleImportPressed(context),
+      ),
+    );
+    final compactImportAction = GestureDetector(
+      onSecondaryTapUp: controller.isBusy
+          ? null
+          : (details) =>
+                onCommand(ShowImportMenuCommand(details.globalPosition)),
+      child: IconButton.filledTonal(
+        onPressed: controller.isBusy
+            ? null
+            : () => _handleImportPressed(context),
+        tooltip: context.l10n.vibeLibrary_importTooltip,
+        icon: controller.isPickingFile
+            ? SizedBox.square(
+                dimension: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  value: MediaQuery.disableAnimationsOf(context) ? 0.5 : null,
+                ),
+              )
+            : const Icon(Icons.file_download_outlined),
+      ),
+    );
 
-  Widget _buildCompact(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: Row(
-                children: [
-                  if (showPageTitle)
-                    Flexible(
-                      child: GalleryCollectionPageTitle(
-                        icon: Icons.auto_awesome_outlined,
-                        title: context.l10n.vibeLibrary_title,
-                        maxWidth: 180,
-                      ),
-                    ),
-                  if (!libraryState.isLoading) ...[
-                    const SizedBox(width: 8),
-                    Text(
-                      libraryState.hasFilters
-                          ? '${libraryState.filteredCount}/${libraryState.totalCount}'
-                          : '${libraryState.totalCount}',
-                    ),
-                  ],
-                ],
-              ),
-            ),
-            IconButton(
-              onPressed: () => onCommand(
-                usePersistentCategories
-                    ? const ToggleCategoryPanelCommand()
-                    : const ShowCategoryPanelCommand(),
-              ),
-              tooltip: context.l10n.common_categories,
-              icon: Icon(
-                showCategoryPanel
-                    ? Icons.view_sidebar
-                    : Icons.view_sidebar_outlined,
-              ),
-            ),
-            IconButton(
-              onPressed: () => onCommand(const EnterSelectionModeCommand()),
-              tooltip: context.l10n.vibeLibrary_enterSelectionMode,
-              icon: const Icon(Icons.checklist),
-            ),
-            PopupMenuButton<_ToolbarMenuAction>(
-              tooltip: context.l10n.nav_more,
-              onSelected: (action) => onCommand(
-                action == _ToolbarMenuAction.export
-                    ? const ExportVibesCommand()
-                    : const OpenLibraryFolderCommand(),
-              ),
-              itemBuilder: (context) => [
-                PopupMenuItem(
-                  value: _ToolbarMenuAction.export,
-                  enabled: libraryState.entries.isNotEmpty,
-                  child: ListTile(
-                    leading: const Icon(Icons.file_upload_outlined),
-                    title: Text(context.l10n.common_export),
-                  ),
-                ),
-                if (PlatformCapabilities.current.supportsOpenFolder)
-                  PopupMenuItem(
-                    value: _ToolbarMenuAction.openFolder,
-                    child: ListTile(
-                      leading: const Icon(Icons.folder_open_outlined),
-                      title: Text(context.l10n.common_folder),
-                    ),
-                  ),
-              ],
-            ),
-          ],
+    return GalleryLibraryToolbar(
+      key: const Key('vibe-library-toolbar'),
+      compact: compact,
+      title: showPageTitle ? title : const SizedBox.shrink(),
+      count: libraryState.isLoading ? null : _CountBadge(state: libraryState),
+      search: _SearchField(controller: controller, touch: compact),
+      desktopActions: [
+        _SortButton(state: libraryState, onCommand: onCommand),
+        CompactIconButton(
+          icon: categoryIcon,
+          label: context.l10n.common_categories,
+          tooltip: categoryTooltip,
+          onPressed: () => onCommand(categoryCommand),
         ),
-        const SizedBox(height: 8),
-        Row(
-          children: [
-            Expanded(child: _SearchField(controller: controller, touch: true)),
-            const SizedBox(width: 4),
-            _SortButton(state: libraryState, onCommand: onCommand, touch: true),
-            if (libraryState.entries.isNotEmpty) ...[
-              const SizedBox(width: 4),
-              GestureDetector(
-                onSecondaryTapUp: controller.isBusy
-                    ? null
-                    : (details) => onCommand(
-                        ShowImportMenuCommand(details.globalPosition),
-                      ),
-                child: IconButton.filledTonal(
-                  onPressed: controller.isBusy
-                      ? null
-                      : () => _handleImportPressed(context),
-                  tooltip: context.l10n.vibeLibrary_importTooltip,
-                  icon: controller.isPickingFile
-                      ? SizedBox.square(
-                          dimension: 20,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            value: MediaQuery.disableAnimationsOf(context)
-                                ? 0.5
-                                : null,
-                          ),
-                        )
-                      : const Icon(Icons.file_download_outlined),
+        CompactIconButton(
+          icon: Icons.checklist,
+          label: context.l10n.common_multiSelect,
+          tooltip: context.l10n.vibeLibrary_enterSelectionMode,
+          onPressed: () => onCommand(const EnterSelectionModeCommand()),
+        ),
+        if (libraryState.entries.isNotEmpty) importAction,
+        CompactIconButton(
+          icon: Icons.file_upload_outlined,
+          label: context.l10n.common_export,
+          tooltip: context.l10n.vibeLibrary_exportTooltip,
+          onPressed: libraryState.entries.isEmpty
+              ? null
+              : () => onCommand(const ExportVibesCommand()),
+        ),
+        if (PlatformCapabilities.current.supportsOpenFolder)
+          CompactIconButton(
+            icon: Icons.folder_open_outlined,
+            label: context.l10n.common_folder,
+            tooltip: context.l10n.vibeLibrary_openFolderTooltip,
+            onPressed: () => onCommand(const OpenLibraryFolderCommand()),
+          ),
+        _RefreshButton(state: libraryState, onCommand: onCommand),
+      ],
+      compactHeaderActions: [
+        IconButton(
+          onPressed: () => onCommand(categoryCommand),
+          tooltip: context.l10n.common_categories,
+          icon: Icon(categoryIcon),
+        ),
+        IconButton(
+          onPressed: () => onCommand(const EnterSelectionModeCommand()),
+          tooltip: context.l10n.vibeLibrary_enterSelectionMode,
+          icon: const Icon(Icons.checklist),
+        ),
+        PopupMenuButton<_ToolbarMenuAction>(
+          tooltip: context.l10n.nav_more,
+          onSelected: (action) => onCommand(
+            action == _ToolbarMenuAction.export
+                ? const ExportVibesCommand()
+                : const OpenLibraryFolderCommand(),
+          ),
+          itemBuilder: (context) => [
+            PopupMenuItem(
+              value: _ToolbarMenuAction.export,
+              enabled: libraryState.entries.isNotEmpty,
+              child: ListTile(
+                leading: const Icon(Icons.file_upload_outlined),
+                title: Text(context.l10n.common_export),
+              ),
+            ),
+            if (PlatformCapabilities.current.supportsOpenFolder)
+              PopupMenuItem(
+                value: _ToolbarMenuAction.openFolder,
+                child: ListTile(
+                  leading: const Icon(Icons.folder_open_outlined),
+                  title: Text(context.l10n.common_folder),
                 ),
               ),
-            ],
-            const SizedBox(width: 4),
-            _RefreshButton(
-              state: libraryState,
-              onCommand: onCommand,
-              touch: true,
-            ),
           ],
         ),
+      ],
+      compactSearchActions: [
+        _SortButton(state: libraryState, onCommand: onCommand, touch: true),
+        if (libraryState.entries.isNotEmpty) compactImportAction,
+        _RefreshButton(state: libraryState, onCommand: onCommand, touch: true),
       ],
     );
   }
@@ -550,21 +482,10 @@ class _CountBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        state.hasFilters
-            ? '${state.filteredCount}/${state.totalCount}'
-            : '${state.totalCount}',
-        style: theme.textTheme.labelSmall?.copyWith(
-          fontWeight: FontWeight.w500,
-        ),
-      ),
+    return GalleryLibraryCountBadge(
+      label: state.hasFilters
+          ? '${state.filteredCount}/${state.totalCount}'
+          : '${state.totalCount}',
     );
   }
 }

--- a/lib/presentation/widgets/gallery/gallery_library_toolbar.dart
+++ b/lib/presentation/widgets/gallery/gallery_library_toolbar.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+import 'gallery_sidebar.dart';
+
+/// Shared responsive toolbar layout for collection-style library pages.
+///
+/// The title and count stay together, search owns the remaining width, and
+/// page-specific actions are supplied as slots so Vibe and Precise Reference
+/// keep one responsive toolbar structure without coupling their commands.
+class GalleryLibraryToolbar extends StatelessWidget {
+  const GalleryLibraryToolbar({
+    super.key,
+    required this.compact,
+    required this.title,
+    required this.search,
+    this.count,
+    this.desktopActions = const [],
+    this.compactHeaderActions = const [],
+    this.compactSearchActions = const [],
+  });
+
+  final bool compact;
+  final Widget title;
+  final Widget? count;
+  final Widget search;
+  final List<Widget> desktopActions;
+  final List<Widget> compactHeaderActions;
+  final List<Widget> compactSearchActions;
+
+  @override
+  Widget build(BuildContext context) {
+    return GalleryCollectionToolbarSurface(
+      child: compact ? _buildCompact() : _buildDesktop(),
+    );
+  }
+
+  Widget _buildDesktop() {
+    return Row(
+      children: [
+        title,
+        if (count != null) ...[const SizedBox(width: 8), count!],
+        const SizedBox(width: GalleryCollectionChrome.toolbarGroupGap),
+        Expanded(child: search),
+        if (desktopActions.isNotEmpty) ...[
+          const SizedBox(width: 8),
+          ..._spaced(desktopActions, 6),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildCompact() {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Row(
+                children: [
+                  Flexible(child: title),
+                  if (count != null) ...[const SizedBox(width: 8), count!],
+                ],
+              ),
+            ),
+            ...compactHeaderActions,
+          ],
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(child: search),
+            if (compactSearchActions.isNotEmpty) ...[
+              const SizedBox(width: 4),
+              ..._spaced(compactSearchActions, 4),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+
+  List<Widget> _spaced(List<Widget> children, double spacing) {
+    return [
+      for (var index = 0; index < children.length; index++) ...[
+        if (index > 0) SizedBox(width: spacing),
+        children[index],
+      ],
+    ];
+  }
+}
+
+class GalleryLibraryCountBadge extends StatelessWidget {
+  const GalleryLibraryCountBadge({super.key, required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}

--- a/test/presentation/screens/precise_ref_library/precise_ref_responsive_layout_test.dart
+++ b/test/presentation/screens/precise_ref_library/precise_ref_responsive_layout_test.dart
@@ -15,6 +15,7 @@ import 'package:nai_launcher/presentation/screens/precise_ref_library/widgets/pr
 import 'package:nai_launcher/presentation/screens/precise_ref_library/widgets/precise_ref_selector_dialog.dart';
 import 'package:nai_launcher/presentation/widgets/common/input_surface_container.dart';
 import 'package:nai_launcher/presentation/widgets/common/pagination_bar.dart';
+import 'package:nai_launcher/presentation/widgets/gallery/gallery_library_toolbar.dart';
 import 'package:nai_launcher/presentation/widgets/gallery/gallery_sidebar.dart';
 
 void main() {
@@ -50,7 +51,7 @@ void main() {
         );
         expect(
           find.byKey(const Key('precise-ref-library-favorites-toggle')),
-          findsOneWidget,
+          findsNothing,
         );
         if (width < 840) {
           final categoriesButton = find.byKey(
@@ -87,15 +88,19 @@ void main() {
           find.byKey(const Key('precise-ref-library-unified-toolbar')),
           findsOneWidget,
         );
-        if (width >= 840) {
+        if (width >= 1050) {
           final titleRect = tester.getRect(
             find.byKey(const Key('precise-ref-library-page-title')),
+          );
+          final countRect = tester.getRect(
+            find.byType(GalleryLibraryCountBadge),
           );
           final searchRect = tester.getRect(
             find.byKey(const Key('precise-ref-library-search-surface')),
           );
+          expect(countRect.left - titleRect.right, 8);
           expect(
-            searchRect.left - titleRect.right,
+            searchRect.left - countRect.right,
             GalleryCollectionChrome.toolbarGroupGap,
           );
         }
@@ -386,8 +391,8 @@ void main() {
       );
       final restingRect = tester.getRect(find.byKey(surfaceKey));
 
-      expect(surface.height, 40);
-      expect(surface.borderRadius, 20);
+      expect(surface.height, 36);
+      expect(surface.borderRadius, 18);
 
       final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
       addTearDown(mouse.removePointer);
@@ -408,7 +413,7 @@ void main() {
                   )
                   .decoration!
               as BoxDecoration;
-      expect(focusedDecoration.borderRadius, BorderRadius.circular(20));
+      expect(focusedDecoration.borderRadius, BorderRadius.circular(18));
       expect(
         (focusedDecoration.border! as Border).top.color.a,
         closeTo(0.38, 0.01),
@@ -417,7 +422,7 @@ void main() {
     },
   );
 
-  testWidgets('desktop toolbar actions expose distinct hover feedback', (
+  testWidgets('desktop shared toolbar omits duplicate favorite filter', (
     tester,
   ) async {
     await _setViewport(tester, const Size(1180, 800));
@@ -430,27 +435,19 @@ void main() {
       ),
     );
 
-    final favorites = tester.widget<IconButton>(
+    expect(find.byType(GalleryLibraryToolbar), findsOneWidget);
+    expect(
       find.byKey(const Key('precise-ref-library-favorites-toggle')),
+      findsNothing,
     );
-    final sort = tester.widget<PopupMenuButton<PreciseRefLibrarySortOrder>>(
+    expect(
       find.byKey(const Key('precise-ref-library-sort-menu')),
+      findsOneWidget,
     );
-    final import = tester.widget<FilledButton>(
+    expect(
       find.byKey(const Key('precise-ref-library-import-button')),
+      findsOneWidget,
     );
-
-    void expectHoverDiffers(ButtonStyle style) {
-      final resting = style.backgroundColor?.resolve(<WidgetState>{});
-      final hovered = style.backgroundColor?.resolve({WidgetState.hovered});
-      final pressed = style.backgroundColor?.resolve({WidgetState.pressed});
-      expect(hovered, isNot(resting));
-      expect(pressed, isNot(hovered));
-    }
-
-    expectHoverDiffers(favorites.style!);
-    expectHoverDiffers(sort.style!);
-    expectHoverDiffers(import.style!);
     expect(tester.takeException(), isNull);
   });
 

--- a/test/presentation/screens/prompt_config/random_config_screen_test.dart
+++ b/test/presentation/screens/prompt_config/random_config_screen_test.dart
@@ -375,6 +375,13 @@ void main() {
         expect(more.width, greaterThanOrEqualTo(44));
         expect(more.height, greaterThanOrEqualTo(44));
       }
+      if (width >= 1050) {
+        final title = tester.getRect(find.text('随机词库'));
+        final selector = tester.getRect(
+          find.byKey(const ValueKey('random-manager-preset-selector')),
+        );
+        expect(selector.left - title.right, 12);
+      }
       if (width < 1050) {
         expect(
           find.byKey(const ValueKey('random-manager-compact-sections')),

--- a/test/presentation/screens/tag_library_page/tag_library_page_screen_test.dart
+++ b/test/presentation/screens/tag_library_page/tag_library_page_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -137,6 +138,36 @@ void main() {
       await tester.pumpAndSettle();
     }
 
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('card tail and content context menu both create entries', (
+    tester,
+  ) async {
+    await _setViewport(tester, const Size(1180, 800));
+    await _pumpTagLibrary(tester, _DialogTagLibraryPageNotifier.new);
+
+    await tester.tap(find.byKey(const Key('tag-library-create-card')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('adaptive-centered-form')),
+      findsOneWidget,
+    );
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(GridView), buttons: kSecondaryMouseButton);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('tag-library-context-create-entry')),
+      findsOneWidget,
+    );
+    await tester.tap(find.byKey(const Key('tag-library-context-create-entry')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('adaptive-centered-form')),
+      findsOneWidget,
+    );
     expect(tester.takeException(), isNull);
   });
 
@@ -279,6 +310,7 @@ class _TestShortcutConfigNotifier extends ShortcutConfigNotifier {
 class _DialogTagLibraryPageNotifier extends TagLibraryPageNotifier {
   @override
   TagLibraryPageState build() => TagLibraryPageState(
+    viewMode: TagLibraryViewMode.card,
     entries: [
       TagLibraryEntry(
         id: 'dialog-entry',

--- a/test/presentation/screens/tag_library_page/tag_library_responsive_layout_test.dart
+++ b/test/presentation/screens/tag_library_page/tag_library_responsive_layout_test.dart
@@ -47,6 +47,10 @@ void main() {
         await _pumpLibrary(tester);
 
         expect(find.byType(GridView), findsOneWidget);
+        expect(
+          find.byKey(const Key('tag-library-create-card')),
+          findsOneWidget,
+        );
         expect(find.text('目标条目'), findsOneWidget);
         expect(find.byType(TextField), findsOneWidget);
 
@@ -72,6 +76,13 @@ void main() {
             tester.getSize(find.byKey(const Key('tag-library-toolbar'))).width,
             1600,
           );
+          final addRect = tester.getRect(
+            find.byKey(const Key('tag-library-add-entry-button')),
+          );
+          final toolbarRect = tester.getRect(
+            find.byKey(const Key('tag-library-toolbar')),
+          );
+          expect(toolbarRect.right - addRect.right, 16);
         }
 
         await tester.enterText(find.byType(TextField), '目标');

--- a/test/presentation/screens/tag_library_page/widgets/category_tree_view_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/category_tree_view_test.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/tag_library/tag_library_category.dart';
@@ -123,5 +124,47 @@ void main() {
       find.ancestor(of: find.text('已选分类'), matching: find.byType(InkWell)),
     );
     expect(selectedInkWell.hoverColor, Colors.transparent);
+  });
+
+  testWidgets('分类右键菜单可在目标分类中创建词条', (tester) async {
+    final category = TagLibraryCategory(
+      id: 'target-category',
+      name: '目标分类',
+      createdAt: DateTime(2026),
+    );
+    String? createdInCategory;
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: 320,
+            height: 320,
+            child: CategoryTreeView(
+              categories: [category],
+              entries: const [],
+              expandedCategoryIds: const {},
+              onExpandedCategoryIdsChanged: (_) {},
+              onCategorySelected: (_) {},
+              onCategoryRename: (_, _) {},
+              onCategoryDelete: (_) {},
+              onAddSubCategory: (_) {},
+              onAddEntry: (id) => createdInCategory = id,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('目标分类'), buttons: kSecondaryMouseButton);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('添加条目'));
+    await tester.pumpAndSettle();
+
+    expect(createdInCategory, 'target-category');
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/presentation/screens/tag_library_page/widgets/entry_list_item_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/entry_list_item_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
@@ -41,6 +42,59 @@ void main() {
     final prompt = find.text(content);
     expect(prompt, findsOneWidget);
     expect(tester.getSize(prompt).width, greaterThan(700));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('桌面悬浮操作不会改变翻译摘要的布局几何', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 320));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final timestamp = DateTime(2026);
+    final entry = TagLibraryEntry(
+      id: 'stable-entry',
+      name: '稳定条目',
+      content: List.filled(20, 'long_prompt_tag').join(', '),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: EntryListItem(
+            entry: entry,
+            onTap: () {},
+            onDelete: () {},
+            onToggleFavorite: () {},
+            onEdit: () {},
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final item = find.byType(EntryListItem);
+    final prompt = find.text(entry.content);
+    final restingItemRect = tester.getRect(item);
+    final restingPromptSize = tester.getSize(prompt);
+    final placeholder = find.byIcon(Icons.image_outlined);
+    expect(
+      tester.getSize(
+        find.ancestor(of: placeholder, matching: find.byType(Container)).first,
+      ),
+      const Size(64, 64),
+    );
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: const Offset(850, 300));
+    await mouse.moveTo(tester.getCenter(item));
+    await tester.pump(const Duration(milliseconds: 220));
+
+    expect(tester.getRect(item).size, restingItemRect.size);
+    expect(tester.getSize(prompt), restingPromptSize);
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/presentation/screens/tag_library_page/widgets/tag_library_toolbar_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/tag_library_toolbar_test.dart
@@ -86,7 +86,7 @@ void main() {
               body: Align(
                 alignment: Alignment.topCenter,
                 child: SizedBox(
-                  height: 132,
+                  height: 180,
                   child: ClipRect(
                     child: TagLibraryToolbar(onShowCategories: () {}),
                   ),

--- a/test/presentation/screens/vibe_library/vibe_library_responsive_layout_test.dart
+++ b/test/presentation/screens/vibe_library/vibe_library_responsive_layout_test.dart
@@ -408,6 +408,9 @@ Future<void> _pumpTouchImportFlow(
         vibeLibraryNotifierProvider.overrideWith(
           _PopulatedVibeLibraryNotifier.new,
         ),
+        vibeLibraryCategoryNotifierProvider.overrideWith(
+          _ResponsiveVibeLibraryCategoryNotifier.new,
+        ),
       ],
       child: MaterialApp(
         locale: const Locale('zh'),
@@ -512,6 +515,9 @@ Future<void> _pumpWorkspace(
         vibeLibraryNotifierProvider.overrideWith(
           _PopulatedVibeLibraryNotifier.new,
         ),
+        vibeLibraryCategoryNotifierProvider.overrideWith(
+          _ResponsiveVibeLibraryCategoryNotifier.new,
+        ),
       ],
       child: MaterialApp(
         locale: const Locale('zh'),
@@ -551,6 +557,12 @@ List<VibeLibraryCategory> _buildCategories(int count) => List.generate(
     createdAt: DateTime(2026),
   ),
 );
+
+class _ResponsiveVibeLibraryCategoryNotifier
+    extends VibeLibraryCategoryNotifier {
+  @override
+  VibeLibraryCategoryState build() => const VibeLibraryCategoryState();
+}
 
 Future<void> _pumpCategoryPanelHost(
   WidgetTester tester, {


### PR DESCRIPTION
## 改动内容

- 抽取 Vibe 库与精准参考库共用的响应式顶栏结构，精准参考库移除重复的“只看收藏”按钮
- 修正随机词库预设下拉框左侧多余留白，并将词库“添加条目”操作移动到顶栏最右侧
- 卡片模式末尾增加虚线加号创建卡片；内容区域、全部条目和分类节点支持右键快速创建并继承目标分类
- 列表模式为桌面悬浮操作预留固定宽度，统一有图与无图条目的 64×64 起始区域，避免翻译换行引发布局抖动
- 补充响应式、右键创建、悬浮几何和顶栏复用回归测试

## 验证结果

- `scripts/verify_flutter_sources.ps1`：通过
- 相关 8 个 Widget test 文件：通过（覆盖 320/600/840/1180/1600、3x 文本、IME、右键与悬浮状态）
- 受影响源码与测试 `dart analyze`：通过
- `git diff --check`：通过

## 注意事项

- 全量 `flutter analyze` 仍报告一项本次改动外的既有 unused import：`test/data/services/random_prompt_generator_preset_test.dart:12`
- 按要求不等待 CI，PR 创建后直接 Squash Merge