### PR TITLE
fix(ui): 修复短表单弹窗异常撑高

### DIFF
--- a/lib/presentation/adaptive/adaptive_presenter.dart
+++ b/lib/presentation/adaptive/adaptive_presenter.dart
@@ -9,7 +9,7 @@ import 'window_size_class.dart';
 /// Builds a panel body with the presenter-owned scroll controller.
 ///
 /// Centered forms receive a loose height constraint so short content can size
-/// naturally. Scrollable short forms must set `shrinkWrap: true`; long,
+/// naturally. Scrollable short forms must use `ContentSizedAdaptiveForm`; long,
 /// virtualized collections can consume the bounded viewport instead.
 typedef AdaptivePanelBuilder =
     Widget Function(BuildContext context, ScrollController scrollController);

--- a/lib/presentation/adaptive/content_sized_adaptive_form.dart
+++ b/lib/presentation/adaptive/content_sized_adaptive_form.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+/// A form body that follows its content until the presenter-imposed height cap
+/// is reached, then scrolls without moving the footer off-screen.
+///
+/// Use this for short and medium editing forms shown by
+/// [AdaptivePresenter.showForm]. Long collections and workspace-like dialogs
+/// should keep an explicitly viewport-sized layout instead.
+class ContentSizedAdaptiveForm extends StatelessWidget {
+  const ContentSizedAdaptiveForm({
+    super.key,
+    required this.scrollController,
+    required this.content,
+    required this.footer,
+    this.scrollViewKey,
+    this.padding = const EdgeInsets.all(16),
+  });
+
+  final ScrollController? scrollController;
+  final List<Widget> content;
+  final Widget footer;
+  final Key? scrollViewKey;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Flexible(
+          fit: FlexFit.loose,
+          child: ListView(
+            key: scrollViewKey,
+            controller: scrollController,
+            shrinkWrap: true,
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            padding: padding,
+            children: content,
+          ),
+        ),
+        footer,
+      ],
+    );
+  }
+}

--- a/lib/presentation/screens/settings/sections/privacy_settings_section.dart
+++ b/lib/presentation/screens/settings/sections/privacy_settings_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../data/models/watermark/watermark_settings.dart';
 import '../../../adaptive/adaptive_presenter.dart';
+import '../../../adaptive/content_sized_adaptive_form.dart';
 import '../../../providers/share_image_settings_provider.dart';
 import '../../../providers/watermark_settings_provider.dart';
 import '../../watermark/watermark_editor_launcher.dart';
