### PR TITLE
fix(ui): 统一卡片分组与悬浮预览层级

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,6 +163,8 @@ Aaalice NAI Launcher 是高频创作工具，而不是视觉陈列品。Prompt�
 
 Material 表面按职责使用：Canvas=`surface`，Section=`surfaceContainerLow`，Control=`surfaceContainer` / `surfaceContainerHighest`，Overlay=`surfaceContainerHigh`。同一页面最多出现三个明显表面层级。
 
+Section、Control 与 Overlay 的语义色必须在实际主题中与 Canvas 保持可辨色差；旧主题若把对应 Material token 映射为相同颜色，统一通过 `sectionSurfaceColor`、`controlSurfaceColor`、`overlaySurfaceColor` 回退解析，禁止组件直接接受与背景融为一体的色面。
+
 **The Semantic Color Rule.** 页面只使用 `ColorScheme` 与具名业务语义；禁止散落固定颜色或把 `secondary` 当作错误色。
 
 **The Quiet Accent Rule.** `primary` 只标记主操作、选择、焦点与关键进度，不能让所有按钮和标签同时高亮。
@@ -273,7 +275,12 @@ Compact/Medium 下没有持久侧栏时，页面名称保留在主工具栏，�
 
 - **Static Card**：`surfaceContainerLow`、无边框、无阴影；内部 padding 使用 16px 或 24px。
 - **Interactive Card**：hover 可提高色面对比或轻移 2px；focus 使用不改变布局的 1px primary 状态线。
-- **Grouping**：优先标题与留白，其次低对比色面，最后才是边界；不使用三层嵌套卡片。
+- **Grouping**：相关内容使用有明确色差的无边框 Card / Section 色面分组，组间依靠标题与留白分层；禁止用横向分隔线承担界面层级，不使用三层嵌套卡片。分隔线只用于无法通过分组与间距表达的同级连续记录，不能与分组卡片重复表达边界。
+
+### Hover previews
+
+- 悬浮预览属于 Overlay 层，统一使用 `overlaySurfaceColor`，必须与所在页面 Canvas 和源卡片保持可辨色差；不得直接使用可能与背景相同的 `surface` 或未校验的容器 token。
+- 预览依靠色面、圆角与环境阴影从工作区浮起，默认不加完整描边；图片留白和元数据区域必须继承同一 Overlay 色面，不能出现与页面背景连成一片的大块空区。
 
 ### Navigation
 
@@ -283,6 +290,7 @@ Compact/Medium 下没有持久侧栏时，页面名称保留在主工具栏，�
 ### Dialogs and adaptive panels
 
 - Dialog 用于需要完成、取消或确认后才能返回的短时模态流程，例如设置表单、内容选择与风险决策；标题直接说明任务，风险流程的正文先说结果，再说原因。
+- Dialog / adaptive panel 标题区使用无边框 Section 色面与正文建立层级，禁止用横向分隔线切开标题和内容。
 - 操作顺序保持低强调取消在前、主操作在后；Esc 与系统返回可关闭并恢复合理焦点。
 - Expanded / Wide 使用位于视口中央、宽高受限的独立模态 Dialog；标题与底部操作区固定，正文独立滚动，弹窗四周必须保留可见遮罩空间，不得贴靠窗口侧边呈现。
 - Compact / Medium 使用避开 SafeArea 与软键盘的 bottom sheet，并保持与桌面 Dialog 相同的字段语义、状态和操作结果。

--- a/lib/presentation/adaptive/adaptive_presenter.dart
+++ b/lib/presentation/adaptive/adaptive_presenter.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+import '../themes/core/layered_surface_style.dart';
 import '../themes/theme_extension.dart';
 import 'window_size_class.dart';
 
