### PR TITLE
feat(tag-library): 添加方形预览与卡片范围框

### DIFF
--- a/lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart
@@ -25,12 +25,12 @@ import '../../../providers/tag_library_page_provider.dart';
 import '../../../widgets/autocomplete/autocomplete.dart';
 import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/safe_dropdown.dart';
-import '../../../widgets/common/thumbnail_display.dart';
 import '../../../widgets/common/themed_input.dart';
 import '../../../widgets/prompt/nai_syntax_controller.dart';
 import '../../../widgets/prompt/prompt_formatter_wrapper.dart';
 import '../../../widgets/prompt/quick_translate_prompt_field.dart';
 import 'thumbnail_crop_dialog.dart';
+import 'thumbnail_selection_preview.dart';
 
 /// 添加/编辑词库条目对话框
 class EntryAddDialog extends ConsumerStatefulWidget {
@@ -500,62 +500,79 @@ class _EntryAddDialogState extends ConsumerState<EntryAddDialog> {
             style: theme.textTheme.labelLarge,
           ),
           const SizedBox(height: 8),
-          GestureDetector(
-            onTap: _thumbnailPath != null
-                ? _showThumbnailOptions
-                : _selectThumbnail,
-            child: Container(
-              width: double.infinity,
-              height: expand ? 112 : 124,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: _thumbnailPath != null
-                  ? Stack(
-                      fit: StackFit.expand,
-                      children: [
-                        ClipRRect(
-                          borderRadius: BorderRadius.circular(11),
-                          child: _buildThumbnailImage(),
-                        ),
-                        Positioned(
-                          top: 4,
-                          right: 4,
-                          child: IconButton.filled(
-                            icon: const Icon(Icons.close, size: 16),
-                            style: IconButton.styleFrom(
-                              backgroundColor: Colors.black54,
-                              foregroundColor: Colors.white,
-                              minimumSize: Size.square(
-                                context.interactionPolicy.minimumControlExtent,
-                              ),
-                              padding: EdgeInsets.zero,
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final previewSize = constraints.maxWidth.clamp(0, 220).toDouble();
+              return Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: SizedBox.square(
+                  key: const ValueKey('entry-thumbnail-square-preview'),
+                  dimension: previewSize,
+                  child: GestureDetector(
+                    onTap: _thumbnailPath != null
+                        ? _showThumbnailOptions
+                        : _selectThumbnail,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: _thumbnailPath != null
+                          ? Stack(
+                              fit: StackFit.expand,
+                              children: [
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(11),
+                                  child: ThumbnailSelectionPreview(
+                                    imagePath: _thumbnailPath!,
+                                    offsetX: _thumbnailOffsetX,
+                                    offsetY: _thumbnailOffsetY,
+                                    scale: _thumbnailScale,
+                                  ),
+                                ),
+                                Positioned(
+                                  top: 4,
+                                  right: 4,
+                                  child: IconButton.filled(
+                                    icon: const Icon(Icons.close, size: 16),
+                                    style: IconButton.styleFrom(
+                                      backgroundColor: Colors.black54,
+                                      foregroundColor: Colors.white,
+                                      minimumSize: Size.square(
+                                        context
+                                            .interactionPolicy
+                                            .minimumControlExtent,
+                                      ),
+                                      padding: EdgeInsets.zero,
+                                    ),
+                                    onPressed: _clearThumbnail,
+                                  ),
+                                ),
+                              ],
+                            )
+                          : Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Icon(
+                                  Icons.add_photo_alternate_outlined,
+                                  size: 36,
+                                  color: theme.colorScheme.outline,
+                                ),
+                                const SizedBox(height: 8),
+                                Text(
+                                  context.l10n.tagLibrary_selectImage,
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color: theme.colorScheme.outline,
+                                  ),
+                                ),
+                              ],
                             ),
-                            onPressed: _clearThumbnail,
-                          ),
-                        ),
-                      ],
-                    )
-                  : Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.add_photo_alternate_outlined,
-                          size: 36,
-                          color: theme.colorScheme.outline,
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          context.l10n.tagLibrary_selectImage,
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: theme.colorScheme.outline,
-                          ),
-                        ),
-                      ],
                     ),
