### PR TITLE
feat(tag-library): 接入提示词助手底栏

### DIFF
--- a/lib/presentation/prompt_assistant/providers/prompt_assistant_history_provider.dart
+++ b/lib/presentation/prompt_assistant/providers/prompt_assistant_history_provider.dart
@@ -13,6 +13,9 @@ class PromptHistorySessionIds {
       'generation_character_${characterId}_negative';
 
   static String fixedTag(String entryId) => 'fixed_tag_${entryId}_prompt';
+
+  static String tagLibraryEntry(String entryId) =>
+      'tag_library_${entryId}_prompt';
 }
 
 class PromptHistoryStack {

--- a/lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart
@@ -15,6 +15,11 @@ import '../../../../data/models/tag_library/tag_library_category.dart';
 import '../../../../data/models/tag_library/tag_library_entry.dart';
 import '../../../adaptive/adaptive_presenter.dart';
 import '../../../adaptive/interaction_policy.dart';
+import '../../../prompt_assistant/providers/prompt_assistant_config_provider.dart';
+import '../../../prompt_assistant/providers/prompt_assistant_history_provider.dart';
+import '../../../prompt_assistant/providers/prompt_assistant_state_provider.dart';
+import '../../../prompt_assistant/widgets/prompt_assistant_overlay.dart';
+import '../../../prompt_assistant/widgets/prompt_assistant_quick_settings.dart';
 import '../../../providers/image_generation_provider.dart';
 import '../../../providers/tag_library_page_provider.dart';
 import '../../../widgets/autocomplete/autocomplete.dart';
@@ -125,6 +130,7 @@ class _EntryAddDialogState extends ConsumerState<EntryAddDialog> {
   late final TextEditingController _nameController;
   late final NaiSyntaxController _contentController;
   late final TextEditingController _tagsController;
+  late final String _assistantSessionId;
   final _nameFocusNode = FocusNode();
   final _contentFocusNode = FocusNode();
   final _tagsFocusNode = FocusNode();
@@ -167,6 +173,9 @@ class _EntryAddDialogState extends ConsumerState<EntryAddDialog> {
     _nameController = TextEditingController(text: initialName);
     _contentController = NaiSyntaxController(text: initialContent);
     _tagsController = TextEditingController(text: entry?.tags.join(', ') ?? '');
+    _assistantSessionId = PromptHistorySessionIds.tagLibraryEntry(
+      entry?.id ?? 'draft-${identityHashCode(this)}',
+    );
     _selectedCategoryId = entry?.categoryId ?? widget.initialCategoryId;
     _thumbnailPath = entry?.thumbnail;
 
@@ -368,16 +377,7 @@ class _EntryAddDialogState extends ConsumerState<EntryAddDialog> {
                     ),
                   ),
                   const SizedBox(height: 4),
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(start: 12),
-                    child: Text(
-                      context.l10n.tagLibrary_characterNegativeSyntaxHelp,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: theme.colorScheme.outline,
-                      ),
-                    ),
-                  ),
+                  _buildPromptFooter(theme),
                 ],
               ),
             ),
