### PR TITLE
fix(cloud-sync): 修正备份选择操作按钮对齐

### DIFF
--- a/lib/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog.dart
+++ b/lib/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog.dart
@@ -241,6 +241,7 @@ class _CloudSyncContentSelectionBodyState
       child: Text(context.l10n.cloudSync_restoreDefaults),
     );
     final actions = Wrap(
+      key: const ValueKey('cloud-sync-content-actions'),
       alignment: WrapAlignment.end,
       spacing: 8,
       runSpacing: 4,
@@ -273,8 +274,10 @@ class _CloudSyncContentSelectionBodyState
           return Row(
             children: [
               defaults,
-              const Spacer(),
-              Flexible(child: actions),
+              const SizedBox(width: 24),
+              Expanded(
+                child: Align(alignment: Alignment.centerRight, child: actions),
+              ),
             ],
           );
         },

--- a/test/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog_test.dart
+++ b/test/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog_test.dart
@@ -110,6 +110,43 @@ void main() {
     });
   }
 
+  testWidgets('桌面弹窗操作按钮贴紧内容区右侧', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1180, 760);
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => FilledButton(
+              onPressed: () => showCloudSyncContentSelectionDialog(
+                context: context,
+                initialSelection: const CloudSyncContentSelection(),
+                skills: const SkillCatalogSnapshot(),
+              ),
+              child: const Text('打开'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+
+    final panel = find.byKey(const ValueKey('adaptive-centered-form'));
+    final actions = find.byKey(const ValueKey('cloud-sync-content-actions'));
+    expect(tester.getTopRight(actions).dx, tester.getTopRight(panel).dx - 20);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('Skill 清单使用独立弹窗，不嵌套在内容清单滚动区', (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(1180, 760);


### PR DESCRIPTION
## 改动内容

- 修正备份内容选择弹窗底部操作区的弹性布局
- 让“取消”和“保存选择”在桌面弹窗中贴紧内容区右侧
- 增加按钮右边缘对齐的 Widget 回归测试

## 验证结果

- `flutter test test/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog_test.dart`：7 项通过
- `flutter analyze lib/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog.dart test/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog_test.dart`：无问题
- `git diff --check`：通过

## 注意事项

- 未执行 Windows 或 Android 运行时验收
- 按要求不等待 CI