### PR TITLE
fix(precise-ref): 补充导出内容选择

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5612,6 +5612,13 @@
   "preciseRefLib_emptyHintTouch": "You can also save images from generation results, history, or the local gallery",
   "preciseRefLib_import": "Import Images",
   "preciseRefLib_exportTitle": "Export Precise Reference Package",
+  "preciseRefLib_exportSelectionHint": "Choose the precise references to include. The selected items will be bundled into one .naipreciseref file.",
+  "preciseRefLib_exportConfirm": "Export Selected ({count})",
+  "@preciseRefLib_exportConfirm": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "preciseRefLib_exportedCount": "Exported {count} precise references",
   "preciseRefLib_exportFailed": "Failed to export precise references: {error}",
   "preciseRefLib_openFolderFailed": "Failed to open the precise reference folder: {error}",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -5619,6 +5619,13 @@
   "preciseRefLib_emptyHintTouch": "生成結果、履歴、ローカルギャラリーから保存することもできます",
   "preciseRefLib_import": "画像をインポート",
   "preciseRefLib_exportTitle": "精密参照パッケージをエクスポート",
+  "preciseRefLib_exportSelectionHint": "含める精密参照を選択してください。選択した項目は 1 つの .naipreciseref ファイルにまとめられます。",
+  "preciseRefLib_exportConfirm": "選択項目をエクスポート ({count})",
+  "@preciseRefLib_exportConfirm": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "preciseRefLib_exportedCount": "精密参照を {count} 件エクスポートしました",
   "preciseRefLib_exportFailed": "精密参照のエクスポートに失敗しました：{error}",
   "preciseRefLib_openFolderFailed": "精密参照フォルダーを開けませんでした：{error}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -20554,6 +20554,18 @@ abstract class AppLocalizations {
   /// **'Export Precise Reference Package'**
   String get preciseRefLib_exportTitle;
 
+  /// No description provided for @preciseRefLib_exportSelectionHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose the precise references to include. The selected items will be bundled into one .naipreciseref file.'**
+  String get preciseRefLib_exportSelectionHint;
+
+  /// No description provided for @preciseRefLib_exportConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Export Selected ({count})'**
+  String preciseRefLib_exportConfirm(int count);
+
   /// No description provided for @preciseRefLib_exportedCount.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -11742,6 +11742,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get preciseRefLib_exportTitle => 'Export Precise Reference Package';
 
   @override
