### PR TITLE
fix(prompt): 修复提示词预览滚动与固定词截断

### DIFF
--- a/lib/presentation/screens/generation/widgets/prompt_input_tooltips.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_input_tooltips.dart
@@ -88,6 +88,7 @@ class PositivePromptTooltip extends StatelessWidget {
             prefixes.map((tag) => _resolve(tag.content)).join(', '),
             isDark,
             initiallyExpanded: expandSection(),
+            maxLines: null,
           ),
           const SizedBox(height: 8),
         ],
@@ -136,6 +137,7 @@ class PositivePromptTooltip extends StatelessWidget {
             suffixes.map((tag) => _resolve(tag.content)).join(', '),
             isDark,
             initiallyExpanded: expandSection(),
+            maxLines: null,
           ),
           const SizedBox(height: 8),
         ],
@@ -151,6 +153,7 @@ class PositivePromptTooltip extends StatelessWidget {
     String content,
     bool isDark, {
     required bool initiallyExpanded,
+    int? maxLines = 3,
   }) => TooltipSection(
     key: ValueKey('prompt-composition-$id'),
     theme: theme,
@@ -160,6 +163,7 @@ class PositivePromptTooltip extends StatelessWidget {
     content: content,
     isDark: isDark,
     initiallyExpanded: initiallyExpanded,
+    maxLines: maxLines,
   );
 
   String _resolve(String value) => aliasResolver.resolveAliases(value);
@@ -270,6 +274,7 @@ class NegativePromptTooltip extends StatelessWidget {
             prefixes.map((tag) => _resolve(tag.content)).join(', '),
             isDark,
             initiallyExpanded: expandSection(),
+            maxLines: null,
           ),
           const SizedBox(height: 8),
         ],
@@ -294,6 +299,7 @@ class NegativePromptTooltip extends StatelessWidget {
             suffixes.map((tag) => _resolve(tag.content)).join(', '),
             isDark,
             initiallyExpanded: expandSection(),
+            maxLines: null,
           ),
           const SizedBox(height: 8),
         ],
@@ -309,6 +315,7 @@ class NegativePromptTooltip extends StatelessWidget {
     String content,
     bool isDark, {
     required bool initiallyExpanded,
+    int? maxLines = 3,
   }) => TooltipSection(
     key: ValueKey('prompt-composition-$id'),
     theme: theme,
@@ -318,6 +325,7 @@ class NegativePromptTooltip extends StatelessWidget {
     content: content,
     isDark: isDark,
     initiallyExpanded: initiallyExpanded,
+    maxLines: maxLines,
   );
 
   String _resolve(String value) => aliasResolver.resolveAliases(value);

--- a/lib/presentation/screens/generation/widgets/prompt_tooltip_components.dart
+++ b/lib/presentation/screens/generation/widgets/prompt_tooltip_components.dart
@@ -85,6 +85,7 @@ class TooltipSection extends StatelessWidget {
     required this.content,
     required this.isDark,
     this.initiallyExpanded = true,
+    this.maxLines = 3,
   });
 
   final ThemeData theme;