@@ -415,6 +415,76 @@ class _EntryAddDialogState extends ConsumerState<EntryAddDialog> {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildPromptFooter(ThemeData theme) {
+    final interactionPolicy = context.interactionPolicy;
+    final assistantConfig = ref.watch(promptAssistantConfigProvider);
+    final assistantVisible =
+        assistantConfig.enabled &&
+        (!interactionPolicy.usesAnchoredMenus ||
+            assistantConfig.desktopOverlayEnabled);
+    final assistantExpanded =
+        assistantVisible &&
+        ref.watch(
+          promptAssistantStateProvider.select(
+            (states) => states[_assistantSessionId]?.expanded ?? false,
+          ),
+        );
+    final assistantToolbarHeight = assistantVisible
+        ? PromptAssistantOverlay.effectiveInlineToolbarHeight(interactionPolicy)
+        : 32.0;
+    final assistantIconOnly = interactionPolicy.prefersTouchPresentation;
+    final collapsedAssistantWidth = assistantIconOnly
+        ? assistantToolbarHeight
+        : PromptAssistantOverlay.collapsedInlineButtonWidth(
+            context,
+            context.l10n.promptAssistant_assistant,
+          );
+    final hint = Text(
+      context.l10n.tagLibrary_characterNegativeSyntaxHelp,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.62),
+        fontSize: 12,
+      ),
+    );
+    final assistant = assistantVisible
+        ? PromptAssistantOverlay(
+            key: ValueKey(
+              'tag-library-entry-prompt-assistant-$_assistantSessionId',
+            ),
+            sessionId: _assistantSessionId,
+            controller: _contentController,
+            interactionPolicy: interactionPolicy,
+            onOpenSettings: () => PromptAssistantQuickSettings.show(context),
+            floatOverEditor: false,
+            iconOnly: assistantIconOnly,
+            stripFixedTagsFromInput: false,
+          )
+        : null;
+
+    return Container(
+      key: const ValueKey('entry-add-dialog-content-footer'),
+      width: double.infinity,
+      constraints: BoxConstraints(minHeight: assistantToolbarHeight),
+      padding: const EdgeInsets.only(left: 12, right: 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerLow.withValues(alpha: 0.72),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        children: [
+          if (!assistantExpanded) Expanded(child: hint),
+          if (!assistantExpanded && assistant != null) const SizedBox(width: 8),
+          if (assistant != null)
+            assistantExpanded
+                ? Expanded(child: assistant)
+                : SizedBox(width: collapsedAssistantWidth, child: assistant),
+        ],
+      ),
     );
   }
 

--- a/test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart';
 import 'package:nai_launcher/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart';
 
 void main() {
@@ -105,6 +106,12 @@ void main() {
     expect(thumbnailSection.height, lessThan(210));
     expect(editor.height, 176);
     expect(editor.top, lessThan(490));
+    final contentFooter = find.byKey(
+      const ValueKey('entry-add-dialog-content-footer'),
+    );
+    final assistant = find.byType(PromptAssistantOverlay);
+    expect(contentFooter, findsOneWidget);
+    expect(assistant, findsOneWidget);
     expect(
       find.descendant(
         of: find.byKey(const Key('entry-add-dialog-content-editor')),
@@ -112,6 +119,36 @@ void main() {
       ),
       findsOneWidget,
     );
+    expect(
+      tester.getTopLeft(contentFooter).dy,
+      closeTo(editor.bottom + 4, 1),
+    );
+    expect(
+      tester.widget<PromptAssistantOverlay>(assistant).floatOverEditor,
+      false,
+    );
+    expect(
+      tester.widget<PromptAssistantOverlay>(assistant).stripFixedTagsFromInput,
+      false,
+    );
+    expect(
+      tester.getTopRight(assistant).dx,
+      closeTo(tester.getTopRight(contentFooter).dx - 4, 1),
+    );
+
+    await tester.tap(
+      find.descendant(
+        of: assistant,
+        matching: find.byIcon(Icons.auto_awesome_rounded),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final expandedAssistantRect = tester.getRect(assistant);
+    final footerRect = tester.getRect(contentFooter);
+    expect(expandedAssistantRect.left, greaterThanOrEqualTo(footerRect.left));
+    expect(expandedAssistantRect.right, lessThanOrEqualTo(footerRect.right));
+    expect(expandedAssistantRect.top, greaterThanOrEqualTo(footerRect.top));
+    expect(expandedAssistantRect.bottom, lessThanOrEqualTo(footerRect.bottom));
 
     await tester.tap(find.byTooltip('关闭'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## 改动内容
- 在词库“添加/编辑条目”的提示词输入框底部加入提示词助手底栏
- 复用固定词编辑器的显示策略、触屏呈现、快捷设置和展开交互
- 为词库条目分配独立助手历史会话，并保留完整条目内容作为处理对象

## 验证结果
- `scripts/run_flutter_tests.ps1 -Path test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart -TimeoutSeconds 120 -Concurrency 1`：通过（4 tests）
- `flutter analyze lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart lib/presentation/prompt_assistant/providers/prompt_assistant_history_provider.dart test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart`：通过
- `scripts/verify_flutter_sources.ps1`：通过

## 注意事项
- 按要求不等待 CI，PR 创建后直接 Squash Merge