-            ),
+                  ),
+                ),
+              );
+            },
           ),
           const SizedBox(height: 8),
           Text(
@@ -652,36 +669,6 @@ class _EntryAddDialogState extends ConsumerState<EntryAddDialog> {
           ),
         ),
       ],
-    );
-  }
-
-  /// 构建带变换效果的预览图
-  /// 使用 ThumbnailDisplay 组件确保与 EntryCard 显示一致
-  Widget _buildThumbnailImage() {
-    if (_thumbnailPath == null) {
-      return Container(
-        color: Colors.grey.shade800,
-        child: const Center(
-          child: Icon(Icons.image_not_supported, color: Colors.white38),
-        ),
-      );
-    }
-
-    // 调试用
-    debugPrint(
-      'EntryAddDialog: offset=($_thumbnailOffsetX, $_thumbnailOffsetY), scale=$_thumbnailScale',
-    );
-
-    // 使用 ThumbnailDisplay 组件确保与 EntryCard 显示一致
-    return LayoutBuilder(
-      builder: (context, constraints) => ThumbnailDisplay(
-        imagePath: _thumbnailPath!,
-        offsetX: _thumbnailOffsetX,
-        offsetY: _thumbnailOffsetY,
-        scale: _thumbnailScale,
-        width: constraints.maxWidth,
-        height: constraints.maxHeight,
-      ),
     );
   }
 