@@ -411,49 +412,44 @@ class _NumberEditorFormState extends State<_NumberEditorForm> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Expanded(
-          child: SingleChildScrollView(
-            controller: widget.scrollController,
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            padding: const EdgeInsets.all(20),
-            child: TextField(
-              controller: _controller,
-              keyboardType: TextInputType.number,
-              autofocus: true,
-              decoration: InputDecoration(
-                labelText: widget.label,
-                suffixText: widget.suffix,
-                helperText: widget.helperText,
-                border: const OutlineInputBorder(),
-              ),
-            ),
-          ),
-        ),
-        SafeArea(
-          top: false,
-          minimum: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-          child: Align(
-            alignment: AlignmentDirectional.centerEnd,
-            child: Wrap(
-              alignment: WrapAlignment.end,
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(context.l10n.common_cancel),
-                ),
-                FilledButton(
-                  onPressed: _save,
-                  child: Text(context.l10n.common_save),
-                ),
-              ],
-            ),
+    return ContentSizedAdaptiveForm(
+      scrollController: widget.scrollController,
+      padding: const EdgeInsets.all(20),
+      content: [
+        TextField(
+          controller: _controller,
+          keyboardType: TextInputType.number,
+          autofocus: true,
+          decoration: InputDecoration(
+            labelText: widget.label,
+            suffixText: widget.suffix,
+            helperText: widget.helperText,
+            border: const OutlineInputBorder(),
           ),
         ),
       ],
+      footer: SafeArea(
+        top: false,
+        minimum: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        child: Align(
+          alignment: AlignmentDirectional.centerEnd,
+          child: Wrap(
+            alignment: WrapAlignment.end,
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(context.l10n.common_cancel),
+              ),
+              FilledButton(
+                onPressed: _save,
+                child: Text(context.l10n.common_save),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/presentation/screens/settings/sections/web_access_settings.dart
+++ b/lib/presentation/screens/settings/sections/web_access_settings.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/network/web_access/web_access_models.dart';
 import '../../../../core/utils/localization_extension.dart';
 import '../../../adaptive/adaptive_presenter.dart';
+import '../../../adaptive/content_sized_adaptive_form.dart';
 import '../../../prompt_assistant/providers/web_access_provider.dart';
 
 class WebAccessSettings extends ConsumerStatefulWidget {
@@ -398,54 +399,49 @@ class _ApiKeyEditorFormState extends State<_ApiKeyEditorForm> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Expanded(
-          child: SingleChildScrollView(
-            controller: widget.scrollController,
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            padding: const EdgeInsets.all(20),
-            child: TextField(
-              controller: _controller,
-              autofocus: true,
-              obscureText: true,
-              decoration: InputDecoration(
-                labelText: context.l10n.promptAssistant_webAccessExaApiKey,
-                hintText: widget.hasKey
-                    ? context.l10n.promptAssistant_apiKeyLeaveEmpty
-                    : null,
-              ),
-            ),
-          ),
-        ),
-        SafeArea(
-          top: false,
-          minimum: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-          child: Align(
-            alignment: AlignmentDirectional.centerEnd,
-            child: Wrap(
-              alignment: WrapAlignment.end,
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                if (widget.hasKey)
-                  TextButton(
-                    onPressed: () => _complete(_ApiKeyAction.clear),
-                    child: Text(context.l10n.promptAssistant_webAccessClearKey),
-                  ),
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(context.l10n.common_cancel),
-                ),
-                FilledButton(
-                  onPressed: () => _complete(_ApiKeyAction.save),
-                  child: Text(context.l10n.common_save),
-                ),
-              ],
-            ),
+    return ContentSizedAdaptiveForm(
+      scrollController: widget.scrollController,
+      padding: const EdgeInsets.all(20),
+      content: [
+        TextField(
+          controller: _controller,
+          autofocus: true,
+          obscureText: true,
+          decoration: InputDecoration(
+            labelText: context.l10n.promptAssistant_webAccessExaApiKey,
+            hintText: widget.hasKey
+                ? context.l10n.promptAssistant_apiKeyLeaveEmpty
+                : null,
           ),
         ),
       ],
+      footer: SafeArea(
+        top: false,
+        minimum: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        child: Align(
+          alignment: AlignmentDirectional.centerEnd,
+          child: Wrap(
+            alignment: WrapAlignment.end,
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              if (widget.hasKey)
+                TextButton(
+                  onPressed: () => _complete(_ApiKeyAction.clear),
+                  child: Text(context.l10n.promptAssistant_webAccessClearKey),
+                ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(context.l10n.common_cancel),
+              ),
+              FilledButton(
+                onPressed: () => _complete(_ApiKeyAction.save),
+                child: Text(context.l10n.common_save),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/presentation/screens/settings/widgets/prompt_assistant_settings_forms.dart
+++ b/lib/presentation/screens/settings/widgets/prompt_assistant_settings_forms.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/utils/localization_extension.dart';
+import '../../../adaptive/content_sized_adaptive_form.dart';
 import '../../../prompt_assistant/models/prompt_assistant_models.dart';
 import '../../../widgets/common/themed_confirm_dialog.dart';
 
@@ -107,77 +108,67 @@ class _PromptAssistantProviderFormState
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return ContentSizedAdaptiveForm(
       key: const ValueKey('prompt-assistant-provider-dialog'),
-      children: [
-        Expanded(
-          child: ListView(
-            controller: widget.scrollController,
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            padding: const EdgeInsets.all(16),
-            children: [
-              TextField(
-                controller: _nameController,
-                decoration: InputDecoration(
-                  labelText: context.l10n.promptAssistant_name,
-                ),
-              ),
-              const SizedBox(height: 12),
-              DropdownButtonFormField<ProviderPreset>(
-                initialValue: _preset,
-                isExpanded: true,
-                items: ProviderPreset.values
-                    .map(
-                      (value) => DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          value.label,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (value) {
-                  if (value != null) {
-                    setState(() => _applyPreset(value));
-                  }
-                },
-                decoration: InputDecoration(
-                  labelText: context.l10n.promptAssistant_protocol,
-                ),
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: _baseController,
-                keyboardType: TextInputType.url,
-                decoration: const InputDecoration(labelText: 'Base URL'),
-              ),
-              const SizedBox(height: 8),
-              SwitchListTile(
-                value: _allowImageInput,
-                contentPadding: EdgeInsets.zero,
-                title: Text(context.l10n.promptAssistant_allowImageInput),
-                subtitle: Text(
-                  context.l10n.promptAssistant_allowImageInputSubtitle,
-                ),
-                onChanged: (value) {
-                  setState(() => _allowImageInput = value);
-                },
-              ),
-              const SizedBox(height: 8),
-              TextField(
-                controller: _keyController,
-                decoration: InputDecoration(
-                  labelText: context.l10n.promptAssistant_apiKeyLeaveEmpty,
-                ),
-                obscureText: true,
-              ),
-            ],
+      scrollController: widget.scrollController,
+      content: [
+        TextField(
+          controller: _nameController,
+          decoration: InputDecoration(
+            labelText: context.l10n.promptAssistant_name,
           ),
         ),
-        _FormFooter(onSave: _save),
+        const SizedBox(height: 12),
+        DropdownButtonFormField<ProviderPreset>(
+          initialValue: _preset,
+          isExpanded: true,
+          items: ProviderPreset.values
+              .map(
+                (value) => DropdownMenuItem(
+                  value: value,
+                  child: Text(
+                    value.label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              )
+              .toList(),
+          onChanged: (value) {
+            if (value != null) {
+              setState(() => _applyPreset(value));
+            }
+          },
+          decoration: InputDecoration(
+            labelText: context.l10n.promptAssistant_protocol,
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _baseController,
+          keyboardType: TextInputType.url,
+          decoration: const InputDecoration(labelText: 'Base URL'),
+        ),
+        const SizedBox(height: 8),
+        SwitchListTile(
+          value: _allowImageInput,
+          contentPadding: EdgeInsets.zero,
+          title: Text(context.l10n.promptAssistant_allowImageInput),
+          subtitle: Text(context.l10n.promptAssistant_allowImageInputSubtitle),
+          onChanged: (value) {
+            setState(() => _allowImageInput = value);
+          },
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: _keyController,
+          decoration: InputDecoration(
+            labelText: context.l10n.promptAssistant_apiKeyLeaveEmpty,
+          ),
+          obscureText: true,
+        ),
       ],
+      footer: _FormFooter(onSave: _save),
     );
   }
 }
@@ -246,60 +237,50 @@ class _PromptAssistantConnectionFormState
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return ContentSizedAdaptiveForm(
       key: const ValueKey('prompt-assistant-connection-dialog'),
-      children: [
-        Expanded(
-          child: ListView(
-            controller: widget.scrollController,
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            padding: const EdgeInsets.all(16),
-            children: [
-              TextField(
-                controller: _baseController,
-                keyboardType: TextInputType.url,
-                decoration: InputDecoration(
-                  labelText: 'Base URL',
-                  hintText: context.l10n.promptAssistant_baseUrlHint,
-                ),
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: _keyController,
-                decoration: InputDecoration(
-                  labelText: context.l10n.promptAssistant_apiKeyLeaveEmpty,
-                ),
-                obscureText: true,
-              ),
-              const SizedBox(height: 8),
-              CheckboxListTile(
-                value: _clearApiKey,
-                contentPadding: EdgeInsets.zero,
-                title: Text(context.l10n.promptAssistant_clearCurrentApiKey),
-                onChanged: (value) {
-                  setState(() => _clearApiKey = value ?? false);
-                },
-              ),
-              SwitchListTile(
-                value: _allowImageInput,
-                contentPadding: EdgeInsets.zero,
-                title: Text(context.l10n.promptAssistant_allowImageInput),
-                subtitle: Text(
-                  widget.provider.protocol.supportsImagePayload
-                      ? context
-                            .l10n
-                            .promptAssistant_protocolSupportsImagePayload
-                      : context.l10n.promptAssistant_protocolTextOnlyWarning,
-                ),
-                onChanged: (value) {
-                  setState(() => _allowImageInput = value);
-                },
-              ),
-            ],
+      scrollController: widget.scrollController,
+      content: [
+        TextField(
+          controller: _baseController,
+          keyboardType: TextInputType.url,
+          decoration: InputDecoration(
+            labelText: 'Base URL',
+            hintText: context.l10n.promptAssistant_baseUrlHint,
           ),
         ),
-        _FormFooter(onSave: _save),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _keyController,
+          decoration: InputDecoration(
+            labelText: context.l10n.promptAssistant_apiKeyLeaveEmpty,
+          ),
+          obscureText: true,
+        ),
+        const SizedBox(height: 8),
+        CheckboxListTile(
+          value: _clearApiKey,
+          contentPadding: EdgeInsets.zero,
+          title: Text(context.l10n.promptAssistant_clearCurrentApiKey),
+          onChanged: (value) {
+            setState(() => _clearApiKey = value ?? false);
+          },
+        ),
+        SwitchListTile(
+          value: _allowImageInput,
+          contentPadding: EdgeInsets.zero,
+          title: Text(context.l10n.promptAssistant_allowImageInput),
+          subtitle: Text(
+            widget.provider.protocol.supportsImagePayload
+                ? context.l10n.promptAssistant_protocolSupportsImagePayload
+                : context.l10n.promptAssistant_protocolTextOnlyWarning,
+          ),
+          onChanged: (value) {
+            setState(() => _allowImageInput = value);
+          },
+        ),
       ],
+      footer: _FormFooter(onSave: _save),
     );
   }
 }
@@ -389,67 +370,59 @@ class _PromptAssistantRuleFormState extends State<PromptAssistantRuleForm> {
   @override
   Widget build(BuildContext context) {
     final rule = widget.rule;
-    return Column(
+    return ContentSizedAdaptiveForm(
       key: const ValueKey('prompt-assistant-rule-dialog'),
-      children: [
-        Expanded(
-          child: ListView(
-            controller: widget.scrollController,
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            padding: const EdgeInsets.all(16),
-            children: [
-              TextField(
-                controller: _nameController,
-                decoration: InputDecoration(
-                  labelText: context.l10n.promptAssistant_name,
-                ),
-              ),
-              const SizedBox(height: 12),
-              DropdownButtonFormField<AssistantTaskType>(
-                initialValue: _taskType,
-                isExpanded: true,
-                items: AssistantTaskType.values
-                    .where((value) => value != AssistantTaskType.chat)
-                    .map(
-                      (value) => DropdownMenuItem(
-                        value: value,
-                        child: Text(
-                          _assistantTaskLabel(context, value),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (value) {
-                  if (value != null) setState(() => _taskType = value);
-                },
-                decoration: InputDecoration(
-                  labelText: context.l10n.promptAssistant_taskType,
-                ),
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: _contentController,
-                minLines: 4,
-                maxLines: 10,
-                decoration: InputDecoration(
-                  labelText: context.l10n.promptAssistant_ruleContent,
-                  alignLabelWithHint: true,
-                ),
-              ),
-            ],
+      scrollController: widget.scrollController,
+      content: [
+        TextField(
+          controller: _nameController,
+          decoration: InputDecoration(
+            labelText: context.l10n.promptAssistant_name,
           ),
         ),
-        _FormFooter(
-          onSave: _save,
-          leading: rule != null && !rule.isDefault
-              ? TextButton(
-                  onPressed: _delete,
-                  child: Text(context.l10n.common_delete),
-                )
-              : null,
+        const SizedBox(height: 12),
+        DropdownButtonFormField<AssistantTaskType>(
+          initialValue: _taskType,
+          isExpanded: true,
+          items: AssistantTaskType.values
+              .where((value) => value != AssistantTaskType.chat)
+              .map(
+                (value) => DropdownMenuItem(
+                  value: value,
+                  child: Text(
+                    _assistantTaskLabel(context, value),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              )
+              .toList(),
+          onChanged: (value) {
+            if (value != null) setState(() => _taskType = value);
+          },
+          decoration: InputDecoration(
+            labelText: context.l10n.promptAssistant_taskType,
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _contentController,
+          minLines: 4,
+          maxLines: 10,
+          decoration: InputDecoration(
+            labelText: context.l10n.promptAssistant_ruleContent,
+            alignLabelWithHint: true,
+          ),
         ),
       ],
+      footer: _FormFooter(
+        onSave: _save,
+        leading: rule != null && !rule.isDefault
+            ? TextButton(
+                onPressed: _delete,
+                child: Text(context.l10n.common_delete),
+              )
+            : null,
+      ),
     );
   }
 }

--- a/lib/presentation/widgets/image_editor/widgets/panels/canvas_size_dialog.dart
+++ b/lib/presentation/widgets/image_editor/widgets/panels/canvas_size_dialog.dart
@@ -6,6 +6,7 @@ import 'package:nai_launcher/presentation/widgets/common/themed_input.dart';
 
 import '../../../../../core/utils/localization_extension.dart';
 import '../../../../adaptive/adaptive_presenter.dart';
+import '../../../../adaptive/content_sized_adaptive_form.dart';
 import '../../../../adaptive/window_size_class.dart';
 
 /// 内容处理模式
@@ -148,152 +149,150 @@ class _CanvasSizeDialogState extends State<CanvasSizeDialog> {
   Widget build(BuildContext context) {
     final compact = context.adaptiveWindow.isCompact;
 
-    return Column(
+    return ContentSizedAdaptiveForm(
       key: const ValueKey('canvas-size-dialog'),
-      children: [
-        Expanded(
-          child: ListView(
-            key: const ValueKey('canvas-size-scroll'),
-            controller: widget.scrollController,
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            padding: EdgeInsets.all(compact ? 12 : 16),
-            children: [
-              DropdownButtonFormField<CanvasSizePreset>(
-                key: const ValueKey('canvas-size-preset'),
-                initialValue: _selectedPreset,
-                isExpanded: true,
-                decoration: InputDecoration(
-                  labelText: context.l10n.editor_presetSize,
-                  isDense: true,
+      scrollController: widget.scrollController,
+      scrollViewKey: const ValueKey('canvas-size-scroll'),
+      padding: EdgeInsets.all(compact ? 12 : 16),
+      content: [
+        DropdownButtonFormField<CanvasSizePreset>(
+          key: const ValueKey('canvas-size-preset'),
+          initialValue: _selectedPreset,
+          isExpanded: true,
+          decoration: InputDecoration(
+            labelText: context.l10n.editor_presetSize,
+            isDense: true,
+          ),
+          items: [
+            DropdownMenuItem(
+              value: null,
+              child: Text(
+                context.l10n.editor_customSize,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            ...canvasPresets.map(
+              (preset) => DropdownMenuItem(
+                value: preset,
+                child: Text(
+                  _presetLabel(context, preset),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
-                items: [
-                  DropdownMenuItem(
-                    value: null,
-                    child: Text(
-                      context.l10n.editor_customSize,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+              ),
+            ),
+          ],
+          onChanged: (preset) {
+            setState(() {
+              _selectedPreset = preset;
+              if (preset != null) {
+                _widthController.text = preset.width.toString();
+                _heightController.text = preset.height.toString();
+                _aspectRatio = preset.width / preset.height;
+              }
+            });
+          },
+        ),
+        const SizedBox(height: 16),
+        DropdownButtonFormField<ContentHandlingMode>(
+          key: const ValueKey('canvas-size-mode'),
+          initialValue: _selectedMode,
+          isExpanded: true,
+          decoration: InputDecoration(
+            labelText: context.l10n.editor_contentHandling,
+            isDense: true,
+          ),
+          items: ContentHandlingMode.values
+              .map(
+                (mode) => DropdownMenuItem(
+                  value: mode,
+                  child: Text(
+                    _modeLabel(context, mode),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  ...canvasPresets.map(
-                    (preset) => DropdownMenuItem(
-                      value: preset,
-                      child: Text(
-                        _presetLabel(context, preset),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ),
+                ),
+              )
+              .toList(),
+          onChanged: (mode) {
+            if (mode != null) {
+              setState(() => _selectedMode = mode);
+            }
+          },
+        ),
+        const SizedBox(height: 16),
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final stackInputs =
+                constraints.maxWidth < 400 ||
+                MediaQuery.textScalerOf(context).scale(1) >= 2;
+            if (stackInputs) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _buildWidthInput(),
+                  Align(child: _buildLinkButton()),
+                  _buildHeightInput(),
                 ],
-                onChanged: (preset) {
-                  setState(() {
-                    _selectedPreset = preset;
-                    if (preset != null) {
-                      _widthController.text = preset.width.toString();
-                      _heightController.text = preset.height.toString();
-                      _aspectRatio = preset.width / preset.height;
-                    }
-                  });
-                },
-              ),
-              const SizedBox(height: 16),
-              DropdownButtonFormField<ContentHandlingMode>(
-                key: const ValueKey('canvas-size-mode'),
-                initialValue: _selectedMode,
-                isExpanded: true,
-                decoration: InputDecoration(
-                  labelText: context.l10n.editor_contentHandling,
-                  isDense: true,
-                ),
-                items: ContentHandlingMode.values
-                    .map(
-                      (mode) => DropdownMenuItem(
-                        value: mode,
-                        child: Text(
-                          _modeLabel(context, mode),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (mode) {
-                  if (mode != null) {
-                    setState(() => _selectedMode = mode);
-                  }
-                },
-              ),
-              const SizedBox(height: 16),
-              LayoutBuilder(
-                builder: (context, constraints) {
-                  final stackInputs =
-                      constraints.maxWidth < 400 ||
-                      MediaQuery.textScalerOf(context).scale(1) >= 2;
-                  if (stackInputs) {
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        _buildWidthInput(),
-                        Align(child: _buildLinkButton()),
-                        _buildHeightInput(),
-                      ],
-                    );
-                  }
-                  return Row(
-                    children: [
-                      Expanded(child: _buildWidthInput()),
-                      _buildLinkButton(),
-                      Expanded(child: _buildHeightInput()),
-                    ],
-                  );
-                },
-              ),
-              const SizedBox(height: 16),
-              Wrap(
+              );
+            }
+            return Row(
+              children: [
+                Expanded(child: _buildWidthInput()),
+                _buildLinkButton(),
+                Expanded(child: _buildHeightInput()),
+              ],
+            );
+          },
+        ),
+        const SizedBox(height: 16),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            _RatioChip(label: '1:1', onTap: () => _setRatio(1, 1)),
+            _RatioChip(label: '4:3', onTap: () => _setRatio(4, 3)),
+            _RatioChip(label: '3:4', onTap: () => _setRatio(3, 4)),
+            _RatioChip(label: '16:9', onTap: () => _setRatio(16, 9)),
+            _RatioChip(label: '9:16', onTap: () => _setRatio(9, 16)),
+          ],
+        ),
+        const SizedBox(height: 16),
+        _CanvasSizePreview(
+          originalSize: widget.initialSize ?? const Size(1024, 1024),
+          newWidth: int.tryParse(_widthController.text) ?? 1024,
+          newHeight: int.tryParse(_heightController.text) ?? 1024,
+          mode: _selectedMode,
+        ),
+      ],
+      footer: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Divider(height: 1),
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: EdgeInsets.all(compact ? 12 : 16),
+              child: Wrap(
+                alignment: WrapAlignment.end,
                 spacing: 8,
                 runSpacing: 8,
                 children: [
-                  _RatioChip(label: '1:1', onTap: () => _setRatio(1, 1)),
-                  _RatioChip(label: '4:3', onTap: () => _setRatio(4, 3)),
-                  _RatioChip(label: '3:4', onTap: () => _setRatio(3, 4)),
-                  _RatioChip(label: '16:9', onTap: () => _setRatio(16, 9)),
-                  _RatioChip(label: '9:16', onTap: () => _setRatio(9, 16)),
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: Text(context.l10n.common_cancel),
+                  ),
+                  FilledButton(
+                    onPressed: _isValid() ? _confirm : null,
+                    child: Text(widget.confirmText),
+                  ),
                 ],
               ),
-              const SizedBox(height: 16),
-              _CanvasSizePreview(
-                originalSize: widget.initialSize ?? const Size(1024, 1024),
-                newWidth: int.tryParse(_widthController.text) ?? 1024,
-                newHeight: int.tryParse(_heightController.text) ?? 1024,
-                mode: _selectedMode,
-              ),
-            ],
-          ),
-        ),
-        const Divider(height: 1),
-        SafeArea(
-          top: false,
-          child: Padding(
-            padding: EdgeInsets.all(compact ? 12 : 16),
-            child: Wrap(
-              alignment: WrapAlignment.end,
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: Text(context.l10n.common_cancel),
-                ),
-                FilledButton(
-                  onPressed: _isValid() ? _confirm : null,
-                  child: Text(widget.confirmText),
-                ),
-              ],
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/lib/presentation/widgets/image_editor/widgets/panels/color_panel.dart
+++ b/lib/presentation/widgets/image_editor/widgets/panels/color_panel.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../../../core/utils/app_logger.dart';
 import '../../../../../core/utils/localization_extension.dart';
 import '../../../../adaptive/adaptive_presenter.dart';
+import '../../../../adaptive/content_sized_adaptive_form.dart';
 import '../../../../widgets/common/themed_input.dart';
 import '../../core/editor_state.dart';
 
@@ -300,87 +301,84 @@ class _ColorPickerDialogState extends State<_ColorPickerDialog> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Column(
-      children: [
-        Expanded(
-          child: ListView(
-            key: const Key('color_picker_scroll'),
-            controller: widget.scrollController,
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            padding: const EdgeInsets.all(16),
-            children: [
-              _AdaptiveColorSurface(
-                hsvColor: _hsvColor,
-                onSVChanged: _updateSV,
-                onHueChanged: _updateHue,
+    return ContentSizedAdaptiveForm(
+      scrollController: widget.scrollController,
+      scrollViewKey: const Key('color_picker_scroll'),
+      content: [
+        _AdaptiveColorSurface(
+          hsvColor: _hsvColor,
+          onSVChanged: _updateSV,
+          onHueChanged: _updateHue,
+        ),
+        const SizedBox(height: 16),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                color: _hsvColor.toColor(),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: theme.dividerColor),
               ),
-              const SizedBox(height: 16),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: ThemedInput(
+                key: const Key('color_picker_hex'),
+                controller: _hexController,
+                decoration: const InputDecoration(
+                  prefixText: '#',
+                  labelText: 'HEX',
+                  isDense: true,
+                ),
+                onSubmitted: _parseHex,
+              ),
+            ),
+          ],
+        ),
+      ],
+      footer: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Divider(height: 1),
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
                 children: [
-                  Container(
-                    width: 48,
-                    height: 48,
-                    decoration: BoxDecoration(
-                      color: _hsvColor.toColor(),
-                      borderRadius: BorderRadius.circular(8),
-                      border: Border.all(color: theme.dividerColor),
+                  Expanded(
+                    child: TextButton(
+                      key: const Key('color_picker_cancel'),
+                      onPressed: () => Navigator.pop(context),
+                      child: Text(
+                        context.l10n.common_cancel,
+                        textAlign: TextAlign.center,
+                      ),
                     ),
                   ),
-                  const SizedBox(width: 16),
+                  const SizedBox(width: 8),
                   Expanded(
-                    child: ThemedInput(
-                      key: const Key('color_picker_hex'),
-                      controller: _hexController,
-                      decoration: const InputDecoration(
-                        prefixText: '#',
-                        labelText: 'HEX',
-                        isDense: true,
+                    child: FilledButton(
+                      key: const Key('color_picker_confirm'),
+                      onPressed: () {
+                        widget.onColorChanged(_hsvColor.toColor());
+                        Navigator.pop(context);
+                      },
+                      child: Text(
+                        context.l10n.common_confirm,
+                        textAlign: TextAlign.center,
                       ),
-                      onSubmitted: _parseHex,
                     ),
                   ),
                 ],
               ),
-            ],
-          ),
-        ),
-        const Divider(height: 1),
-        SafeArea(
-          top: false,
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextButton(
-                    key: const Key('color_picker_cancel'),
-                    onPressed: () => Navigator.pop(context),
-                    child: Text(
-                      context.l10n.common_cancel,
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: FilledButton(
-                    key: const Key('color_picker_confirm'),
-                    onPressed: () {
-                      widget.onColorChanged(_hsvColor.toColor());
-                      Navigator.pop(context);
-                    },
-                    child: Text(
-                      context.l10n.common_confirm,
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                ),
-              ],
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/test/presentation/screens/settings/web_access_settings_test.dart
+++ b/test/presentation/screens/settings/web_access_settings_test.dart
@@ -159,8 +159,8 @@ void main() {
 
     await tester.tap(find.text('Configure'));
     await tester.pumpAndSettle();
-    final panel = find.byKey(const ValueKey('adaptive-bottom-sheet'));
-    final editor = find.descendant(of: panel, matching: find.byType(TextField));
+    final editor = find.byType(TextField);
+    expect(editor, findsOneWidget);
     await tester.enterText(editor, '  replacement-key  ');
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();

--- a/test/presentation/screens/settings/widgets/prompt_assistant_settings_forms_test.dart
+++ b/test/presentation/screens/settings/widgets/prompt_assistant_settings_forms_test.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/adaptive/adaptive_presenter.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/models/prompt_assistant_models.dart';
+import 'package:nai_launcher/presentation/screens/settings/widgets/prompt_assistant_settings_forms.dart';
+
+void main() {
+  testWidgets('连接配置弹窗在桌面按内容高度呈现', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(610, 1025);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => FilledButton(
+              onPressed: () {
+                unawaited(
+                  AdaptivePresenter.showForm<
+                    PromptAssistantConnectionFormResult
+                  >(
+                    context: context,
+                    dialogWidth: 520,
+                    title: '美饭 连接配置',
+                    builder: (context, scrollController) =>
+                        PromptAssistantConnectionForm(
+                          provider: const ProviderConfig(
+                            id: 'meifan',
+                            name: '美饭',
+                            baseUrl: 'https://sub.mathhomework.top/v1beta',
+                            allowImageInput: true,
+                          ),
+                          scrollController: scrollController,
+                        ),
+                  ),
+                );
+              },
+              child: const Text('打开'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+
+    final surface = find.byKey(const ValueKey('adaptive-centered-form'));
+    expect(surface, findsOneWidget);
+    expect(tester.getSize(surface).height, lessThan(560));
+    expect(find.text('保存'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('连接配置内容受限时滚动且操作区保持可见', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(600, 500);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(textScaler: const TextScaler.linear(3)),
+          child: child!,
+        ),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => FilledButton(
+              onPressed: () {
+                unawaited(
+                  AdaptivePresenter.showForm<
+                    PromptAssistantConnectionFormResult
+                  >(
+                    context: context,
+                    dialogWidth: 520,
+                    title: '美饭 连接配置',
+                    builder: (context, scrollController) =>
+                        PromptAssistantConnectionForm(
+                          provider: const ProviderConfig(
+                            id: 'meifan',
+                            name: '美饭',
+                            baseUrl: 'https://sub.mathhomework.top/v1beta',
+                            allowImageInput: true,
+                          ),
+                          scrollController: scrollController,
+                        ),
+                  ),
+                );
+              },
+              child: const Text('打开'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开'));
+    await tester.pumpAndSettle();
+
+    final surface = find.byKey(const ValueKey('adaptive-centered-form'));
+    final save = find.text('保存');
+    expect(surface, findsOneWidget);
+    expect(save, findsOneWidget);
+    expect(
+      tester.getBottomRight(save).dy,
+      lessThanOrEqualTo(tester.getBottomRight(surface).dy),
+    );
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## 改动内容

- 新增按内容高度收缩的共享自适应表单容器，达到窗口高度上限后仅滚动表单主体
- 迁移提示词助手、Web Access、隐私设置、颜色选择和画布尺寸等短表单弹窗
- 修复短内容被 `Expanded` 与非收缩 `ListView` 强制撑满可用高度的问题
- 补充真实连接配置弹窗及受限窗口、大字号场景的回归测试

## 验证结果

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/verify_flutter_sources.ps1`
- `scripts/test_affected.ps1`：8 个测试文件、50 项测试全部通过
- 相关文件 `flutter analyze`：No issues found
- `git diff --check`

## 注意事项

- 未等待 CI；按要求创建后立即执行 Squash Merge
- 未执行 Windows 或 Android 运行时截图验收