### PR TITLE
feat(vibe-library): 优化卡片悬浮预览

### DIFF
--- a/lib/presentation/screens/vibe_library/widgets/vibe_card.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_card.dart
@@ -1,8 +1,7 @@
 import 'dart:math' as math;
-import 'dart:typed_data';
-import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/utils/localization_extension.dart';
@@ -14,7 +13,7 @@ import '../../../widgets/common/card_action_buttons.dart';
 import '../../../widgets/common/card_hover_preview_controller.dart';
 import '../../../widgets/common/image_card_actions.dart';
 import '../../../widgets/common/library_card_badges.dart';
-import '../../../widgets/common/translated_tag_text.dart';
+import 'vibe_hover_preview.dart';
 
 /// Vibe 图像卡片统一采用 4:5 纵向比例，为缩略图和底部参数保留稳定空间。
 const double vibeCardAspectRatio = 4 / 5;
@@ -82,6 +81,7 @@ class VibeCard extends ConsumerStatefulWidget {
 class _VibeCardState extends ConsumerState<VibeCard>
     with SingleTickerProviderStateMixin {
   bool _isHovered = false;
+  bool _isFocused = false;
   bool _branchVisible = true;
   Uint8List? _lazyThumbnailData;
   Future<void>? _thumbnailLoadFuture;
@@ -128,7 +128,9 @@ class _VibeCardState extends ConsumerState<VibeCard>
         : const Duration(milliseconds: 300);
     if (disableAnimations) {
       _animationController.stop();
-      _animationController.value = _isHovered && widget.entry.isBundle ? 1 : 0;
+      _animationController.value = _isInteractive && widget.entry.isBundle
+          ? 1
+          : 0;
     }
   }
 
@@ -140,9 +142,13 @@ class _VibeCardState extends ConsumerState<VibeCard>
       _lazyThumbnailData = null;
       _thumbnailLoadFuture = null;
       _hoverDetailFuture = null;
-      _isHovered = false;
       _animationController.value = 0;
       _loadThumbnailIfNeeded();
+      if (_isInteractive) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && _isInteractive) _scheduleHoverPreview();
+        });
+      }
       return;
     }
 
@@ -191,28 +197,42 @@ class _VibeCardState extends ConsumerState<VibeCard>
         });
   }
 