@@ -403,40 +404,37 @@ class _PanelSurface extends StatelessWidget {
                   ),
                 ),
               if (showHeader) ...[
-                ConstrainedBox(
-                  constraints: const BoxConstraints(minHeight: 56),
-                  child: Padding(
-                    padding: const EdgeInsetsDirectional.only(
-                      start: 20,
-                      end: 8,
-                    ),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: DefaultTextStyle.merge(
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            child: titleBuilder(context),
+                ColoredBox(
+                  key: const ValueKey('adaptive-panel-header-surface'),
+                  color: sectionSurfaceColor(theme.colorScheme),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 56),
+                    child: Padding(
+                      padding: const EdgeInsetsDirectional.only(
+                        start: 20,
+                        end: 8,
+                      ),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: DefaultTextStyle.merge(
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              child: titleBuilder(context),
+                            ),
                           ),
-                        ),
-                        IconButton(
-                          onPressed: () => Navigator.of(context).maybePop(),
-                          tooltip: MaterialLocalizations.of(
-                            context,
-                          ).closeButtonTooltip,
-                          icon: const Icon(Icons.close),
-                        ),
-                      ],
+                          IconButton(
+                            onPressed: () => Navigator.of(context).maybePop(),
+                            tooltip: MaterialLocalizations.of(
+                              context,
+                            ).closeButtonTooltip,
+                            icon: const Icon(Icons.close),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),
-                if (theme.appTheme.useDivider)
-                  Divider(
-                    key: const ValueKey('adaptive-panel-header-divider'),
-                    height: 1,
-                    thickness: theme.appTheme.dividerThickness,
-                    color: theme.appTheme.dividerColor,
-                  ),
               ],
               Flexible(
                 fit: centered ? FlexFit.loose : FlexFit.tight,

--- a/lib/presentation/screens/cloud_sync/cloud_sync_agent_content_section.dart
+++ b/lib/presentation/screens/cloud_sync/cloud_sync_agent_content_section.dart
@@ -46,12 +46,7 @@ class _CloudSyncAgentContentSectionState
             widget.selection.copyWith(includeAgentSystemPrompt: value == true),
           ),
         ),
