### PR TITLE
style(library): 调整词库导出布局

### DIFF
--- a/lib/presentation/screens/tag_library_page/widgets/export_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/export_dialog.dart
@@ -124,13 +124,8 @@ class _ExportDialogState extends ConsumerState<ExportDialog> {
               ),
             ),
           ] else ...[
-            // 统计信息
-            _buildStatsBar(theme),
-
-            const SizedBox(height: 16),
-
-            // 全选/全不选按钮
-            _buildSelectionActions(theme),
+            // 统计与选择操作
+            _buildSelectionHeader(theme),
 
             const SizedBox(height: 8),
 
@@ -154,31 +149,50 @@ class _ExportDialogState extends ConsumerState<ExportDialog> {
             const SizedBox(height: 16),
 
             // 操作按钮
-            Wrap(
-              alignment: WrapAlignment.end,
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(context.l10n.common_cancel),
-                ),
-                FilledButton.icon(
-                  onPressed:
-                      _selectedEntryIds.isNotEmpty ||
-                          _selectedCategoryIds.isNotEmpty
-                      ? _export
-                      : null,
-                  icon: const Icon(Icons.file_download),
-                  label: Text(
-                    context.l10n.tagLibrary_selectedExportCount(
-                      _selectedEntryIds.length + _selectedCategoryIds.length,
+            Align(
+              alignment: Alignment.centerRight,
+              child: Wrap(
+                key: const Key('tag-library-export-dialog-actions'),
+                alignment: WrapAlignment.end,
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(context.l10n.common_cancel),
+                  ),
+                  FilledButton.icon(
+                    onPressed:
+                        _selectedEntryIds.isNotEmpty ||
+                            _selectedCategoryIds.isNotEmpty
+                        ? _export
+                        : null,
+                    icon: const Icon(Icons.file_download),
+                    label: Text(
+                      context.l10n.tagLibrary_selectedExportCount(
+                        _selectedEntryIds.length + _selectedCategoryIds.length,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSelectionHeader(ThemeData theme) {
+    return SingleChildScrollView(
+      key: const Key('tag-library-export-selection-header-scroll'),
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        key: const Key('tag-library-export-selection-header'),
+        children: [
+          _buildStatsBar(theme),
+          const SizedBox(width: 16),
+          _buildSelectionActions(theme),
         ],
       ),
     );
@@ -187,20 +201,20 @@ class _ExportDialogState extends ConsumerState<ExportDialog> {
   /// 构建统计信息栏
   Widget _buildStatsBar(ThemeData theme) {
     return Container(
+      key: const Key('tag-library-export-stats'),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Wrap(
-        spacing: 24,
-        runSpacing: 8,
+      child: Row(
         children: [
           _StatItem(
             label: context.l10n.tagLibrary_entriesLabel,
             value: '${_selectedEntryIds.length}/${widget.entries.length}',
             icon: Icons.article_outlined,
           ),
+          const SizedBox(width: 24),
           _StatItem(
             label: context.l10n.tagLibrary_categoriesLabel,
             value: '${_selectedCategoryIds.length}/${widget.categories.length}',
@@ -219,16 +233,14 @@ class _ExportDialogState extends ConsumerState<ExportDialog> {
         _selectedCategoryIds.length == widget.categories.length;
     final allSelected = allEntriesSelected && allCategoriesSelected;
 
-    return Wrap(
-      alignment: WrapAlignment.spaceBetween,
-      crossAxisAlignment: WrapCrossAlignment.center,
-      spacing: 8,
-      runSpacing: 8,
+    return Row(
+      key: const Key('tag-library-export-selection-actions'),
       children: [
         Text(
           context.l10n.tagLibrary_selectExportContent,
           style: theme.textTheme.titleSmall,
         ),
+        const SizedBox(width: 8),
         TextButton.icon(
           onPressed: allSelected ? null : _selectAll,
           icon: const Icon(Icons.select_all, size: 18),
@@ -237,6 +249,7 @@ class _ExportDialogState extends ConsumerState<ExportDialog> {
             padding: const EdgeInsets.symmetric(horizontal: 8),
           ),
         ),
+        const SizedBox(width: 4),
         TextButton.icon(
           onPressed: _selectedEntryIds.isEmpty && _selectedCategoryIds.isEmpty
               ? null

--- a/test/presentation/screens/tag_library_page/tag_library_dialog_responsive_test.dart
+++ b/test/presentation/screens/tag_library_page/tag_library_dialog_responsive_test.dart
@@ -209,6 +209,11 @@ void main() {
       await tester.ensureVisible(export);
       expect(export, findsOneWidget);
       expect(find.text('包含预览图'), findsOneWidget);
+      final stats = find.byKey(const ValueKey('tag-library-export-stats'));
+      final selectionActions = find.byKey(
+        const ValueKey('tag-library-export-selection-actions'),
+      );
+      expect(tester.getCenter(stats).dy, tester.getCenter(selectionActions).dy);
       expect(tester.takeException(), isNull);
     },
   );
@@ -269,6 +274,20 @@ void main() {
     expect(panel, findsOneWidget);
     expect(tester.getSize(panel).width, 600);
     expect(find.text('宽屏条目'), findsOneWidget);
+    final stats = find.byKey(const ValueKey('tag-library-export-stats'));
+    final selectionActions = find.byKey(
+      const ValueKey('tag-library-export-selection-actions'),
+    );
+    expect(tester.getCenter(stats).dy, tester.getCenter(selectionActions).dy);
+
+    final content = find.byKey(const ValueKey('tag-library-export-content'));
+    final dialogActions = find.byKey(
+      const ValueKey('tag-library-export-dialog-actions'),
+    );
+    expect(
+      tester.getRect(content).right - tester.getRect(dialogActions).right,
+      16,
+    );
     expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
## 改动内容

- 将词库导出弹窗的统计信息、选择标题和全选操作合并为单行布局
- 宽度不足时允许该行水平滚动，避免文案裁切或 overflow
- 将底部“取消”与“导出”按钮组靠右排列
- 补充紧凑与宽屏下的对齐回归断言

## 验证结果

- `scripts/test_affected.ps1 -Path "lib/presentation/screens/tag_library_page/widgets/export_dialog.dart" -Include "test/presentation/screens/tag_library_page/tag_library_dialog_responsive_test.dart"` 通过（5 项测试）
- `dart analyze lib/presentation/screens/tag_library_page/widgets/export_dialog.dart` 通过
- `scripts/verify_flutter_sources.ps1` 通过
- Impeccable layout detector 无发现

## 注意事项

- 无