### PR TITLE
fix(statistics): 增强统计卡片分组层级

### DIFF
--- a/lib/presentation/screens/statistics/widgets/cards/chart_card.dart
+++ b/lib/presentation/screens/statistics/widgets/cards/chart_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:nai_launcher/presentation/themes/theme_extension.dart';
 
 import '../../../../adaptive/window_size_class.dart';
+import '../../../../themes/core/layered_surface_style.dart';
 
 /// Section header widget
 /// 章节标题组件
@@ -107,8 +108,8 @@ class _ChartCardState extends State<ChartCard> {
             curve: theme.appTheme.standardCurve,
             decoration: BoxDecoration(
               color: _isHovered
-                  ? colorScheme.surfaceContainer
-                  : colorScheme.surfaceContainerLow,
+                  ? controlSurfaceColor(colorScheme)
+                  : sectionSurfaceColor(colorScheme),
               borderRadius: BorderRadius.circular(8),
             ),
             child: ClipRRect(

--- a/lib/presentation/screens/statistics/widgets/cards/metric_card.dart
+++ b/lib/presentation/screens/statistics/widgets/cards/metric_card.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:nai_launcher/presentation/themes/theme_extension.dart';
 
+import '../../../../themes/core/layered_surface_style.dart';
+
 /// Metric card with value, trend indicator and optional sparkline.
 class MetricCard extends StatefulWidget {
   final IconData icon;
@@ -60,8 +62,8 @@ class _MetricCardState extends State<MetricCard> {
             curve: theme.appTheme.standardCurve,
             decoration: BoxDecoration(
               color: interactive && _isHovered
-                  ? colorScheme.surfaceContainer
-                  : colorScheme.surfaceContainerLow,
+                  ? controlSurfaceColor(colorScheme)
+                  : sectionSurfaceColor(colorScheme),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Material(

--- a/lib/presentation/screens/statistics/widgets/common/section_container.dart
+++ b/lib/presentation/screens/statistics/widgets/common/section_container.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../adaptive/window_size_class.dart';
-import '../../../../widgets/common/themed_divider.dart';
+import '../../../../themes/core/layered_surface_style.dart';
 
 /// Container for statistics sections with consistent styling
 class SectionContainer extends StatelessWidget {
@@ -11,7 +11,6 @@ class SectionContainer extends StatelessWidget {
   final Widget child;
   final Widget? trailing;
   final EdgeInsetsGeometry? padding;
-  final bool showDivider;
 
   const SectionContainer({
     super.key,
@@ -21,7 +20,6 @@ class SectionContainer extends StatelessWidget {
     required this.child,
     this.trailing,
     this.padding,
-    this.showDivider = true,
   });
 
   @override
@@ -42,6 +40,10 @@ class SectionContainer extends StatelessWidget {
                 horizontal: useExpandedSpacing ? 24 : 16,
                 vertical: useExpandedSpacing ? 24 : 20,
               ),
+          decoration: BoxDecoration(
+            color: sectionSurfaceColor(colorScheme),
+            borderRadius: BorderRadius.circular(8),
+          ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -71,13 +73,7 @@ class SectionContainer extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 20),
-              // Section content
               child,
-              // Bottom divider
-              if (showDivider) ...[
-                const SizedBox(height: 24),
-                const ThemedDivider(height: 1),
-              ],
             ],
           ),
         );

--- a/test/presentation/screens/statistics/widgets/statistics_widget_responsive_test.dart
+++ b/test/presentation/screens/statistics/widgets/statistics_widget_responsive_test.dart
@@ -4,12 +4,86 @@ import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
 import 'package:nai_launcher/presentation/screens/statistics/widgets/animated/animated_number.dart';
 import 'package:nai_launcher/presentation/screens/statistics/widgets/cards/chart_card.dart';
+import 'package:nai_launcher/presentation/screens/statistics/widgets/cards/metric_card.dart';
 import 'package:nai_launcher/presentation/screens/statistics/widgets/charts/aspect_ratio_chart.dart';
 import 'package:nai_launcher/presentation/screens/statistics/widgets/charts/heatmap_chart.dart';
 import 'package:nai_launcher/presentation/screens/statistics/widgets/charts/top_tags_ranking.dart';
 import 'package:nai_launcher/presentation/screens/statistics/widgets/common/section_container.dart';
+import 'package:nai_launcher/presentation/themes/core/layered_surface_style.dart';
 
 void main() {
+  testWidgets(
+    'statistics cards keep tonal grouping when theme container roles collapse',
+    (tester) async {
+      const canvas = Color(0xFF181818);
+      final collapsedScheme = const ColorScheme.dark(
+        surface: canvas,
+      ).copyWith(surfaceContainerLow: canvas, surfaceContainer: canvas);
+      final sectionKey = GlobalKey();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(colorScheme: collapsedScheme),
+          home: Scaffold(
+            body: Column(
+              children: [
+                const MetricCard(
+                  key: ValueKey('grouped-metric-card'),
+                  icon: Icons.photo_outlined,
+                  label: 'Images',
+                  value: '42',
+                  compact: true,
+                ),
+                const ChartCard(
+                  key: ValueKey('grouped-chart-card'),
+                  title: 'Activity',
+                  child: SizedBox(height: 20),
+                ),
+                SectionContainer(
+                  sectionKey: sectionKey,
+                  title: 'Section',
+                  icon: Icons.bar_chart,
+                  child: const SizedBox(height: 20),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final metricSurface = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byKey(const ValueKey('grouped-metric-card')),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      final chartSurface = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byKey(const ValueKey('grouped-chart-card')),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      final sectionSurface = tester.widget<Container>(find.byKey(sectionKey));
+      final expectedSurface = sectionSurfaceColor(collapsedScheme);
+
+      expect(
+        (metricSurface.decoration! as BoxDecoration).color,
+        expectedSurface,
+      );
+      expect(
+        (chartSurface.decoration! as BoxDecoration).color,
+        expectedSurface,
+      );
+      expect(
+        (sectionSurface.decoration! as BoxDecoration).color,
+        expectedSurface,
+      );
+      expect(expectedSurface, isNot(canvas));
+      expect(find.byType(Divider), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets(
     'statistics containers use their local width at 700, 840, and 1180',
     (tester) async {
@@ -34,7 +108,6 @@ void main() {
                     sectionKey: sectionKey,
                     title: 'Section',
                     icon: Icons.bar_chart,
-                    showDivider: false,
                     child: const SizedBox(key: sectionChildKey, height: 20),
                   ),
                   const ChartCard(


### PR DESCRIPTION
## 改动内容
- 为统计指标卡片和图表卡片使用可辨识的语义色面，强化内容分组层级
- 移除统计分组容器底部的横向分隔线，改用低对比背景卡片表达边界
- 增加旧主题容器色与页面背景重合时的回归测试

## 验证结果
- `flutter test test/presentation/screens/statistics/widgets/statistics_widget_responsive_test.dart test/presentation/screens/statistics/widgets/statistics_hover_motion_test.dart`：13 项测试通过
- `dart analyze lib/presentation/screens/statistics`：无问题
- `git diff --check`：通过

## 注意事项
- 未执行 Windows 或 Android 运行时验收