+  String get preciseRefLib_exportSelectionHint =>
+      'Choose the precise references to include. The selected items will be bundled into one .naipreciseref file.';
+
+  @override
+  String preciseRefLib_exportConfirm(int count) {
+    return 'Export Selected ($count)';
+  }
+
+  @override
   String preciseRefLib_exportedCount(Object count) {
     return 'Exported $count precise references';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -11459,6 +11459,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get preciseRefLib_exportTitle => '精密参照パッケージをエクスポート';
 
   @override
+  String get preciseRefLib_exportSelectionHint =>
+      '含める精密参照を選択してください。選択した項目は 1 つの .naipreciseref ファイルにまとめられます。';
+
+  @override
+  String preciseRefLib_exportConfirm(int count) {
+    return '選択項目をエクスポート ($count)';
+  }
+
+  @override
   String preciseRefLib_exportedCount(Object count) {
     return '精密参照を $count 件エクスポートしました';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -11260,6 +11260,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get preciseRefLib_exportTitle => '导出精准参考配置包';
 
   @override
+  String get preciseRefLib_exportSelectionHint =>
+      '选择要包含的精准参考；所选内容会打包为一个 .naipreciseref 文件。';
+
+  @override
+  String preciseRefLib_exportConfirm(int count) {
+    return '导出所选 ($count)';
+  }
+
+  @override
   String preciseRefLib_exportedCount(Object count) {
     return '已导出 $count 个精准参考';
   }
@@ -25148,6 +25157,15 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get preciseRefLib_exportTitle => '匯出精準參考設定包';
+
+  @override
+  String get preciseRefLib_exportSelectionHint =>
+      '選擇要包含的精準參考；所選內容會封裝成一個 .naipreciseref 檔案。';
+
+  @override
+  String preciseRefLib_exportConfirm(int count) {
+    return '匯出所選 ($count)';
+  }
 
   @override
   String preciseRefLib_exportedCount(Object count) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -5400,6 +5400,13 @@
   "preciseRefLib_emptyHintTouch": "也可以从生成结果、历史记录或本地画廊保存",
   "preciseRefLib_import": "导入图片",
   "preciseRefLib_exportTitle": "导出精准参考配置包",
+  "preciseRefLib_exportSelectionHint": "选择要包含的精准参考；所选内容会打包为一个 .naipreciseref 文件。",
+  "preciseRefLib_exportConfirm": "导出所选 ({count})",
+  "@preciseRefLib_exportConfirm": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "preciseRefLib_exportedCount": "已导出 {count} 个精准参考",
   "preciseRefLib_exportFailed": "导出精准参考失败：{error}",
   "preciseRefLib_openFolderFailed": "打开精准参考目录失败：{error}",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -5482,6 +5482,13 @@
   "preciseRefLib_emptyHintTouch": "也可以從生成結果、歷史記錄或本地相簿儲存",
   "preciseRefLib_import": "匯入圖片",
   "preciseRefLib_exportTitle": "匯出精準參考設定包",
+  "preciseRefLib_exportSelectionHint": "選擇要包含的精準參考；所選內容會封裝成一個 .naipreciseref 檔案。",
+  "preciseRefLib_exportConfirm": "匯出所選 ({count})",
+  "@preciseRefLib_exportConfirm": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "preciseRefLib_exportedCount": "已匯出 {count} 個精準參考",
   "preciseRefLib_exportFailed": "匯出精準參考失敗：{error}",
   "preciseRefLib_openFolderFailed": "開啟精準參考目錄失敗：{error}",

--- a/lib/presentation/screens/precise_ref_library/precise_ref_library_screen.dart
+++ b/lib/presentation/screens/precise_ref_library/precise_ref_library_screen.dart
@@ -40,6 +40,7 @@ import '../../agent_chat/widgets/agent_resource_drop_region.dart';
 import 'widgets/precise_ref_card.dart';
 import 'widgets/precise_ref_entry_edit_dialog.dart';
 import 'widgets/precise_ref_library_sidebar.dart';
+import 'widgets/precise_ref_selector_dialog.dart';
 
 /// 精准参考库页面
 ///
@@ -236,6 +237,15 @@ class _PreciseRefLibraryScreenState
       }
       if (mounted) setState(() => _isExporting = false);
     }
