### PR TITLE
fix(tag-library): 消除列表条目悬浮闪烁

### DIFF
--- a/lib/presentation/screens/tag_library_page/widgets/entry_list_item.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_list_item.dart
@@ -67,12 +67,16 @@ class _EntryListItemState extends State<EntryListItem> {
     final theme = Theme.of(context);
     final entry = widget.entry;
     final isTouch = context.interactionPolicy.shouldExposeTouchAlternatives;
+    final restingBackground = theme.colorScheme.surfaceContainerLow;
 
     final backgroundColor = widget.isSelected
         ? theme.colorScheme.primary.withValues(alpha: 0.12)
         : (_isHovering && !widget.isSelectionMode
-              ? theme.colorScheme.primary.withValues(alpha: 0.08)
-              : theme.colorScheme.surfaceContainerLow);
+              ? Color.alphaBlend(
+                  theme.colorScheme.primary.withValues(alpha: 0.08),
+                  restingBackground,
+                )
+              : restingBackground);
 
     final itemContent = MouseRegion(
       onEnter: (_) {

--- a/test/presentation/screens/tag_library_page/widgets/entry_list_item_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/entry_list_item_test.dart
@@ -46,7 +46,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('桌面悬浮使用选中态高亮且不会抬升或改变布局几何', (tester) async {
+  testWidgets('桌面悬浮使用不闪烁的高亮且不会抬升或改变布局几何', (tester) async {
     await tester.binding.setSurfaceSize(const Size(900, 320));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     final timestamp = DateTime(2026);
@@ -117,8 +117,12 @@ void main() {
     expect(hoveredContainer.transform, isNull);
     expect(
       hoveredDecoration.color,
-      theme.colorScheme.primary.withValues(alpha: 0.08),
+      Color.alphaBlend(
+        theme.colorScheme.primary.withValues(alpha: 0.08),
+        theme.colorScheme.surfaceContainerLow,
+      ),
     );
+    expect(hoveredDecoration.color!.a, 1);
     expect(tester.getRect(item).size, restingItemRect.size);
     expect(tester.getSize(prompt), restingPromptSize);
     expect(tester.takeException(), isNull);


### PR DESCRIPTION
## 改动内容

- 将词库列表条目的悬浮强调色与静态背景预先合成，避免透明色动画产生短暂亮度过冲
- 保留平滑悬浮高亮、固定布局和桌面操作按钮
- 更新 Widget 回归测试，断言悬浮目标色为不透明合成色且布局几何保持稳定

## 验证结果

- `scripts/test_affected.ps1 -Path "lib/presentation/screens/tag_library_page/widgets/entry_list_item.dart" -Include "test/presentation/screens/tag_library_page/widgets/entry_list_item_test.dart"`：2 项测试通过
- `flutter analyze lib/presentation/screens/tag_library_page/widgets/entry_list_item.dart`：通过
- `flutter analyze test/presentation/screens/tag_library_page/widgets/entry_list_item_test.dart`：通过
- `scripts/verify_flutter_sources.ps1`：通过
- `git diff --check`：通过

## 注意事项

- 未启动或热重载运行中的应用
- 按要求创建后直接执行 Squash Merge，不等待 CI