-        Divider(
-          height: 1,
-          color: Theme.of(
-            context,
-          ).colorScheme.outlineVariant.withValues(alpha: 0.45),
-        ),
+        const SizedBox(height: 4),
         SwitchListTile(
           key: const ValueKey('cloud-sync-agent-skills'),
           contentPadding: EdgeInsets.zero,
@@ -63,12 +58,7 @@ class _CloudSyncAgentContentSectionState
               widget.onChanged(widget.selection.copyWith(includeSkills: value)),
         ),
         if (widget.selection.includeSkills) ...[
-          Divider(
-            height: 1,
-            color: Theme.of(
-              context,
-            ).colorScheme.outlineVariant.withValues(alpha: 0.45),
-          ),
+          const SizedBox(height: 4),
           ListTile(
             key: const ValueKey('cloud-sync-skill-selection-entry'),
             contentPadding: EdgeInsets.zero,

--- a/lib/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog.dart
+++ b/lib/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog.dart
@@ -6,6 +6,7 @@ import '../../../core/agent/skill_catalog.dart';
 import '../../../core/cloud_sync/content_selection.dart';
 import '../../../core/utils/localization_extension.dart';
 import '../../adaptive/adaptive_presenter.dart';
+import '../../themes/core/layered_surface_style.dart';
 import 'cloud_sync_agent_content_section.dart';
 
 Future<CloudSyncContentSelection?> showCloudSyncContentSelectionDialog({
@@ -209,7 +210,8 @@ class _CloudSyncContentSelectionBodyState
           ),
         ),
         Material(
-          color: theme.colorScheme.surfaceContainerLow,
+          key: ValueKey('cloud-sync-content-group-$key-surface'),
+          color: sectionSurfaceColor(theme.colorScheme),
           borderRadius: BorderRadius.circular(12),
           clipBehavior: Clip.antiAlias,
           child: Padding(
@@ -217,13 +219,7 @@ class _CloudSyncContentSelectionBodyState
             child: Column(
               children: [
                 for (var index = 0; index < children.length; index++) ...[
-                  if (index > 0)
-                    Divider(
-                      height: 1,
-                      color: theme.colorScheme.outlineVariant.withValues(
-                        alpha: 0.45,
-                      ),
-                    ),
+                  if (index > 0) const SizedBox(height: 4),
                   children[index],
                 ],
               ],

--- a/lib/presentation/screens/precise_ref_library/widgets/precise_ref_hover_preview.dart
+++ b/lib/presentation/screens/precise_ref_library/widgets/precise_ref_hover_preview.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import '../../../../core/extensions/precise_ref_type_extensions.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../data/models/precise_ref/precise_ref_library_entry.dart';
+import '../../../themes/core/layered_surface_style.dart';
 import '../../../widgets/common/library_card_badges.dart';
 
 /// 精准参考卡片的桌面悬浮预览。
@@ -141,7 +142,7 @@ class _PreciseRefHoverPreviewContentState
         width: imageSize.width,
         constraints: BoxConstraints(maxHeight: widget.maxHeight),
         decoration: BoxDecoration(
-          color: theme.colorScheme.surface,
+          color: overlaySurfaceColor(theme.colorScheme),
           borderRadius: BorderRadius.circular(12),
           boxShadow: [
             BoxShadow(
@@ -163,7 +164,7 @@ class _PreciseRefHoverPreviewContentState
                 child: Stack(
                   fit: StackFit.expand,
                   children: [
-                    ColoredBox(color: theme.colorScheme.surfaceContainerLowest),
+                    ColoredBox(color: overlaySurfaceColor(theme.colorScheme)),
                     if (widget.image != null)
                       Image.memory(
                         widget.image!,

--- a/lib/presentation/screens/vibe_library/widgets/vibe_hover_preview.dart
+++ b/lib/presentation/screens/vibe_library/widgets/vibe_hover_preview.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../data/models/vibe/vibe_library_entry.dart';
 import '../../../../data/services/vibe_library_storage_service.dart';
+import '../../../themes/core/layered_surface_style.dart';
 
 /// Desktop quick-look for a Vibe library entry.
 ///
@@ -99,7 +100,7 @@ class _VibeHoverPreviewFrame extends StatelessWidget {
         width: maxWidth,
         height: maxHeight,
         decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceContainerHigh,
+          color: overlaySurfaceColor(theme.colorScheme),
           borderRadius: BorderRadius.circular(12),
           boxShadow: [
             BoxShadow(
@@ -118,7 +119,7 @@ class _VibeHoverPreviewFrame extends StatelessWidget {
                   key: const ValueKey('vibe-hover-media'),
                   fit: StackFit.expand,
                   children: [
-                    ColoredBox(color: theme.colorScheme.surfaceContainerLowest),
+                    ColoredBox(color: overlaySurfaceColor(theme.colorScheme)),
                     if (image != null)
                       Image.memory(
                         image!,
@@ -223,7 +224,7 @@ class _VibeHoverMetadata extends StatelessWidget {
     ].join('  ');
 
     return ColoredBox(
-      color: colorScheme.surfaceContainerHigh,
+      color: overlaySurfaceColor(colorScheme),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
         child: Column(
@@ -267,13 +268,9 @@ class _VibeHoverMetadata extends StatelessWidget {
               ),
             ],
             const SizedBox(height: 10),
-            Divider(height: 1, color: colorScheme.outlineVariant),
-            const SizedBox(height: 9),
             _VibeHoverStats(entry: entry),
             if (tagText.isNotEmpty) ...[
-              const SizedBox(height: 9),
-              Divider(height: 1, color: colorScheme.outlineVariant),
-              const SizedBox(height: 8),
+              const SizedBox(height: 12),
               Text(
                 tagText,
                 key: const ValueKey('vibe-hover-tags'),

--- a/lib/presentation/themes/core/layered_surface_style.dart
+++ b/lib/presentation/themes/core/layered_surface_style.dart
@@ -26,3 +26,17 @@ Color controlSurfaceColor(ColorScheme colorScheme) {
     colorScheme.surface,
   );
 }
+
+/// Returns the overlay surface used by hover previews and other transient
+/// quick-look cards. It remains distinct when a theme collapses Material
+/// container roles back to the page canvas.
+Color overlaySurfaceColor(ColorScheme colorScheme) {
+  final base = colorScheme.surfaceContainerHigh;
+  if (base != colorScheme.surface) return base;
+  return Color.alphaBlend(
+    colorScheme.onSurface.withValues(
+      alpha: colorScheme.brightness == Brightness.dark ? 0.11 : 0.07,
+    ),
+    colorScheme.surface,
+  );
+}

--- a/lib/presentation/widgets/common/hover_image_preview.dart
+++ b/lib/presentation/widgets/common/hover_image_preview.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 
+import '../../themes/core/layered_surface_style.dart';
 import 'decoded_memory_image.dart';
 import 'thumbnail_display.dart';
 
@@ -180,7 +181,7 @@ class _HoverImagePreviewState extends State<HoverImagePreview> {
           borderRadius: BorderRadius.circular(12),
           clipBehavior: Clip.antiAlias,
           child: ColoredBox(
-            color: Theme.of(context).colorScheme.surface,
+            color: overlaySurfaceColor(Theme.of(context).colorScheme),
             child: _buildPreviewContent(
               context,
               previewWidth: previewWidth,

--- a/lib/presentation/widgets/common/hover_preview_card.dart
+++ b/lib/presentation/widgets/common/hover_preview_card.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import '../../../core/utils/localization_extension.dart';
+import '../../themes/core/layered_surface_style.dart';
 
 /// 悬浮预览卡片组件
 ///
@@ -87,6 +88,7 @@ class _HoverPreviewCardState extends State<HoverPreviewCard> {
         followerAnchor: Alignment.topLeft,
         offset: widget.offset,
         child: Material(
+          color: overlaySurfaceColor(Theme.of(context).colorScheme),
           elevation: 8,
           borderRadius: BorderRadius.circular(12),
           clipBehavior: Clip.antiAlias,

--- a/lib/presentation/widgets/danbooru_post_card.dart
+++ b/lib/presentation/widgets/danbooru_post_card.dart
@@ -22,6 +22,7 @@ import '../providers/character_prompt_provider.dart';
 import '../providers/replication_queue_provider.dart';
 import '../providers/reverse_prompt_provider.dart';
 import '../services/generation_prompt_transfer_service.dart';
+import '../themes/core/layered_surface_style.dart';
 import '../themes/theme_extension.dart';
 import 'common/card_action_buttons.dart';
 import 'common/image_card_actions.dart';
@@ -1061,7 +1062,7 @@ class _HoverPreviewCardInnerState
         width: maxWidth,
         constraints: BoxConstraints(maxHeight: maxHeight),
         decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceContainerHigh,
+          color: overlaySurfaceColor(theme.colorScheme),
           borderRadius: BorderRadius.circular(12),
           boxShadow: [
             BoxShadow(
@@ -1086,7 +1087,7 @@ class _HoverPreviewCardInnerState
                 child: Stack(
                   fit: StackFit.expand,
                   children: [
-                    ColoredBox(color: theme.colorScheme.surfaceContainerLowest),
+                    ColoredBox(color: overlaySurfaceColor(theme.colorScheme)),
                     if (imageUrl.isEmpty)
                       Center(
                         child: Icon(

--- a/lib/presentation/widgets/gallery/local_image_hover_preview.dart
+++ b/lib/presentation/widgets/gallery/local_image_hover_preview.dart
@@ -9,6 +9,7 @@ import '../../../core/cache/local_gallery_thumbnail_provider.dart';
 import '../../../core/utils/byte_format.dart';
 import '../../../data/models/gallery/local_image_record.dart';
 import '../../../data/models/gallery/nai_image_metadata.dart';
+import '../../themes/core/layered_surface_style.dart';
 import '../../utils/local_gallery_metadata_resolver.dart';
 import '../common/gallery_hover_controller.dart';
 
@@ -292,7 +293,7 @@ class _LocalImageHoverPreviewCardState
         width: cardWidth,
         constraints: BoxConstraints(maxHeight: widget.maxHeight),
         decoration: BoxDecoration(
-          color: theme.colorScheme.surface,
+          color: overlaySurfaceColor(theme.colorScheme),
           borderRadius: BorderRadius.circular(12),
           boxShadow: [
             BoxShadow(
@@ -328,7 +329,7 @@ class _LocalImageHoverPreviewCardState
                 width: cardWidth,
                 height: imageHeight,
                 child: ColoredBox(
-                  color: theme.colorScheme.surfaceContainerLowest,
+                  color: overlaySurfaceColor(theme.colorScheme),
                   child: imageProvider == null
                       ? Center(
                           child: CircularProgressIndicator(

--- a/lib/presentation/widgets/tag_library/tag_library_entry_hover_preview.dart
+++ b/lib/presentation/widgets/tag_library/tag_library_entry_hover_preview.dart
@@ -6,8 +6,8 @@ import 'package:intl/intl.dart';
 
 import '../../../core/utils/localization_extension.dart';
 import '../../../data/models/tag_library/tag_library_entry.dart';
+import '../../themes/core/layered_surface_style.dart';
 import '../common/gallery_hover_controller.dart';
-import '../common/themed_divider.dart';
 import '../common/thumbnail_display.dart';
 import '../common/translated_tag_text.dart';
 
@@ -180,7 +180,7 @@ class _TagLibraryEntryPreviewOverlayState
           key: const ValueKey('tag-library-entry-preview-overlay'),
           elevation: 16,
           borderRadius: BorderRadius.circular(16),
-          color: theme.colorScheme.surfaceContainerHigh,
+          color: overlaySurfaceColor(theme.colorScheme),
           child: SizedBox(
             width: previewWidth,
             child: ConstrainedBox(
@@ -222,9 +222,7 @@ class _TagLibraryEntryPreviewOverlayState
                                   fontWeight: FontWeight.w600,
                                 ),
                               ),
-                              const SizedBox(height: 8),
-                              const ThemedDivider(height: 1),
-                              const SizedBox(height: 8),
+                              const SizedBox(height: 12),
                               TranslatedPromptText(
                                 entry.content,
                                 selectable: false,

--- a/test/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog_test.dart
+++ b/test/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog_test.dart
@@ -5,6 +5,7 @@ import 'package:nai_launcher/core/agent/skill_catalog.dart';
 import 'package:nai_launcher/core/cloud_sync/content_selection.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/screens/cloud_sync/cloud_sync_content_selection_dialog.dart';
+import 'package:nai_launcher/presentation/themes/core/layered_surface_style.dart';
 
 void main() {
   for (final width in const [320.0, 600.0, 840.0, 1180.0, 1600.0]) {
@@ -144,6 +145,51 @@ void main() {
     final panel = find.byKey(const ValueKey('adaptive-centered-form'));
     final actions = find.byKey(const ValueKey('cloud-sync-content-actions'));
     expect(tester.getTopRight(actions).dx, tester.getTopRight(panel).dx - 20);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('内容分组使用有色差的无边框卡片且不绘制层级横线', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1180, 760);
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => FilledButton(
+              onPressed: () => showCloudSyncContentSelectionDialog(
+                context: context,
+                initialSelection: const CloudSyncContentSelection(),
+                skills: const SkillCatalogSnapshot(),
+              ),
+              child: const Text('打开'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+
+    const surfaceKey = ValueKey('cloud-sync-content-group-lightweight-surface');
+    final surface = tester.widget<Material>(find.byKey(surfaceKey));
+    final surfaceContext = tester.element(find.byKey(surfaceKey));
+    final colors = Theme.of(surfaceContext).colorScheme;
+    expect(surface.color, sectionSurfaceColor(colors));
+    expect(surface.color, isNot(colors.surface));
+    expect(find.byType(Divider), findsNothing);
+    expect(
+      find.byKey(const ValueKey('adaptive-panel-header-divider')),
+      findsNothing,
+    );
     expect(tester.takeException(), isNull);
   });
 

--- a/test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart
+++ b/test/presentation/screens/vibe_library/widgets/vibe_card_hover_test.dart
@@ -74,6 +74,14 @@ void main() {
 
     final preview = find.byKey(const ValueKey('vibe-hover-preview'));
     expect(preview, findsOneWidget);
+    final previewDecoration = tester.widget<Container>(preview).decoration;
+    final previewColor = (previewDecoration! as BoxDecoration).color;
+    final previewContext = tester.element(preview);
+    expect(previewColor, isNot(Theme.of(previewContext).colorScheme.surface));
+    expect(
+      find.descendant(of: preview, matching: find.byType(Divider)),
+      findsNothing,
+    );
     final rect = tester.getRect(preview);
     expect(rect.left, greaterThanOrEqualTo(10));
     expect(rect.top, greaterThanOrEqualTo(10));

--- a/test/presentation/themes/core/layered_surface_style_test.dart
+++ b/test/presentation/themes/core/layered_surface_style_test.dart
@@ -8,15 +8,18 @@ void main() {
     final colors = const GrungePalette().darkScheme;
     final section = sectionSurfaceColor(colors);
     final control = controlSurfaceColor(colors);
+    final overlay = overlaySurfaceColor(colors);
 
     expect(section, isNot(colors.surface));
     expect(control, isNot(colors.surface));
+    expect(overlay, isNot(colors.surface));
     expect(control, isNot(section));
     expect(
       section.computeLuminance(),
       greaterThan(colors.surface.computeLuminance()),
     );
     expect(control.computeLuminance(), greaterThan(section.computeLuminance()));
+    expect(overlay.computeLuminance(), greaterThan(section.computeLuminance()));
   });
 
   test('已经声明容器色的主题保持原有语义颜色', () {
@@ -27,5 +30,6 @@ void main() {
 
     expect(sectionSurfaceColor(colors), colors.surfaceContainerLow);
     expect(controlSurfaceColor(colors), colors.surfaceContainer);
+    expect(overlaySurfaceColor(colors), colors.surfaceContainerHigh);
   });
 }

--- a/test/presentation/widgets/prompt/new_preset_dialog_test.dart
+++ b/test/presentation/widgets/prompt/new_preset_dialog_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
-import 'package:nai_launcher/presentation/themes/theme_extension.dart';
+import 'package:nai_launcher/presentation/themes/core/layered_surface_style.dart';
 import 'package:nai_launcher/presentation/widgets/prompt/new_preset_dialog.dart';
 
 void main() {
@@ -33,13 +33,20 @@ void main() {
 
     expect(find.byKey(const ValueKey('adaptive-bottom-sheet')), findsOneWidget);
     _expectBoundedDialog(tester, surfaceKey: 'adaptive-bottom-sheet');
-    final headerDivider = tester.widget<Divider>(
+    expect(
       find.byKey(const ValueKey('adaptive-panel-header-divider')),
+      findsNothing,
     );
-    final dividerContext = tester.element(
-      find.byKey(const ValueKey('adaptive-panel-header-divider')),
+    final headerSurface = tester.widget<ColoredBox>(
+      find.byKey(const ValueKey('adaptive-panel-header-surface')),
     );
-    expect(headerDivider.color, Theme.of(dividerContext).appTheme.dividerColor);
+    final headerContext = tester.element(
+      find.byKey(const ValueKey('adaptive-panel-header-surface')),
+    );
+    expect(
+      headerSurface.color,
+      sectionSurfaceColor(Theme.of(headerContext).colorScheme),
+    );
 
     await tester.tap(find.byTooltip('关闭'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## 改动内容

- 将备份内容选择弹窗改为有明确色差的无边框分组卡片，移除条目与弹窗标题区的层级横线
- 新增 `overlaySurfaceColor`，统一 Vibe、精准参考、词库、本地画廊、在线画廊和通用悬浮预览的 Overlay 色面
- 更新 `DESIGN.md`，固定“卡片分组 + 色差 + 无边框”和悬浮预览不可融入背景的规范
- 补充弹窗分组、Overlay 色差与无分隔线的回归断言

## 验证结果

- `scripts/verify_flutter_sources.ps1`
- 相关 9 个 Widget / 单元测试文件，共 58 项测试通过
- 变更范围 `flutter analyze --no-pub`：No issues found
- `git diff --check`

## 注意事项

- 新工作树首次运行测试前执行了一次 `build_runner` 以补齐被忽略的生成文件；未提交生成产物
- 按要求创建后立即 Squash Merge，不等待 CI