### PR TITLE
fix(navigation): 调整随机词库按钮顺序

### DIFF
--- a/lib/presentation/widgets/navigation/main_nav_rail.dart
+++ b/lib/presentation/widgets/navigation/main_nav_rail.dart
@@ -191,16 +191,6 @@ class MainNavRail extends ConsumerWidget {
                     ),
                   ),
 
-                  // 随机配置
-                  _NavIcon(
-                    key: const Key('nav-branch-5'),
-                    icon: Icons.casino, // Random prompt config
-                    label: context.l10n.nav_randomConfig,
-                    isSelected: selectedIndex == 5,
-                    onTap: () =>
-                        navigationShell.goBranch(AppBranch.promptConfig.index),
-                  ),
-
                   // 词库
                   _NavIcon(
                     key: const Key('nav-branch-6'),
@@ -209,6 +199,16 @@ class MainNavRail extends ConsumerWidget {
                     isSelected: selectedIndex == 6,
                     onTap: () =>
                         navigationShell.goBranch(AppBranch.tagLibrary.index),
+                  ),
+
+                  // 随机配置
+                  _NavIcon(
+                    key: const Key('nav-branch-5'),
+                    icon: Icons.casino, // Random prompt config
+                    label: context.l10n.nav_randomConfig,
+                    isSelected: selectedIndex == 5,
+                    onTap: () =>
+                        navigationShell.goBranch(AppBranch.promptConfig.index),
                   ),
 
                   // 统计

--- a/test/presentation/widgets/main_nav_rail_test.dart
+++ b/test/presentation/widgets/main_nav_rail_test.dart
@@ -117,6 +117,14 @@ void main() {
     expect(find.byIcon(Icons.settings), findsOneWidget);
     expect(find.byIcon(Icons.keyboard_double_arrow_right), findsOneWidget);
     expect(
+      tester.getCenter(find.byKey(const Key('nav-branch-6'))).dy,
+      lessThan(tester.getCenter(find.byKey(const Key('nav-branch-5'))).dy),
+    );
+    expect(
+      tester.getCenter(find.byKey(const Key('nav-branch-5'))).dy,
+      lessThan(tester.getCenter(find.byKey(const Key('nav-branch-7'))).dy),
+    );
+    expect(
       tester.getCenter(find.byKey(const Key('main-nav-toggle'))).dy,
       greaterThan(tester.getCenter(find.byIcon(Icons.settings)).dy),
     );


### PR DESCRIPTION
## 改动内容
- 将桌面主导航栏中的随机词库按钮从倒数第 3 位调整到倒数第 2 位
- 保持按钮对应的路由分支与选中状态不变
- 增加导航按钮相对顺序回归断言

## 验证结果
- `scripts/test_affected.ps1 -Path "lib/presentation/widgets/navigation/main_nav_rail.dart" -Include "test/presentation/widgets/main_nav_rail_test.dart"`：通过（9 项测试）
- `git diff --check`：通过

## 注意事项
- 未等待 CI，按要求创建后直接执行 Squash Merge