@@ -94,6 +95,7 @@ class TooltipSection extends StatelessWidget {
   final String content;
   final bool isDark;
   final bool initiallyExpanded;
+  final int? maxLines;
 
   @override
   Widget build(BuildContext context) => _TooltipCompositionCard(
@@ -107,7 +109,7 @@ class TooltipSection extends StatelessWidget {
     child: TranslatedPromptText(
       content,
       selectable: false,
-      maxLines: 3,
+      maxLines: maxLines,
       includeUntranslated: true,
       style: theme.textTheme.bodySmall?.copyWith(
         color: theme.colorScheme.onSurfaceVariant,

--- a/lib/presentation/widgets/common/rich_tooltip_surface.dart
+++ b/lib/presentation/widgets/common/rich_tooltip_surface.dart
@@ -74,10 +74,15 @@ class _RichTooltipSurfaceState extends State<RichTooltipSurface> {
               interactive: true,
               thickness: 4,
               radius: const Radius.circular(4),
-              child: SingleChildScrollView(
-                controller: _scrollController,
-                primary: false,
-                child: widget.child,
+              child: ScrollConfiguration(
+                behavior: ScrollConfiguration.of(
+                  context,
+                ).copyWith(scrollbars: false),
+                child: SingleChildScrollView(
+                  controller: _scrollController,
+                  primary: false,
+                  child: widget.child,
+                ),
               ),
             ),
           ),

--- a/test/presentation/screens/generation/prompt_tooltip_components_test.dart
+++ b/test/presentation/screens/generation/prompt_tooltip_components_test.dart
@@ -116,7 +116,7 @@ void main() {
   }
 
   testWidgets(
-    'rich tooltip surface separates overlay and scrolls long content',
+    'rich tooltip surface owns one scrollbar while scrolling on desktop',
     (tester) async {
       tester.view.physicalSize = const Size(600, 360);
       tester.view.devicePixelRatio = 1;
@@ -125,7 +125,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData.dark(),
+          theme: ThemeData.dark().copyWith(platform: TargetPlatform.windows),
           home: const Scaffold(
             body: RichTooltipSurface(
               maxWidth: 420,
@@ -161,6 +161,18 @@ void main() {
         find.descendant(of: surface, matching: find.byType(Scrollbar)),
       );
       expect(scrollbar.thumbVisibility, isTrue);
+      expect(
+        find.descendant(of: surface, matching: find.byType(Scrollbar)),
+        findsOneWidget,
+      );
+
+      await tester.drag(scrollView, const Offset(0, -120));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(of: surface, matching: find.byType(Scrollbar)),
+        findsOneWidget,
+      );
       expect(tester.takeException(), isNull);
     },
   );
@@ -467,6 +479,75 @@ void main() {
 
     expect(positiveCopies, 1);
     expect(negativeCopies, 1);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('fixed-tag sections show every enabled entry without clipping', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final theme = ThemeData.dark();
+    final prefixes = List.generate(
+      3,
+      (index) => FixedTagEntry.create(
+        name: 'prefix $index',
+        content: List.filled(8, 'prefix_${index}_tag').join(', '),
+        sortOrder: index,
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: theme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Consumer(
+            builder: (context, ref, _) => Scaffold(
+              body: SizedBox(
+                width: 320,
+                child: PositivePromptTooltip(
+                  theme: theme,
+                  userPrompt: '',
+                  prefixes: prefixes,
+                  suffixes: const [],
+                  qualityContent: null,
+                  characters: const [],
+                  globalAiChoice: true,
+                  l10n: AppLocalizations.of(context)!,
+                  aliasResolver: ref.read(
+                    aliasResolverServiceProvider.notifier,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final fixedTagSection = find.byWidgetPredicate(
+      (widget) =>
+          widget is TooltipSection &&
+          widget.label ==
+              AppLocalizations.of(
+                tester.element(find.byType(PositivePromptTooltip)),
+              )!.fixedTags_prefix,
+    );
+    final fixedTagPrompt = tester.widget<TranslatedPromptText>(
+      find.descendant(
+        of: fixedTagSection,
+        matching: find.byType(TranslatedPromptText),
+      ),
+    );
+
+    expect(fixedTagPrompt.maxLines, isNull);
+    for (var index = 0; index < prefixes.length; index++) {
+      expect(fixedTagPrompt.prompt, contains('prefix_${index}_tag'));
+    }
     expect(tester.takeException(), isNull);
   });
 


### PR DESCRIPTION
## 改动内容
- 禁用富提示词预览内部滚动视图的桌面自动滚动条，保留唯一的显式滚动条
- 正向与负向固定词的前缀、后缀预览不再限制为三行，完整显示所有已启用固定词
- 新增 Windows 滚动场景与多固定词显示回归测试

## 验证结果
- `flutter test test/presentation/screens/generation/prompt_tooltip_components_test.dart`
- `flutter analyze lib/presentation/screens/generation/widgets/prompt_input_tooltips.dart lib/presentation/screens/generation/widgets/prompt_tooltip_components.dart lib/presentation/widgets/common/rich_tooltip_surface.dart test/presentation/screens/generation/prompt_tooltip_components_test.dart`

## 注意事项
- 按要求创建后直接 Squash Merge，不等待 CI。