-  void _onHoverEnter(PointerEvent event) {
-    setState(() => _isHovered = true);
-    if (widget.entry.isBundle) {
-      if (_disableAnimations) {
-        _animationController.value = 1;
-      } else {
-        _animationController.forward();
-      }
-    }
-    _scheduleHoverPreview();
+  bool get _isInteractive => _isHovered || _isFocused;
+
+  void _onHoverEnter(PointerEvent event) => _setHovered(true);
+
+  void _onHoverExit(PointerEvent event) => _setHovered(false);
+
+  void _setHovered(bool value) {
+    if (_isHovered == value) return;
+    final wasInteractive = _isInteractive;
+    setState(() => _isHovered = value);
+    _syncInteractiveState(wasInteractive);
   }
 
-  void _onHoverExit(PointerEvent event) {
-    setState(() => _isHovered = false);
+  void _onFocusChange(bool value) {
+    if (_isFocused == value) return;
+    final wasInteractive = _isInteractive;
+    setState(() => _isFocused = value);
+    _syncInteractiveState(wasInteractive);
+  }
+
+  void _syncInteractiveState(bool wasInteractive) {
+    if (wasInteractive == _isInteractive) return;
     if (widget.entry.isBundle) {
       if (_disableAnimations) {
-        _animationController.value = 0;
+        _animationController.value = _isInteractive ? 1 : 0;
+      } else if (_isInteractive) {
+        _animationController.forward();
       } else {
         _animationController.reverse();
       }
     }
-    _hoverController.dismissFor(widget.entry.id);
+    if (_isInteractive) {
+      _scheduleHoverPreview();
+    } else {
+      _hoverController.dismissFor(widget.entry.id);
+    }
   }
 
   void _scheduleHoverPreview() {
@@ -233,7 +253,8 @@ class _VibeCardState extends ConsumerState<VibeCard>
       layerLink: _layerLink,
       targetRect: targetRect,
       previewSize: previewSize,
-      builder: (_) => _VibeHoverPreview(
+      verticalAlignment: CardHoverPreviewVerticalAlignment.targetTop,
+      builder: (_) => VibeHoverPreview(
         displayEntry: widget.entry,
         detailFuture: _hoverDetailFuture!,
         fallbackImage: _thumbnailData,
@@ -262,106 +283,123 @@ class _VibeCardState extends ConsumerState<VibeCard>
 
     return CompositedTransformTarget(
       link: _layerLink,
-      child: MouseRegion(
-        onEnter: _onHoverEnter,
-        onExit: _onHoverExit,
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          onTap: widget.onTap,
-          onDoubleTap: widget.onDoubleTap,
-          onLongPress: widget.onLongPress,
-          // 必须抬起后弹菜单：按住时 push 会合成 touch 取消事件，令 DraggableWidget 整批重建闪烁
-          onSecondaryTapUp: widget.onSecondaryTapUp,
-          child: AnimatedContainer(
-            duration: _disableAnimations
-                ? Duration.zero
-                : const Duration(milliseconds: 150),
-            curve: Curves.easeOut,
-            width: widget.width,
-            height: cardHeight,
-            transform: Matrix4.identity()
-              ..translateByDouble(0, _isHovered ? -2 : 0, 0, 1),
-            transformAlignment: Alignment.center,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              boxShadow: _buildShadows(colorScheme),
-            ),
-            foregroundDecoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              border: _buildBorder(colorScheme),
-            ),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(12),
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  // 主内容层
-                  _buildMainContent(),
+      child: FocusableActionDetector(
+        onFocusChange: _onFocusChange,
+        shortcuts: const {
+          SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+          SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+        },
+        actions: {
+          ActivateIntent: CallbackAction<ActivateIntent>(
+            onInvoke: (_) {
+              (widget.onTap ?? widget.onDoubleTap)?.call();
+              return null;
+            },
+          ),
+        },
+        child: MouseRegion(
+          onEnter: _onHoverEnter,
+          onExit: _onHoverExit,
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: widget.onTap,
+            onDoubleTap: widget.onDoubleTap,
+            onLongPress: widget.onLongPress,
+            // 必须抬起后弹菜单：按住时 push 会合成 touch 取消事件，令 DraggableWidget 整批重建闪烁
+            onSecondaryTapUp: widget.onSecondaryTapUp,
+            child: AnimatedContainer(
+              duration: _disableAnimations
+                  ? Duration.zero
+                  : const Duration(milliseconds: 150),
+              curve: Curves.easeOut,
+              width: widget.width,
+              height: cardHeight,
+              transform: Matrix4.identity()
+                ..translateByDouble(0, _isInteractive ? -2 : 0, 0, 1),
+              transformAlignment: Alignment.center,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: _buildShadows(colorScheme),
+              ),
+              foregroundDecoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                border: _buildBorder(colorScheme),
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    // 主内容层
+                    _buildMainContent(),
 
-                  // Bundle 扑克牌层叠展开层
-                  if (widget.entry.isBundle)
-                    FadeTransition(
-                      opacity: _fadeAnimation,
-                      child: _buildCardStack(),
-                    ),
+                    // Bundle 扑克牌层叠展开层
+                    if (widget.entry.isBundle)
+                      FadeTransition(
+                        opacity: _fadeAnimation,
+                        child: _buildCardStack(),
+                      ),
 
-                  // 信息层
-                  _buildInfoOverlay(),
+                    // 信息层
+                    _buildInfoOverlay(),
 
-                  // Bundle 数量标识
-                  if (widget.entry.isBundle) _buildBundleBadge(),
+                    // Bundle 数量标识
+                    if (widget.entry.isBundle) _buildBundleBadge(),
 
-                  if (widget.categoryLabel case final categoryLabel?)
-                    Positioned(
-                      top: 8,
-                      left: 8,
-                      child: LibraryCardCategoryBadge(
-                        key: ValueKey('vibe-card-category-${widget.entry.id}'),
-                        icon: Icons.category_outlined,
-                        label: categoryLabel,
-                        maxWidth: math.max(
-                          80,
-                          widget.width -
-                              (widget.entry.isFavorite && !isTouch ? 48 : 16),
+                    if (widget.categoryLabel case final categoryLabel?)
+                      Positioned(
+                        top: 8,
+                        left: 8,
+                        child: LibraryCardCategoryBadge(
+                          key: ValueKey(
+                            'vibe-card-category-${widget.entry.id}',
+                          ),
+                          icon: Icons.category_outlined,
+                          label: categoryLabel,
+                          maxWidth: math.max(
+                            80,
+                            widget.width -
+                                (widget.entry.isFavorite && !isTouch ? 48 : 16),
+                          ),
                         ),
                       ),
-                    ),
 
-                  if (!isTouch &&
-                      !_isHovered &&
-                      !widget.isSelected &&
-                      widget.showFavoriteIndicator &&
-                      widget.entry.isFavorite)
-                    Positioned(
-                      top: 8,
-                      right: 8,
-                      child: LibraryCardFavoriteBadge(
-                        key: ValueKey(
-                          'vibe-card-favorite-badge-${widget.entry.id}',
+                    if (!isTouch &&
+                        !_isInteractive &&
+                        !widget.isSelected &&
+                        widget.showFavoriteIndicator &&
+                        widget.entry.isFavorite)
+                      Positioned(
+                        top: 8,
+                        right: 8,
+                        child: LibraryCardFavoriteBadge(
+                          key: ValueKey(
+                            'vibe-card-favorite-badge-${widget.entry.id}',
+                          ),
+                          semanticLabel: context.l10n.common_favorite,
                         ),
-                        semanticLabel: context.l10n.common_favorite,
                       ),
-                    ),
 
-                  // 选中状态
-                  if (widget.isSelected) _buildSelectionOverlay(colorScheme),
+                    // 选中状态
+                    if (widget.isSelected) _buildSelectionOverlay(colorScheme),
 
-                  // 操作按钮
-                  if (isTouch &&
-                      !widget.isSelected &&
-                      (widget.onLongPress != null ||
-                          (widget.showFavoriteIndicator &&
-                              widget.onFavoriteToggle != null) ||
-                          onAddToAgent != null ||
-                          widget.onSendToGeneration != null ||
-                          widget.onExport != null ||
-                          widget.onEdit != null ||
-                          widget.onClassify != null ||
-                          widget.onDelete != null))
-                    _buildTouchActionMenu()
-                  else if (_isHovered && !widget.isSelected)
-                    _buildActionButtons(),
-                ],
+                    // 操作按钮
+                    if (isTouch &&
+                        !widget.isSelected &&
+                        (widget.onLongPress != null ||
+                            (widget.showFavoriteIndicator &&
+                                widget.onFavoriteToggle != null) ||
+                            onAddToAgent != null ||
+                            widget.onSendToGeneration != null ||
+                            widget.onExport != null ||
+                            widget.onEdit != null ||
+                            widget.onClassify != null ||
+                            widget.onDelete != null))
+                      _buildTouchActionMenu()
+                    else if (_isInteractive && !widget.isSelected)
+                      _buildActionButtons(),
+                  ],
+                ),
               ),
             ),
           ),
@@ -371,12 +409,15 @@ class _VibeCardState extends ConsumerState<VibeCard>
   }
 
   Border? _buildBorder(ColorScheme colorScheme) {
-    if (!widget.isSelected) return null;
-    return Border.all(color: colorScheme.primary, width: 1);
+    if (!widget.isSelected && !_isFocused) return null;
+    return Border.all(
+      color: colorScheme.primary,
+      width: widget.isSelected ? 2 : 1,
+    );
   }
 
   List<BoxShadow> _buildShadows(ColorScheme colorScheme) {
-    if (!_isHovered) return const [];
+    if (!_isInteractive) return const [];
     return [
       BoxShadow(
         color: colorScheme.shadow.withValues(alpha: 0.12),
@@ -939,414 +980,6 @@ class _VibeCardState extends ConsumerState<VibeCard>
         visible: true,
         direction: Axis.vertical,
         buttons: actions,
-      ),
-    );
-  }
-}
-
-class _VibeHoverPreview extends StatefulWidget {
-  const _VibeHoverPreview({
-    required this.displayEntry,
-    required this.detailFuture,
-    required this.fallbackImage,
-    required this.maxWidth,
-    required this.maxHeight,
-  });
-
-  final VibeLibraryEntry displayEntry;
-  final Future<VibeLibraryDetailData?> detailFuture;
-  final Uint8List? fallbackImage;
-  final double maxWidth;
-  final double maxHeight;
-
-  @override
-  State<_VibeHoverPreview> createState() => _VibeHoverPreviewState();
-}
-
-class _VibeHoverPreviewState extends State<_VibeHoverPreview> {
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<VibeLibraryDetailData?>(
-      future: widget.detailFuture,
-      builder: (context, snapshot) {
-        final detail = snapshot.data;
-        final entry = detail?.entry ?? widget.displayEntry;
-        final image = _bestPreviewImage(detail, widget.fallbackImage);
-        return _VibeHoverPreviewContent(
-          entry: entry,
-          image: image,
-          maxWidth: widget.maxWidth,
-          maxHeight: widget.maxHeight,
-          isLoading: snapshot.connectionState != ConnectionState.done,
-        );
-      },
-    );
-  }
-
-  Uint8List? _bestPreviewImage(
-    VibeLibraryDetailData? detail,
-    Uint8List? fallback,
-  ) {
-    final entry = detail?.entry;
-    final candidates = <Uint8List?>[
-      entry?.rawImageData,
-      if (detail != null && detail.bundleVibes.isNotEmpty)
-        detail.bundleVibes.first.rawImageData,
-      entry?.thumbnail,
-      entry?.vibeThumbnail,
-      if (detail != null && detail.bundleVibes.isNotEmpty)
-        detail.bundleVibes.first.thumbnail,
-      fallback,
-    ];
-    for (final candidate in candidates) {
-      if (candidate != null && candidate.isNotEmpty) return candidate;
-    }
-    return null;
-  }
-}
-
-class _VibeHoverPreviewContent extends StatefulWidget {
-  const _VibeHoverPreviewContent({
-    required this.entry,
-    required this.image,
-    required this.maxWidth,
-    required this.maxHeight,
-    required this.isLoading,
-  });
-
-  final VibeLibraryEntry entry;
-  final Uint8List? image;
-  final double maxWidth;
-  final double maxHeight;
-  final bool isLoading;
-
-  @override
-  State<_VibeHoverPreviewContent> createState() =>
-      _VibeHoverPreviewContentState();
-}
-
-class _VibeHoverPreviewContentState extends State<_VibeHoverPreviewContent> {
-  Future<double>? _aspectRatioFuture;
-
-  @override
-  void initState() {
-    super.initState();
-    _resolveAspectRatio();
-  }
-
-  @override
-  void didUpdateWidget(covariant _VibeHoverPreviewContent oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.image, widget.image)) _resolveAspectRatio();
-  }
-
-  void _resolveAspectRatio() {
-    final image = widget.image;
-    _aspectRatioFuture = image == null ? Future.value(1) : _decodeRatio(image);
-  }
-
-  Future<double> _decodeRatio(Uint8List bytes) async {
-    ui.Codec? codec;
-    ui.FrameInfo? frame;
-    try {
-      codec = await ui.instantiateImageCodec(bytes);
-      frame = await codec.getNextFrame();
-      final width = frame.image.width;
-      final height = frame.image.height;
-      return width > 0 && height > 0 ? width / height : 1;
-    } catch (_) {
-      return 1;
-    } finally {
-      frame?.image.dispose();
-      codec?.dispose();
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<double>(
-      future: _aspectRatioFuture,
-      initialData: 1,
-      builder: (context, snapshot) =>
-          _buildCard(context, (snapshot.data ?? 1).clamp(0.1, 10).toDouble()),
-    );
-  }
-
-  Widget _buildCard(BuildContext context, double aspectRatio) {
-    final theme = Theme.of(context);
-    final entry = widget.entry;
-    final hasTags = entry.tags.isNotEmpty;
-    final metadataHeight = hasTags ? 160.0 : 92.0;
-    final imageSize = computeVibeHoverImageSize(
-      aspectRatio: aspectRatio,
-      maxWidth: widget.maxWidth,
-      maxHeight: math.max(80, widget.maxHeight - metadataHeight - 4),
-    );
-    final cardWidth = imageSize.width;
-    final pixelRatio = MediaQuery.devicePixelRatioOf(context);
-
-    return Material(
-      color: Colors.transparent,
-      child: Container(
-        key: const ValueKey('vibe-hover-preview'),
-        width: cardWidth,
-        constraints: BoxConstraints(maxHeight: widget.maxHeight),
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surface,
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.32),
-              blurRadius: 28,
-              offset: const Offset(0, 14),
-            ),
-          ],
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(10),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(
-                key: const ValueKey('vibe-hover-media'),
-                width: cardWidth,
-                height: imageSize.height,
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    ColoredBox(color: theme.colorScheme.surfaceContainerLowest),
-                    if (widget.image != null)
-                      Image.memory(
-                        widget.image!,
-                        fit: BoxFit.contain,
-                        cacheWidth: (cardWidth * pixelRatio).round(),
-                        gaplessPlayback: true,
-                        errorBuilder: (_, __, ___) => _imageFallback(theme),
-                      )
-                    else
-                      _imageFallback(theme),
-                    if (widget.isLoading)
-                      Positioned(
-                        top: 10,
-                        right: 10,
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: Colors.white.withValues(alpha: 0.9),
-                            value: MediaQuery.disableAnimationsOf(context)
-                                ? 0.5
-                                : null,
-                          ),
-                        ),
-                      ),
-                    if (entry.isBundle)
-                      Positioned(
-                        left: 10,
-                        top: 10,
-                        child: _HoverBadge(
-                          icon: Icons.layers_outlined,
-                          label: '${entry.bundledVibeCount}',
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            entry.displayName,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.titleSmall?.copyWith(
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                        ),
-                        if (entry.encodingModel case final model?) ...[
-                          const SizedBox(width: 8),
-                          _HoverBadge(
-                            icon: Icons.memory_outlined,
-                            label: model,
-                            subtle: true,
-                          ),
-                        ],
-                      ],
-                    ),
-                    const SizedBox(height: 10),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: _VibeHoverStat(
-                            icon: Icons.tune,
-                            label: context.l10n.vibe_strength,
-                            value: '${(entry.strength * 100).round()}%',
-                          ),
-                        ),
-                        Expanded(
-                          child: _VibeHoverStat(
-                            icon: Icons.auto_awesome_outlined,
-                            label: context.l10n.vibe_infoExtracted,
-                            value: '${(entry.infoExtracted * 100).round()}%',
-                          ),
-                        ),
-                        Expanded(
-                          child: _VibeHoverStat(
-                            icon: Icons.history,
-                            label: context.l10n.vibeDetail_usageCount,
-                            value: '${entry.usedCount}',
-                          ),
-                        ),
-                      ],
-                    ),
-                    if (hasTags) ...[
-                      const SizedBox(height: 10),
-                      TranslatedPromptText(
-                        entry.tags.take(6).join(', '),
-                        originalText: entry.tags
-                            .take(6)
-                            .map((tag) => '#$tag')
-                            .join('  '),
-                        selectable: false,
-                        maxLines: 2,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                          height: 1.35,
-                        ),
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _imageFallback(ThemeData theme) {
-    return ColoredBox(
-      color: theme.colorScheme.surfaceContainerHighest,
-      child: Center(
-        child: Icon(
-          widget.entry.isBundle ? Icons.style : Icons.auto_fix_high,
-          size: 46,
-          color: theme.colorScheme.outline,
-        ),
-      ),
-    );
-  }
-}
-
-@visibleForTesting
-Size computeVibeHoverPreviewBounds(Size viewport) {
-  return Size(
-    math.min(380.0, math.max(0.0, viewport.width - 20)),
-    math.min(680.0, math.max(0.0, viewport.height - 20)),
-  );
-}
-
-@visibleForTesting
-Size computeVibeHoverImageSize({
-  required double aspectRatio,
-  required double maxWidth,
-  required double maxHeight,
-}) {
-  final safeRatio = aspectRatio > 0 ? aspectRatio : 1.0;
-  final width = safeRatio >= 1
-      ? maxWidth
-      : math.min(maxWidth, math.max(240.0, maxHeight * safeRatio));
-  final naturalHeight = width / safeRatio;
-  final height = math.min(maxHeight, math.max(120.0, naturalHeight));
-  return Size(width, height);
-}
-
-class _VibeHoverStat extends StatelessWidget {
-  const _VibeHoverStat({
-    required this.icon,
-    required this.label,
-    required this.value,
-  });
-
-  final IconData icon;
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(icon, size: 14, color: theme.colorScheme.onSurfaceVariant),
-        const SizedBox(width: 5),
-        Flexible(
-          child: Text(
-            '$label $value',
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-              fontFeatures: const [ui.FontFeature.tabularFigures()],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _HoverBadge extends StatelessWidget {
-  const _HoverBadge({
-    required this.icon,
-    required this.label,
-    this.subtle = false,
-  });
-
-  final IconData icon;
-  final String label;
-  final bool subtle;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final foreground = subtle
-        ? theme.colorScheme.onSurfaceVariant
-        : Colors.white;
-    return Container(
-      constraints: const BoxConstraints(maxWidth: 150),
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
-      decoration: BoxDecoration(
-        color: subtle
-            ? theme.colorScheme.surfaceContainerHighest
-            : Colors.black.withValues(alpha: 0.62),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 13, color: foreground),
-          const SizedBox(width: 4),
-          Flexible(
-            child: Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: theme.textTheme.labelSmall?.copyWith(
-                color: foreground,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/presentation/screens/vibe_library/widgets/vibe_hover_preview.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_hover_preview.dart
@@ -1,0 +1,432 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+import '../../../../core/utils/localization_extension.dart';
+import '../../../../data/models/vibe/vibe_library_entry.dart';
+import '../../../../data/services/vibe_library_storage_service.dart';
+
+/// Desktop quick-look for a Vibe library entry.
+///
+/// The frame deliberately keeps a stable width and height while the full image
+/// loads. This prevents the overlay from jumping when the thumbnail and source
+/// image have different encoded dimensions.
+class VibeHoverPreview extends StatelessWidget {
+  const VibeHoverPreview({
+    super.key,
+    required this.displayEntry,
+    required this.detailFuture,
+    required this.fallbackImage,
+    required this.maxWidth,
+    required this.maxHeight,
+  });
+
+  final VibeLibraryEntry displayEntry;
+  final Future<VibeLibraryDetailData?> detailFuture;
+  final Uint8List? fallbackImage;
+  final double maxWidth;
+  final double maxHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<VibeLibraryDetailData?>(
+      future: detailFuture,
+      builder: (context, snapshot) {
+        final detail = snapshot.data;
+        final entry = detail?.entry ?? displayEntry;
+        return _VibeHoverPreviewFrame(
+          entry: entry,
+          image: _bestPreviewImage(detail, fallbackImage),
+          maxWidth: maxWidth,
+          maxHeight: maxHeight,
+          isLoading: snapshot.connectionState != ConnectionState.done,
+          loadFailed: snapshot.hasError,
+        );
+      },
+    );
+  }
+
+  Uint8List? _bestPreviewImage(
+    VibeLibraryDetailData? detail,
+    Uint8List? fallback,
+  ) {
+    final entry = detail?.entry;
+    final candidates = <Uint8List?>[
+      entry?.rawImageData,
+      if (detail != null && detail.bundleVibes.isNotEmpty)
+        detail.bundleVibes.first.rawImageData,
+      entry?.thumbnail,
+      entry?.vibeThumbnail,
+      if (detail != null && detail.bundleVibes.isNotEmpty)
+        detail.bundleVibes.first.thumbnail,
+      fallback,
+    ];
+    for (final candidate in candidates) {
+      if (candidate != null && candidate.isNotEmpty) return candidate;
+    }
+    return null;
+  }
+}
+
+class _VibeHoverPreviewFrame extends StatelessWidget {
+  const _VibeHoverPreviewFrame({
+    required this.entry,
+    required this.image,
+    required this.maxWidth,
+    required this.maxHeight,
+    required this.isLoading,
+    required this.loadFailed,
+  });
+
+  final VibeLibraryEntry entry;
+  final Uint8List? image;
+  final double maxWidth;
+  final double maxHeight;
+  final bool isLoading;
+  final bool loadFailed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final pixelRatio = MediaQuery.devicePixelRatioOf(context);
+
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        key: const ValueKey('vibe-hover-preview'),
+        width: maxWidth,
+        height: maxHeight,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHigh,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: theme.colorScheme.shadow.withValues(alpha: 0.16),
+              blurRadius: 14,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: Column(
+            children: [
+              Expanded(
+                child: Stack(
+                  key: const ValueKey('vibe-hover-media'),
+                  fit: StackFit.expand,
+                  children: [
+                    ColoredBox(color: theme.colorScheme.surfaceContainerLowest),
+                    if (image != null)
+                      Image.memory(
+                        image!,
+                        fit: BoxFit.contain,
+                        cacheWidth: (maxWidth * pixelRatio).round(),
+                        gaplessPlayback: true,
+                        errorBuilder: (_, __, ___) =>
+                            _imageFallback(context, loadFailed: true),
+                      )
+                    else
+                      _imageFallback(context, loadFailed: loadFailed),
+                    if (isLoading)
+                      Positioned(
+                        top: 10,
+                        right: 10,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: Colors.black.withValues(alpha: 0.58),
+                            shape: BoxShape.circle,
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(7),
+                            child: SizedBox.square(
+                              dimension: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: Colors.white.withValues(alpha: 0.9),
+                                value: MediaQuery.disableAnimationsOf(context)
+                                    ? 0.5
+                                    : null,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    if (entry.isBundle)
+                      Positioned(
+                        left: 10,
+                        top: 10,
+                        child: _BundleCountBadge(count: entry.bundledVibeCount),
+                      ),
+                  ],
+                ),
+              ),
+              _VibeHoverMetadata(entry: entry),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _imageFallback(BuildContext context, {required bool loadFailed}) {
+    final theme = Theme.of(context);
+    return ColoredBox(
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              loadFailed
+                  ? Icons.broken_image_outlined
+                  : entry.isBundle
+                  ? Icons.style
+                  : Icons.auto_fix_high,
+              size: 46,
+              color: theme.colorScheme.outline,
+            ),
+            if (loadFailed) ...[
+              const SizedBox(height: 8),
+              Text(
+                context.l10n.common_previewLoadFailed,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _VibeHoverMetadata extends StatelessWidget {
+  const _VibeHoverMetadata({required this.entry});
+
+  final VibeLibraryEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textScaler = MediaQuery.textScalerOf(context);
+    final usesLargeText = textScaler.scale(12) / 12 > 1.45;
+    final visibleTags = entry.tags.take(4).toList(growable: false);
+    final remainingTags = entry.tags.length - visibleTags.length;
+    final tagText = [
+      ...visibleTags.map((tag) => '#$tag'),
+      if (remainingTags > 0) '+$remainingTags',
+    ].join('  ');
+
+    return ColoredBox(
+      color: colorScheme.surfaceContainerHigh,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              entry.displayName,
+              key: const ValueKey('vibe-hover-title'),
+              maxLines: usesLargeText ? 1 : 2,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            if (entry.encodingModel case final model?) ...[
+              const SizedBox(height: 4),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 1),
+                    child: Icon(
+                      Icons.memory_outlined,
+                      size: 13,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(width: 5),
+                  Expanded(
+                    child: Text(
+                      model,
+                      key: const ValueKey('vibe-hover-model'),
+                      maxLines: usesLargeText ? 1 : 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+            const SizedBox(height: 10),
+            Divider(height: 1, color: colorScheme.outlineVariant),
+            const SizedBox(height: 9),
+            _VibeHoverStats(entry: entry),
+            if (tagText.isNotEmpty) ...[
+              const SizedBox(height: 9),
+              Divider(height: 1, color: colorScheme.outlineVariant),
+              const SizedBox(height: 8),
+              Text(
+                tagText,
+                key: const ValueKey('vibe-hover-tags'),
+                maxLines: usesLargeText ? 1 : 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                  height: 1.35,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _VibeHoverStats extends StatelessWidget {
+  const _VibeHoverStats({required this.entry});
+
+  final VibeLibraryEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = [
+      (
+        key: const ValueKey('vibe-hover-strength'),
+        label: context.l10n.vibe_strength,
+        value: '${(entry.strength * 100).round()}%',
+      ),
+      (
+        key: const ValueKey('vibe-hover-info-extracted'),
+        label: context.l10n.vibe_infoExtracted,
+        value: '${(entry.infoExtracted * 100).round()}%',
+      ),
+      (
+        key: const ValueKey('vibe-hover-usage-count'),
+        label: context.l10n.vibeDetail_usageCount,
+        value: '${entry.usedCount}',
+      ),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final columns = constraints.maxWidth < 320 ? 1 : 3;
+        const spacing = 12.0;
+        final itemWidth =
+            (constraints.maxWidth - spacing * (columns - 1)) / columns;
+        return Wrap(
+          spacing: spacing,
+          runSpacing: 6,
+          children: [
+            for (final stat in stats)
+              SizedBox(
+                key: stat.key,
+                width: itemWidth,
+                child: _VibeHoverStat(label: stat.label, value: stat.value),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _VibeHoverStat extends StatelessWidget {
+  const _VibeHoverStat({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textScaler = MediaQuery.textScalerOf(context);
+    final usesLargeText = textScaler.scale(12) / 12 > 1.45;
+    final style = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+      fontFeatures: const [ui.FontFeature.tabularFigures()],
+    );
+    if (usesLargeText) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: style,
+          ),
+          Text(
+            value,
+            maxLines: 1,
+            style: style?.copyWith(fontWeight: FontWeight.w700),
+          ),
+        ],
+      );
+    }
+    return Text.rich(
+      TextSpan(
+        text: '$label ',
+        children: [
+          TextSpan(
+            text: value,
+            style: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+        ],
+      ),
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+      style: style,
+    );
+  }
+}
+
+class _BundleCountBadge extends StatelessWidget {
+  const _BundleCountBadge({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.62),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.layers_outlined, size: 13, color: Colors.white),
+            const SizedBox(width: 4),
+            Text(
+              '$count',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Size computeVibeHoverPreviewBounds(Size viewport) {
+  return Size(
+    math.min(420.0, math.max(0.0, viewport.width - 20)),
+    math.min(620.0, math.max(0.0, viewport.height - 20)),
+  );
+}

--- a/lib/presentation/widgets/common/card_hover_preview_controller.dart
+++ b/lib/presentation/widgets/common/card_hover_preview_controller.dart
@@ -3,6 +3,8 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 
+enum CardHoverPreviewVerticalAlignment { center, targetTop }
+
 /// 在根 Overlay 中显示卡片悬浮预览，并自动避让窗口边缘。
 class CardHoverPreviewController {
   OverlayEntry? _entry;
@@ -21,6 +23,8 @@ class CardHoverPreviewController {
     required Size previewSize,
     required WidgetBuilder builder,
     VoidCallback? onIntent,
+    CardHoverPreviewVerticalAlignment verticalAlignment =
+        CardHoverPreviewVerticalAlignment.center,
     Duration delay = const Duration(milliseconds: 280),
   }) {
     onIntent?.call();
@@ -60,6 +64,7 @@ class CardHoverPreviewController {
                     targetRect: liveTargetRect,
                     viewportSize: mediaSize,
                     maxPreviewSize: Size(safeWidth, safeHeight),
+                    verticalAlignment: verticalAlignment,
                   ),
                   child: Builder(builder: builder),
                 ),
@@ -93,11 +98,13 @@ class _HoverFollowerLayoutDelegate extends SingleChildLayoutDelegate {
     required this.targetRect,
     required this.viewportSize,
     required this.maxPreviewSize,
+    required this.verticalAlignment,
   });
 
   final Rect targetRect;
   final Size viewportSize;
   final Size maxPreviewSize;
+  final CardHoverPreviewVerticalAlignment verticalAlignment;
 
   @override
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) =>
@@ -130,10 +137,12 @@ class _HoverFollowerLayoutDelegate extends SingleChildLayoutDelegate {
       viewportMargin,
       viewportSize.height - childSize.height - viewportMargin,
     );
-    final globalTop = (targetRect.center.dy - childSize.height / 2).clamp(
-      viewportMargin,
-      maxTop,
-    );
+    final preferredTop = switch (verticalAlignment) {
+      CardHoverPreviewVerticalAlignment.center =>
+        targetRect.center.dy - childSize.height / 2,
+      CardHoverPreviewVerticalAlignment.targetTop => targetRect.top,
+    };
+    final globalTop = preferredTop.clamp(viewportMargin, maxTop);
     return Offset(globalLeft - targetRect.left, globalTop - targetRect.top);
   }
 
@@ -141,5 +150,6 @@ class _HoverFollowerLayoutDelegate extends SingleChildLayoutDelegate {
   bool shouldRelayout(covariant _HoverFollowerLayoutDelegate oldDelegate) =>
       targetRect != oldDelegate.targetRect ||
       viewportSize != oldDelegate.viewportSize ||
-      maxPreviewSize != oldDelegate.maxPreviewSize;
+      maxPreviewSize != oldDelegate.maxPreviewSize ||
+      verticalAlignment != oldDelegate.verticalAlignment;
 }

--- a/test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart
+++ b/test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nai_launcher/data/models/vibe/vibe_library_entry.dart';
@@ -11,31 +11,20 @@ import 'package:nai_launcher/data/services/vibe_library_storage_service.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
 import 'package:nai_launcher/presentation/screens/vibe_library/widgets/vibe_card.dart';
+import 'package:nai_launcher/presentation/screens/vibe_library/widgets/vibe_hover_preview.dart';
 import 'package:nai_launcher/presentation/widgets/common/card_action_buttons.dart';
 import 'package:nai_launcher/presentation/widgets/common/image_card_actions.dart';
 import 'package:nai_launcher/presentation/widgets/common/library_card_badges.dart';
 
 void main() {
-  test('悬浮大图按比例适配且不会随高窗口无限增高', () {
+  test('悬浮预览使用稳定的可读宽度且不会随窗口无限增长', () {
     expect(
       computeVibeHoverPreviewBounds(const Size(700, 520)),
-      const Size(380, 500),
+      const Size(420, 500),
     );
     expect(
       computeVibeHoverPreviewBounds(const Size(1200, 1000)),
-      const Size(380, 680),
-    );
-    expect(
-      computeVibeHoverImageSize(aspectRatio: 2, maxWidth: 380, maxHeight: 500),
-      const Size(380, 190),
-    );
-    expect(
-      computeVibeHoverImageSize(
-        aspectRatio: 0.5,
-        maxWidth: 380,
-        maxHeight: 500,
-      ),
-      const Size(250, 500),
+      const Size(420, 620),
     );
   });
 
@@ -112,6 +101,153 @@ void main() {
       (resized.imageProvider as MemoryImage).bytes,
       same(highResolutionImage),
     );
+  });
+
+  testWidgets('悬浮预览优先与源卡片顶对齐', (tester) async {
+    tester.view.physicalSize = const Size(900, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final entry = _entry(rawImageData: _onePixelPng);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          vibeLibraryStorageServiceProvider.overrideWithValue(
+            _HoverStorage(entry, _onePixelPng),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Stack(
+              children: [
+                Positioned(
+                  left: 80,
+                  top: 100,
+                  child: VibeCard(entry: entry.toDisplayEntry(), width: 150),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final card = find.byType(VibeCard);
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(card));
+    await tester.pump(const Duration(milliseconds: 281));
+    await tester.pump();
+
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('vibe-hover-preview'))).dy,
+      closeTo(tester.getTopLeft(card).dy, 0.01),
+    );
+  });
+
+  testWidgets('键盘聚焦可显示预览并用 Enter 触发卡片', (tester) async {
+    tester.view.physicalSize = const Size(900, 700);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    var activationCount = 0;
+    final entry = _entry(rawImageData: _onePixelPng);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          vibeLibraryStorageServiceProvider.overrideWithValue(
+            _HoverStorage(entry, _onePixelPng),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: VibeCard(
+                entry: entry.toDisplayEntry(),
+                width: 180,
+                onTap: () => activationCount++,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump(const Duration(milliseconds: 281));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('vibe-hover-preview')), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+    expect(activationCount, 1);
+  });
+
+  testWidgets('放大文本下关键数值仍完整且无 overflow', (tester) async {
+    tester.view.physicalSize = const Size(700, 520);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final entry = _entry(rawImageData: _onePixelPng).copyWith(
+      name: '用于验证长标题不会挤掉关键统计数值的人像 Vibe',
+      encodingModel: 'nai-diffusion-4-5-full-long-model-name',
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          vibeLibraryStorageServiceProvider.overrideWithValue(
+            _HoverStorage(entry, _onePixelPng),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(textScaler: const TextScaler.linear(3)),
+            child: child!,
+          ),
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.bottomRight,
+              child: VibeCard(entry: entry.toDisplayEntry(), width: 150),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final card = find.byType(VibeCard);
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(card));
+    await tester.pump(const Duration(milliseconds: 281));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('vibe-hover-strength')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('vibe-hover-info-extracted')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('vibe-hover-usage-count')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('Vibe 卡片仅在有分类时显示类别，并为收藏条目显示常驻徽章', (tester) async {


### PR DESCRIPTION
## 改动内容

- 将 Vibe 卡片悬浮预览拆分为独立组件，固定可读尺寸并提升图片区域利用率
- 紧凑呈现标题、模型、强度、信息提取、使用次数与标签
- 增加顶部优先对齐、窗口边缘避让、键盘焦点和 Enter/Space 操作
- 保留桌面 hover 与触屏操作入口的能力一致性，并适配 3x 文本缩放

## 验证结果

- `flutter analyze --no-pub lib/presentation/screens/vibe_library/widgets/vibe_card.dart lib/presentation/screens/vibe_library/widgets/vibe_hover_preview.dart lib/presentation/widgets/common/card_hover_preview_controller.dart test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart`
- `flutter test --no-pub test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart`（8 项通过）
- `flutter test --no-pub test/presentation/screens/vibe_library/widgets/vibe_library_content_view_test.dart`（10 项通过）

## 注意事项

- 未执行 Windows/Android Runner 自动化截图验收。
- 扩展 affected-tests 中现有的 Hive 初始化场景仍会因未提供存储路径而失败，本次未修改该无关测试环境问题。