### PR TITLE
refactor(prompt): 重构固定词侧栏布局与卡片

### DIFF
--- a/lib/presentation/screens/generation/widgets/fixed_tags_category_rail.dart
+++ b/lib/presentation/screens/generation/widgets/fixed_tags_category_rail.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+
+/// A category destination shared by the positive and negative fixed-tag panes.
+class FixedTagsRailDestination {
+  const FixedTagsRailDestination({
+    required this.id,
+    required this.label,
+    required this.count,
+    required this.icon,
+    required this.color,
+  });
+
+  final String id;
+  final String label;
+  final int count;
+  final IconData icon;
+  final Color color;
+}
+
+/// Compact, pane-local category navigation for the fixed-tags sidebar.
+///
+/// The rail owns navigation presentation only. Filtering and selection state
+/// remain with [FixedTagsSidebar], so both list and grid views share one source
+/// of truth.
+class FixedTagsCategoryRail extends StatelessWidget {
+  const FixedTagsCategoryRail({
+    super.key,
+    required this.keyPrefix,
+    required this.destinations,
+    required this.selectedId,
+    required this.onSelected,
+    required this.compact,
+  });
+
+  final String keyPrefix;
+  final List<FixedTagsRailDestination> destinations;
+  final String selectedId;
+  final ValueChanged<String> onSelected;
+  final bool compact;
+
+  double get width => compact ? 48 : 68;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      key: ValueKey('$keyPrefix-category-rail'),
+      width: width,
+      child: ListView.separated(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+        itemCount: destinations.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 4),
+        itemBuilder: (context, index) {
+          final destination = destinations[index];
+          return _RailDestinationButton(
+            key: ValueKey('$keyPrefix-category-${destination.id}'),
+            destination: destination,
+            selected: destination.id == selectedId,
+            compact: compact,
+            onTap: () => onSelected(destination.id),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RailDestinationButton extends StatelessWidget {
+  const _RailDestinationButton({
+    super.key,
+    required this.destination,
+    required this.selected,
+    required this.compact,
+    required this.onTap,
+  });
+
+  final FixedTagsRailDestination destination;
+  final bool selected;
+  final bool compact;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final foreground = selected
+        ? destination.color
+        : theme.colorScheme.onSurfaceVariant;
+    final button = Semantics(
+      button: true,
+      selected: selected,
+      label: '${destination.label} ${destination.count}',
+      child: Material(
+        color: selected
+            ? destination.color.withValues(alpha: 0.12)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(6),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(6),
+          onTap: onTap,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: compact ? 48 : 58),
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: compact ? 4 : 6,
+                vertical: 6,
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(destination.icon, size: 18, color: foreground),
+                  if (!compact) ...[
+                    const SizedBox(height: 3),
+                    Text(
+                      destination.label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: foreground,
+                        fontWeight: selected
+                            ? FontWeight.w700
+                            : FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 2),
+                  Text(
+                    destination.count.toString(),
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: foreground,
+                      fontWeight: FontWeight.w700,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    if (!compact) return button;
+    return Tooltip(message: destination.label, child: button);
+  }
+}

--- a/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
+++ b/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../data/models/fixed_tag/fixed_tag_entry.dart';
+import '../../../../data/models/fixed_tag/fixed_tag_link.dart';
 import '../../../../data/models/fixed_tag/fixed_tag_prompt_type.dart';
 import '../../../../data/models/tag_library/tag_library_category.dart';
 import '../../../../data/models/tag_library/tag_library_entry.dart';
@@ -15,24 +16,21 @@ import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/themed_confirm_dialog.dart';
 import '../../../widgets/prompt/fixed_tag_edit_dialog.dart';
 import '../../../widgets/tag_library/tag_library_picker_dialog.dart';
+import 'fixed_tags_category_rail.dart';
 import 'sidebar_entry_tile.dart';
 import 'sidebar_link_painter.dart';
 
 const _enabledSectionId = 'enabled';
+const _allNegativeSectionId = 'all-negative';
 const _uncategorizedSectionId = '__uncategorized__';
 const _linkDetachDistance = 36.0;
-const _linkEndpointHitSize = 30.0;
 
-double _gridCardHeight(
-  BuildContext context, {
-  required double cardWidth,
-  required bool hasCategory,
-}) {
+double _gridCardHeight(BuildContext context, {required double cardWidth}) {
   final scaledLabelSize = MediaQuery.textScalerOf(context).scale(14);
   final usesActionMenu =
       context.interactionPolicy.shouldExposeTouchAlternatives ||
       scaledLabelSize >= 20;
-  final needsTallBase = !hasCategory || cardWidth < 180 || usesActionMenu;
+  final needsTallBase = cardWidth < 180 || usesActionMenu;
 
   // Grid previews can contain up to five scaled text lines. Grow the fixed
   // extent with the text scaler so asynchronous translations cannot outgrow it.
@@ -62,13 +60,14 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
   final _linkLayerKey = GlobalKey();
   final _positiveAnchorKeys = <String, GlobalKey>{};
   final _negativeAnchorKeys = <String, GlobalKey>{};
-  final _sectionKeys = <String, GlobalKey>{};
 
   var _positiveAnchorCenters = <String, Offset>{};
   var _negativeAnchorCenters = <String, Offset>{};
   _LinkDragPreview? _linkDragPreview;
   String _searchQuery = '';
-  String _activeCategoryId = _enabledSectionId;
+  String _activePositiveCategoryId = _enabledSectionId;
+  String _activeNegativeCategoryId = _allNegativeSectionId;
+  String? _highlightedLinkEntryId;
   bool _linkRepaintScheduled = false;
 
   @override
@@ -101,6 +100,36 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
       tagLibraryPageNotifierProvider.select((state) => state.entries),
     );
     final isListMode = layoutState.fixedTagsSidebarViewMode == 'list';
+    final positiveSections = _tagSections(
+      fixedState.positiveEntries,
+      categories,
+    );
+    final negativeSections = _tagSections(
+      fixedState.negativeEntries,
+      categories,
+    );
+    final activePositiveCategoryId = _effectivePositiveCategoryId(
+      positiveSections,
+    );
+    final activeNegativeCategoryId = _effectiveNegativeCategoryId(
+      negativeSections,
+    );
+    final mediaQuery = MediaQuery.of(context);
+    final availableHeight =
+        mediaQuery.size.height -
+        mediaQuery.padding.vertical -
+        mediaQuery.viewInsets.vertical;
+    // With large text and an IME, preserving the stored split can leave the
+    // positive pane with less than one accessible header row. Both panes stay
+    // scrollable, so temporarily favor a usable split without mutating it.
+    final negativeHeight = mediaQuery.textScaler.scale(1) >= 2
+        ? layoutState.fixedTagsNegativeHeight
+              .clamp(
+                60.0,
+                (availableHeight * 0.16).clamp(60.0, double.infinity),
+              )
+              .toDouble()
+        : layoutState.fixedTagsNegativeHeight;
     _pruneAnchorKeys(fixedState);
     _scheduleLinkRepaint();
 
@@ -112,35 +141,36 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
           children: [
             _buildHeader(theme, fixedState, isListMode),
             _buildSearchBar(theme),
-            _buildCategoryChips(theme, fixedState, categories),
-            const Divider(height: 1),
+            _buildEnabledStrip(theme, fixedState),
             Expanded(
               child: _buildPositiveArea(
                 theme,
                 fixedState,
-                categories,
+                positiveSections,
                 libraryEntries,
                 isListMode,
+                activePositiveCategoryId,
               ),
             ),
             _buildNegativeResizeDivider(theme, layoutState),
             SizedBox(
-              height: layoutState.fixedTagsNegativeHeight,
+              height: negativeHeight,
               child: _buildNegativeArea(
                 theme,
                 fixedState,
+                negativeSections,
                 libraryEntries,
                 isListMode,
+                activeNegativeCategoryId,
               ),
             ),
           ],
         ),
-        _buildLinkEndpointOverlay(fixedState),
         Positioned.fill(
           child: IgnorePointer(
             child: CustomPaint(
               painter: SidebarLinkPainter(
-                links: fixedState.links,
+                links: _visibleLinks(fixedState),
                 isMismatched: fixedState.isMismatched,
                 color: theme.colorScheme.secondary,
                 positiveAnchors: _positiveAnchorCenters,
@@ -281,39 +311,79 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
     );
   }
 
-  Widget _buildCategoryChips(
-    ThemeData theme,
-    FixedTagsState fixedState,
-    List<TagLibraryCategory> categories,
-  ) {
-    final sections = _positiveSections(fixedState, categories);
-    final enabledCount = fixedState.enabledEntries.search(_searchQuery).length;
-
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 96),
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-        child: Wrap(
-          spacing: 6,
-          runSpacing: 6,
-          children: [
-            _CategoryChip(
-              label: context.l10n.fixedTags_enabled,
-              count: enabledCount,
-              selected: _activeCategoryId == _enabledSectionId,
-              color: theme.colorScheme.secondary,
-              onTap: () => _scrollToCategory(_enabledSectionId),
-            ),
-            for (final section in sections)
-              _CategoryChip(
-                label: section.name,
-                count: section.entries.length,
-                selected: _activeCategoryId == section.id,
-                color: section.color,
-                onTap: () => _scrollToCategory(section.id),
-              ),
-          ],
+  Widget _buildEnabledStrip(ThemeData theme, FixedTagsState fixedState) {
+    final entries = fixedState.enabledEntries;
+    final label = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.bolt_rounded, size: 15, color: theme.colorScheme.secondary),
+        const SizedBox(width: 6),
+        Text(
+          context.l10n.fixedTags_enabledPositive,
+          style: theme.textTheme.labelMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
         ),
+      ],
+    );
+    final entryContent = entries.isEmpty
+        ? Text(
+            context.l10n.fixedTags_emptyEnabledPositive,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          )
+        : Row(
+            children: [
+              for (final entry in entries) ...[
+                InputChip(
+                  label: Text(entry.displayName),
+                  visualDensity: VisualDensity.compact,
+                  onDeleted: () => ref
+                      .read(fixedTagsNotifierProvider.notifier)
+                      .toggleEnabled(entry.id),
+                ),
+                const SizedBox(width: 6),
+              ],
+            ],
+          );
+
+    return Container(
+      key: const ValueKey('fixed-tags-enabled-strip'),
+      margin: const EdgeInsets.fromLTRB(10, 0, 10, 8),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.16),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final stackContent =
+              constraints.maxWidth < 300 ||
+              MediaQuery.textScalerOf(context).scale(1) >= 1.6;
+          if (stackContent) {
+            return SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [label, const SizedBox(width: 8), entryContent],
+              ),
+            );
+          }
+          return Row(
+            children: [
+              label,
+              const SizedBox(width: 8),
+              Expanded(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: entryContent,
+                ),
+              ),
+            ],
+          );
+        },
       ),
     );
   }