+  }
+
+  Future<void> _chooseAndExportEntries() async {
+    final entries = await PreciseRefSelectorDialog.show(
+      context,
+      purpose: PreciseRefSelectorPurpose.export,
+    );
+    if (!mounted || entries == null || entries.isEmpty) return;
+    await _exportEntries(entries);
   }
 
   Future<void> _openLibraryFolder() async {
@@ -782,7 +792,7 @@ class _PreciseRefLibraryScreenState
           isLoading: _isExporting,
           onPressed: state.entries.isEmpty || _isExporting
               ? null
-              : () => _exportEntries(state.entries),
+              : _chooseAndExportEntries,
         ),
         if (PlatformCapabilities.current.supportsOpenFolder)
           GalleryLibraryAction(

--- a/lib/presentation/screens/precise_ref_library/widgets/precise_ref_selector_dialog.dart
+++ b/lib/presentation/screens/precise_ref_library/widgets/precise_ref_selector_dialog.dart
@@ -13,29 +13,37 @@ import '../../../adaptive/adaptive_presenter.dart';
 import '../../../providers/precise_ref_library_provider.dart';
 import 'precise_ref_type_filter_chips.dart';
 
+enum PreciseRefSelectorPurpose { add, export }
+
 /// 精准参考库条目选择器对话框
 ///
-/// 供生成页「从库导入」使用：网格 + 搜索 + 类型过滤。
+/// 供生成页「从库导入」及精准参考库导出使用：网格 + 搜索 + 类型过滤。
 /// [multiSelect] 为 false 时点击条目直接返回单个条目。
+/// 导出用途默认全选，并提供当前筛选结果的全选与全不选操作。
 /// 搜索与类型过滤为对话框内部状态，不影响库页面的过滤条件。
 class PreciseRefSelectorDialog extends ConsumerStatefulWidget {
   const PreciseRefSelectorDialog({
     super.key,
     this.multiSelect = true,
+    this.purpose = PreciseRefSelectorPurpose.add,
     this.scrollController,
   });
 
   final bool multiSelect;
+  final PreciseRefSelectorPurpose purpose;
   final ScrollController? scrollController;
 
   static Future<List<PreciseRefLibraryEntry>?> show(
     BuildContext context, {
     bool multiSelect = true,
+    PreciseRefSelectorPurpose purpose = PreciseRefSelectorPurpose.add,
   }) {
     return AdaptivePresenter.showForm<List<PreciseRefLibraryEntry>>(
       context: context,
       titleBuilder: (panelContext) => Text(
-        panelContext.l10n.preciseRefLib_selectorTitle,
+        purpose == PreciseRefSelectorPurpose.export
+            ? panelContext.l10n.preciseRefLib_exportTitle
+            : panelContext.l10n.preciseRefLib_selectorTitle,
         maxLines: 2,
         overflow: TextOverflow.ellipsis,
         style: Theme.of(panelContext).textTheme.titleLarge,
@@ -43,6 +51,7 @@ class PreciseRefSelectorDialog extends ConsumerStatefulWidget {
       dialogWidth: 720,
       builder: (panelContext, scrollController) => PreciseRefSelectorDialog(
         multiSelect: multiSelect,
+        purpose: purpose,
         scrollController: scrollController,
       ),
     );
@@ -63,6 +72,7 @@ class _PreciseRefSelectorDialogState
   String? _cachedQuery;
   PreciseRefType? _cachedTypeFilter;
   List<PreciseRefLibraryEntry> _cachedVisibleEntries = const [];
+  bool _initializedExportSelection = false;
 
   @override
   void initState() {
@@ -119,6 +129,12 @@ class _PreciseRefSelectorDialogState
     final theme = Theme.of(context);
     final state = ref.watch(preciseRefLibraryNotifierProvider);
     final entries = _visibleEntries(state.entries);
+    if (widget.purpose == PreciseRefSelectorPurpose.export &&
+        !_initializedExportSelection &&
+        !state.isLoading) {
+      _selectedIds.addAll(state.entries.map((entry) => entry.id));
+      _initializedExportSelection = true;
+    }
 
     return LayoutBuilder(
       key: const Key('precise-ref-selector-dialog'),
@@ -138,6 +154,15 @@ class _PreciseRefSelectorDialogState
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
               sliver: SliverList.list(
                 children: [
+                  if (widget.purpose == PreciseRefSelectorPurpose.export) ...[
+                    Text(
+                      l10n.preciseRefLib_exportSelectionHint,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                  ],
                   TextField(
                     key: const Key('precise-ref-selector-search'),
                     textAlignVertical: TextAlignVertical.center,
@@ -158,6 +183,31 @@ class _PreciseRefSelectorDialogState
                       onChanged: (type) => setState(() => _typeFilter = type),
                     ),
                   ),
+                  if (widget.purpose == PreciseRefSelectorPurpose.export) ...[
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        TextButton(
+                          key: const Key('precise-ref-export-select-all'),
+                          onPressed: entries.isEmpty
+                              ? null
+                              : () => setState(
+                                  () => _selectedIds.addAll(
+                                    entries.map((entry) => entry.id),
+                                  ),
+                                ),
+                          child: Text(l10n.common_selectAll),
+                        ),
+                        TextButton(
+                          key: const Key('precise-ref-export-deselect-all'),
+                          onPressed: _selectedIds.isEmpty
+                              ? null
+                              : () => setState(_selectedIds.clear),
+                          child: Text(l10n.common_deselectAll),
+                        ),
+                      ],
+                    ),
+                  ],
                 ],
               ),
             ),
@@ -240,9 +290,13 @@ class _PreciseRefSelectorDialogState
                             ? null
                             : () => _confirm(state.entries),
                         child: Text(
-                          l10n.preciseRefLib_selectorConfirm(
-                            _selectedIds.length,
-                          ),
+                          widget.purpose == PreciseRefSelectorPurpose.export
+                              ? l10n.preciseRefLib_exportConfirm(
+                                  _selectedIds.length,
+                                )
+                              : l10n.preciseRefLib_selectorConfirm(
+                                  _selectedIds.length,
+                                ),
                         ),
                       ),
                   ],

--- a/test/presentation/screens/precise_ref_library/precise_ref_library_screen_test.dart
+++ b/test/presentation/screens/precise_ref_library/precise_ref_library_screen_test.dart
@@ -185,6 +185,52 @@ void main() {
     expect(find.text('精准参考库'), findsOneWidget);
   });
 
+  testWidgets('顶栏导出先选择包内内容并默认全选', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1180, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          preciseRefLibraryNotifierProvider.overrideWith(
+            _PopulatedLibraryNotifier.new,
+          ),
+          preciseRefLibraryStorageServiceProvider.overrideWithValue(
+            _ThumbnailFreeStorage(),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: PreciseRefLibraryScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const Key('precise-ref-library-export-button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('导出精准参考配置包'), findsOneWidget);
+    expect(find.textContaining('一个 .naipreciseref 文件'), findsOneWidget);
+    expect(find.text('导出所选 (2)'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('precise-ref-selector-item-first')));
+    await tester.pump();
+    expect(find.text('导出所选 (1)'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('precise-ref-export-deselect-all')));
+    await tester.pump();
+    expect(find.text('导出所选 (0)'), findsOneWidget);
+    final confirm = tester.widget<FilledButton>(
+      find.byKey(const Key('precise-ref-selector-confirm')),
+    );
+    expect(confirm.onPressed, isNull);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('快捷保存失败时显示错误提示', (tester) async {
     await tester.pumpWidget(
       ProviderScope(

--- a/test/presentation/screens/precise_ref_library/precise_ref_responsive_layout_test.dart
+++ b/test/presentation/screens/precise_ref_library/precise_ref_responsive_layout_test.dart
@@ -313,6 +313,37 @@ void main() {
     });
   }
 
+  testWidgets('320px 3x text keeps export selection controls reachable', (
+    tester,
+  ) async {
+    await _setViewport(tester, const Size(320, 720));
+    await _pumpSelectorHost(
+      tester,
+      purpose: PreciseRefSelectorPurpose.export,
+      textScale: 3,
+    );
+
+    await tester.tap(find.text('打开选择器'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('一个 .naipreciseref 文件'), findsOneWidget);
+    final deselectAll = find.byKey(
+      const Key('precise-ref-export-deselect-all'),
+    );
+    await tester.ensureVisible(deselectAll);
+    await tester.tap(deselectAll);
+    await tester.pump();
+
+    final selectAll = find.byKey(const Key('precise-ref-export-select-all'));
+    await tester.ensureVisible(selectAll);
+    await tester.tap(selectAll);
+    await tester.pump();
+    final confirm = find.byKey(const Key('precise-ref-selector-confirm'));
+    await tester.ensureVisible(confirm);
+    expect(find.text('导出所选 (2)'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
     '320px 3x text with SafeArea and IME keeps the edit form scrollable and submittable',
     (tester) async {
@@ -505,7 +536,11 @@ Future<void> _setViewport(
   });
 }
 
-Future<void> _pumpSelectorHost(WidgetTester tester) async {
+Future<void> _pumpSelectorHost(
+  WidgetTester tester, {
+  PreciseRefSelectorPurpose purpose = PreciseRefSelectorPurpose.add,
+  double textScale = 1,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
@@ -520,10 +555,17 @@ Future<void> _pumpSelectorHost(WidgetTester tester) async {
         locale: const Locale('zh'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(textScaler: TextScaler.linear(textScale)),
+          child: child!,
+        ),
         home: Scaffold(
           body: Builder(
             builder: (context) => TextButton(
-              onPressed: () => PreciseRefSelectorDialog.show(context),
+              onPressed: () =>
+                  PreciseRefSelectorDialog.show(context, purpose: purpose),
               child: const Text('打开选择器'),
             ),
           ),


### PR DESCRIPTION
## 改动内容

- 精准参考库顶栏导出前增加内容选择界面
- 支持搜索、类型筛选、逐项选择、全选与全不选
- 明确所选内容会打包为单个 `.naipreciseref` 配置包
- 补充简中、繁中、英文、日文本地化与响应式回归测试

## 验证结果

- `scripts/test_affected.ps1`：3 个相关测试文件、22 项测试全部通过
- `git diff --check`：通过
- `flutter analyze`：存在 1 条与本次改动无关的既有 unused import 警告（`test/data/services/random_prompt_generator_preset_test.dart:12`）

## 注意事项

- 顶栏导出会先弹出选择界面；多选模式中的导出仍直接导出当前已选内容
- 导出结果仍是单个配置包文件，包内包含所有选中的精准参考