### PR TITLE
fix(tag-library): 补齐顶栏分类与文件夹按钮

### DIFF
--- a/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
+++ b/lib/presentation/screens/tag_library_page/tag_library_page_screen.dart
@@ -1,12 +1,18 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
 
 import '../../../core/agent/resources/agent_chat_resource_reference.dart';
+import '../../../core/platform/platform_capabilities.dart';
 import '../../../core/shortcuts/default_shortcuts.dart';
 import '../../../core/utils/character_prompt_block_parser.dart';
 import '../../../core/utils/comfyui_prompt_parser/pipe_parser.dart';
+import '../../../core/utils/file_explorer_utils.dart';
 import '../../../core/utils/localization_extension.dart';
 import '../../../core/utils/sd_to_nai_converter.dart';
 import '../../../data/models/tag_library/tag_library_entry.dart';
@@ -62,6 +68,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
   final ValueNotifier<Set<String>> _expandedCategoryIds =
       ValueNotifier<Set<String>>(<String>{});
   bool _categoriesExpanded = true;
+  bool _showCategoryPanel = true;
 
   @override
   void dispose() {
@@ -157,13 +164,20 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
         child: Scaffold(
           body: LayoutBuilder(
             builder: (context, constraints) {
-              final showSidebar = constraints.maxWidth >= 840;
+              final persistentCategories = constraints.maxWidth >= 840;
+              final showSidebar = persistentCategories && _showCategoryPanel;
               return GalleryCollectionWorkspace(
                 toolbar: TagLibraryToolbar(
                   showPageTitle: true,
-                  onShowCategories: showSidebar
-                      ? null
-                      : () => _showCategoryPanel(state),
+                  showCategoryPanel: showSidebar,
+                  onShowCategories: persistentCategories
+                      ? () => setState(
+                          () => _showCategoryPanel = !_showCategoryPanel,
+                        )
+                      : () => _showCategoryPanelSheet(state),
+                  onOpenFolder: PlatformCapabilities.current.supportsOpenFolder
+                      ? _openLibraryFolder
+                      : null,
                   onEnterSelectionMode: () => ref
                       .read(tagLibrarySelectionNotifierProvider.notifier)
                       .enter(),
@@ -374,7 +388,7 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
     );
   }
 
-  Future<void> _showCategoryPanel(TagLibraryPageState state) {
+  Future<void> _showCategoryPanelSheet(TagLibraryPageState state) {
     return AdaptivePresenter.showPanel<void>(
       context: context,
       title: context.l10n.tagLibrary_categories,
@@ -385,6 +399,24 @@ class _TagLibraryPageScreenState extends ConsumerState<TagLibraryPageScreen> {
         onCategorySelectionComplete: () => Navigator.of(panelContext).pop(),
       ),
     );
+  }
+
+  Future<void> _openLibraryFolder() async {
+    try {
+      final appDir = await getApplicationDocumentsDirectory();
+      final directory = Directory(
+        path.join(appDir.path, 'tag_library_thumbnails'),
+      );
+      await directory.create(recursive: true);
+      await FileExplorerUtils.openDirectory(directory.path);
+    } catch (error) {
+      if (mounted) {
+        AppToast.error(
+          context,
+          context.l10n.localGallery_openFolderFailed('$error'),
+        );
+      }
+    }
   }
 
   /// 构建内容区域

--- a/lib/presentation/screens/tag_library_page/widgets/tag_library_toolbar.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/tag_library_toolbar.dart
@@ -16,6 +16,8 @@ class TagLibraryToolbar extends ConsumerStatefulWidget {
   const TagLibraryToolbar({
     super.key,
     this.onShowCategories,
+    this.showCategoryPanel = true,
+    this.onOpenFolder,
     this.onEnterSelectionMode,
     this.onBulkDelete,
     this.onBulkMoveCategory,
@@ -29,6 +31,8 @@ class TagLibraryToolbar extends ConsumerStatefulWidget {
   });
 
   final VoidCallback? onShowCategories;
+  final bool showCategoryPanel;
+  final VoidCallback? onOpenFolder;
   final VoidCallback? onEnterSelectionMode;
   final VoidCallback? onBulkDelete;
   final VoidCallback? onBulkMoveCategory;
@@ -121,7 +125,7 @@ class _TagLibraryToolbarState extends ConsumerState<TagLibraryToolbar> {
       );
     }
 
-    final openCategories = widget.onShowCategories ?? widget.onOpenCategories;
+    final toggleCategories = widget.onShowCategories ?? widget.onOpenCategories;
     final filtered = state.filteredEntries.length != state.entries.length;
     return GalleryLibraryToolbar(
       key: const Key('tag-library-toolbar'),
@@ -138,6 +142,18 @@ class _TagLibraryToolbarState extends ConsumerState<TagLibraryToolbar> {
       ),
       search: _buildSearchField(),
       actions: [
+        if (toggleCategories != null)
+          GalleryLibraryAction(
+            key: const Key('tag-library-categories-button'),
+            icon: widget.showCategoryPanel
+                ? Icons.view_sidebar
+                : Icons.view_sidebar_outlined,
+            label: context.l10n.common_categories,
+            tooltip: widget.showCategoryPanel
+                ? context.l10n.localGallery_hideCategoryPanel
+                : context.l10n.localGallery_showCategoryPanel,
+            onPressed: toggleCategories,
+          ),
         GalleryLibrarySortMenu<TagLibrarySortBy>(
           key: const Key('tag-library-sort-menu-anchor'),
           label: _sortLabel(state.sortBy),
@@ -187,13 +203,6 @@ class _TagLibraryToolbarState extends ConsumerState<TagLibraryToolbar> {
               .read(tagLibraryPageNotifierProvider.notifier)
               .setViewMode(value),
         ),
-        if (openCategories != null)
-          GalleryLibraryAction(
-            key: const Key('tag-library-categories-button'),
-            icon: Icons.account_tree_outlined,
-            label: context.l10n.common_categories,
-            onPressed: openCategories,
-          ),
         GalleryLibraryAction(
           icon: Icons.checklist,
           label: context.l10n.common_multiSelect,
@@ -209,6 +218,14 @@ class _TagLibraryToolbarState extends ConsumerState<TagLibraryToolbar> {
           label: context.l10n.common_export,
           onPressed: state.entries.isEmpty ? null : widget.onExport,
         ),
+        if (widget.onOpenFolder != null)
+          GalleryLibraryAction(
+            key: const Key('tag-library-folder-button'),
+            icon: Icons.folder_open_outlined,
+            label: context.l10n.common_folder,
+            tooltip: context.l10n.shortcut_action_open_folder,
+            onPressed: widget.onOpenFolder,
+          ),
       ],
       primaryAction: GalleryLibraryPrimaryAction(
         key: const Key('tag-library-add-entry-button'),

--- a/test/presentation/screens/tag_library_page/tag_library_page_screen_test.dart
+++ b/test/presentation/screens/tag_library_page/tag_library_page_screen_test.dart
@@ -93,6 +93,33 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('desktop toolbar toggles the persistent category panel', (
+    tester,
+  ) async {
+    await _setViewport(tester, const Size(1180, 700));
+    await _pumpTagLibrary(tester, _TestTagLibraryPageNotifier.new);
+
+    final categoriesButton = find.byKey(
+      const Key('tag-library-categories-button'),
+    );
+    expect(
+      find.byKey(const Key('tag-library-category-sidebar')),
+      findsOneWidget,
+    );
+
+    await tester.tap(categoriesButton);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('tag-library-category-sidebar')), findsNothing);
+
+    await tester.tap(categoriesButton);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('tag-library-category-sidebar')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('compact category panel keeps expansion after close and reopen', (
     tester,
   ) async {

--- a/test/presentation/screens/tag_library_page/widgets/tag_library_toolbar_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/tag_library_toolbar_test.dart
@@ -22,6 +22,9 @@ void main() {
 
   for (final width in [320.0, 600.0, 840.0, 1180.0, 1600.0]) {
     testWidgets('词库使用公共顶栏并保留全部能力 ${width.toInt()}px', (tester) async {
+      PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+        TargetPlatform.windows,
+      );
       await _pumpToolbar(tester, width: width);
 
       expect(find.byType(GalleryLibraryToolbar), findsOneWidget);
@@ -34,7 +37,7 @@ void main() {
         find.byType(GalleryLibraryViewModeSelector<TagLibraryViewMode>),
         findsOneWidget,
       );
-      for (final label in ['分类', '多选', '导入', '导出', '添加条目']) {
+      for (final label in ['分类', '多选', '导入', '导出', '文件夹', '添加条目']) {
         expect(find.text(label), findsOneWidget);
       }
       expect(find.text('0'), findsOneWidget);
@@ -53,7 +56,27 @@ void main() {
     expect(find.text('名称'), findsOneWidget);
   });
 
+  testWidgets('分类与文件夹按钮转发顶栏操作', (tester) async {
+    var categoryToggleCount = 0;
+    var openFolderCount = 0;
+    await _pumpToolbar(
+      tester,
+      width: 1180,
+      onShowCategories: () => categoryToggleCount++,
+      onOpenFolder: () => openFolderCount++,
+    );
+
+    await tester.tap(find.byKey(const Key('tag-library-categories-button')));
+    await tester.tap(find.byKey(const Key('tag-library-folder-button')));
+
+    expect(categoryToggleCount, 1);
+    expect(openFolderCount, 1);
+  });
+
   testWidgets('3x 文本保留完整可横向滚动操作区', (tester) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
     await _pumpToolbar(tester, width: 320, textScale: 3);
 
     expect(
@@ -64,7 +87,7 @@ void main() {
       find.byKey(const ValueKey('gallery-library-toolbar-actions')),
       findsOneWidget,
     );
-    for (final label in ['分类', '多选', '导入', '导出', '添加条目']) {
+    for (final label in ['分类', '多选', '导入', '导出', '文件夹', '添加条目']) {
       expect(find.text(label), findsOneWidget);
     }
     expect(tester.takeException(), isNull);
@@ -75,6 +98,8 @@ Future<void> _pumpToolbar(
   WidgetTester tester, {
   required double width,
   double textScale = 1,
+  VoidCallback? onShowCategories,
+  VoidCallback? onOpenFolder,
 }) async {
   await tester.binding.setSurfaceSize(Size(width, 900));
   addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -96,7 +121,8 @@ Future<void> _pumpToolbar(
             ).copyWith(textScaler: TextScaler.linear(textScale)),
             child: Scaffold(
               body: TagLibraryToolbar(
-                onShowCategories: () {},
+                onShowCategories: onShowCategories ?? () {},
+                onOpenFolder: onOpenFolder ?? () {},
                 onEnterSelectionMode: () {},
                 onImport: () {},
                 onExport: () {},


### PR DESCRIPTION
## 改动内容
- 在词库顶栏补回分类面板显隐按钮，桌面端直接切换侧栏，紧凑布局继续打开分类面板
- 复用资料库顶栏操作组件添加“打开文件夹”按钮，打开词库缩略图目录
- 将分类入口前置，保证窄屏无需先横向滚动即可访问

## 验证结果
- `flutter test test/presentation/screens/tag_library_page/widgets/tag_library_toolbar_test.dart test/presentation/screens/tag_library_page/tag_library_page_screen_test.dart`
- `flutter analyze lib/presentation/screens/tag_library_page/tag_library_page_screen.dart lib/presentation/screens/tag_library_page/widgets/tag_library_toolbar.dart`
- `scripts/verify_flutter_sources.ps1`

## 注意事项
- 打开文件夹能力仅在桌面平台显示；移动端不暴露无效入口