@@ -321,201 +391,223 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
   Widget _buildPositiveArea(
     ThemeData theme,
     FixedTagsState fixedState,
-    List<TagLibraryCategory> categories,
+    List<_TagSection> sections,
     List<TagLibraryEntry> libraryEntries,
     bool isListMode,
+    String activeCategoryId,
   ) {
-    final sections = _positiveSections(fixedState, categories);
-    return CustomScrollView(
-      controller: _positiveScrollController,
-      slivers: [
-        SliverPadding(
-          padding: const EdgeInsets.fromLTRB(10, 8, 10, 12),
-          sliver: SliverMainAxisGroup(
-            slivers: [
-              SliverToBoxAdapter(
-                child: _buildEnabledSummary(theme, fixedState),
-              ),
-              for (final section in sections)
-                _buildPositiveSection(
-                  theme,
-                  section,
-                  libraryEntries,
-                  isListMode,
-                ),
-            ],
-          ),
+    final isSearching = _searchQuery.trim().isNotEmpty;
+    final selectedSection = sections.cast<_TagSection?>().firstWhere(
+      (section) => section?.id == activeCategoryId,
+      orElse: () => null,
+    );
+    final entries = isSearching
+        ? fixedState.positiveEntries.search(_searchQuery)
+        : activeCategoryId == _enabledSectionId
+        ? fixedState.enabledEntries
+        : selectedSection?.entries ?? const <FixedTagEntry>[];
+    final color = activeCategoryId == _enabledSectionId
+        ? theme.colorScheme.secondary
+        : selectedSection?.color ?? theme.colorScheme.outline;
+    final label = isSearching
+        ? context.l10n.fixedTags_searchNameOrContent
+        : activeCategoryId == _enabledSectionId
+        ? context.l10n.fixedTags_enabled
+        : selectedSection?.name ?? context.l10n.fixedTags_uncategorized;
+    final destinations = [
+      FixedTagsRailDestination(
+        id: _enabledSectionId,
+        label: context.l10n.fixedTags_enabled,
+        count: fixedState.enabledEntries.length,
+        icon: Icons.check_circle_outline_rounded,
+        color: theme.colorScheme.secondary,
+      ),
+      for (final section in sections)
+        FixedTagsRailDestination(
+          id: section.id,
+          label: section.name,
+          count: section.entries.length,
+          icon: Icons.folder_outlined,
+          color: section.color,
         ),
-      ],
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compactRail =
+            constraints.maxWidth < 300 ||
+            MediaQuery.textScalerOf(context).scale(1) >= 1.6;
+        return Row(
+          children: [
+            FixedTagsCategoryRail(
+              keyPrefix: 'fixed-tags-positive',
+              destinations: destinations,
+              selectedId: activeCategoryId,
+              compact: compactRail,
+              onSelected: _selectPositiveCategory,
+            ),
+            VerticalDivider(
+              width: 1,
+              thickness: 1,
+              color: theme.colorScheme.outlineVariant.withValues(alpha: 0.25),
+            ),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _buildPaneHeader(
+                    icon: isSearching
+                        ? Icons.search_rounded
+                        : activeCategoryId == _enabledSectionId
+                        ? Icons.check_circle_outline_rounded
+                        : Icons.folder_rounded,
+                    label: label,
+                    count: entries.length,
+                    color: color,
+                  ),
+                  Expanded(
+                    child: _buildEntryCollection(
+                      entries: entries,
+                      promptType: FixedTagPromptType.positive,
+                      categoryColor: color,
+                      categoryName: isSearching ? null : label,
+                      libraryEntries: libraryEntries,
+                      isListMode: isListMode,
+                      controller: _positiveScrollController,
+                      emptyText: _searchQuery.isEmpty
+                          ? context.l10n.fixedTags_emptyEnabledPositive
+                          : context.l10n.fixedTags_noMatchingEnabled,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 
-  Widget _buildEnabledSummary(ThemeData theme, FixedTagsState fixedState) {
-    final enabledEntries = fixedState.enabledEntries.search(_searchQuery);
-    return Container(
-      key: _sectionKeyFor(_enabledSectionId),
-      margin: const EdgeInsets.only(bottom: 10),
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.22),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+  Widget _buildPaneHeader({
+    required IconData icon,
+    required String label,
+    required int count,
+    required Color color,
+    Widget? trailing,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(10, 8, 6, 6),
+      child: Row(
         children: [
-          _SectionTitle(
-            icon: Icons.bolt_rounded,
-            label: context.l10n.fixedTags_enabledPositive,
-            count: enabledEntries.length,
-            color: theme.colorScheme.secondary,
-          ),
-          const SizedBox(height: 8),
-          if (enabledEntries.isEmpty)
-            Text(
-              _searchQuery.isEmpty
-                  ? context.l10n.fixedTags_emptyEnabledPositive
-                  : context.l10n.fixedTags_noMatchingEnabled,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            )
-          else
-            Wrap(
-              spacing: 6,
-              runSpacing: 6,
-              children: [
-                for (final entry in enabledEntries)
-                  InputChip(
-                    label: Text(entry.displayName),
-                    visualDensity: VisualDensity.compact,
-                    onPressed: () => ref
-                        .read(fixedTagsNotifierProvider.notifier)
-                        .toggleEnabled(entry.id),
-                    onDeleted: () => ref
-                        .read(fixedTagsNotifierProvider.notifier)
-                        .toggleEnabled(entry.id),
-                  ),
-              ],
+          Expanded(
+            child: _SectionTitle(
+              icon: icon,
+              label: label,
+              count: count,
+              color: color,
             ),
+          ),
+          if (trailing != null) trailing,
         ],
       ),
     );
   }
 
-  Widget _buildPositiveSection(
-    ThemeData theme,
-    _PositiveSection section,
-    List<TagLibraryEntry> libraryEntries,
-    bool isListMode,
-  ) {
-    final entries = section.entries;
-    return SliverMainAxisGroup(
-      key: ValueKey('positive-section-${section.id}'),
-      slivers: [
-        SliverToBoxAdapter(
-          child: Container(
-            key: _sectionKeyFor(section.id),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _SectionTitle(
-                  icon: Icons.folder_rounded,
-                  label: section.name,
-                  count: entries.length,
-                  color: section.color,
-                ),
-                const SizedBox(height: 7),
-              ],
+  Widget _buildEntryCollection({
+    required List<FixedTagEntry> entries,
+    required FixedTagPromptType promptType,
+    required Color categoryColor,
+    required List<TagLibraryEntry> libraryEntries,
+    required bool isListMode,
+    required ScrollController controller,
+    required String emptyText,
+    String? categoryName,
+  }) {
+    if (entries.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            emptyText,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),
           ),
         ),
-        if (isListMode)
-          SliverReorderableList(
-            key: ValueKey('positive-list-${section.id}'),
-            itemCount: entries.length,
-            prototypeItem: _buildListEntryPrototype(
-              entry: entries.first,
-              categoryColor: section.color,
+      );
+    }
+
+    if (isListMode) {
+      return ReorderableListView.builder(
+        key: ValueKey('${promptType.name}-list-${categoryName ?? 'all'}'),
+        buildDefaultDragHandles: false,
+        padding: const EdgeInsets.fromLTRB(8, 0, 8, 10),
+        itemCount: entries.length,
+        scrollController: controller,
+        prototypeItem: _buildListEntryPrototype(
+          entry: entries.first,
+          categoryColor: categoryColor,
+        ),
+        onReorderItem: (oldIndex, newIndex) => ref
+            .read(fixedTagsNotifierProvider.notifier)
+            .reorderWithinVisibleIds(
+              promptType: promptType,
+              visibleIds: entries.map((entry) => entry.id).toList(),
+              oldIndex: oldIndex,
+              newIndex: newIndex,
             ),
-            onReorderItem: (oldIndex, newIndex) {
-              ref
-                  .read(fixedTagsNotifierProvider.notifier)
-                  .reorderWithinVisibleIds(
-                    promptType: FixedTagPromptType.positive,
-                    visibleIds: entries.map((entry) => entry.id).toList(),
-                    oldIndex: oldIndex,
-                    newIndex: newIndex,
-                  );
-            },
-            itemBuilder: (context, index) {
-              final entry = entries[index];
-              return Padding(
-                key: ValueKey('positive-${entry.id}'),
-                padding: const EdgeInsets.only(bottom: 7),
-                child: _buildEntryTile(
-                  entry: entry,
-                  categoryName: section.name,
-                  categoryColor: section.color,
-                  libraryEntries: libraryEntries,
-                  isListMode: isListMode,
-                  dragHandleBuilder: entries.length > 1
-                      ? (child) => ReorderableDragStartListener(
-                          index: index,
-                          child: child,
-                        )
-                      : null,
-                ),
-              );
-            },
-          )
-        else
-          SliverLayoutBuilder(
-            builder: (context, constraints) {
-              const spacing = 7.0;
-              final largeText =
-                  MediaQuery.textScalerOf(context).scale(14) >= 20;
-              final minimumCardWidth = largeText ? 220.0 : 140.0;
-              final crossAxisCount =
-                  ((constraints.crossAxisExtent + spacing) /
-                          (minimumCardWidth + spacing))
-                      .floor()
-                      .clamp(1, 3);
-              final cardWidth =
-                  (constraints.crossAxisExtent -
-                      spacing * (crossAxisCount - 1)) /
-                  crossAxisCount;
-              final mainAxisExtent = _gridCardHeight(
-                context,
-                cardWidth: cardWidth,
-                hasCategory: true,
-              );
-              return SliverGrid.builder(
-                key: ValueKey('positive-grid-${section.id}'),
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: crossAxisCount,
-                  mainAxisSpacing: spacing,
-                  crossAxisSpacing: spacing,
-                  mainAxisExtent: mainAxisExtent,
-                ),
-                itemCount: entries.length,
-                itemBuilder: (context, index) {
-                  final entry = entries[index];
-                  return KeyedSubtree(
-                    key: ValueKey('grid-${entry.id}'),
-                    child: _buildEntryTile(
-                      entry: entry,
-                      categoryName: section.name,
-                      categoryColor: section.color,
-                      libraryEntries: libraryEntries,
-                      isListMode: false,
-                    ),
-                  );
-                },
-              );
-            },
+        itemBuilder: (context, index) {
+          final entry = entries[index];
+          return Padding(
+            key: ValueKey('${promptType.name}-${entry.id}'),
+            padding: const EdgeInsets.only(bottom: 4),
+            child: _buildEntryTile(
+              entry: entry,
+              categoryColor: categoryColor,
+              libraryEntries: libraryEntries,
+              isListMode: true,
+              dragHandleBuilder: entries.length > 1
+                  ? (child) =>
+                        ReorderableDragStartListener(index: index, child: child)
+                  : null,
+            ),
+          );
+        },
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const spacing = 7.0;
+        final largeText = MediaQuery.textScalerOf(context).scale(14) >= 20;
+        final minimumCardWidth = largeText ? 220.0 : 140.0;
+        final columnCount =
+            ((constraints.maxWidth + spacing) / (minimumCardWidth + spacing))
+                .floor()
+                .clamp(1, 3);
+        final cardWidth =
+            (constraints.maxWidth - spacing * (columnCount - 1)) / columnCount;
+        final cardHeight = _gridCardHeight(context, cardWidth: cardWidth);
+        return GridView.builder(
+          key: ValueKey('${promptType.name}-grid-${categoryName ?? 'all'}'),
+          controller: controller,
+          padding: const EdgeInsets.fromLTRB(8, 0, 8, 10),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: columnCount,
+            mainAxisSpacing: spacing,
+            crossAxisSpacing: spacing,
+            mainAxisExtent: cardHeight,
           ),
-        const SliverToBoxAdapter(child: SizedBox(height: 12)),
-      ],
+          itemCount: entries.length,
+          itemBuilder: (context, index) => _buildEntryTile(
+            entry: entries[index],
+            categoryColor: categoryColor,
+            libraryEntries: libraryEntries,
+            isListMode: false,
+          ),
+        );
+      },
     );
   }
 
@@ -561,152 +653,99 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
   Widget _buildNegativeArea(
     ThemeData theme,
     FixedTagsState fixedState,
+    List<_TagSection> sections,
     List<TagLibraryEntry> libraryEntries,
     bool isListMode,
+    String activeCategoryId,
   ) {
-    final entries = fixedState.negativeEntries.search(_searchQuery);
+    final isSearching = _searchQuery.trim().isNotEmpty;
+    final selectedSection = sections.cast<_TagSection?>().firstWhere(
+      (section) => section?.id == activeCategoryId,
+      orElse: () => null,
+    );
+    final entries = isSearching
+        ? fixedState.negativeEntries.search(_searchQuery)
+        : activeCategoryId == _allNegativeSectionId
+        ? fixedState.negativeEntries
+        : selectedSection?.entries ?? const <FixedTagEntry>[];
+    final color = selectedSection?.color ?? theme.colorScheme.error;
+    final destinations = [
+      FixedTagsRailDestination(
+        id: _allNegativeSectionId,
+        label: context.l10n.fixedTags_negativeTitle,
+        count: fixedState.negativeEntries.length,
+        icon: Icons.select_all_rounded,
+        color: theme.colorScheme.error,
+      ),
+      for (final section in sections)
+        FixedTagsRailDestination(
+          id: section.id,
+          label: section.name,
+          count: section.entries.length,
+          icon: Icons.folder_outlined,
+          color: theme.colorScheme.error,
+        ),
+    ];
     return DecoratedBox(
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.2),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(10, 8, 6, 5),
-            child: Row(
-              children: [
-                Expanded(
-                  child: _SectionTitle(
-                    icon: Icons.block_rounded,
-                    label: context.l10n.fixedTags_negativeTitle,
-                    count: entries.length,
-                    color: theme.colorScheme.error,
-                  ),
-                ),
-                IconButton(
-                  tooltip: context.l10n.fixedTags_addNegative,
-                  icon: const Icon(Icons.add_rounded, size: 18),
-                  onPressed: () =>
-                      _addEntry(promptType: FixedTagPromptType.negative),
-                ),
-              ],
-            ),
-          ),
-          Expanded(
-            child: entries.isEmpty
-                ? Center(
-                    child: Text(
-                      _searchQuery.isEmpty
-                          ? context.l10n.fixedTags_emptyNegative
-                          : context.l10n.fixedTags_noMatchingNegative,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final compactRail =
+              constraints.maxWidth < 300 ||
+              MediaQuery.textScalerOf(context).scale(1) >= 1.6;
+          return Row(
+            children: [
+              FixedTagsCategoryRail(
+                keyPrefix: 'fixed-tags-negative',
+                destinations: destinations,
+                selectedId: activeCategoryId,
+                compact: compactRail,
+                onSelected: _selectNegativeCategory,
+              ),
+              VerticalDivider(
+                width: 1,
+                thickness: 1,
+                color: theme.colorScheme.outlineVariant.withValues(alpha: 0.25),
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _buildPaneHeader(
+                      icon: Icons.block_rounded,
+                      label: context.l10n.fixedTags_negativeTitle,
+                      count: entries.length,
+                      color: theme.colorScheme.error,
+                      trailing: IconButton(
+                        tooltip: context.l10n.fixedTags_addNegative,
+                        icon: const Icon(Icons.add_rounded, size: 18),
+                        onPressed: () =>
+                            _addEntry(promptType: FixedTagPromptType.negative),
                       ),
                     ),
-                  )
-                : isListMode
-                ? ReorderableListView.builder(
-                    buildDefaultDragHandles: false,
-                    padding: const EdgeInsets.fromLTRB(10, 0, 10, 10),
-                    itemCount: entries.length,
-                    scrollController: _negativeScrollController,
-                    prototypeItem: _buildListEntryPrototype(
-                      entry: entries.first,
-                      categoryColor: theme.colorScheme.error,
+                    Expanded(
+                      child: _buildEntryCollection(
+                        entries: entries,
+                        promptType: FixedTagPromptType.negative,
+                        categoryColor: color,
+                        categoryName: selectedSection?.name,
+                        libraryEntries: libraryEntries,
+                        isListMode: isListMode,
+                        controller: _negativeScrollController,
+                        emptyText: _searchQuery.isEmpty
+                            ? context.l10n.fixedTags_emptyNegative
+                            : context.l10n.fixedTags_noMatchingNegative,
+                      ),
                     ),
-                    onReorderItem: (oldIndex, newIndex) {
-                      ref
-                          .read(fixedTagsNotifierProvider.notifier)
-                          .reorderWithinVisibleIds(
-                            promptType: FixedTagPromptType.negative,
-                            visibleIds: entries
-                                .map((entry) => entry.id)
-                                .toList(),
-                            oldIndex: oldIndex,
-                            newIndex: newIndex,
-                          );
-                    },
-                    itemBuilder: (context, index) {
-                      final entry = entries[index];
-                      return Padding(
-                        key: ValueKey('negative-${entry.id}'),
-                        padding: const EdgeInsets.only(bottom: 7),
-                        child: _buildEntryTile(
-                          entry: entry,
-                          categoryColor: theme.colorScheme.error,
-                          libraryEntries: libraryEntries,
-                          isListMode: isListMode,
-                          dragHandleBuilder: entries.length > 1
-                              ? (child) => ReorderableDragStartListener(
-                                  index: index,
-                                  child: child,
-                                )
-                              : null,
-                        ),
-                      );
-                    },
-                  )
-                : SingleChildScrollView(
-                    controller: _negativeScrollController,
-                    padding: const EdgeInsets.fromLTRB(10, 0, 10, 10),
-                    child: _buildEntryGrid(
-                      entries: entries,
-                      categoryColor: theme.colorScheme.error,
-                      libraryEntries: libraryEntries,
-                    ),
-                  ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildEntryGrid({
-    required List<FixedTagEntry> entries,
-    required Color categoryColor,
-    required List<TagLibraryEntry> libraryEntries,
-    String? categoryName,
-  }) {
-    const spacing = 7.0;
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final availableWidth = constraints.maxWidth.isFinite
-            ? constraints.maxWidth
-            : 320.0;
-        final textScale = MediaQuery.textScalerOf(context).scale(1);
-        final minItemWidth = textScale >= 2 ? 220.0 : 140.0;
-        final columnCount =
-            ((availableWidth + spacing) / (minItemWidth + spacing))
-                .floor()
-                .clamp(1, 3);
-        final itemWidth =
-            (availableWidth - spacing * (columnCount - 1)) / columnCount;
-        final itemHeight = _gridCardHeight(
-          context,
-          cardWidth: itemWidth,
-          hasCategory: categoryName != null,
-        );
-        return Wrap(
-          spacing: spacing,
-          runSpacing: spacing,
-          children: [
-            for (final entry in entries)
-              SizedBox(
-                key: ValueKey('grid-${entry.id}'),
-                width: itemWidth,
-                height: itemHeight,
-                child: _buildEntryTile(
-                  entry: entry,
-                  categoryColor: categoryColor,
-                  categoryName: categoryName,
-                  libraryEntries: libraryEntries,
-                  isListMode: false,
+                  ],
                 ),
               ),
-          ],
-        );
-      },
+            ],
+          );
+        },
+      ),
     );
   }
 
@@ -715,14 +754,12 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
     required Color categoryColor,
     required List<TagLibraryEntry> libraryEntries,
     required bool isListMode,
-    String? categoryName,
     SidebarDragHandleBuilder? dragHandleBuilder,
   }) {
     final tile = SidebarEntryTile(
       entry: entry,
       categoryColor: categoryColor,
       isListMode: isListMode,
-      categoryName: categoryName,
       libraryEntry: resolveFixedTagLibraryEntry(entry, libraryEntries),
       dragHandleBuilder: dragHandleBuilder,
       linkAnchor: _buildLinkAnchor(entry),
@@ -754,7 +791,11 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
         entry: prototypeEntry,
         categoryColor: categoryColor,
         isListMode: true,
-        linkAnchor: const SizedBox(width: 22, height: 22),
+        linkAnchor: SizedBox.square(
+          dimension: context.interactionPolicy.precisePointerAvailable
+              ? 24
+              : 44,
+        ),
         onToggle: _noop,
         onEdit: _noop,
         onDelete: _noop,
@@ -766,109 +807,134 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
 
   Widget _buildLinkAnchor(FixedTagEntry entry) {
     final theme = Theme.of(context);
+    final anchorExtent = context.interactionPolicy.precisePointerAvailable
+        ? 24.0
+        : 44.0;
     final state = ref.watch(fixedTagsNotifierProvider);
+    final linkedPositiveIds = entry.promptType == FixedTagPromptType.negative
+        ? state.linkedPositivesOf(entry.id).map((linked) => linked.id).toList()
+        : const <String>[];
     final linkCount = entry.promptType == FixedTagPromptType.positive
         ? state.linkedNegativesOf(entry.id).length
-        : state.linkedPositivesOf(entry.id).length;
+        : linkedPositiveIds.length;
 
-    final visual = SizedBox(
-      width: 22,
-      height: 22,
-      child: Icon(
-        Icons.link_rounded,
-        size: 16,
-        color: linkCount > 0
-            ? theme.colorScheme.secondary
-            : theme.colorScheme.outline,
-      ),
-    );
-
-    if (entry.promptType == FixedTagPromptType.positive) {
-      return KeyedSubtree(
-        key: _anchorKeyFor(entry),
-        child: Draggable<_LinkDragPayload>(
-          data: _LinkDragPayload(entry.id),
-          onDragStarted: () => _startLinkDragPreview(entry.id),
-          onDragUpdate: (details) => _updateLinkDragPreview(
-            positiveEntryId: entry.id,
-            globalPosition: details.globalPosition,
-          ),
-          onDragEnd: (_) => _clearLinkDragPreview(),
-          onDragCompleted: _clearLinkDragPreview,
-          onDraggableCanceled: (_, __) => _clearLinkDragPreview(),
-          feedback: Material(
-            color: Colors.transparent,
-            child: Icon(
-              Icons.link_rounded,
-              color: theme.colorScheme.secondary,
-              size: 22,
-            ),
-          ),
-          childWhenDragging: Opacity(opacity: 0.35, child: visual),
-          child: visual,
-        ),
-      );
-    }
-
-    return KeyedSubtree(key: _anchorKeyFor(entry), child: visual);
-  }
-
-  Widget _buildLinkEndpointOverlay(FixedTagsState fixedState) {
-    final ignoreDuringNewLinkDrag =
-        _linkDragPreview != null && !_linkDragPreview!.isDetaching;
-    return Positioned.fill(
-      child: IgnorePointer(
-        ignoring: ignoreDuringNewLinkDrag,
+    final visual = Semantics(
+      label: linkCount > 0 ? 'Linked $linkCount' : 'Not linked',
+      child: SizedBox.square(
+        dimension: anchorExtent,
         child: Stack(
+          clipBehavior: Clip.none,
           children: [
-            for (final link in fixedState.links)
-              if (_positiveAnchorCenters.containsKey(link.positiveEntryId) &&
-                  _negativeAnchorCenters.containsKey(link.negativeEntryId))
-                Positioned(
-                  left:
-                      _negativeAnchorCenters[link.negativeEntryId]!.dx -
-                      _linkEndpointHitSize / 2,
-                  top:
-                      _negativeAnchorCenters[link.negativeEntryId]!.dy -
-                      _linkEndpointHitSize / 2,
-                  width: _linkEndpointHitSize,
-                  height: _linkEndpointHitSize,
-                  child: MouseRegion(
-                    cursor: SystemMouseCursors.grab,
-                    child: Draggable<_LinkDetachPayload>(
-                      data: _LinkDetachPayload(
-                        positiveEntryId: link.positiveEntryId,
-                        negativeEntryId: link.negativeEntryId,
-                      ),
-                      hitTestBehavior: HitTestBehavior.opaque,
-                      feedback: const SizedBox(width: 1, height: 1),
-                      childWhenDragging: const SizedBox.expand(),
-                      onDragStarted: () => _startLinkDragPreview(
-                        link.positiveEntryId,
-                        negativeEntryId: link.negativeEntryId,
-                        isDetaching: true,
-                      ),
-                      onDragUpdate: (details) => _updateLinkDragPreview(
-                        positiveEntryId: link.positiveEntryId,
-                        globalPosition: details.globalPosition,
-                        isDetaching: true,
-                      ),
-                      onDragEnd: (_) => _completeLinkDetachDrag(
-                        positiveEntryId: link.positiveEntryId,
-                        negativeEntryId: link.negativeEntryId,
-                      ),
-                      onDraggableCanceled: (_, __) => _completeLinkDetachDrag(
-                        positiveEntryId: link.positiveEntryId,
-                        negativeEntryId: link.negativeEntryId,
-                      ),
-                      child: const SizedBox.expand(),
-                    ),
+            Center(
+              child: Icon(
+                Icons.link_rounded,
+                size: 16,
+                color: linkCount > 0
+                    ? theme.colorScheme.secondary
+                    : theme.colorScheme.outline,
+              ),
+            ),
+            if (linkCount > 1)
+              Positioned(
+                right: -2,
+                top: -2,
+                child: Text(
+                  '$linkCount',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.secondary,
+                    fontWeight: FontWeight.w800,
+                    fontSize: 9,
                   ),
                 ),
+              ),
           ],
         ),
       ),
     );
+
+    Widget revealRelatedLinks(Widget child) {
+      return MouseRegion(
+        onEnter: (_) => _setHighlightedLinkEntry(entry.id, true),
+        onExit: (_) => _setHighlightedLinkEntry(entry.id, false),
+        child: Focus(
+          onFocusChange: (focused) =>
+              _setHighlightedLinkEntry(entry.id, focused),
+          child: child,
+        ),
+      );
+    }
+
+    if (entry.promptType == FixedTagPromptType.positive) {
+      return KeyedSubtree(
+        key: _anchorKeyFor(entry),
+        child: revealRelatedLinks(
+          Draggable<_LinkDragPayload>(
+            data: _LinkDragPayload(entry.id),
+            onDragStarted: () => _startLinkDragPreview(entry.id),
+            onDragUpdate: (details) => _updateLinkDragPreview(
+              positiveEntryId: entry.id,
+              globalPosition: details.globalPosition,
+            ),
+            onDragEnd: (_) => _clearLinkDragPreview(),
+            onDragCompleted: _clearLinkDragPreview,
+            onDraggableCanceled: (_, __) => _clearLinkDragPreview(),
+            feedback: Material(
+              color: Colors.transparent,
+              child: Icon(
+                Icons.link_rounded,
+                color: theme.colorScheme.secondary,
+                size: 22,
+              ),
+            ),
+            childWhenDragging: Opacity(opacity: 0.35, child: visual),
+            child: visual,
+          ),
+        ),
+      );
+    }
+
+    final negativeAnchor = linkedPositiveIds.isEmpty
+        ? visual
+        : Draggable<String>(
+            data: entry.id,
+            feedback: const SizedBox(width: 1, height: 1),
+            childWhenDragging: Opacity(opacity: 0.35, child: visual),
+            onDragStarted: () => _startLinkDragPreview(
+              linkedPositiveIds.first,
+              negativeEntryId: entry.id,
+              isDetaching: true,
+            ),
+            onDragUpdate: (details) => _updateLinkDragPreview(
+              positiveEntryId: linkedPositiveIds.first,
+              globalPosition: details.globalPosition,
+              isDetaching: true,
+            ),
+            onDragEnd: (details) => _completeLinkDetachDrag(
+              positiveEntryId: linkedPositiveIds.first,
+              negativeEntryId: entry.id,
+              globalPosition: details.offset,
+            ),
+            onDraggableCanceled: (_, offset) => _completeLinkDetachDrag(
+              positiveEntryId: linkedPositiveIds.first,
+              negativeEntryId: entry.id,
+              globalPosition: offset,
+            ),
+            child: visual,
+          );
+    return KeyedSubtree(
+      key: _anchorKeyFor(entry),
+      child: revealRelatedLinks(negativeAnchor),
+    );
+  }
+
+  void _setHighlightedLinkEntry(String entryId, bool highlighted) {
+    if (highlighted) {
+      if (_highlightedLinkEntryId == entryId) return;
+      setState(() => _highlightedLinkEntryId = entryId);
+      return;
+    }
+    if (_highlightedLinkEntryId != entryId || _linkDragPreview != null) return;
+    setState(() => _highlightedLinkEntryId = null);
   }
 
   Widget _buildNegativeLinkTarget(FixedTagEntry entry, Widget child) {
@@ -958,8 +1024,11 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
   void _completeLinkDetachDrag({
     required String positiveEntryId,
     required String negativeEntryId,
+    Offset? globalPosition,
   }) {
-    final dragEnd = _linkDragPreview?.end;
+    final dragEnd = globalPosition == null
+        ? _linkDragPreview?.end
+        : _globalToLinkLayer(globalPosition);
     final endpoint = _negativeAnchorCenters[negativeEntryId];
     if (dragEnd != null &&
         endpoint != null &&
@@ -1012,6 +1081,7 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
           position: result.position,
           enabled: result.enabled,
           promptType: result.promptType,
+          categoryId: result.categoryId,
         );
   }
 
@@ -1043,22 +1113,23 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
     await ref.read(fixedTagsNotifierProvider.notifier).deleteEntry(entry.id);
   }
 
-  List<_PositiveSection> _positiveSections(
-    FixedTagsState fixedState,
+  List<_TagSection> _tagSections(
+    List<FixedTagEntry> sourceEntries,
     List<TagLibraryCategory> categories,
   ) {
     final categoriesById = {
       for (final category in categories) category.id: category,
     };
-    final grouped = fixedState.positiveByCategory;
-    final sections = <_PositiveSection>[];
+    final grouped = <String?, List<FixedTagEntry>>{};
+    for (final entry in sourceEntries) {
+      grouped.putIfAbsent(entry.categoryId, () => []).add(entry);
+    }
+    final sections = <_TagSection>[];
     for (final category in categories.sortedByOrder()) {
-      final entries = (grouped[category.id] ?? const <FixedTagEntry>[]).search(
-        _searchQuery,
-      );
+      final entries = grouped[category.id] ?? const <FixedTagEntry>[];
       if (entries.isEmpty) continue;
       sections.add(
-        _PositiveSection(
+        _TagSection(
           id: category.id,
           name: category.displayName,
           entries: entries,
@@ -1071,12 +1142,10 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
       (id) => id != null && !categoriesById.containsKey(id),
     );
     for (final categoryId in unknownCategoryIds) {
-      final entries = (grouped[categoryId] ?? const <FixedTagEntry>[]).search(
-        _searchQuery,
-      );
+      final entries = grouped[categoryId] ?? const <FixedTagEntry>[];
       if (entries.isEmpty) continue;
       sections.add(
-        _PositiveSection(
+        _TagSection(
           id: categoryId!,
           name: context.l10n.fixedTags_unknownCategory,
           entries: entries,
@@ -1085,12 +1154,10 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
       );
     }
 
-    final uncategorized = (grouped[null] ?? const <FixedTagEntry>[]).search(
-      _searchQuery,
-    );
+    final uncategorized = grouped[null] ?? const <FixedTagEntry>[];
     if (uncategorized.isNotEmpty) {
       sections.add(
-        _PositiveSection(
+        _TagSection(
           id: _uncategorizedSectionId,
           name: context.l10n.fixedTags_uncategorized,
           entries: uncategorized,
@@ -1099,6 +1166,50 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
       );
     }
     return sections;
+  }
+
+  String _effectivePositiveCategoryId(List<_TagSection> sections) {
+    if (_activePositiveCategoryId == _enabledSectionId ||
+        sections.any((section) => section.id == _activePositiveCategoryId)) {
+      return _activePositiveCategoryId;
+    }
+    return _enabledSectionId;
+  }
+
+  String _effectiveNegativeCategoryId(List<_TagSection> sections) {
+    if (_activeNegativeCategoryId == _allNegativeSectionId ||
+        sections.any((section) => section.id == _activeNegativeCategoryId)) {
+      return _activeNegativeCategoryId;
+    }
+    return _allNegativeSectionId;
+  }
+
+  void _selectPositiveCategory(String categoryId) {
+    if (_activePositiveCategoryId == categoryId) return;
+    setState(() => _activePositiveCategoryId = categoryId);
+    if (_positiveScrollController.hasClients) {
+      _positiveScrollController.jumpTo(0);
+    }
+  }
+
+  void _selectNegativeCategory(String categoryId) {
+    if (_activeNegativeCategoryId == categoryId) return;
+    setState(() => _activeNegativeCategoryId = categoryId);
+    if (_negativeScrollController.hasClients) {
+      _negativeScrollController.jumpTo(0);
+    }
+  }
+
+  List<FixedTagLink> _visibleLinks(FixedTagsState state) {
+    final highlightedEntryId = _highlightedLinkEntryId;
+    if (highlightedEntryId == null) return const [];
+    return state.links
+        .where(
+          (link) =>
+              link.positiveEntryId == highlightedEntryId ||
+              link.negativeEntryId == highlightedEntryId,
+        )
+        .toList();
   }
 
   Color _categoryColor(String? categoryId) {
@@ -1110,27 +1221,11 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
     return HSLColor.fromAHSL(1, (hash % 360).toDouble(), 0.58, 0.55).toColor();
   }
 
-  GlobalKey _sectionKeyFor(String id) {
-    return _sectionKeys.putIfAbsent(id, () => GlobalKey());
-  }
-
   GlobalKey _anchorKeyFor(FixedTagEntry entry) {
     final keys = entry.promptType == FixedTagPromptType.positive
         ? _positiveAnchorKeys
         : _negativeAnchorKeys;
     return keys.putIfAbsent(entry.id, () => GlobalKey());
-  }
-
-  void _scrollToCategory(String categoryId) {
-    setState(() => _activeCategoryId = categoryId);
-    final context = _sectionKeys[categoryId]?.currentContext;
-    if (context == null) return;
-    Scrollable.ensureVisible(
-      context,
-      duration: const Duration(milliseconds: 220),
-      curve: Curves.easeOutCubic,
-      alignment: 0.05,
-    );
   }
 
   void _pruneAnchorKeys(FixedTagsState state) {
@@ -1174,16 +1269,6 @@ class _LinkDragPayload {
   final String positiveEntryId;
 }
 
-class _LinkDetachPayload {
-  const _LinkDetachPayload({
-    required this.positiveEntryId,
-    required this.negativeEntryId,
-  });
-
-  final String positiveEntryId;
-  final String negativeEntryId;
-}
-
 class _LinkDragPreview {
   const _LinkDragPreview({
     required this.start,
@@ -1196,8 +1281,8 @@ class _LinkDragPreview {
   final bool isDetaching;
 }
 
-class _PositiveSection {
-  const _PositiveSection({
+class _TagSection {
+  const _TagSection({
     required this.id,
     required this.name,
     required this.entries,
@@ -1208,39 +1293,6 @@ class _PositiveSection {
   final String name;
   final List<FixedTagEntry> entries;
   final Color color;
-}
-
-class _CategoryChip extends StatelessWidget {
-  const _CategoryChip({
-    required this.label,
-    required this.count,
-    required this.selected,
-    required this.color,
-    required this.onTap,
-  });
-
-  final String label;
-  final int count;
-  final bool selected;
-  final Color color;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return ChoiceChip(
-      selected: selected,
-      label: Text('$label $count'),
-      visualDensity: VisualDensity.compact,
-      labelStyle: theme.textTheme.labelSmall?.copyWith(
-        color: selected ? theme.colorScheme.onSecondaryContainer : color,
-        fontWeight: FontWeight.w700,
-      ),
-      side: BorderSide(color: color.withValues(alpha: 0.35)),
-      selectedColor: color.withValues(alpha: 0.18),
-      onSelected: (_) => onTap(),
-    );
-  }
 }
 
 class _SectionTitle extends StatelessWidget {

--- a/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
+++ b/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
@@ -4,9 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../../../core/utils/localization_extension.dart';
-import '../../../adaptive/interaction_policy.dart';
 import '../../../../data/models/fixed_tag/fixed_tag_entry.dart';
 import '../../../../data/models/tag_library/tag_library_entry.dart';
+import '../../../adaptive/interaction_policy.dart';
 import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/hover_image_preview.dart';
 import '../../../widgets/common/thumbnail_display.dart';
@@ -16,7 +16,10 @@ typedef SidebarDragHandleBuilder = Widget Function(Widget child);
 
 enum _SidebarEntryAction { copy, edit, delete }
 
-/// 固定词侧边栏条目卡片。
+/// A fixed-tag row or preview card.
+///
+/// List and grid presentations share the same action, status, and text
+/// building blocks so their capabilities cannot drift apart.
 class SidebarEntryTile extends StatefulWidget {
   const SidebarEntryTile({
     super.key,
@@ -26,7 +29,6 @@ class SidebarEntryTile extends StatefulWidget {
     required this.onToggle,
     required this.onEdit,
     required this.onDelete,
-    this.categoryName,
     this.linkAnchor,
     this.libraryEntry,
     this.dragHandleBuilder,
@@ -38,7 +40,6 @@ class SidebarEntryTile extends StatefulWidget {
   final VoidCallback onToggle;
   final VoidCallback onEdit;
   final VoidCallback onDelete;
-  final String? categoryName;
   final Widget? linkAnchor;
   final TagLibraryEntry? libraryEntry;
   final SidebarDragHandleBuilder? dragHandleBuilder;
@@ -51,26 +52,18 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
   bool _isHovering = false;
   bool _isFocused = false;
 
+  bool get _hasThumbnail =>
+      !widget.isListMode && (widget.libraryEntry?.hasThumbnail ?? false);
+
+  bool get _showActionMenu =>
+      _isHovering ||
+      _isFocused ||
+      context.interactionPolicy.shouldExposeTouchAlternatives ||
+      MediaQuery.textScalerOf(context).scale(14) >= 20;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final entry = widget.entry;
-    final enabled = entry.enabled;
-    final foreground = enabled
-        ? theme.colorScheme.onSurface
-        : theme.colorScheme.onSurfaceVariant;
-    final background = enabled
-        ? widget.categoryColor.withValues(alpha: 0.12)
-        : theme.colorScheme.surfaceContainerHigh;
-    final hasThumbnailBackground = _hasThumbnailBackground;
-    final contentPadding = EdgeInsets.symmetric(
-      horizontal: widget.isListMode ? 10 : 8,
-      vertical: widget.isListMode ? 8 : 10,
-    );
-    final contentForeground = hasThumbnailBackground
-        ? Colors.white
-        : foreground;
-
     final tile = MouseRegion(
       onEnter: (_) {
         if (context.interactionPolicy.precisePointerAvailable) {
@@ -78,52 +71,24 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
         }
       },
       onExit: (_) => setState(() => _isHovering = false),
-      child: InkWell(
+      child: Material(
+        color: _backgroundColor(theme),
         borderRadius: BorderRadius.circular(10),
-        onFocusChange: (focused) => setState(() => _isFocused = focused),
-        onTap: widget.onToggle,
-        child: AnimatedContainer(
-          duration: MediaQuery.disableAnimationsOf(context)
-              ? Duration.zero
-              : const Duration(milliseconds: 120),
-          clipBehavior: Clip.antiAlias,
-          decoration: BoxDecoration(
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(10),
+          onFocusChange: (focused) => setState(() => _isFocused = focused),
+          onTap: widget.onToggle,
+          child: AnimatedContainer(
+            duration: MediaQuery.disableAnimationsOf(context)
+                ? Duration.zero
+                : const Duration(milliseconds: 120),
             color: _isHovering
-                ? Color.alphaBlend(
-                    theme.colorScheme.onSurface.withValues(alpha: 0.05),
-                    background,
-                  )
-                : background,
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: Stack(
-            children: [
-              if (hasThumbnailBackground)
-                Positioned.fill(
-                  child: _buildThumbnailBackground(widget.libraryEntry!),
-                ),
-              if (hasThumbnailBackground)
-                Positioned.fill(
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          Colors.black.withValues(alpha: 0.26),
-                          Colors.black.withValues(alpha: 0.58),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              Padding(
-                padding: contentPadding,
-                child: widget.isListMode
-                    ? _buildListContent(theme, contentForeground)
-                    : _buildGridContent(theme, contentForeground),
-              ),
-            ],
+                ? theme.colorScheme.onSurface.withValues(alpha: 0.045)
+                : Colors.transparent,
+            child: widget.isListMode
+                ? _buildListContent(theme)
+                : _buildCardContent(theme),
           ),
         ),
       ),
@@ -131,7 +96,6 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
 
     final libraryEntry = widget.libraryEntry;
     if (libraryEntry == null || !libraryEntry.hasThumbnail) return tile;
-
     return HoverImagePreview.file(
       imagePath: libraryEntry.thumbnail!,
       previewMaxSize: 320,
@@ -143,90 +107,82 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
     );
   }
 
-  bool get _hasThumbnailBackground =>
-      !widget.isListMode && (widget.libraryEntry?.hasThumbnail ?? false);
-
-  Widget _buildThumbnailBackground(TagLibraryEntry libraryEntry) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final width = constraints.maxWidth.isFinite
-            ? constraints.maxWidth
-            : 220.0;
-        final height = constraints.maxHeight.isFinite
-            ? constraints.maxHeight
-            : 130.0;
-        return ThumbnailDisplay(
-          imagePath: libraryEntry.thumbnail!,
-          offsetX: libraryEntry.thumbnailOffsetX,
-          offsetY: libraryEntry.thumbnailOffsetY,
-          scale: libraryEntry.thumbnailScale,
-          width: width,
-          height: height,
-        );
-      },
-    );
+  Color _backgroundColor(ThemeData theme) {
+    if (!widget.entry.enabled) return theme.colorScheme.surfaceContainerHigh;
+    return widget.categoryColor.withValues(alpha: 0.11);
   }
 
-  Widget _buildListContent(ThemeData theme, Color foreground) {
-    return Row(
-      children: [
-        _buildStatusDot(),
-        const SizedBox(width: 8),
-        if (widget.linkAnchor != null) ...[
-          widget.linkAnchor!,
-          const SizedBox(width: 6),
-        ],
-        Expanded(child: _buildDragRegion(_buildText(theme, foreground))),
-        SizedBox(
-          width: 72,
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: AnimatedSwitcher(
-              duration: MediaQuery.disableAnimationsOf(context)
-                  ? Duration.zero
-                  : const Duration(milliseconds: 120),
-              child:
-                  _isHovering ||
-                      _isFocused ||
-                      _usesPersistentActionMenu(context)
-                  ? _buildActionAffordance(theme)
-                  : _buildWeightBadge(theme),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildGridContent(ThemeData theme, Color foreground) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            _buildStatusDot(),
-            const Spacer(),
-            if (widget.linkAnchor != null) widget.linkAnchor!,
+  Widget _buildListContent(ThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 7),
+      child: Row(
+        children: [
+          _buildStatusDot(),
+          const SizedBox(width: 7),
+          if (widget.linkAnchor != null) ...[
+            widget.linkAnchor!,
+            const SizedBox(width: 4),
           ],
-        ),
-        const SizedBox(height: 8),
+          Expanded(
+            child: _buildDragRegion(
+              _buildText(theme, maxLines: 1, includeWeight: true),
+            ),
+          ),
+          const SizedBox(width: 6),
+          if (_showActionMenu) ...[_buildActionMenu(theme)],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCardContent(ThemeData theme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (_hasThumbnail)
+          Expanded(flex: 4, child: _buildThumbnail(widget.libraryEntry!)),
         Expanded(
-          child: _buildDragRegion(
-            _buildText(
-              theme,
-              foreground,
-              maxLines: widget.categoryName == null ? 2 : 1,
+          flex: _hasThumbnail ? 5 : 1,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(9, 8, 7, 7),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: _buildDragRegion(
+                    _buildText(
+                      theme,
+                      maxLines: _hasThumbnail ? 1 : 2,
+                      includeWeight: true,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 5),
+                Row(
+                  children: [
+                    if (widget.linkAnchor != null) widget.linkAnchor!,
+                    const Spacer(),
+                    _buildActionMenu(theme),
+                  ],
+                ),
+              ],
             ),
           ),
         ),
-        const SizedBox(height: 8),
-        Align(
-          alignment: Alignment.centerRight,
-          child: _isHovering || _isFocused || _usesPersistentActionMenu(context)
-              ? _buildActionAffordance(theme)
-              : _buildWeightBadge(theme),
-        ),
       ],
+    );
+  }
+
+  Widget _buildThumbnail(TagLibraryEntry libraryEntry) {
+    return LayoutBuilder(
+      builder: (context, constraints) => ThumbnailDisplay(
+        imagePath: libraryEntry.thumbnail!,
+        offsetX: libraryEntry.thumbnailOffsetX,
+        offsetY: libraryEntry.thumbnailOffsetY,
+        scale: libraryEntry.thumbnailScale,
+        width: constraints.maxWidth,
+        height: constraints.maxHeight,
+      ),
     );
   }
 
@@ -236,55 +192,57 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
     return MouseRegion(cursor: SystemMouseCursors.grab, child: builder(child));
   }
 
-  Widget _buildText(ThemeData theme, Color foreground, {int maxLines = 1}) {
-    final entry = widget.entry;
-    final hasThumbnailBackground = _hasThumbnailBackground;
-    final secondaryColor = hasThumbnailBackground
-        ? Colors.white.withValues(alpha: 0.82)
+  Widget _buildText(
+    ThemeData theme, {
+    required int maxLines,
+    bool includeWeight = false,
+  }) {
+    final foreground = widget.entry.enabled
+        ? theme.colorScheme.onSurface
         : theme.colorScheme.onSurfaceVariant;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          entry.displayName,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.labelLarge?.copyWith(
-            color: foreground,
-            fontWeight: entry.enabled ? FontWeight.w700 : FontWeight.w500,
-          ),
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                widget.entry.displayName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: foreground,
+                  fontWeight: widget.entry.enabled
+                      ? FontWeight.w700
+                      : FontWeight.w500,
+                ),
+              ),
+            ),
+            if (includeWeight) ...[
+              const SizedBox(width: 6),
+              _buildWeight(theme),
+            ],
+          ],
         ),
-        const SizedBox(height: 2),
+        if (widget.isListMode) const SizedBox(height: 2),
         TranslatedPromptText(
-          entry.content,
+          widget.entry.content,
           selectable: false,
           maxLines: maxLines,
           reserveTranslationSpace: widget.isListMode,
-          style: theme.textTheme.bodySmall?.copyWith(color: secondaryColor),
-        ),
-        if (widget.categoryName != null && !widget.isListMode) ...[
-          const SizedBox(height: 6),
-          Text(
-            widget.categoryName!,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: hasThumbnailBackground
-                  ? Colors.white.withValues(alpha: 0.88)
-                  : widget.categoryColor,
-              fontWeight: FontWeight.w600,
-            ),
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
           ),
-        ],
+        ),
       ],
     );
   }
 
   Widget _buildStatusDot() {
     return Container(
-      width: 9,
-      height: 9,
+      width: 8,
+      height: 8,
       decoration: BoxDecoration(
         color: widget.entry.enabled
             ? widget.categoryColor
@@ -294,75 +252,28 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
     );
   }
 
-  Widget _buildWeightBadge(ThemeData theme) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surface.withValues(alpha: 0.75),
-        borderRadius: BorderRadius.circular(99),
-      ),
+  Widget _buildWeight(ThemeData theme) {
+    return MediaQuery.withClampedTextScaling(
+      maxScaleFactor: 1.5,
       child: Text(
         widget.entry.weight.toStringAsFixed(2),
         style: theme.textTheme.labelSmall?.copyWith(
           color: theme.colorScheme.onSurfaceVariant,
-          fontWeight: FontWeight.w600,
+          fontWeight: FontWeight.w700,
+          fontFeatures: const [FontFeature.tabularFigures()],
         ),
       ),
     );
   }
 
-  bool _usesPersistentActionMenu(BuildContext context) =>
-      context.interactionPolicy.shouldExposeTouchAlternatives ||
-      MediaQuery.textScalerOf(context).scale(14) >= 20;
-
-  Widget _buildActionAffordance(ThemeData theme) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final inlineActionsExtent =
-            _ActionButton.extent * _SidebarEntryAction.values.length;
-        final useMenu =
-            _usesPersistentActionMenu(context) ||
-            constraints.maxWidth < inlineActionsExtent;
-        return Align(
-          alignment: Alignment.centerRight,
-          child: useMenu ? _buildActionMenu(theme) : _buildInlineActions(theme),
-        );
-      },
-    );
-  }
-
-  Widget _buildInlineActions(ThemeData theme) {
-    return Row(
-      key: const ValueKey('actions'),
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        _ActionButton(
-          icon: Icons.copy_rounded,
-          tooltip: context.l10n.common_copy,
-          onPressed: _copyContent,
-        ),
-        _ActionButton(
-          icon: Icons.edit_rounded,
-          tooltip: context.l10n.common_edit,
-          onPressed: widget.onEdit,
-        ),
-        _ActionButton(
-          icon: Icons.delete_outline_rounded,
-          tooltip: context.l10n.common_delete,
-          color: theme.colorScheme.error,
-          onPressed: widget.onDelete,
-        ),
-      ],
-    );
-  }
-
   Widget _buildActionMenu(ThemeData theme) {
+    final interactionPolicy = context.interactionPolicy;
     return SizedBox.square(
-      dimension: context.interactionPolicy.minimumControlExtent,
+      dimension: interactionPolicy.precisePointerAvailable ? 32 : 44,
       child: PopupMenuButton<_SidebarEntryAction>(
         key: const ValueKey('sidebar-entry-actions-menu'),
         tooltip: MaterialLocalizations.of(context).showMenuTooltip,
-        icon: const Icon(Icons.more_horiz_rounded, size: 20),
+        icon: const Icon(Icons.more_horiz_rounded, size: 18),
         padding: EdgeInsets.zero,
         onSelected: (action) {
           switch (action) {
@@ -414,43 +325,5 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
     await Clipboard.setData(ClipboardData(text: widget.entry.content));
     if (!mounted) return;
     AppToast.info(context, context.l10n.common_copied);
-  }
-}
-
-class _ActionButton extends StatelessWidget {
-  const _ActionButton({
-    required this.icon,
-    required this.tooltip,
-    required this.onPressed,
-    this.color,
-  });
-
-  static const extent = 21.0;
-
-  final IconData icon;
-  final String tooltip;
-  final VoidCallback onPressed;
-  final Color? color;
-
-  @override
-  Widget build(BuildContext context) {
-    return Tooltip(
-      message: tooltip,
-      waitDuration: const Duration(milliseconds: 300),
-      child: SizedBox.square(
-        dimension: extent,
-        child: InkResponse(
-          radius: 16,
-          onTap: onPressed,
-          child: Center(
-            child: Icon(
-              icon,
-              size: 15,
-              color: color ?? Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lib/presentation/widgets/prompt/fixed_tag_edit_dialog.dart
+++ b/lib/presentation/widgets/prompt/fixed_tag_edit_dialog.dart
@@ -89,6 +89,7 @@ class _FixedTagEditDialogState extends ConsumerState<FixedTagEditDialog> {
     _promptType = entry?.promptType ?? widget.initialPromptType;
     _weight = entry?.weight ?? 1.0;
     _enabled = entry?.enabled ?? true;
+    _selectedCategoryId = entry?.categoryId;
     _assistantSessionId = PromptHistorySessionIds.fixedTag(
       entry?.id ?? 'draft-${identityHashCode(this)}',
     );
@@ -488,6 +489,8 @@ class _FixedTagEditDialogState extends ConsumerState<FixedTagEditDialog> {
           ),
           dense: true,
         ),
+        const SizedBox(height: 12),
+        _buildCategorySelector(theme),
         if (!_isEditing) ...[
           const SizedBox(height: 8),
           _buildSaveToLibrary(theme),
@@ -690,10 +693,6 @@ class _FixedTagEditDialogState extends ConsumerState<FixedTagEditDialog> {
               ],
             ),
           ),
-          if (_saveToLibrary) ...[
-            const SizedBox(height: 10),
-            _buildCompactCategorySelector(theme),
-          ],
         ],
       ),
     );
@@ -753,14 +752,16 @@ class _FixedTagEditDialogState extends ConsumerState<FixedTagEditDialog> {
     if (content.isEmpty) return;
 
     final result =
-        widget.entry?.update(
-          name: name,
-          content: content,
-          weight: _weight,
-          position: _position,
-          promptType: _promptType,
-          enabled: _enabled,
-        ) ??
+        widget.entry
+            ?.update(
+              name: name,
+              content: content,
+              weight: _weight,
+              position: _position,
+              promptType: _promptType,
+              enabled: _enabled,
+            )
+            .copyWith(categoryId: _selectedCategoryId) ??
         FixedTagEntry.create(
           name: name,
           content: content,
@@ -768,6 +769,7 @@ class _FixedTagEditDialogState extends ConsumerState<FixedTagEditDialog> {
           position: _position,
           promptType: _promptType,
           enabled: _enabled,
+          categoryId: _selectedCategoryId,
         );
 
     if (_saveToLibrary && !_isEditing) {
@@ -789,9 +791,12 @@ class _FixedTagEditDialogState extends ConsumerState<FixedTagEditDialog> {
     Navigator.of(context).pop(result);
   }
 
-  Widget _buildCompactCategorySelector(ThemeData theme) {
+  Widget _buildCategorySelector(ThemeData theme) {
     final state = ref.watch(tagLibraryPageNotifierProvider);
     final categories = state.categories;
+    final itemHeight = (MediaQuery.textScalerOf(context).scale(20) + 16)
+        .clamp(48.0, double.infinity)
+        .toDouble();
     final items = <DropdownMenuItem<String?>>[];
 
     items.add(
@@ -805,9 +810,12 @@ class _FixedTagEditDialogState extends ConsumerState<FixedTagEditDialog> {
               color: theme.colorScheme.primary,
             ),
             const SizedBox(width: 8),
-            Text(
-              context.l10n.tagLibrary_rootCategory,
-              style: const TextStyle(fontSize: 13),
+            Expanded(
+              child: Text(
+                context.l10n.tagLibrary_rootCategory,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(fontSize: 13),
+              ),
             ),
           ],
         ),
@@ -860,12 +868,12 @@ class _FixedTagEditDialogState extends ConsumerState<FixedTagEditDialog> {
         const SizedBox(height: 6),
         DropdownButtonFormField<String?>(
           initialValue: _selectedCategoryId,
+          itemHeight: itemHeight,
           decoration: InputDecoration(
             contentPadding: const EdgeInsets.symmetric(
               horizontal: 10,
-              vertical: 6,
+              vertical: 12,
             ),
-            isDense: true,
             filled: true,
             fillColor: inputSurfaceFillColor(theme.colorScheme),
           ),

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
@@ -799,7 +799,7 @@ void main() {
   );
 
   testWidgets(
-    'renders enabled categorized entries without duplicate key errors',
+    'search spans enabled and disabled positive categories without key errors',
     (tester) async {
       final category = TagLibraryCategory.create(name: '画师');
       final enabled = FixedTagEntry.create(
@@ -860,13 +860,7 @@ void main() {
         ),
         findsOneWidget,
       );
-      expect(
-        find.descendant(
-          of: find.byType(SidebarEntryTile),
-          matching: find.text('quality'),
-        ),
-        findsOneWidget,
-      );
+      expect(find.text('quality'), findsNothing);
       expect(tester.takeException(), isNull);
 
       await tester.enterText(find.byType(TextField), 'quality');
@@ -891,7 +885,9 @@ void main() {
     },
   );
 
-  testWidgets('category chips wrap when the sidebar is narrow', (tester) async {
+  testWidgets('category rails stay compact and support negative categories', (
+    tester,
+  ) async {
     final categories = [
       TagLibraryCategory.create(name: '质量词'),
       TagLibraryCategory.create(name: '画风'),
@@ -905,6 +901,12 @@ void main() {
           content: 'tag ${category.name}',
           categoryId: category.id,
         ),
+      FixedTagEntry.create(
+        name: 'negative quality',
+        content: 'bad quality',
+        categoryId: categories.first.id,
+        promptType: FixedTagPromptType.negative,
+      ),
     ];
     final storage = _SidebarTestStorage(
       fixedEntries: entries,
@@ -927,13 +929,23 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final wrappedChip = find.text('角色 1');
-    expect(wrappedChip, findsOneWidget);
+    final positiveRail = find.byKey(
+      const ValueKey('fixed-tags-positive-category-rail'),
+    );
+    final negativeRail = find.byKey(
+      const ValueKey('fixed-tags-negative-category-rail'),
+    );
+    expect(positiveRail, findsOneWidget);
+    expect(negativeRail, findsOneWidget);
+    expect(tester.getSize(positiveRail).width, 48);
 
-    final firstTop = tester.getTopLeft(find.text('已启用 4')).dy;
-    final wrappedTop = tester.getTopLeft(wrappedChip).dy;
-
-    expect(wrappedTop, greaterThan(firstTop + 20));
+    await tester.tap(
+      find.byKey(
+        ValueKey('fixed-tags-negative-category-${categories.first.id}'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('negative quality'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
@@ -1627,13 +1639,40 @@ void main() {
         );
         expect(container.read(fixedTagsNotifierProvider).links, hasLength(1));
 
-        final endpoint = find.byIcon(Icons.link_rounded).last;
+        final negativeTile = find.ancestor(
+          of: find.text('negative'),
+          matching: find.byType(SidebarEntryTile),
+        );
+        final endpoint = find.descendant(
+          of: negativeTile,
+          matching: find.byIcon(Icons.link_rounded),
+        );
+        await tester.ensureVisible(endpoint);
+        await tester.pumpAndSettle();
         final endpointCenter = tester.getCenter(endpoint);
-        await tester.dragFrom(endpointCenter, const Offset(12, 0));
+        final shortDrag = await tester.startGesture(
+          endpointCenter,
+          kind: PointerDeviceKind.mouse,
+        );
+        await shortDrag.moveBy(const Offset(12, 0));
+        await tester.pump();
+        await shortDrag.up();
         await tester.pumpAndSettle();
         expect(container.read(fixedTagsNotifierProvider).links, hasLength(1));
 
-        await tester.dragFrom(endpointCenter, const Offset(72, 0));
+        final refreshedEndpointCenter = tester.getCenter(
+          find.descendant(
+            of: negativeTile,
+            matching: find.byIcon(Icons.link_rounded),
+          ),
+        );
+        final detachDrag = await tester.startGesture(
+          refreshedEndpointCenter,
+          kind: PointerDeviceKind.mouse,
+        );
+        await detachDrag.moveBy(const Offset(72, 0));
+        await tester.pump();
+        await detachDrag.up();
         await tester.pumpAndSettle();
 
         expect(container.read(fixedTagsNotifierProvider).links, isEmpty);
@@ -1733,13 +1772,18 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
 
-      await tester.tap(
-        find.byKey(const ValueKey('sidebar-entry-actions-menu')),
+      final entryMenu = find.byKey(
+        const ValueKey('sidebar-entry-actions-menu'),
       );
+      await tester.ensureVisible(entryMenu);
+      await tester.pumpAndSettle();
+      await tester.tap(entryMenu);
       await tester.pumpAndSettle();
       await tester.tap(find.byIcon(Icons.edit_rounded));
       await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
 
       expect(
         find.byKey(const ValueKey('adaptive-bottom-sheet')),
@@ -1776,9 +1820,10 @@ void main() {
       tester.view.devicePixelRatio = 1;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
+      final negativeCategory = TagLibraryCategory.create(name: '负面质量');
       final storage = _SidebarTestStorage(
         fixedEntries: const [],
-        categories: const [],
+        categories: [negativeCategory],
         libraryEntries: const [],
       );
       await _pumpSidebar(tester, storage);
@@ -1804,6 +1849,13 @@ void main() {
       final container = ProviderScope.containerOf(
         tester.element(find.byType(FixedTagsSidebar)),
       );
+      final categorySelector = find.byType(DropdownButtonFormField<String?>);
+      await tester.ensureVisible(categorySelector);
+      await tester.pumpAndSettle();
+      await tester.tap(categorySelector);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('负面质量').last);
+      await tester.pumpAndSettle();
       await tester.enterText(contentField, ',');
       await tester.pump();
       await tester.tap(find.text('保存').hitTestable());
@@ -1822,6 +1874,7 @@ void main() {
       expect(added.position, FixedTagPosition.prefix);
       expect(added.enabled, isTrue);
       expect(added.weight, 1.0);
+      expect(added.categoryId, negativeCategory.id);
       expect(tester.takeException(), isNull);
 
       await tester.pumpWidget(const SizedBox.shrink());
@@ -1878,21 +1931,19 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.byType(ThumbnailDisplay), findsNWidgets(2));
+    expect(find.byType(ThumbnailDisplay), findsNWidgets(3));
 
     final tiles = find.byType(SidebarEntryTile);
-    expect(tiles, findsNWidgets(2));
+    expect(tiles, findsNWidgets(3));
     final firstTop = tester.getTopLeft(tiles.at(0)).dy;
     expect(tester.getTopLeft(tiles.at(1)).dy, closeTo(firstTop, 1));
-
-    final scrollView = tester.widget<CustomScrollView>(
-      find.byType(CustomScrollView),
+    expect(
+      find.descendant(
+        of: find.byType(SidebarEntryTile),
+        matching: find.text('thumb three'),
+      ),
+      findsOneWidget,
     );
-    scrollView.controller!.jumpTo(
-      scrollView.controller!.position.maxScrollExtent,
-    );
-    await tester.pumpAndSettle();
-    expect(find.text('thumb three'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
@@ -1908,10 +1959,16 @@ void main() {
 
       await _pumpSidebar(tester, storage, textScale: 1.35);
 
-      final positiveScrollView = find.byType(CustomScrollView);
+      await tester.tap(
+        find.byKey(
+          ValueKey('fixed-tags-positive-category-${fixture.categories[1].id}'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final positiveScrollView = find.byType(ReorderableListView);
       final controller = tester
-          .widget<CustomScrollView>(positiveScrollView)
-          .controller!;
+          .widget<ReorderableListView>(positiveScrollView)
+          .scrollController!;
       final initialMax = await _expectStableScrollMetrics(
         tester,
         controller: controller,
@@ -1919,17 +1976,14 @@ void main() {
       );
 
       controller.jumpTo(0);
-      await tester.enterText(find.byType(TextField), 'section-3-');
+      await tester.enterText(find.byType(TextField), 'section-0-');
       await tester.pumpAndSettle();
 
       final filteredMax = controller.position.maxScrollExtent;
-      expect(filteredMax, greaterThan(0));
+      expect(filteredMax, 0);
       expect(filteredMax, lessThan(initialMax));
-      await _expectStableScrollMetrics(
-        tester,
-        controller: controller,
-        scrollable: positiveScrollView,
-      );
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(controller.position.maxScrollExtent, filteredMax);
       expect(tester.takeException(), isNull);
     },
   );
@@ -1946,9 +2000,15 @@ void main() {
 
       await _pumpSidebar(tester, storage);
 
-      final positiveScrollView = find.byType(CustomScrollView);
+      await tester.tap(
+        find.byKey(
+          ValueKey('fixed-tags-positive-category-${fixture.categories[1].id}'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final positiveScrollView = find.byType(GridView).first;
       final controller = tester
-          .widget<CustomScrollView>(positiveScrollView)
+          .widget<GridView>(positiveScrollView)
           .controller!;
       await _expectStableScrollMetrics(
         tester,
@@ -1995,6 +2055,11 @@ void main() {
         translationLookup: lookup,
       );
 
+      await tester.tap(
+        find.byKey(ValueKey('fixed-tags-positive-category-${category.id}')),
+      );
+      await tester.pumpAndSettle();
+
       expect(
         find.byKey(const ValueKey('translated-prompt-translation')),
         findsNWidgets(2),
@@ -2038,7 +2103,7 @@ void main() {
   });
 
   testWidgets(
-    'category chip scrolls to a section beyond the initial viewport',
+    'category rail switches directly to a section without retaining scroll',
     (tester) async {
       final near = TagLibraryCategory.create(name: 'Near', sortOrder: 0);
       final far = TagLibraryCategory.create(name: 'Far', sortOrder: 1);
@@ -2075,28 +2140,25 @@ void main() {
         ),
       );
 
-      final positiveScrollView = find.byType(CustomScrollView);
+      await tester.tap(
+        find.byKey(ValueKey('fixed-tags-positive-category-${near.id}')),
+      );
+      await tester.pumpAndSettle();
+      final positiveList = find.byType(ReorderableListView);
       final controller = tester
-          .widget<CustomScrollView>(positiveScrollView)
-          .controller!;
-      final initialMax = controller.position.maxScrollExtent;
+          .widget<ReorderableListView>(positiveList)
+          .scrollController!;
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pump();
 
-      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await mouse.addPointer();
-      addTearDown(mouse.removePointer);
-      await mouse.moveTo(tester.getCenter(find.text('Far 1')));
-      await mouse.down(tester.getCenter(find.text('Far 1')));
-      await mouse.up();
+      await tester.tap(
+        find.byKey(ValueKey('fixed-tags-positive-category-${far.id}')),
+      );
       await tester.pumpAndSettle();
 
-      expect(controller.offset, greaterThan(0));
-      expect(controller.position.maxScrollExtent, closeTo(initialMax, 0.01));
-      expect(
-        tester
-            .getRect(positiveScrollView)
-            .overlaps(tester.getRect(find.text('Far'))),
-        isTrue,
-      );
+      expect(controller.offset, 0);
+      expect(find.text('far-entry'), findsOneWidget);
+      expect(find.text('near-0'), findsNothing);
       expect(tester.takeException(), isNull);
     },
   );
@@ -2226,75 +2288,74 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets(
-    'SidebarEntryTile pointer actions remain full-size and invoke commands at 320',
-    (tester) async {
-      tester.view.physicalSize = const Size(320, 300);
-      tester.view.devicePixelRatio = 1;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
+  testWidgets('SidebarEntryTile pointer menu exposes every action at 320', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 300);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
 
-      var edited = 0;
-      var deleted = 0;
-      String? copiedText;
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    var edited = 0;
+    var deleted = 0;
+    String? copiedText;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copiedText =
+              (call.arguments as Map<Object?, Object?>)['text'] as String?;
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
         SystemChannels.platform,
-        (call) async {
-          if (call.method == 'Clipboard.setData') {
-            copiedText =
-                (call.arguments as Map<Object?, Object?>)['text'] as String?;
-          }
-          return null;
-        },
-      );
-      addTearDown(
-        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-          SystemChannels.platform,
-          null,
-        ),
-      );
+        null,
+      ),
+    );
 
-      final entry = FixedTagEntry.create(name: 'tile', content: 'copied tag');
-      await _pumpEntryTile(
-        tester,
-        entry: entry,
-        width: 288,
-        policy: const InteractionPolicy(
-          modality: InteractionModality.pointer,
-          touchAvailable: false,
-          precisePointerAvailable: true,
-        ),
-        onEdit: () => edited++,
-        onDelete: () => deleted++,
-      );
+    final entry = FixedTagEntry.create(name: 'tile', content: 'copied tag');
+    await _pumpEntryTile(
+      tester,
+      entry: entry,
+      width: 288,
+      policy: const InteractionPolicy(
+        modality: InteractionModality.pointer,
+        touchAvailable: false,
+        precisePointerAvailable: true,
+      ),
+      onEdit: () => edited++,
+      onDelete: () => deleted++,
+    );
 
-      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await mouse.addPointer();
-      addTearDown(mouse.removePointer);
-      await mouse.moveTo(tester.getCenter(find.byType(SidebarEntryTile)));
-      await tester.pumpAndSettle();
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer();
+    addTearDown(mouse.removePointer);
+    await mouse.moveTo(tester.getCenter(find.byType(SidebarEntryTile)));
+    await tester.pumpAndSettle();
 
-      expect(find.byType(FittedBox), findsNothing);
-      for (final icon in const [
-        Icons.copy_rounded,
-        Icons.edit_rounded,
-        Icons.delete_outline_rounded,
-      ]) {
-        final iconFinder = find.byIcon(icon);
-        expect(iconFinder, findsOneWidget);
-        expect(tester.getSize(iconFinder), const Size.square(15));
-      }
+    final menu = find.byKey(const ValueKey('sidebar-entry-actions-menu'));
+    expect(menu, findsOneWidget);
 
-      await tester.tap(find.byIcon(Icons.copy_rounded));
-      await tester.tap(find.byIcon(Icons.edit_rounded));
-      await tester.tap(find.byIcon(Icons.delete_outline_rounded));
+    await tester.tap(menu);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.copy_rounded));
+    await tester.pumpAndSettle();
+    await tester.tap(menu);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.edit_rounded));
+    await tester.pumpAndSettle();
+    await tester.tap(menu);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.delete_outline_rounded));
 
-      expect(copiedText, 'copied tag');
-      expect(edited, 1);
-      expect(deleted, 1);
-      expect(tester.takeException(), isNull);
-    },
-  );
+    expect(copiedText, 'copied tag');
+    expect(edited, 1);
+    expect(deleted, 1);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets('SidebarEntryTile touch menu invokes edit and delete callbacks', (
     tester,
@@ -2450,6 +2511,10 @@ void main() {
     expect(find.byIcon(Icons.remove_rounded), findsNothing);
     expect(find.byIcon(Icons.add_rounded), findsNothing);
 
+    final menu = find.byKey(const ValueKey('sidebar-entry-actions-menu'));
+    expect(menu, findsOneWidget);
+    await tester.tap(menu);
+    await tester.pumpAndSettle();
     await tester.tap(find.byIcon(Icons.edit_rounded));
 
     expect(edited, isTrue);


### PR DESCRIPTION
## 改动内容
- 为正面和负面固定词增加紧凑分类 Rail，并保留跨分类搜索
- 统一列表与卡片模式的条目能力，优化信息层级、触屏命中区和大字号布局
- 默认隐藏关联连线，仅在相关条目交互时显示，并支持从负面端拖离解除关联
- 新增和编辑固定词时均可选择分类，负面固定词同样支持分类
- 删除旧分类 Chip、旧滚动定位、旧内联操作和对应过时测试

## 验证结果
- E:/flutter/bin/flutter.bat test test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart：41 项通过
- 变更相关文件执行 lutter analyze：无问题
- git diff --check：通过

## 注意事项
- 未执行 Windows 或 Android 运行时自动化验收