### PR TITLE
fix(dialog): 统一短内容弹窗高度

### DIFF
--- a/lib/presentation/screens/generation/handlers/vibe_import_handler.dart
+++ b/lib/presentation/screens/generation/handlers/vibe_import_handler.dart
@@ -513,8 +513,10 @@ Future<VibeLibrarySaveFormResult?> showVibeLibrarySaveForm({
     dialogWidth: 440,
     builder: (panelContext, scrollController) => StatefulBuilder(
       builder: (panelContext, setState) => Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(
+          Flexible(
+            fit: FlexFit.loose,
             child: SingleChildScrollView(
               key: const ValueKey('vibe-library-save-form-scroll'),
               controller: scrollController,

--- a/lib/presentation/screens/settings/sections/agent/agent_profile_actions.dart
+++ b/lib/presentation/screens/settings/sections/agent/agent_profile_actions.dart
@@ -90,11 +90,14 @@ class _AgentProfileActionsState extends ConsumerState<AgentProfileActions> {
         title: context.l10n.agentSettings_confirmProfileImport,
         builder: (context, scrollController) => LayoutBuilder(
           builder: (context, constraints) => Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              Expanded(
+              Flexible(
+                fit: FlexFit.loose,
                 child: ListView(
                   key: const Key('agent-profile-import-review-list'),
                   controller: scrollController,
+                  shrinkWrap: true,
                   padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
                   children: [
                     Text(context.l10n.agentSettings_profilePrivacy),

--- a/lib/presentation/screens/tag_library_page/widgets/import_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/import_dialog.dart
@@ -67,14 +67,14 @@ class _ImportDialogState extends ConsumerState<ImportDialog> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Padding(
-      key: const Key('tag-library-import-content'),
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (_isImporting) ...[
-            // 导入进度
+    if (_isImporting) {
+      return Padding(
+        key: const Key('tag-library-import-content'),
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
             LinearProgressIndicator(value: _progress),
             const SizedBox(height: 12),
             Text(
@@ -83,54 +83,61 @@ class _ImportDialogState extends ConsumerState<ImportDialog> {
                 color: theme.colorScheme.outline,
               ),
             ),
-          ] else if (_preview == null) ...[
-            // 文件选择说明可能在大字号或软键盘下超过可用高度。
-            Expanded(
-              child: SingleChildScrollView(
-                keyboardDismissBehavior:
-                    ScrollViewKeyboardDismissBehavior.onDrag,
-                child: _buildFileSelection(theme),
+          ],
+        ),
+      );
+    }
+
+    if (_preview == null) {
+      return SingleChildScrollView(
+        key: const Key('tag-library-import-content'),
+        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+        padding: const EdgeInsets.all(16),
+        child: _buildFileSelection(theme),
+      );
+    }
+
+    return Padding(
+      key: const Key('tag-library-import-content'),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(child: _buildPreview(theme)),
+
+          const SizedBox(height: 16),
+
+          Wrap(
+            alignment: WrapAlignment.end,
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              TextButton(
+                onPressed: () {
+                  setState(() {
+                    _selectedFile = null;
+                    _preview = null;
+                    _conflicts = [];
+                    _conflictResolutions.clear();
+                  });
+                },
+                child: Text(context.l10n.tagLibrary_reselect),
               ),
-            ),
-          ] else ...[
-            // 预览和选择
-            Expanded(child: _buildPreview(theme)),
-
-            const SizedBox(height: 16),
-
-            // 操作按钮
-            Wrap(
-              alignment: WrapAlignment.end,
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                TextButton(
-                  onPressed: () {
-                    setState(() {
-                      _selectedFile = null;
-                      _preview = null;
-                      _conflicts = [];
-                      _conflictResolutions.clear();
-                    });
-                  },
-                  child: Text(context.l10n.tagLibrary_reselect),
-                ),
-                FilledButton.icon(
-                  onPressed:
-                      _selectedEntryIds.isNotEmpty ||
-                          _selectedCategoryIds.isNotEmpty
-                      ? _import
-                      : null,
-                  icon: const Icon(Icons.file_download),
-                  label: Text(
-                    context.l10n.tagLibrary_selectedImportCount(
-                      _selectedEntryIds.length + _selectedCategoryIds.length,
-                    ),
+              FilledButton.icon(
+                onPressed:
+                    _selectedEntryIds.isNotEmpty ||
+                        _selectedCategoryIds.isNotEmpty
+                    ? _import
+                    : null,
+                icon: const Icon(Icons.file_download),
+                label: Text(
+                  context.l10n.tagLibrary_selectedImportCount(
+                    _selectedEntryIds.length + _selectedCategoryIds.length,
                   ),
                 ),
-              ],
-            ),
-          ],
+              ),
+            ],
+          ),
         ],
       ),
     );

--- a/lib/presentation/widgets/character/add_to_library_dialog.dart
+++ b/lib/presentation/widgets/character/add_to_library_dialog.dart
@@ -114,10 +114,13 @@ class _AddToLibraryDialogState extends ConsumerState<AddToLibraryDialog> {
     final categories = ref.watch(tagLibraryPageCategoriesProvider);
 
     return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        Expanded(
+        Flexible(
+          fit: FlexFit.loose,
           child: ListView(
             controller: widget.scrollController,
+            shrinkWrap: true,
             keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
             padding: const EdgeInsets.all(16),
             children: [

--- a/lib/presentation/widgets/prompt/diy/dialogs/preset_import_dialog.dart
+++ b/lib/presentation/widgets/prompt/diy/dialogs/preset_import_dialog.dart
@@ -153,11 +153,14 @@ class _PresetImportDialogState extends State<PresetImportDialog> {
         : _error;
 
     return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        Expanded(
+        Flexible(
+          fit: FlexFit.loose,
           child: ListView(
             key: const ValueKey('preset-import-scroll'),
             controller: widget.scrollController,
+            shrinkWrap: true,
             keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
             padding: const EdgeInsets.all(16),
             children: [

--- a/lib/presentation/widgets/prompt/regex_rules_dialog.dart
+++ b/lib/presentation/widgets/prompt/regex_rules_dialog.dart
@@ -70,10 +70,13 @@ class _RegexRulesDialogState extends ConsumerState<RegexRulesDialog> {
       minChildSize: 0.36,
       dialogWidth: 440,
       builder: (dialogContext, scrollController) => Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(
+          Flexible(
+            fit: FlexFit.loose,
             child: ListView(
               controller: scrollController,
+              shrinkWrap: true,
               padding: const EdgeInsets.all(16),
               children: [Text(l10n.regexRules_deleteConfirmMessage(label))],
             ),
@@ -113,10 +116,13 @@ class _RegexRulesDialogState extends ConsumerState<RegexRulesDialog> {
     final rules = ref.watch(promptRegexRulesProvider);
 
     return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        Expanded(
+        Flexible(
+          fit: FlexFit.loose,
           child: ListView(
             controller: widget.scrollController,
+            shrinkWrap: true,
             keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
             children: [
@@ -529,10 +535,13 @@ class _RuleEditDialogState extends State<_RuleEditDialog> {
     final isEditing = widget.rule != null;
 
     return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        Expanded(
+        Flexible(
+          fit: FlexFit.loose,
           child: ListView(
             controller: widget.scrollController,
+            shrinkWrap: true,
             keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
             padding: const EdgeInsets.all(16),
             children: [

--- a/lib/presentation/widgets/prompt/weight_adjust_dialog.dart
+++ b/lib/presentation/widgets/prompt/weight_adjust_dialog.dart
@@ -429,8 +429,10 @@ class _TagEditDialogState extends State<TagEditDialog> {
   @override
   Widget build(BuildContext context) {
     return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        Expanded(
+        Flexible(
+          fit: FlexFit.loose,
           child: SingleChildScrollView(
             keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
             padding: const EdgeInsets.all(16),

--- a/test/presentation/screens/tag_library_page/tag_library_dialog_responsive_test.dart
+++ b/test/presentation/screens/tag_library_page/tag_library_dialog_responsive_test.dart
@@ -258,6 +258,8 @@ void main() {
     var panel = find.byKey(const ValueKey('adaptive-centered-form'));
     expect(panel, findsOneWidget);
     expect(tester.getSize(panel).width, 700);
+    expect(tester.getSize(panel).height, lessThan(700));
+    expect(tester.getRect(panel).center.dy, moreOrLessEquals(400));
     await tester.tap(find.byIcon(Icons.close));
     await tester.pumpAndSettle();
 

--- a/test/presentation/widgets/prompt/diy/dialogs/preset_import_dialog_test.dart
+++ b/test/presentation/widgets/prompt/diy/dialogs/preset_import_dialog_test.dart
@@ -55,9 +55,12 @@ void main() {
     final contentRect = tester.getRect(
       find.byKey(const ValueKey('preset-import-scroll')),
     );
+    final panel = find.byKey(const ValueKey('adaptive-centered-form'));
     expect(find.byType(Dialog), findsNothing);
     expect(contentRect.width, lessThanOrEqualTo(560));
     expect(contentRect.right, lessThanOrEqualTo(1600));
+    expect(tester.getSize(panel).height, lessThan(700));
+    expect(tester.getRect(panel).center.dy, moreOrLessEquals(450));
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/presentation/widgets/prompt/prompt_character_dialogs_responsive_test.dart
+++ b/test/presentation/widgets/prompt/prompt_character_dialogs_responsive_test.dart
@@ -77,6 +77,43 @@ void main() {
       }
     },
   );
+
+  testWidgets('short desktop prompt dialogs follow their content height', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1000, 800);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          promptRegexRulesProvider.overrideWith(_EmptyRegexRules.new),
+          tagLibraryPageCategoriesProvider.overrideWith((ref) => const []),
+        ],
+        child: const MaterialApp(
+          locale: Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: _PanelTestHost(),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Library'));
+    await tester.pumpAndSettle();
+    var panel = find.byKey(const ValueKey('adaptive-centered-form'));
+    expect(tester.getSize(panel).height, lessThan(650));
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Regex'));
+    await tester.pumpAndSettle();
+    panel = find.byKey(const ValueKey('adaptive-centered-form'));
+    expect(tester.getSize(panel).height, lessThan(700));
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class _PanelTestHost extends StatelessWidget {

--- a/test/presentation/widgets/prompt/weight_adjust_dialog_responsive_test.dart
+++ b/test/presentation/widgets/prompt/weight_adjust_dialog_responsive_test.dart
@@ -114,6 +114,39 @@ void main() {
     expect(tester.getSize(panel).width, lessThanOrEqualTo(640));
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('wide tag edit form follows its content height', (tester) async {
+    final view =
+        TestWidgetsFlutterBinding.instance.platformDispatcher.views.single;
+    view.devicePixelRatio = 1;
+    view.physicalSize = const Size(1000, 800);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () =>
+                  TagEditDialog.show(context, tag: _tag, onTextChanged: (_) {}),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    final panel = find.byKey(const ValueKey('adaptive-centered-form'));
+    expect(panel, findsOneWidget);
+    expect(tester.getSize(panel).height, lessThan(320));
+    expect(tester.getRect(panel).center.dy, moreOrLessEquals(400));
+    expect(tester.takeException(), isNull);
+  });
 }
 
 Widget _app({required ValueChanged<BuildContext> onPressed}) {


### PR DESCRIPTION
## 改动内容
- 修复词库导入、随机预设导入等短内容弹窗被 `Expanded` 撑满可用高度的问题
- 统一标签编辑、正则规则、角色入库、Vibe 保存和 Agent 配置导入审阅弹窗的自然高度与有界滚动行为
- 保留长列表、工作流和指南类弹窗的稳定滚动视口

## 验证结果
- 相关 6 个 Widget test 文件，共 25 项测试通过
- 受影响 Dart 文件定向分析通过，无诊断问题
- `git diff --check origin/main...HEAD` 通过

## 注意事项
- 未执行运行时自动化验收
- 按要求不等待 CI