--- a/lib/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog.dart
@@ -6,6 +6,7 @@ import 'package:flutter/gestures.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../adaptive/adaptive_presenter.dart';
+import 'thumbnail_selection_preview.dart';
 
 /// 缩略图裁剪调整结果
 class ThumbnailCropResult {
@@ -62,9 +63,6 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
   // 桌面端保持原有高效预览尺寸，紧凑窗口由实际 constraints 决定。
   static const Size _desktopDisplaySize = Size(640, 360);
 
-  // EntryCard 比例
-  static const double _cardAspectRatio = 2.5; // 200 / 80
-
   @override
   void initState() {
     super.initState();
@@ -95,43 +93,12 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
   /// 计算图像在当前预览区域中的尺寸（保持比例）
   Size _displayedImageSize(Size displaySize) {
     if (_imageSize == null) return displaySize;
-
-    final imageAspectRatio = _imageSize!.width / _imageSize!.height;
-    final displayAspectRatio = displaySize.width / displaySize.height;
-
-    if (imageAspectRatio > displayAspectRatio) {
-      final width = displaySize.width;
-      final height = width / imageAspectRatio;
-      return Size(width, height);
-    } else {
-      final height = displaySize.height;
-      final width = height * imageAspectRatio;
-      return Size(width, height);
-    }
+    return displayedThumbnailImageSize(_imageSize!, displaySize);
   }
 
   /// 计算裁剪框尺寸
   Size _cropBoxSize(Size displayedSize) {
-    // 裁剪框的比例是 EntryCard 的比例
-    // 当 scale = 1.0 时，裁剪框尽可能大但保持比例
-    // 当 scale > 1.0 时，裁剪框变小（放大图像）
-
-    // 基础裁剪框尺寸（scale = 1.0）
-    double baseWidth, baseHeight;
-
-    if (displayedSize.width / displayedSize.height > _cardAspectRatio) {
-      // 图像比裁剪框更宽，以高度为准
-      baseHeight = displayedSize.height;
-      baseWidth = baseHeight * _cardAspectRatio;
-    } else {
-      // 图像比裁剪框更高，以宽度为准
-      baseWidth = displayedSize.width;
-      baseHeight = baseWidth / _cardAspectRatio;
-    }
-
-    // 根据缩放调整裁剪框大小
-    final scaleFactor = 1.0 / _cropScale;
-    return Size(baseWidth * scaleFactor, baseHeight * scaleFactor);
+    return thumbnailCropBoxSize(displayedSize, _cropScale);
   }
 
   void _onScaleStart(ScaleStartDetails details) {
@@ -302,12 +269,12 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
     final cropSize = _cropBoxSize(displayedSize);
     final imageOffsetX = (displaySize.width - displayedSize.width) / 2;
     final imageOffsetY = (displaySize.height - displayedSize.height) / 2;
-    final cropLeft =
-        imageOffsetX +
-        (displayedSize.width - cropSize.width) / 2 * (1 + _cropX);
-    final cropTop =
-        imageOffsetY +
-        (displayedSize.height - cropSize.height) / 2 * (1 + _cropY);
+    final cropRect = thumbnailCropRect(
+      displayedSize: displayedSize,
+      cropBoxSize: cropSize,
+      offsetX: _cropX,
+      offsetY: _cropY,
+    );
 
     return Listener(
       onPointerSignal: (event) {
@@ -360,16 +327,12 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
                   top: imageOffsetY,
                   child: CustomPaint(
                     size: displayedSize,
-                    painter: _CropOverlayPainter(
-                      cropBoxSize: cropSize,
-                      offsetX: _cropX,
-                      offsetY: _cropY,
-                    ),
+                    painter: _CropOverlayPainter(cropRect: cropRect),
                   ),
                 ),
                 Positioned(
-                  left: cropLeft,
-                  top: cropTop,
+                  left: imageOffsetX + cropRect.left,
+                  top: imageOffsetY + cropRect.top,
                   child: IgnorePointer(
                     child: Container(
                       key: const ValueKey('thumbnail-crop-selection'),
@@ -466,33 +429,15 @@ class _ThumbnailCropDialogState extends State<ThumbnailCropDialog> {
 
 /// 裁剪框遮罩绘制器
 class _CropOverlayPainter extends CustomPainter {
-  final Size cropBoxSize;
-  final double offsetX;
-  final double offsetY;
+  final Rect cropRect;
 
-  _CropOverlayPainter({
-    required this.cropBoxSize,
-    required this.offsetX,
-    required this.offsetY,
-  });
+  _CropOverlayPainter({required this.cropRect});
 
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
       ..color = Colors.black.withValues(alpha: 0.5)
       ..style = PaintingStyle.fill;
-
-    // 计算裁剪框位置（中心对齐）
-    final centerX = size.width / 2;
-    final centerY = size.height / 2;
-
-    final maxOffsetX = (size.width - cropBoxSize.width) / 2;
-    final maxOffsetY = (size.height - cropBoxSize.height) / 2;
-
-    final cropLeft = centerX - cropBoxSize.width / 2 + offsetX * maxOffsetX;
-    final cropTop = centerY - cropBoxSize.height / 2 + offsetY * maxOffsetY;
-    final cropRight = cropLeft + cropBoxSize.width;
-    final cropBottom = cropTop + cropBoxSize.height;
 
     // 绘制整个背景，然后挖空中间
     canvas.saveLayer(Rect.fromLTWH(0, 0, size.width, size.height), Paint());
@@ -503,19 +448,14 @@ class _CropOverlayPainter extends CustomPainter {
     // 使用混合模式清除中间区域
     final clearPaint = Paint()..blendMode = BlendMode.clear;
 
-    canvas.drawRect(
-      Rect.fromLTRB(cropLeft, cropTop, cropRight, cropBottom),
-      clearPaint,
-    );
+    canvas.drawRect(cropRect, clearPaint);
 
     canvas.restore();
   }
 
   @override
   bool shouldRepaint(covariant _CropOverlayPainter oldDelegate) {
-    return oldDelegate.cropBoxSize != cropBoxSize ||
-        oldDelegate.offsetX != offsetX ||
-        oldDelegate.offsetY != offsetY;
+    return oldDelegate.cropRect != cropRect;
   }
 }
 

--- a/lib/presentation/screens/tag_library_page/widgets/thumbnail_selection_preview.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/thumbnail_selection_preview.dart
@@ -1,0 +1,259 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+const double tagLibraryCardAspectRatio = 2.5;
+
+Size displayedThumbnailImageSize(Size imageSize, Size displaySize) {
+  final imageAspectRatio = imageSize.width / imageSize.height;
+  final displayAspectRatio = displaySize.width / displaySize.height;
+
+  if (imageAspectRatio > displayAspectRatio) {
+    final width = displaySize.width;
+    return Size(width, width / imageAspectRatio);
+  }
+
+  final height = displaySize.height;
+  return Size(height * imageAspectRatio, height);
+}
+
+Size thumbnailCropBoxSize(Size displayedSize, double scale) {
+  final double baseWidth;
+  final double baseHeight;
+  if (displayedSize.width / displayedSize.height > tagLibraryCardAspectRatio) {
+    baseHeight = displayedSize.height;
+    baseWidth = baseHeight * tagLibraryCardAspectRatio;
+  } else {
+    baseWidth = displayedSize.width;
+    baseHeight = baseWidth / tagLibraryCardAspectRatio;
+  }
+
+  final scaleFactor = 1 / scale.clamp(1.0, 3.0);
+  return Size(baseWidth * scaleFactor, baseHeight * scaleFactor);
+}
+
+Rect thumbnailCropRect({
+  required Size displayedSize,
+  required Size cropBoxSize,
+  required double offsetX,
+  required double offsetY,
+}) {
+  final maxOffsetX = (displayedSize.width - cropBoxSize.width) / 2;
+  final maxOffsetY = (displayedSize.height - cropBoxSize.height) / 2;
+  final center = Offset(
+    displayedSize.width / 2 + offsetX.clamp(-1.0, 1.0) * maxOffsetX,
+    displayedSize.height / 2 + offsetY.clamp(-1.0, 1.0) * maxOffsetY,
+  );
+  return Rect.fromCenter(
+    center: center,
+    width: cropBoxSize.width,
+    height: cropBoxSize.height,
+  );
+}
+
+/// 在完整图像上标出词库卡片实际使用的长方形范围。
+class ThumbnailSelectionPreview extends StatefulWidget {
+  const ThumbnailSelectionPreview({
+    super.key,
+    required this.imagePath,
+    required this.offsetX,
+    required this.offsetY,
+    required this.scale,
+  });
+
+  final String imagePath;
+  final double offsetX;
+  final double offsetY;
+  final double scale;
+
+  @override
+  State<ThumbnailSelectionPreview> createState() =>
+      _ThumbnailSelectionPreviewState();
+}
+
+class _ThumbnailSelectionPreviewState extends State<ThumbnailSelectionPreview> {
+  ImageStream? _imageStream;
+  ImageStreamListener? _imageStreamListener;
+  Size? _imageSize;
+  bool _imageLoadFailed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadImageSize();
+  }
+
+  @override
+  void didUpdateWidget(ThumbnailSelectionPreview oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imagePath != widget.imagePath) {
+      _loadImageSize();
+    }
+  }
+
+  void _loadImageSize() {
+    _removeImageListener();
+    _imageSize = null;
+    _imageLoadFailed = false;
+    final stream = FileImage(
+      File(widget.imagePath),
+    ).resolve(const ImageConfiguration());
+    late final ImageStreamListener listener;
+    listener = ImageStreamListener(
+      (info, _) {
+        if (!mounted || stream != _imageStream) return;
+        setState(() {
+          _imageSize = Size(
+            info.image.width.toDouble(),
+            info.image.height.toDouble(),
+          );
+        });
+        stream.removeListener(listener);
+        _imageStream = null;
+        _imageStreamListener = null;
+      },
+      onError: (_, __) {
+        if (stream != _imageStream) return;
+        stream.removeListener(listener);
+        _imageStream = null;
+        _imageStreamListener = null;
+        if (mounted) setState(() => _imageLoadFailed = true);
+      },
+    );
+    _imageStream = stream;
+    _imageStreamListener = listener;
+    stream.addListener(listener);
+  }
+
+  void _removeImageListener() {
+    final stream = _imageStream;
+    final listener = _imageStreamListener;
+    if (stream != null && listener != null) {
+      stream.removeListener(listener);
+    }
+    _imageStream = null;
+    _imageStreamListener = null;
+  }
+
+  @override
+  void dispose() {
+    _removeImageListener();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final displaySize = constraints.biggest;
+        final imageSize = _imageSize;
+        if (imageSize == null) {
+          if (_imageLoadFailed) {
+            return Center(
+              child: Icon(
+                Icons.broken_image_outlined,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            );
+          }
+          return Center(
+            child: CircularProgressIndicator(
+              value: MediaQuery.disableAnimationsOf(context) ? 0.72 : null,
+            ),
+          );
+        }
+
+        final displayedSize = displayedThumbnailImageSize(
+          imageSize,
+          displaySize,
+        );
+        final imageOffset = Offset(
+          (displaySize.width - displayedSize.width) / 2,
+          (displaySize.height - displayedSize.height) / 2,
+        );
+        final cropSize = thumbnailCropBoxSize(displayedSize, widget.scale);
+        final cropRect = thumbnailCropRect(
+          displayedSize: displayedSize,
+          cropBoxSize: cropSize,
+          offsetX: widget.offsetX,
+          offsetY: widget.offsetY,
+        ).shift(imageOffset);
+
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            Positioned(
+              left: imageOffset.dx,
+              top: imageOffset.dy,
+              width: displayedSize.width,
+              height: displayedSize.height,
+              child: Image.file(
+                File(widget.imagePath),
+                fit: BoxFit.contain,
+                errorBuilder: (_, __, ___) => Center(
+                  child: Icon(
+                    Icons.broken_image_outlined,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ),
+            CustomPaint(
+              painter: _ThumbnailSelectionPainter(
+                imageRect: imageOffset & displayedSize,
+                cropRect: cropRect,
+                scrimColor: theme.colorScheme.scrim.withValues(alpha: 0.48),
+                borderColor: theme.colorScheme.onSurface,
+              ),
+            ),
+            Positioned.fromRect(
+              rect: cropRect,
+              child: const IgnorePointer(
+                child: SizedBox(key: ValueKey('entry-thumbnail-card-frame')),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ThumbnailSelectionPainter extends CustomPainter {
+  const _ThumbnailSelectionPainter({
+    required this.imageRect,
+    required this.cropRect,
+    required this.scrimColor,
+    required this.borderColor,
+  });
+
+  final Rect imageRect;
+  final Rect cropRect;
+  final Color scrimColor;
+  final Color borderColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final outsideCrop = Path()
+      ..fillType = PathFillType.evenOdd
+      ..addRect(imageRect)
+      ..addRect(cropRect);
+    canvas.drawPath(outsideCrop, Paint()..color = scrimColor);
+    canvas.drawRect(
+      cropRect.deflate(1),
+      Paint()
+        ..color = borderColor
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _ThumbnailSelectionPainter oldDelegate) {
+    return oldDelegate.imageRect != imageRect ||
+        oldDelegate.cropRect != cropRect ||
+        oldDelegate.scrimColor != scrimColor ||
+        oldDelegate.borderColor != borderColor;
+  }
+}

--- a/test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/prompt_assistant/widgets/prompt_assistant_overlay.dart';
 import 'package:nai_launcher/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart';
@@ -103,7 +107,11 @@ void main() {
       find.byKey(const Key('entry-add-dialog-content-editor')),
     );
     expect(thumbnailSection.width, 220);
-    expect(thumbnailSection.height, lessThan(210));
+    expect(thumbnailSection.height, greaterThan(240));
+    final squarePreview = tester.getRect(
+      find.byKey(const ValueKey('entry-thumbnail-square-preview')),
+    );
+    expect(squarePreview.size, const Size.square(220));
     expect(editor.height, 176);
     expect(editor.top, lessThan(490));
     final contentFooter = find.byKey(
@@ -119,10 +127,7 @@ void main() {
       ),
       findsOneWidget,
     );
-    expect(
-      tester.getTopLeft(contentFooter).dy,
-      closeTo(editor.bottom + 4, 1),
-    );
+    expect(tester.getTopLeft(contentFooter).dy, closeTo(editor.bottom + 4, 1));
     expect(
       tester.widget<PromptAssistantOverlay>(assistant).floatOverEditor,
       false,
@@ -136,6 +141,14 @@ void main() {
       closeTo(tester.getTopRight(contentFooter).dx - 4, 1),
     );
 
+    final dialogScrollable = find
+        .descendant(
+          of: find.byKey(const Key('entry-add-dialog-scroll')),
+          matching: find.byType(Scrollable),
+        )
+        .first;
+    await tester.drag(dialogScrollable, const Offset(0, -180));
+    await tester.pumpAndSettle();
     await tester.tap(
       find.descendant(
         of: assistant,
@@ -153,6 +166,40 @@ void main() {
     await tester.tap(find.byTooltip('关闭'));
     await tester.pumpAndSettle();
     expect(completed, isTrue);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('已有预览图时在方形区域标出卡片显示范围', (tester) async {
+    final testImage = File('assets/icons/android/playstore-icon.png').absolute;
+    await _cacheFileImage(tester, testImage);
+    final entry = TagLibraryEntry(
+      id: 'entry-with-preview',
+      name: '测试词条',
+      content: '1girl',
+      thumbnail: testImage.path,
+      thumbnailOffsetX: 0.4,
+      thumbnailOffsetY: -0.3,
+      thumbnailScale: 1.5,
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+    );
+    await _pumpLauncher(tester, size: const Size(1180, 800), entry: entry);
+
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+
+    final preview = tester.getRect(
+      find.byKey(const ValueKey('entry-thumbnail-square-preview')),
+    );
+    final frame = tester.getRect(
+      find.byKey(const ValueKey('entry-thumbnail-card-frame')),
+    );
+    expect(preview.size, const Size.square(220));
+    expect(frame.width / frame.height, closeTo(2.5, 0.01));
+    expect(preview.contains(frame.topLeft), isTrue);
+    expect(preview.contains(frame.bottomRight), isTrue);
+    expect(frame.center.dx, greaterThan(preview.center.dx));
+    expect(frame.center.dy, lessThan(preview.center.dy));
     expect(tester.takeException(), isNull);
   });
 
@@ -177,6 +224,28 @@ void main() {
   });
 }
 
+Future<void> _cacheFileImage(WidgetTester tester, File file) async {
+  await tester.runAsync(() async {
+    final completed = Completer<void>();
+    final stream = FileImage(file).resolve(ImageConfiguration.empty);
+    late final ImageStreamListener listener;
+    listener = ImageStreamListener(
+      (_, __) {
+        if (!completed.isCompleted) completed.complete();
+        stream.removeListener(listener);
+      },
+      onError: (Object error, StackTrace? stackTrace) {
+        if (!completed.isCompleted) {
+          completed.completeError(error, stackTrace);
+        }
+        stream.removeListener(listener);
+      },
+    );
+    stream.addListener(listener);
+    await completed.future;
+  });
+}
+
 Future<void> _pumpLauncher(
   WidgetTester tester, {
   required Size size,
@@ -184,6 +253,7 @@ Future<void> _pumpLauncher(
   EdgeInsets padding = EdgeInsets.zero,
   EdgeInsets viewInsets = EdgeInsets.zero,
   VoidCallback? onCompleted,
+  TagLibraryEntry? entry,
 }) async {
   tester.view.physicalSize = size;
   tester.view.devicePixelRatio = 1;
@@ -211,7 +281,11 @@ Future<void> _pumpLauncher(
             builder: (context) => Center(
               child: FilledButton(
                 onPressed: () async {
-                  await EntryAddDialog.show(context, categories: const []);
+                  await EntryAddDialog.show(
+                    context,
+                    categories: const [],
+                    entry: entry,
+                  );
                   onCompleted?.call();
                 },
                 child: const Text('打开'),


### PR DESCRIPTION
## 改动内容
- 将词库条目新增/编辑弹窗的预览图区域改为自适应方形区域
- 在完整预览图上绘制词库卡片比例的范围框，并根据已有偏移和缩放实时标示实际显示范围
- 复用裁剪对话框的范围计算，避免主弹窗预览与调整结果不一致
- 补充方形尺寸、范围框比例、偏移方向和响应式布局回归测试

## 验证结果
- `flutter test test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart test/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog_test.dart`（11 项通过）
- `dart analyze lib/presentation/screens/tag_library_page/widgets/entry_add_dialog.dart lib/presentation/screens/tag_library_page/widgets/thumbnail_crop_dialog.dart lib/presentation/screens/tag_library_page/widgets/thumbnail_selection_preview.dart test/presentation/screens/tag_library_page/widgets/entry_add_dialog_test.dart`（无问题）
- Impeccable layout detector（无发现）

## 注意事项
- 按要求创建后直接 Squash Merge，不等待 CI。