### PR TITLE
fix(settings): 移除重复的 API Key 状态图标

### DIFF
--- a/lib/presentation/screens/settings/sections/prompt_assistant_settings_section.dart
+++ b/lib/presentation/screens/settings/sections/prompt_assistant_settings_section.dart
@@ -356,7 +356,6 @@ class PromptAssistantSettingsSection extends ConsumerWidget {
                   icon: const Icon(Icons.link, size: 16),
                   label: Text(context.l10n.promptAssistant_connectionConfig),
                 ),
-                Icon(hasApiKey ? Icons.key : Icons.key_off, size: 18),
                 IconButton(
                   icon: const Icon(Icons.download_for_offline_outlined),
                   tooltip: context.l10n.promptAssistant_pullModelList,

--- a/test/presentation/screens/settings/settings_screen_test.dart
+++ b/test/presentation/screens/settings/settings_screen_test.dart
@@ -387,11 +387,19 @@ void main() {
     expect(tester.takeException(), isNull);
     await tester.pumpAndSettle();
 
-    expect(
-      find.byKey(const ValueKey('prompt-assistant-provider-openai_chat')),
-      findsOneWidget,
+    final providerCard = find.byKey(
+      const ValueKey('prompt-assistant-provider-openai_chat'),
     );
+    expect(providerCard, findsOneWidget);
     expect(find.text('连接配置'), findsOneWidget);
+    expect(
+      find.descendant(of: providerCard, matching: find.byIcon(Icons.key)),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: providerCard, matching: find.byIcon(Icons.key_off)),
+      findsNothing,
+    );
     expect(tester.takeException(), isNull);
 
     await tester.pumpWidget(const SizedBox.shrink());


### PR DESCRIPTION
## 改动内容

- 移除提示词助手服务商列表中不可点击且与状态文案重复的 API Key 图标
- 增加回归断言，确保已配置和未配置图标都不再显示

## 验证结果

- `scripts/verify_flutter_sources.ps1`
- `scripts/test_affected.ps1 -Path lib/presentation/screens/settings/sections/prompt_assistant_settings_section.dart -Include test/presentation/screens/settings/settings_screen_test.dart`
- `dart analyze lib/presentation/screens/settings/sections/prompt_assistant_settings_section.dart test/presentation/screens/settings/settings_screen_test.dart`
- `git diff --check`

## 注意事项

- API Key 配置状态仍通过“已配置 / 未配置”文字展示；连接配置、拉取模型、编辑和删除操作保持不变。