### PR TITLE
feat(autocomplete): 内置基础标签翻译补充库

### DIFF
--- a/assets/databases/manifest.json
+++ b/assets/databases/manifest.json
@@ -2,13 +2,13 @@
   "schemaVersion": 1,
   "databases": {
     "tag_catalog.db": {
-      "schemaVersion": 2,
-      "dataVersion": "42f35be9d394",
-      "sha256": "270538fc623bb1a88acf1f347372568d51bf55510c53e0fb700cb370e0da798d",
-      "size": 46772224,
+      "schemaVersion": 3,
+      "dataVersion": "125148ac88dc",
+      "sha256": "9b9693af5f6cfafda2ed8d85488b0a6c3741b0c589da935291b20dff439a2288",
+      "size": 46792704,
       "release": {
-        "tag": "autocomplete-data-tag-catalog-42f35be9-v1",
-        "url": "https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/download/autocomplete-data-tag-catalog-42f35be9-v1/tag_catalog.db",
+        "tag": "autocomplete-data-tag-catalog-125148ac-v1",
+        "url": "https://github.com/Aaalice233/Aaalice_NAI_Launcher/releases/download/autocomplete-data-tag-catalog-125148ac-v1/tag_catalog.db",
         "prerelease": true,
         "makeLatest": false
       }

--- a/assets/databases/tag_catalog.db
+++ b/assets/databases/tag_catalog.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:270538fc623bb1a88acf1f347372568d51bf55510c53e0fb700cb370e0da798d
-size 46772224
+oid sha256:9b9693af5f6cfafda2ed8d85488b0a6c3741b0c589da935291b20dff439a2288
+size 46792704

--- a/lib/core/autocomplete/autocomplete_providers.dart
+++ b/lib/core/autocomplete/autocomplete_providers.dart
@@ -13,10 +13,15 @@ import 'cooccurrence_completion_source.dart';
 import 'completion_models.dart';
 import 'completion_orchestrator.dart';
 import 'danbooru_completion_source.dart';
+import 'fast_tag_service_provider.dart';
 import 'llm_translation_resolver.dart';
-import 'tag_catalog_repository.dart';
 import 'tag_library_completion_source.dart';
-import 'zh_dictionary_service.dart';
+
+export 'fast_tag_service_provider.dart'
+    show
+        fastTagServiceProvider,
+        tagCatalogRepositoryProvider,
+        zhDictionaryServiceProvider;
 
 final autocompleteCacheDatabaseProvider = Provider<AutocompleteCacheDatabase>((
   ref,
@@ -31,25 +36,6 @@ final autocompleteCacheStatisticsProvider =
     FutureProvider.autoDispose<Map<String, int>>((ref) {
       return ref.watch(autocompleteCacheDatabaseProvider).statistics();
     });
-
-final tagCatalogRepositoryProvider = Provider<TagCatalogRepository>((ref) {
-  final repository = TagCatalogRepository();
-  ref.onDispose(() => unawaited(repository.dispose()));
-  return repository;
-});
-
-final zhDictionaryServiceProvider = ChangeNotifierProvider<ZhDictionaryService>(
-  (ref) {
-    final service = ZhDictionaryService();
-    unawaited(() async {
-      await service.initialize();
-      if (service.state.isInstalled) {
-        await service.checkForUpdate();
-      }
-    }());
-    return service;
-  },
-);
 
 final danbooruCompletionSourceProvider = Provider<DanbooruCompletionSource>((
   ref,
@@ -123,8 +109,7 @@ final autocompleteLocalSourcesProvider = Provider<List<CompletionSource>>((
   ref,
 ) {
   return <CompletionSource>[
-    ref.watch(tagCatalogRepositoryProvider),
-    ref.watch(zhDictionaryServiceProvider),
+    ref.watch(fastTagServiceProvider),
     ref.watch(cooccurrenceCompletionSourceProvider),
   ];
 });
@@ -146,12 +131,11 @@ final tagLibraryCompletionSourceProvider = Provider<TagLibraryCompletionSource>(
 );
 
 final autocompleteServicesProvider = Provider<AutocompleteServices>((ref) {
-  final zhDictionary = ref.watch(zhDictionaryServiceProvider);
-  final tagCatalog = ref.watch(tagCatalogRepositoryProvider);
+  final fastTags = ref.watch(fastTagServiceProvider);
   return AutocompleteServices(
     localSources: ref.watch(autocompleteLocalSourcesProvider),
-    tagLookupSources: [tagCatalog, zhDictionary],
-    dictionaryTranslations: zhDictionary,
+    tagLookupSources: [fastTags],
+    dictionaryTranslations: fastTags,
     llmTranslations: ref.watch(llmTranslationResolverProvider),
     danbooru: ref.watch(danbooruCompletionSourceProvider),
     libraryAliases: ref.watch(tagLibraryCompletionSourceProvider),

--- a/lib/core/autocomplete/fast_tag_service.dart
+++ b/lib/core/autocomplete/fast_tag_service.dart
@@ -1,0 +1,104 @@
+import 'completion_models.dart';
+import 'completion_ranker.dart';
+import 'tag_catalog_repository.dart';
+import 'zh_dictionary_service.dart';
+
+/// Reusable local tag search and translation boundary.
+///
+/// Consumers do not need to know which bundled or optional database owns a
+/// result. Search and translation precedence live here so autocomplete,
+/// prompt tools, and future modules share the same behavior.
+class FastTagService implements CompletionSource, TranslationResolver {
+  const FastTagService({
+    required TagCatalogRepository catalog,
+    required ZhDictionaryService dictionary,
+  }) : _catalog = catalog,
+       _dictionary = dictionary;
+
+  final TagCatalogRepository _catalog;
+  final ZhDictionaryService _dictionary;
+
+  @override
+  Future<List<CompletionCandidate>> search(CompletionQuery query) async {
+    final bundledBatches = await Future.wait([
+      _catalog.search(query),
+      _catalog.searchTranslations(query),
+    ]);
+    final dictionaryResults = await _searchOptionalDictionary(query);
+    return CompletionRanker.mergeAndSort([
+      ...bundledBatches.expand((batch) => batch),
+      ...dictionaryResults,
+    ], query: query);
+  }
+
+  /// Resolves reviewed corrections before ffdkj and bundled gap-fillers after
+  /// it. A later ffdkj update can therefore replace an ordinary fallback but
+  /// cannot reintroduce a confirmed mistranslation.
+  @override
+  Future<Map<String, String>> resolve(
+    List<String> canonicalTags, {
+    required String locale,
+  }) async {
+    if (!locale.toLowerCase().startsWith('zh') || canonicalTags.isEmpty) {
+      return const {};
+    }
+    final normalized = canonicalTags
+        .map((tag) => tag.trim().toLowerCase().replaceAll(' ', '_'))
+        .where((tag) => tag.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (normalized.isEmpty) return const {};
+
+    final overrides = await _catalog.resolveTranslations(
+      normalized,
+      mode: BundledTranslationMode.override,
+    );
+    final dictionaryTags = normalized
+        .where((tag) => !overrides.containsKey(tag))
+        .toList(growable: false);
+    final dictionary = await _resolveOptionalDictionary(
+      dictionaryTags,
+      locale: locale,
+    );
+    final missingTags = dictionaryTags
+        .where((tag) => !dictionary.containsKey(tag))
+        .toList(growable: false);
+    final fallbacks = await _catalog.resolveTranslations(
+      missingTags,
+      mode: BundledTranslationMode.missing,
+    );
+    return {...overrides, ...dictionary, ...fallbacks};
+  }
+
+  Future<Map<String, String>> resolveFuzzy(List<String> canonicalTags) async {
+    try {
+      return await _dictionary.resolveFuzzy(canonicalTags);
+    } catch (_) {
+      return const {};
+    }
+  }
+
+  Future<List<CompletionCandidate>> _searchOptionalDictionary(
+    CompletionQuery query,
+  ) async {
+    try {
+      return await _dictionary.search(query);
+    } catch (_) {
+      // ffdkj is user-installed optional data; bundled completion must remain
+      // available when that database is absent, outdated, or damaged.
+      return const [];
+    }
+  }
+
+  Future<Map<String, String>> _resolveOptionalDictionary(
+    List<String> canonicalTags, {
+    required String locale,
+  }) async {
+    try {
+      return await _dictionary.resolve(canonicalTags, locale: locale);
+    } catch (_) {
+      // The bundled fallback is independently usable without ffdkj.
+      return const {};
+    }
+  }
+}

--- a/lib/core/autocomplete/fast_tag_service_provider.dart
+++ b/lib/core/autocomplete/fast_tag_service_provider.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'fast_tag_service.dart';
+import 'tag_catalog_repository.dart';
+import 'zh_dictionary_service.dart';
+
+final tagCatalogRepositoryProvider = Provider<TagCatalogRepository>((ref) {
+  final repository = TagCatalogRepository();
+  ref.onDispose(() => unawaited(repository.dispose()));
+  return repository;
+});
+
+final zhDictionaryServiceProvider = ChangeNotifierProvider<ZhDictionaryService>(
+  (ref) {
+    final service = ZhDictionaryService();
+    unawaited(() async {
+      await service.initialize();
+      if (service.state.isInstalled) {
+        await service.checkForUpdate();
+      }
+    }());
+    return service;
+  },
+);
+
+final fastTagServiceProvider = Provider<FastTagService>(
+  (ref) => FastTagService(
+    catalog: ref.watch(tagCatalogRepositoryProvider),
+    dictionary: ref.watch(zhDictionaryServiceProvider),
+  ),
+);

--- a/lib/core/autocomplete/local_first_prompt_translation.dart
+++ b/lib/core/autocomplete/local_first_prompt_translation.dart
@@ -1,0 +1,58 @@
+import 'tag_translation_lookup.dart';
+
+typedef MissingTagTranslator =
+    Future<Map<String, String>> Function(List<String> canonicalTags);
+
+/// Translates tag prompts locally first and delegates only unresolved tags.
+///
+/// Returning `null` means the input looks like prose or requests a non-Chinese
+/// target, so the caller should preserve its normal general-purpose flow.
+class LocalFirstPromptTranslationPipeline {
+  const LocalFirstPromptTranslationPipeline(this._localTranslations);
+
+  final TagTranslationLookup _localTranslations;
+
+  Future<TagTextTranslation?> translate(
+    String input, {
+    String? targetLanguage,
+    required MissingTagTranslator translateMissing,
+    int batchSize = 8,
+  }) async {
+    assert(batchSize > 0);
+    if (RegExp(r'[\u3400-\u9fff]').hasMatch(input)) return null;
+    final requestedLanguage = targetLanguage?.trim().toLowerCase() ?? '';
+    if (requestedLanguage.isNotEmpty &&
+        !RegExp(r'(zh|chinese|中文)').hasMatch(requestedLanguage)) {
+      return null;
+    }
+
+    final plan = await _localTranslations.prepareTagTextTranslation(input);
+    if (plan.tagCount == 0 ||
+        plan.unresolvedTags.any(
+          (tag) => !RegExp(r'^[a-z0-9_():.!+\-]+$').hasMatch(tag),
+        )) {
+      return null;
+    }
+    final isTagList = input.contains(RegExp(r'[,，\r\n]'));
+    final isSingleCanonicalTag = RegExp(
+      r'^[\s{}\[\]()*+\-:.0-9a-zA-Z_\\]+$',
+    ).hasMatch(input);
+    if (plan.localTranslations.isEmpty && !isTagList && !isSingleCanonicalTag) {
+      return null;
+    }
+
+    final delegated = <String, String>{};
+    for (
+      var offset = 0;
+      offset < plan.unresolvedTags.length;
+      offset += batchSize
+    ) {
+      final batch = plan.unresolvedTags
+          .skip(offset)
+          .take(batchSize)
+          .toList(growable: false);
+      delegated.addAll(await translateMissing(batch));
+    }
+    return plan.render(delegated);
+  }
+}

--- a/lib/core/autocomplete/tag_catalog_repository.dart
+++ b/lib/core/autocomplete/tag_catalog_repository.dart
@@ -3,6 +3,15 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import '../database/asset_database_manager.dart';
 import 'completion_models.dart';
 
+enum BundledTranslationMode {
+  missing(0),
+  override(1);
+
+  const BundledTranslationMode(this.databaseValue);
+
+  final int databaseValue;
+}
+
 class TagCatalogRecord {
   const TagCatalogRecord({
     required this.canonicalTag,
@@ -227,6 +236,105 @@ class TagCatalogRepository implements CompletionSource {
     return result;
   }
 
+  Future<Map<String, String>> resolveTranslations(
+    Iterable<String> terms, {
+    required BundledTranslationMode mode,
+  }) async {
+    final normalized = terms
+        .map((term) => term.trim().toLowerCase().replaceAll(' ', '_'))
+        .where((term) => term.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (normalized.isEmpty) return const {};
+    await initialize();
+
+    final result = <String, String>{};
+    for (var offset = 0; offset < normalized.length; offset += 400) {
+      final chunk = normalized.skip(offset).take(400).toList(growable: false);
+      final placeholders = List.filled(chunk.length, '?').join(',');
+      final rows = await _database!.rawQuery(
+        'SELECT tag, zh_cn FROM zh_translations '
+        'WHERE mode = ? AND tag IN ($placeholders)',
+        [mode.databaseValue, ...chunk],
+      );
+      for (final row in rows) {
+        result[row['tag'] as String] = (row['zh_cn'] as String).trim();
+      }
+    }
+    return result;
+  }
+
+  /// Searches the compact bundled translation index by either tag or Chinese
+  /// label. Records missing from the full tag catalog remain usable with safe
+  /// general-category defaults instead of disappearing from autocomplete.
+  Future<List<CompletionCandidate>> searchTranslations(
+    CompletionQuery query,
+  ) async {
+    final token = query.token.trim().toLowerCase();
+    if (token.isEmpty) return const [];
+    await initialize();
+
+    final requestedLimit =
+        token.runes.length == 1 && CompletionResultLimits.isAll(query.limit)
+        ? CompletionResultLimits.oneCharacter
+        : query.limit;
+    final escaped = _escapeLike(token);
+    final field = query.isChinese ? 'zh_cn' : 'tag';
+    final rows = await _database!.rawQuery(
+      '''
+      SELECT tag, zh_cn,
+        CASE
+          WHEN $field = ? THEN 0
+          WHEN $field LIKE ? ESCAPE '\\' THEN 1
+          ELSE 2
+        END AS match_rank
+      FROM zh_translations
+      WHERE $field = ?
+         OR $field LIKE ? ESCAPE '\\'
+         OR $field LIKE ? ESCAPE '\\'
+      ORDER BY match_rank, tag ASC
+      LIMIT ?
+      ''',
+      [token, '$escaped%', token, '$escaped%', '%$escaped%', requestedLimit],
+    );
+    if (rows.isEmpty) return const [];
+
+    final records = await recordsByCanonicalTag(
+      rows.map((row) => row['tag'] as String),
+    );
+    final candidates = <CompletionCandidate>[];
+    for (final row in rows) {
+      final tag = row['tag'] as String;
+      final record = records[tag];
+      final category = record?.category ?? TagCategory.general;
+      if (query.categoryFilter != null && query.categoryFilter != category) {
+        continue;
+      }
+      final rank = (row['match_rank'] as num).toInt();
+      candidates.add(
+        CompletionCandidate(
+          canonicalTag: tag,
+          category: category,
+          postCount: record?.postCount ?? 0,
+          translation: row['zh_cn'] as String,
+          matchKind: query.isChinese
+              ? rank == 0
+                    ? CompletionMatchKind.chineseExact
+                    : rank == 1
+                    ? CompletionMatchKind.chinesePrefix
+                    : CompletionMatchKind.chineseContains
+              : rank == 0
+              ? CompletionMatchKind.englishExact
+              : rank == 1
+              ? CompletionMatchKind.englishPrefix
+              : CompletionMatchKind.fullText,
+          sources: const {CompletionSourceKind.base},
+        ),
+      );
+    }
+    return candidates;
+  }
+
   Future<Map<String, String>> metadata() async {
     await initialize();
     final rows = await _database!.rawQuery('SELECT key, value FROM metadata');
@@ -268,6 +376,11 @@ class TagCatalogRepository implements CompletionSource {
         .toList();
     return tokens.map((token) => '"${token.replaceAll('"', '""')}"*').join(' ');
   }
+
+  static String _escapeLike(String value) => value
+      .replaceAll(r'\', r'\\')
+      .replaceAll('%', r'\%')
+      .replaceAll('_', r'\_');
 
   static CompletionMatchKind _matchKind(String term, int kind, String query) {
     if (query.isEmpty) return CompletionMatchKind.fullText;

--- a/lib/core/autocomplete/tag_translation_lookup.dart
+++ b/lib/core/autocomplete/tag_translation_lookup.dart
@@ -3,7 +3,7 @@ import 'dart:collection';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../utils/tag_normalizer.dart';
-import 'autocomplete_providers.dart';
+import 'fast_tag_service_provider.dart';
 import 'zh_dictionary_service.dart';
 
 /// Result of translating a prompt-like, comma-delimited tag document.
@@ -17,6 +17,27 @@ class TagTextTranslation {
   final int translatedTagCount;
 
   bool get hasTranslations => translatedTagCount > 0;
+}
+
+/// A reusable local-first translation plan for prompt-like tag text.
+class TagTextTranslationPlan {
+  const TagTextTranslationPlan({
+    required this.source,
+    required this.localTranslations,
+    required this.unresolvedTags,
+    required this.tagCount,
+  });
+
+  final String source;
+  final Map<String, String> localTranslations;
+  final List<String> unresolvedTags;
+  final int tagCount;
+
+  TagTextTranslation render([Map<String, String> additional = const {}]) =>
+      TagTranslationLookup.applyTagTextTranslations(source, {
+        ...additional,
+        ...localTranslations,
+      });
 }
 
 /// Shared optional Chinese lookup used outside the autocomplete overlay.
@@ -173,24 +194,60 @@ class TagTranslationLookup {
   /// Translates each tag payload while preserving weights, grouping syntax,
   /// separators, whitespace, and unmatched source text byte-for-byte.
   ///
-  /// Any prompt or tag-library surface can use this ffdkj-backed readable
+  /// Any prompt or tag-library surface can use this local readable
   /// transformation. The source string is never mutated.
   Future<TagTextTranslation> translateTagText(String source) async {
+    return (await prepareTagTextTranslation(source)).render();
+  }
+
+  /// Resolves everything available locally and returns only the remaining
+  /// canonical tags for an optional slower translation backend.
+  Future<TagTextTranslationPlan> prepareTagTextTranslation(
+    String source,
+  ) async {
     if (source.isEmpty) {
-      return const TagTextTranslation(text: '', translatedTagCount: 0);
+      return const TagTextTranslationPlan(
+        source: '',
+        localTranslations: {},
+        unresolvedTags: [],
+        tagCount: 0,
+      );
     }
 
+    final tagKeys = source
+        .split(RegExp(r'(?<=[,，\r\n])|(?=[,，\r\n])'))
+        .where((part) => !_isTagSeparator(part))
+        .map(_TranslatableTagSlice.parse)
+        .map((slice) => slice.lookupKey)
+        .where((tag) => tag.isNotEmpty)
+        .toList(growable: false);
+    final translations = await translateBatch(tagKeys);
+    final unresolved = tagKeys
+        .where((tag) => !translations.containsKey(tag))
+        .toSet()
+        .toList(growable: false);
+    return TagTextTranslationPlan(
+      source: source,
+      localTranslations: translations,
+      unresolvedTags: unresolved,
+      tagCount: tagKeys.length,
+    );
+  }
+
+  /// Applies translations without changing separators, weights, emphasis, or
+  /// unmatched source text. Translation keys must use [normalizeTag].
+  static TagTextTranslation applyTagTextTranslations(
+    String source,
+    Map<String, String> translations,
+  ) {
+    if (source.isEmpty || translations.isEmpty) {
+      return TagTextTranslation(text: source, translatedTagCount: 0);
+    }
     final parts = source.split(RegExp(r'(?<=[,，\r\n])|(?=[,，\r\n])'));
     final slices = parts
         .where((part) => !_isTagSeparator(part))
         .map(_TranslatableTagSlice.parse)
         .toList(growable: false);
-    final translations = await translateBatch(
-      slices
-          .map((slice) => slice.lookupKey)
-          .where((tag) => tag.isNotEmpty)
-          .toList(growable: false),
-    );
     var translatedTagCount = 0;
     var sliceIndex = 0;
 
@@ -358,5 +415,9 @@ class _TranslatableTagSlice {
 }
 
 final tagTranslationLookupProvider = Provider<TagTranslationLookup>((ref) {
-  return TagTranslationLookup(ref.watch(zhDictionaryServiceProvider));
+  final service = ref.watch(fastTagServiceProvider);
+  return TagTranslationLookup.fromResolver(
+    (tags) => service.resolve(tags, locale: 'zh-CN'),
+    fuzzyResolver: service.resolveFuzzy,
+  );
 });

--- a/lib/core/autocomplete/zh_dictionary_service.dart
+++ b/lib/core/autocomplete/zh_dictionary_service.dart
@@ -264,12 +264,14 @@ class ZhDictionaryService extends ChangeNotifier
     return result;
   }
 
-  /// Resolves a narrowly scoped typo fallback for plain single-word tags.
+  /// Resolves a narrowly scoped missing-character fallback for plain words.
   ///
   /// Structured tags, artist names, identifiers and multi-word tags are
   /// deliberately excluded because an approximate match could silently change
-  /// their meaning. A match is accepted only when exactly one dictionary tag
-  /// is one edit away.
+  /// their meaning. Substitutions and extra characters are also rejected so a
+  /// valid word absent from the dictionary cannot become another word such as
+  /// `fewer` -> `fever`. A match is accepted only when exactly one dictionary
+  /// tag with the same first character can restore one omitted character.
   Future<Map<String, String>> resolveFuzzy(List<String> canonicalTags) async {
     if (canonicalTags.isEmpty || !await _openIfInstalled()) return const {};
     final result = <String, String>{};
@@ -288,15 +290,15 @@ class ZhDictionaryService extends ChangeNotifier
         '''
         SELECT name, cn_name FROM tags
         WHERE name >= ? AND name < ?
-          AND LENGTH(name) BETWEEN ? AND ?
+          AND LENGTH(name) = ?
           AND cn_name IS NOT NULL
           AND TRIM(cn_name) <> ''
         ORDER BY post_count DESC
         ''',
-        [prefix, prefixUpperBound, tag.length - 1, tag.length + 1],
+        [prefix, prefixUpperBound, tag.length + 1],
       );
       final matches = rows.where(
-        (row) => _isOneEditApart(tag, row['name'] as String),
+        (row) => _isSingleMissingCharacterAway(tag, row['name'] as String),
       );
       final unique = matches.take(2).toList(growable: false);
       if (unique.length == 1) {
@@ -451,32 +453,21 @@ class ZhDictionaryService extends ChangeNotifier
   static String _normalize(String value) =>
       value.trim().toLowerCase().replaceAll(' ', '_');
 
-  static bool _isOneEditApart(String left, String right) {
-    if ((left.length - right.length).abs() > 1 || left == right) return false;
-    if (left.length == right.length) {
-      var differences = 0;
-      for (var index = 0; index < left.length; index++) {
-        if (left.codeUnitAt(index) != right.codeUnitAt(index) &&
-            ++differences > 1) {
-          return false;
-        }
-      }
-      return differences == 1;
-    }
-    final shorter = left.length < right.length ? left : right;
-    final longer = left.length < right.length ? right : left;
-    var shortIndex = 0;
-    var longIndex = 0;
+  static bool _isSingleMissingCharacterAway(String source, String candidate) {
+    if (candidate.length != source.length + 1) return false;
+    var sourceIndex = 0;
+    var candidateIndex = 0;
     var skipped = false;
-    while (shortIndex < shorter.length && longIndex < longer.length) {
-      if (shorter.codeUnitAt(shortIndex) == longer.codeUnitAt(longIndex)) {
-        shortIndex++;
-        longIndex++;
+    while (sourceIndex < source.length && candidateIndex < candidate.length) {
+      if (source.codeUnitAt(sourceIndex) ==
+          candidate.codeUnitAt(candidateIndex)) {
+        sourceIndex++;
+        candidateIndex++;
       } else if (skipped) {
         return false;
       } else {
         skipped = true;
-        longIndex++;
+        candidateIndex++;
       }
     }
     return true;

--- a/lib/core/database/asset_database_manager.dart
+++ b/lib/core/database/asset_database_manager.dart
@@ -69,6 +69,7 @@ class AssetDatabaseManager {
         'tags': {'id', 'name', 'category', 'post_count'},
         'aliases': {'id', 'tag_id', 'alias'},
         'tag_search': {'term', 'search_key', 'tag_id', 'kind'},
+        'zh_translations': {'tag', 'zh_cn', 'mode'},
       },
     );
     await _migrateLegacyAutocompleteData(appDir, assetDbDir);

--- a/lib/presentation/prompt_assistant/services/prompt_assistant_service.dart
+++ b/lib/presentation/prompt_assistant/services/prompt_assistant_service.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:dio/dio.dart';
 
+import '../../../core/autocomplete/local_first_prompt_translation.dart';
+import '../../../core/autocomplete/tag_translation_lookup.dart';
 import '../../../core/utils/app_logger.dart';
 import '../../providers/proxy_settings_provider.dart';
 import '../models/prompt_assistant_models.dart';
@@ -32,6 +34,9 @@ final promptAssistantServiceProvider = Provider<PromptAssistantService>((ref) {
   return PromptAssistantService(
     ref: ref,
     apiClient: PromptAssistantApiClient(dio: dio),
+    localFirstTranslation: LocalFirstPromptTranslationPipeline(
+      ref.watch(tagTranslationLookupProvider),
+    ),
   );
 });
 
@@ -49,11 +54,14 @@ class PromptAssistantService {
   PromptAssistantService({
     required Ref ref,
     required PromptAssistantApiClient apiClient,
+    LocalFirstPromptTranslationPipeline? localFirstTranslation,
   }) : _ref = ref,
-       _apiClient = apiClient;
+       _apiClient = apiClient,
+       _localFirstTranslation = localFirstTranslation;
 
   final Ref _ref;
   final PromptAssistantApiClient _apiClient;
+  final LocalFirstPromptTranslationPipeline? _localFirstTranslation;
 
   Future<void> cancelCurrentTask({String? sessionId}) async {
     _apiClient.cancelCurrentRequest(sessionId: sessionId);
@@ -89,6 +97,18 @@ class PromptAssistantService {
     required String sessionId,
     String? targetLanguage,
   }) async* {
+    final localFirst = await _localFirstTranslation?.translate(
+      input,
+      targetLanguage: targetLanguage,
+      translateMissing: (tags) async =>
+          (await translateTags(tags, sessionId: sessionId)).translations,
+    );
+    if (localFirst != null) {
+      yield StreamingChunk(delta: localFirst.text);
+      yield const StreamingChunk(delta: '', done: true);
+      return;
+    }
+
     final instruction = targetLanguage == null || targetLanguage.isEmpty
         ? 'Automatically detect the source language and translate between Chinese and English. Return only the translation.'
         : 'Translate the text into $targetLanguage. Return only the translation.';

--- a/lib/presentation/widgets/prompt/quick_translate_prompt_field.dart
+++ b/lib/presentation/widgets/prompt/quick_translate_prompt_field.dart
@@ -16,7 +16,7 @@ import '../common/themed_confirm_dialog.dart';
 import '../common/themed_input.dart';
 import 'nai_syntax_controller.dart';
 
-/// Adds a local ffdkj translation preview to a prompt editor.
+/// Adds a local bundled/ffdkj translation preview to a prompt editor.
 ///
 /// The translated editor owns a separate controller. Its text can be selected
 /// or edited for inspection, but the source controller remains untouched and
@@ -113,10 +113,6 @@ class _QuickTranslatePromptFieldState
     final dictionary = ref.read(zhDictionaryServiceProvider);
     await dictionary.initialize();
     if (!mounted) return;
-    if (!dictionary.state.isInstalled) {
-      await _offerDictionaryInstall(dictionary.state.isBusy);
-      return;
-    }
 
     final snapshot = widget.controller.value;
     final requestGeneration = ++_requestGeneration;
@@ -137,6 +133,10 @@ class _QuickTranslatePromptFieldState
     setState(() => _isTranslating = false);
     if (widget.controller.value != snapshot) return;
     if (!result.hasTranslations) {
+      if (!dictionary.state.isInstalled) {
+        await _offerDictionaryInstall(dictionary.state.isBusy);
+        return;
+      }
       AppToast.info(context, context.l10n.quickTranslate_noMatches);
       return;
     }

--- a/lib/presentation/widgets/prompt/unified/unified_prompt_config.dart
+++ b/lib/presentation/widgets/prompt/unified/unified_prompt_config.dart
@@ -47,7 +47,7 @@ class UnifiedPromptConfig {
   /// 会弹出导入确认框，支持转换为 NAI 多角色格式。
   final bool enableComfyuiImport;
 
-  /// 是否显示基于本地 ffdkj 词库的快速翻译入口。
+  /// 是否显示基于内置补充与本地 ffdkj 词库的快速翻译入口。
   final bool enableQuickTranslation;
 
   // ==================== 外观选项 ====================

--- a/test/core/autocomplete/fast_tag_service_test.dart
+++ b/test/core/autocomplete/fast_tag_service_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/autocomplete/completion_models.dart';
+import 'package:nai_launcher/core/autocomplete/fast_tag_service.dart';
+import 'package:nai_launcher/core/autocomplete/tag_catalog_repository.dart';
+import 'package:nai_launcher/core/autocomplete/tag_translation_lookup.dart';
+import 'package:nai_launcher/core/autocomplete/zh_dictionary_service.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  late Database database;
+  late TagCatalogRepository catalog;
+  late FastTagService service;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    database = await databaseFactoryFfi.openDatabase(inMemoryDatabasePath);
+    await database.execute('''
+      CREATE TABLE tags(id INTEGER PRIMARY KEY, name TEXT, category INTEGER, post_count INTEGER);
+      CREATE TABLE aliases(id INTEGER PRIMARY KEY, tag_id INTEGER, alias TEXT);
+      CREATE VIRTUAL TABLE tag_search USING fts5(term, search_key, tag_id UNINDEXED, kind UNINDEXED);
+      CREATE TABLE zh_translations(tag TEXT PRIMARY KEY, zh_cn TEXT NOT NULL, mode INTEGER NOT NULL);
+      INSERT INTO tags VALUES (1, 'masterpiece', 0, 1000);
+      INSERT INTO tag_search VALUES ('masterpiece', 'masterpiece', 1, 0);
+      INSERT INTO zh_translations VALUES ('masterpiece', '杰作', 0);
+      INSERT INTO zh_translations VALUES ('extra', '额外', 1);
+      INSERT INTO zh_translations VALUES ('worst_quality', '最差质量', 0);
+      INSERT INTO zh_translations VALUES ('new_tag', '新标签', 0);
+    ''');
+    catalog = TagCatalogRepository(database: database);
+    service = FastTagService(
+      catalog: catalog,
+      dictionary: _FakeDictionary({
+        'extra': '额外插画',
+        'worst_quality': '极差质量',
+        'ffdkj_only': '词库翻译',
+      }),
+    );
+  });
+
+  tearDown(() async {
+    await catalog.dispose();
+  });
+
+  test('中英文前缀都能补全内置标签并直接显示翻译', () async {
+    final english = await service.search(_query('mast'));
+    final chinese = await service.search(_query('杰'));
+
+    for (final result in [english, chinese]) {
+      expect(result.single.canonicalTag, 'masterpiece');
+      expect(result.single.translation, '杰作');
+    }
+    expect(english.single.matchKind, CompletionMatchKind.englishPrefix);
+    expect(chinese.single.matchKind, CompletionMatchKind.chinesePrefix);
+  });
+
+  test('覆盖项优先，ffdkj 优于普通补充项，缺失项由内置库补齐', () async {
+    final result = await service.resolve([
+      'extra',
+      'worst quality',
+      'new_tag',
+      'ffdkj_only',
+    ], locale: 'zh-CN');
+
+    expect(result, {
+      'extra': '额外',
+      'worst_quality': '极差质量',
+      'new_tag': '新标签',
+      'ffdkj_only': '词库翻译',
+    });
+  });
+
+  test('非中文界面不查询翻译层', () async {
+    expect(await service.resolve(['extra'], locale: 'en-US'), isEmpty);
+  });
+
+  test('可选 ffdkj 数据库异常时仍保留内置补全与翻译', () async {
+    final fallbackService = FastTagService(
+      catalog: catalog,
+      dictionary: _ThrowingDictionary(),
+    );
+
+    expect(
+      (await fallbackService.search(_query('杰'))).single.canonicalTag,
+      'masterpiece',
+    );
+    expect(
+      await TagTranslationLookup.fromResolver(
+        (tags) => fallbackService.resolve(tags, locale: 'zh-CN'),
+        fuzzyResolver: fallbackService.resolveFuzzy,
+      ).translateBatch(['new_tag', 'unknown_tag']),
+      {'new_tag': '新标签'},
+    );
+  });
+}
+
+CompletionQuery _query(String token) => CompletionQuery(
+  fullText: token,
+  cursorPosition: token.length,
+  token: token,
+  replacementRange: TextReplacementRange(start: 0, end: token.length),
+  existingTags: const {},
+  limit: 20,
+  locale: 'zh-CN',
+);
+
+class _FakeDictionary extends ZhDictionaryService {
+  _FakeDictionary(this.values);
+
+  final Map<String, String> values;
+
+  @override
+  Future<List<CompletionCandidate>> search(CompletionQuery query) async =>
+      const [];
+
+  @override
+  Future<Map<String, String>> resolve(
+    List<String> canonicalTags, {
+    required String locale,
+  }) async => {
+    for (final tag in canonicalTags)
+      if (values[tag] case final value?) tag: value,
+  };
+
+  @override
+  Future<Map<String, String>> resolveFuzzy(List<String> canonicalTags) async =>
+      const {};
+}
+
+class _ThrowingDictionary extends ZhDictionaryService {
+  @override
+  Future<List<CompletionCandidate>> search(CompletionQuery query) =>
+      Future.error(StateError('damaged ffdkj database'));
+
+  @override
+  Future<Map<String, String>> resolve(
+    List<String> canonicalTags, {
+    required String locale,
+  }) => Future.error(StateError('damaged ffdkj database'));
+
+  @override
+  Future<Map<String, String>> resolveFuzzy(List<String> canonicalTags) =>
+      Future.error(StateError('damaged ffdkj database'));
+}

--- a/test/core/autocomplete/local_first_prompt_translation_test.dart
+++ b/test/core/autocomplete/local_first_prompt_translation_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/autocomplete/local_first_prompt_translation.dart';
+import 'package:nai_launcher/core/autocomplete/tag_translation_lookup.dart';
+
+void main() {
+  test('只把本地未命中的标签交给 AI 并按原语法合并结果', () async {
+    final delegated = <List<String>>[];
+    final pipeline = LocalFirstPromptTranslationPipeline(
+      TagTranslationLookup.fromResolver(
+        (tags) async => {
+          if (tags.contains('masterpiece')) 'masterpiece': '杰作',
+          if (tags.contains('worst_quality')) 'worst_quality': '最差质量',
+        },
+      ),
+    );
+
+    final result = await pipeline.translate(
+      'masterpiece, 1.2::unknown_tag::, {worst_quality}',
+      translateMissing: (tags) async {
+        delegated.add(tags);
+        return {'unknown_tag': '未知标签'};
+      },
+    );
+
+    expect(delegated, [
+      ['unknown_tag'],
+    ]);
+    expect(result?.text, '杰作, 1.2::未知标签::, {最差质量}');
+    expect(result?.translatedTagCount, 3);
+  });
+
+  test('全部本地命中时不会调用 AI', () async {
+    var called = false;
+    final pipeline = LocalFirstPromptTranslationPipeline(
+      TagTranslationLookup.fromResolver((tags) async => {'masterpiece': '杰作'}),
+    );
+
+    final result = await pipeline.translate(
+      'masterpiece',
+      translateMissing: (tags) async {
+        called = true;
+        return const {};
+      },
+    );
+
+    expect(called, isFalse);
+    expect(result?.text, '杰作');
+  });
+
+  test('未命中项按 AI 批量上限切分', () async {
+    final batches = <List<String>>[];
+    final pipeline = LocalFirstPromptTranslationPipeline(
+      TagTranslationLookup.fromResolver((tags) async => const {}),
+    );
+    final source = List.generate(10, (index) => 'unknown_$index').join(', ');
+
+    final result = await pipeline.translate(
+      source,
+      translateMissing: (tags) async {
+        batches.add(tags);
+        return {for (final tag in tags) tag: '译$tag'};
+      },
+    );
+
+    expect(batches.map((batch) => batch.length), [8, 2]);
+    expect(result?.translatedTagCount, 10);
+  });
+
+  test('中文输入、非中文目标和普通句子保留原通用翻译流程', () async {
+    final pipeline = LocalFirstPromptTranslationPipeline(
+      TagTranslationLookup.fromResolver((tags) async => const {}),
+    );
+    Future<Map<String, String>> unused(List<String> tags) async => const {};
+
+    expect(
+      await pipeline.translate('杰作, 女孩', translateMissing: unused),
+      isNull,
+    );
+    expect(
+      await pipeline.translate(
+        'masterpiece',
+        targetLanguage: 'English',
+        translateMissing: unused,
+      ),
+      isNull,
+    );
+    expect(
+      await pipeline.translate(
+        'Please translate this sentence!',
+        translateMissing: unused,
+      ),
+      isNull,
+    );
+  });
+}

--- a/test/core/autocomplete/tag_catalog_builder_test.dart
+++ b/test/core/autocomplete/tag_catalog_builder_test.dart
@@ -36,14 +36,35 @@ void main() {
         ].join('\n'),
       );
       final hash = await sha256.bind(input.openRead()).first;
+      final translations = File('${temp.path}/translations.json');
+      await translations.writeAsString(
+        jsonEncode({
+          'schemaVersion': 1,
+          'ffdkjBaseline': {'blobSha': 'baseline-sha'},
+          'entries': [
+            {'tag': 'missing_quality', 'zhCn': '缺失质量词', 'mode': 'missing'},
+            {'tag': 'extra', 'zhCn': '额外', 'mode': 'override'},
+          ],
+        }),
+      );
+      final translationHash = await sha256.bind(translations.openRead()).first;
+      final dataVersion = _dataVersion(hash, translationHash);
       final lock = File('${temp.path}/lock.json');
       await lock.writeAsString(
         jsonEncode({
           'commit': '1234567890abcdef',
+          'dataVersion': dataVersion,
           'url': 'https://example.invalid/tags.csv',
           'sha256': hash.toString(),
           'expectedTagCount': 5,
           'expectedAliasCount': 5,
+          'translations': {
+            'sha256': translationHash.toString(),
+            'expectedCount': 2,
+            'expectedOverrideCount': 1,
+            'overrideTags': ['extra'],
+            'ffdkjBaselineBlobSha': 'baseline-sha',
+          },
         }),
       );
       final manifest = File('${temp.path}/manifest.json');
@@ -54,6 +75,7 @@ void main() {
 
       await builder.main([
         '--input=${input.path}',
+        '--translation-input=${translations.path}',
         '--output=$output',
         '--lock=${lock.path}',
         '--manifest=${manifest.path}',
@@ -94,6 +116,17 @@ void main() {
         expect(db.select('PRAGMA quick_check').first.values.first, 'ok');
         expect(
           db
+              .select(
+                'SELECT tag, zh_cn, mode FROM zh_translations ORDER BY tag',
+              )
+              .map((row) => [row['tag'], row['zh_cn'], row['mode']]),
+          [
+            ['extra', '额外', 1],
+            ['missing_quality', '缺失质量词', 0],
+          ],
+        );
+        expect(
+          db
               .select("SELECT value FROM metadata WHERE key='source_sha256'")
               .single['value'],
           hash.toString(),
@@ -101,6 +134,17 @@ void main() {
       } finally {
         db.dispose();
       }
+
+      final firstOutputHash = await sha256.bind(File(output).openRead()).first;
+      await builder.main([
+        '--input=${input.path}',
+        '--translation-input=${translations.path}',
+        '--output=$output',
+        '--lock=${lock.path}',
+        '--manifest=${manifest.path}',
+      ]);
+      final secondOutputHash = await sha256.bind(File(output).openRead()).first;
+      expect(secondOutputHash, firstOutputHash);
     },
   );
 
@@ -111,8 +155,16 @@ void main() {
       ..writeAsStringSync(
         jsonEncode({
           'commit': '1234567890abcdef',
+          'dataVersion': 'fedcba098765',
           'url': 'https://example.invalid/tags.csv',
           'sha256': List.filled(64, '0').join(),
+          'translations': {
+            'sha256': List.filled(64, '0').join(),
+            'expectedCount': 0,
+            'expectedOverrideCount': 0,
+            'overrideTags': <String>[],
+            'ffdkjBaselineBlobSha': 'baseline-sha',
+          },
         }),
       );
     final manifest = File('${temp.path}/manifest.json')
@@ -128,4 +180,59 @@ void main() {
       throwsStateError,
     );
   });
+
+  test('rejects duplicate or ambiguous translation rows', () async {
+    final input = File('${temp.path}/tags.csv')
+      ..writeAsStringSync('blue_eyes,0,1,""');
+    final inputHash = await sha256.bind(input.openRead()).first;
+    final translations = File('${temp.path}/translations.json')
+      ..writeAsStringSync(
+        jsonEncode({
+          'schemaVersion': 1,
+          'ffdkjBaseline': {'blobSha': 'baseline-sha'},
+          'entries': [
+            {'tag': 'bad_quality', 'zhCn': '差/低质量', 'mode': 'missing'},
+            {'tag': 'bad_quality', 'zhCn': '差质量', 'mode': 'missing'},
+          ],
+        }),
+      );
+    final translationHash = await sha256.bind(translations.openRead()).first;
+    final dataVersion = _dataVersion(inputHash, translationHash);
+    final lock = File('${temp.path}/lock.json')
+      ..writeAsStringSync(
+        jsonEncode({
+          'commit': '1234567890abcdef',
+          'dataVersion': dataVersion,
+          'url': 'https://example.invalid/tags.csv',
+          'sha256': inputHash.toString(),
+          'expectedTagCount': 1,
+          'expectedAliasCount': 0,
+          'translations': {
+            'sha256': translationHash.toString(),
+            'expectedCount': 2,
+            'expectedOverrideCount': 0,
+            'overrideTags': <String>[],
+            'ffdkjBaselineBlobSha': 'baseline-sha',
+          },
+        }),
+      );
+    final manifest = File('${temp.path}/manifest.json')
+      ..writeAsStringSync(jsonEncode({'databases': <String, dynamic>{}}));
+
+    expect(
+      () => builder.main([
+        '--input=${input.path}',
+        '--translation-input=${translations.path}',
+        '--output=${temp.path}/catalog.db',
+        '--lock=${lock.path}',
+        '--manifest=${manifest.path}',
+      ]),
+      throwsStateError,
+    );
+  });
 }
+
+String _dataVersion(Digest sourceHash, Digest translationHash) => sha256
+    .convert(utf8.encode('$sourceHash:$translationHash'))
+    .toString()
+    .substring(0, 12);

--- a/test/core/autocomplete/tag_catalog_repository_test.dart
+++ b/test/core/autocomplete/tag_catalog_repository_test.dart
@@ -24,6 +24,7 @@ void main() {
       CREATE TABLE tags(id INTEGER PRIMARY KEY, name TEXT, category INTEGER, post_count INTEGER);
       CREATE TABLE aliases(id INTEGER PRIMARY KEY, tag_id INTEGER, alias TEXT);
       CREATE VIRTUAL TABLE tag_search USING fts5(term, search_key, tag_id UNINDEXED, kind UNINDEXED);
+      CREATE TABLE zh_translations(tag TEXT PRIMARY KEY, zh_cn TEXT, mode INTEGER);
       INSERT INTO tags VALUES (1, 'blue_eyes', 0, 1000);
       INSERT INTO tags VALUES (2, 'blue_hair', 0, 2000);
       INSERT INTO tags VALUES (3, 'artist_blue', 1, 500);
@@ -42,6 +43,8 @@ void main() {
       INSERT INTO tag_search VALUES ('story_contributor', 'story contributor', 6, 0);
       INSERT INTO tag_search VALUES ('world_lore', 'world lore', 7, 0);
       INSERT INTO tag_search VALUES ('painter_blue', 'painter blue', 8, 0);
+      INSERT INTO zh_translations VALUES ('extra', '额外', 1);
+      INSERT INTO zh_translations VALUES ('worst_quality', '最差质量', 0);
       WITH RECURSIVE seq(i) AS (
         SELECT 1 UNION ALL SELECT i + 1 FROM seq WHERE i < 450
       )
@@ -151,6 +154,20 @@ void main() {
     expect(results, hasLength(450));
     expect(results.first.canonicalTag, 'blue_archive_001');
     expect(results.last.canonicalTag, 'blue_archive_450');
+  });
+
+  test('按覆盖与补充模式分别查询内置翻译', () async {
+    final overrides = await repository.resolveTranslations([
+      'extra',
+      'worst quality',
+    ], mode: BundledTranslationMode.override);
+    final missing = await repository.resolveTranslations([
+      'extra',
+      'worst quality',
+    ], mode: BundledTranslationMode.missing);
+
+    expect(overrides, {'extra': '额外'});
+    expect(missing, {'worst_quality': '最差质量'});
   });
 }
 

--- a/test/core/autocomplete/zh_dictionary_service_test.dart
+++ b/test/core/autocomplete/zh_dictionary_service_test.dart
@@ -70,32 +70,31 @@ void main() {
     expect(results.first.translation, '标签0');
   });
 
-  test(
-    'fuzzy translation accepts one unambiguous typo and skips identifiers',
-    () async {
-      final dictionaryDirectory = Directory(
-        p.join(temp.path, 'autocomplete', 'ffdkj'),
-      );
-      await dictionaryDirectory.create(recursive: true);
-      _createDictionary(
-        p.join(dictionaryDirectory.path, 'tag.sqlite'),
-        rows: 1000,
-        extraRows: const {'toddler': '幼儿'},
-      );
+  test('fuzzy translation only restores one missing character', () async {
+    final dictionaryDirectory = Directory(
+      p.join(temp.path, 'autocomplete', 'ffdkj'),
+    );
+    await dictionaryDirectory.create(recursive: true);
+    _createDictionary(
+      p.join(dictionaryDirectory.path, 'tag.sqlite'),
+      rows: 1000,
+      extraRows: const {'toddler': '幼儿', 'screentones': '网点', 'fever': '发烧'},
+    );
 
-      final result = await service.resolveFuzzy([
-        '',
-        'a',
-        '3d',
-        '::',
-        'todder',
-        'artist:mx2j',
-        'year_2026',
-      ]);
+    final result = await service.resolveFuzzy([
+      '',
+      'a',
+      '3d',
+      '::',
+      'todder',
+      'screentone',
+      'fewer',
+      'artist:mx2j',
+      'year_2026',
+    ]);
 
-      expect(result, {'todder': '幼儿'});
-    },
-  );
+    expect(result, {'todder': '幼儿', 'screentone': '网点'});
+  });
 
   test('rejects a corrupt SQLite file', () async {
     final file = File('${temp.path}/corrupt.sqlite');

--- a/test/core/database/asset_database_manager_test.dart
+++ b/test/core/database/asset_database_manager_test.dart
@@ -254,6 +254,7 @@ Future<File> _createCatalogFixture(String directory) async {
     CREATE TABLE tags(id INTEGER PRIMARY KEY, name TEXT, category INTEGER, post_count INTEGER);
     CREATE TABLE aliases(id INTEGER PRIMARY KEY, tag_id INTEGER, alias TEXT);
     CREATE VIRTUAL TABLE tag_search USING fts5(term, search_key, tag_id UNINDEXED, kind UNINDEXED);
+    CREATE TABLE zh_translations(tag TEXT PRIMARY KEY, zh_cn TEXT, mode INTEGER);
   ''');
   db.dispose();
   return file;

--- a/test/presentation/widgets/prompt/quick_translate_prompt_field_test.dart
+++ b/test/presentation/widgets/prompt/quick_translate_prompt_field_test.dart
@@ -163,6 +163,9 @@ ultra\_complexity, perfect\_rendering, realistic\_rendering, detailed\_textures,
       ProviderScope(
         overrides: [
           zhDictionaryServiceProvider.overrideWith((ref) => dictionary),
+          tagTranslationLookupProvider.overrideWithValue(
+            TagTranslationLookup.fromResolver((tags) async => const {}),
+          ),
         ],
         child: MaterialApp.router(
           locale: const Locale('zh'),
@@ -182,6 +185,25 @@ ultra\_complexity, perfect\_rendering, realistic\_rendering, detailed\_textures,
 
     expect(find.text('settings:storage'), findsOneWidget);
     expect(dictionary.installCalled, isTrue);
+  });
+
+  testWidgets('未安装 ffdkj 时仍可使用内置补充翻译', (tester) async {
+    final source = TextEditingController(text: 'worst_quality');
+    addTearDown(source.dispose);
+    await _pumpField(
+      tester,
+      source: source,
+      dictionary: _FakeZhDictionaryService(installed: false),
+      lookup: TagTranslationLookup.fromResolver(
+        (tags) async => {'worst_quality': '最差质量'},
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('quick-translate-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('最差质量'), findsOneWidget);
+    expect(find.text('需要汉化词库'), findsNothing);
   });
 
   testWidgets('紧凑触屏与桌面宽度均保持右下角入口和安全命中区', (tester) async {

--- a/tool/tag_catalog/README.md
+++ b/tool/tag_catalog/README.md
@@ -1,0 +1,38 @@
+# 标签目录数据库
+
+`build_tag_catalog.dart` 将两类锁定数据合并为唯一内置数据库
+`assets/databases/tag_catalog.db`：
+
+- `source_lock.json` 固定完整 Danbooru/e621 英文标签来源。
+- `zh_translations.json` 保存经过清洗和复核的简体中文补充翻译。
+
+中文翻译只有两种模式：
+
+- `override`：确认过的 ffdkj 错译，查询时优先于 ffdkj。
+- `missing`：ffdkj 基线中缺失的翻译，查询时排在 ffdkj 后面。
+
+这种顺序允许 ffdkj 后续新增或改善普通翻译，同时持续修正确认过的错译。
+原始研究报告和 CSV 不参与客户端构建，也不得放入 `assets/`。
+
+运行时统一通过 `FastTagService` 使用这些数据。它同时提供中英文标签补全和批量翻译，
+调用方不需要感知内置数据库、ffdkj 或两种补充模式。提示词助手再通过
+`LocalFirstPromptTranslationPipeline` 先消费本地结果，只把未命中的规范化标签分批交给
+AI，并按原有权重、强调和分隔语法合并结果。
+
+## 更新翻译
+
+1. 清洗并复核候选项，更新 `zh_translations.json`。每个 `tag` 只能出现一次，
+   `zhCn` 只能包含一个推荐译文。
+2. 更新 `source_lock.json` 中翻译源的 SHA-256、数量和 ffdkj 基线 blob SHA。
+3. 根据英文源 SHA-256 与翻译源 SHA-256 计算新的 12 位 `dataVersion`。
+4. 获取锁定的英文 CSV 后构建并验证：
+
+```powershell
+dart run tool/tag_catalog/build_tag_catalog.dart
+dart run tool/tag_catalog/verify_bundled_databases.dart
+```
+
+数据库版本变化后，必须把新数据库发布为独立的
+`autocomplete-data-tag-catalog-<dataVersion 前 8 位>-vN` prerelease，随后把固定
+下载地址、大小和 SHA-256 写入 `assets/databases/manifest.json`。数据 Release 不得设为
+latest。

--- a/tool/tag_catalog/build_tag_catalog.dart
+++ b/tool/tag_catalog/build_tag_catalog.dart
@@ -5,8 +5,9 @@ import 'package:crypto/crypto.dart';
 import 'package:csv/csv.dart';
 import 'package:sqlite3/sqlite3.dart';
 
-const catalogSchemaVersion = 2;
+const catalogSchemaVersion = 3;
 const supportedSourceCategories = {0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 12, 14, 15};
+const translationModes = {'missing': 0, 'override': 1};
 
 Future<void> main(List<String> args) async {
   final options = _Options.parse(args);
@@ -21,10 +22,40 @@ Future<void> main(List<String> args) async {
   }
 
   final actualHash = await sha256.bind(input.openRead()).first;
-  final expectedHash = lock['sha256'] as String?;
+  final expectedHash = lock['sha256'] as String;
   if (actualHash.toString() != expectedHash) {
     throw StateError(
       'Source SHA256 mismatch: expected=$expectedHash actual=$actualHash',
+    );
+  }
+
+  final translationLock = Map<String, dynamic>.from(
+    lock['translations'] as Map,
+  );
+  final translationInput = File(options.translationInputPath);
+  if (!await translationInput.exists()) {
+    throw StateError('Missing translation source: ${translationInput.path}');
+  }
+  final translationHash = await sha256.bind(translationInput.openRead()).first;
+  if ('$translationHash' != translationLock['sha256']) {
+    throw StateError(
+      'Translation source SHA256 mismatch: '
+      'expected=${translationLock['sha256']} actual=$translationHash',
+    );
+  }
+  final translations = await _readTranslations(
+    translationInput,
+    translationLock,
+  );
+  final dataVersion = lock['dataVersion'] as String;
+  final expectedDataVersion = sha256
+      .convert(utf8.encode('$expectedHash:$translationHash'))
+      .toString()
+      .substring(0, 12);
+  if (dataVersion != expectedDataVersion) {
+    throw StateError(
+      'Catalog dataVersion mismatch: '
+      'expected=$expectedDataVersion actual=$dataVersion',
     );
   }
 
@@ -44,6 +75,9 @@ Future<void> main(List<String> args) async {
     );
     final insertSearch = db.prepare(
       'INSERT INTO tag_search(term, search_key, tag_id, kind) VALUES (?, ?, ?, ?)',
+    );
+    final insertTranslation = db.prepare(
+      'INSERT INTO zh_translations(tag, zh_cn, mode) VALUES (?, ?, ?)',
     );
 
     var imported = 0;
@@ -114,6 +148,13 @@ Future<void> main(List<String> args) async {
           'Imported alias count mismatch: expected=$expectedAliasCount actual=$aliases',
         );
       }
+      for (final translation in translations) {
+        insertTranslation.execute([
+          translation.tag,
+          translation.zhCn,
+          translationModes[translation.mode],
+        ]);
+      }
       db.execute('COMMIT');
     } catch (_) {
       db.execute('ROLLBACK');
@@ -123,20 +164,25 @@ Future<void> main(List<String> args) async {
       findTag.dispose();
       insertAlias.dispose();
       insertSearch.dispose();
+      insertTranslation.dispose();
     }
 
-    final importedAt = DateTime.now().toUtc().toIso8601String();
     final metadata = <String, String>{
       'schema_version': '$catalogSchemaVersion',
-      'data_version': ('${lock['commit']}').substring(0, 12),
+      'data_version': dataVersion,
       'source_url': '${lock['url']}',
       'source_format': 'tag_name,category,post_count,aliases',
       'source_scope': 'danbooru_e621_full',
       'source_sha256': actualHash.toString(),
       'source_commit': '${lock['commit']}',
-      'imported_at': importedAt,
+      'translation_source_sha256': '$translationHash',
+      'translation_ffdkj_baseline_blob_sha':
+          '${translationLock['ffdkjBaselineBlobSha']}',
       'tag_count': '$imported',
       'alias_count': '$aliases',
+      'translation_count': '${translations.length}',
+      'translation_override_count':
+          '${translations.where((entry) => entry.mode == 'override').length}',
     };
     final insertMeta = db.prepare(
       'INSERT INTO metadata(key, value) VALUES (?, ?)',
@@ -167,7 +213,6 @@ Future<void> main(List<String> args) async {
   final databases = manifest['databases'] as Map<String, dynamic>;
   final previousEntry = databases['tag_catalog.db'] as Map<String, dynamic>?;
   final outputSize = await output.length();
-  final dataVersion = ('${lock['commit']}').substring(0, 12);
   final nextEntry = <String, dynamic>{
     'schemaVersion': catalogSchemaVersion,
     'dataVersion': dataVersion,
@@ -216,7 +261,102 @@ void _createSchema(Database db) {
       kind UNINDEXED,
       tokenize='unicode61 remove_diacritics 2'
     );
+    CREATE TABLE zh_translations(
+      tag TEXT PRIMARY KEY COLLATE NOCASE,
+      zh_cn TEXT NOT NULL CHECK(TRIM(zh_cn) <> ''),
+      mode INTEGER NOT NULL CHECK(mode IN (0, 1))
+    ) WITHOUT ROWID;
   ''');
+}
+
+Future<List<_TranslationEntry>> _readTranslations(
+  File input,
+  Map<String, dynamic> lock,
+) async {
+  final document = jsonDecode(await input.readAsString());
+  if (document is! Map<String, dynamic> || document['schemaVersion'] != 1) {
+    throw StateError('Unsupported translation source schema');
+  }
+  final baseline = document['ffdkjBaseline'];
+  if (baseline is! Map || baseline['blobSha'] != lock['ffdkjBaselineBlobSha']) {
+    throw StateError('Translation ffdkj baseline does not match source lock');
+  }
+  final rawEntries = document['entries'];
+  if (rawEntries is! List) {
+    throw StateError('Translation source entries must be a list');
+  }
+  final entries = <_TranslationEntry>[];
+  final seen = <String>{};
+  for (final raw in rawEntries) {
+    if (raw is! Map) throw StateError('Invalid translation source entry');
+    final tag = '${raw['tag'] ?? ''}'.trim();
+    final zhCn = '${raw['zhCn'] ?? ''}'.trim();
+    final mode = '${raw['mode'] ?? ''}'.trim();
+    if (tag != tag.toLowerCase() ||
+        tag.contains(RegExp(r'[\s,\u0000-\u001f]')) ||
+        !_isValidTag(tag) ||
+        zhCn.isEmpty ||
+        zhCn.contains(RegExp(r'[/／]')) ||
+        !translationModes.containsKey(mode) ||
+        !seen.add(tag)) {
+      throw StateError('Invalid translation source entry for tag "$tag"');
+    }
+    entries.add(_TranslationEntry(tag: tag, zhCn: zhCn, mode: mode));
+  }
+  final expectedCount = (lock['expectedCount'] as num).toInt();
+  final expectedOverrides = (lock['expectedOverrideCount'] as num).toInt();
+  final actualOverrides = entries
+      .where((entry) => entry.mode == 'override')
+      .length;
+  final expectedOverrideTags = (lock['overrideTags'] as List)
+      .map((value) => '$value')
+      .toSet();
+  final actualOverrideTags = entries
+      .where((entry) => entry.mode == 'override')
+      .map((entry) => entry.tag)
+      .toSet();
+  if (entries.length != expectedCount || actualOverrides != expectedOverrides) {
+    throw StateError(
+      'Translation count mismatch: '
+      'entries=${entries.length}/$expectedCount '
+      'overrides=$actualOverrides/$expectedOverrides',
+    );
+  }
+  if (actualOverrideTags.length != expectedOverrideTags.length ||
+      !actualOverrideTags.containsAll(expectedOverrideTags)) {
+    throw StateError(
+      'Translation override tags mismatch: '
+      'actual=$actualOverrideTags expected=$expectedOverrideTags',
+    );
+  }
+  final requiredEntries = Map<String, dynamic>.from(
+    lock['requiredEntries'] as Map? ?? const {},
+  );
+  final translationsByTag = {
+    for (final entry in entries) entry.tag: entry.zhCn,
+  };
+  for (final required in requiredEntries.entries) {
+    if (translationsByTag[required.key] != required.value) {
+      throw StateError(
+        'Required translation mismatch: '
+        'tag=${required.key} expected=${required.value} '
+        'actual=${translationsByTag[required.key]}',
+      );
+    }
+  }
+  return entries;
+}
+
+class _TranslationEntry {
+  const _TranslationEntry({
+    required this.tag,
+    required this.zhCn,
+    required this.mode,
+  });
+
+  final String tag;
+  final String zhCn;
+  final String mode;
 }
 
 bool _isValidTag(String value) =>
@@ -228,12 +368,14 @@ String _searchKey(String value) =>
 class _Options {
   const _Options({
     required this.inputPath,
+    required this.translationInputPath,
     required this.outputPath,
     required this.lockPath,
     required this.manifestPath,
   });
 
   final String inputPath;
+  final String translationInputPath;
   final String outputPath;
   final String lockPath;
   final String manifestPath;
@@ -249,6 +391,10 @@ class _Options {
       inputPath: value(
         'input',
         'tool/tag_catalog/.cache/danbooru_e621_merged.csv',
+      ),
+      translationInputPath: value(
+        'translation-input',
+        'tool/tag_catalog/zh_translations.json',
       ),
       outputPath: value('output', 'assets/databases/tag_catalog.db'),
       lockPath: value('lock', 'tool/tag_catalog/source_lock.json'),

--- a/tool/tag_catalog/source_lock.json
+++ b/tool/tag_catalog/source_lock.json
@@ -5,9 +5,34 @@
   "commit": "42f35be9d394ff62fc9e9a39b8c500b8f9b67bfe",
   "url": "https://raw.githubusercontent.com/willmiao/ComfyUI-Lora-Manager/42f35be9d394ff62fc9e9a39b8c500b8f9b67bfe/refs/danbooru_e621_merged.csv",
   "sha256": "71297f7e4adaeae005cba1259b25a10374ed01e071cb4801a6195e709c32a9e5",
+  "dataVersion": "125148ac88dc",
   "upstreamData": "https://github.com/DraconicDragon/dbr-e621-lists-archive",
   "upstreamLicense": "Unlicense",
   "includedCategories": [0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 12, 14, 15],
   "expectedTagCount": 221787,
-  "expectedAliasCount": 71504
+  "expectedAliasCount": 71504,
+  "translations": {
+    "path": "tool/tag_catalog/zh_translations.json",
+    "sha256": "3640d606f65b544ab850311277f3e723c05b2a32eefe7dd162d3ddb432a9ec09",
+    "expectedCount": 517,
+    "expectedOverrideCount": 2,
+    "overrideTags": ["extra", "fewer_digits"],
+    "requiredEntries": {
+      "masterpiece": "杰作",
+      "worst_quality": "最差质量",
+      "bad_quality": "差质量",
+      "very_displeasing": "非常不美观",
+      "realistic_face": "写实面部",
+      "low_complexity": "低复杂度",
+      "unfinished_small_objects": "未完成的小物件",
+      "detailed_skin": "细致皮肤",
+      "perfect_rendering": "完美渲染",
+      "realistic_rendering": "写实渲染",
+      "detailed_textures": "精细纹理",
+      "intricate_details": "繁复细节",
+      "simple_face": "简化面部",
+      "round_face": "圆脸"
+    },
+    "ffdkjBaselineBlobSha": "98c4c94c9f17249274ca4a8b6f98966b63eedd12"
+  }
 }

--- a/tool/tag_catalog/verify_bundled_databases.dart
+++ b/tool/tag_catalog/verify_bundled_databases.dart
@@ -40,7 +40,13 @@ Future<void> main() async {
         throw StateError('quick_check failed for ${file.path}');
       }
       if (entry.key == 'tag_catalog.db') {
-        for (final table in ['metadata', 'tags', 'aliases', 'tag_search']) {
+        for (final table in [
+          'metadata',
+          'tags',
+          'aliases',
+          'tag_search',
+          'zh_translations',
+        ]) {
           if (db.select("SELECT 1 FROM sqlite_master WHERE name = ?", [
             table,
           ]).isEmpty) {
@@ -60,11 +66,53 @@ Future<void> main() async {
         final actualAliases =
             db.select('SELECT COUNT(*) AS count FROM aliases').single['count']
                 as int;
-        if (actualTags != expectedTags || actualAliases != expectedAliases) {
+        final translationLock = Map<String, dynamic>.from(
+          sourceLock['translations'] as Map,
+        );
+        final expectedTranslations = (translationLock['expectedCount'] as num)
+            .toInt();
+        final expectedOverrides =
+            (translationLock['expectedOverrideCount'] as num).toInt();
+        final actualTranslations =
+            db
+                    .select('SELECT COUNT(*) AS count FROM zh_translations')
+                    .single['count']
+                as int;
+        final actualOverrides =
+            db
+                    .select(
+                      'SELECT COUNT(*) AS count FROM zh_translations WHERE mode = 1',
+                    )
+                    .single['count']
+                as int;
+        if (actualTags != expectedTags ||
+            actualAliases != expectedAliases ||
+            actualTranslations != expectedTranslations ||
+            actualOverrides != expectedOverrides) {
           throw StateError(
             'Incomplete merged catalog: tags=$actualTags/$expectedTags '
-            'aliases=$actualAliases/$expectedAliases',
+            'aliases=$actualAliases/$expectedAliases '
+            'translations=$actualTranslations/$expectedTranslations '
+            'overrides=$actualOverrides/$expectedOverrides',
           );
+        }
+        if (metadata['translation_source_sha256'] !=
+                translationLock['sha256'] ||
+            metadata['translation_ffdkj_baseline_blob_sha'] !=
+                translationLock['ffdkjBaselineBlobSha']) {
+          throw StateError('Translation metadata does not match source lock');
+        }
+        final requiredEntries = Map<String, dynamic>.from(
+          translationLock['requiredEntries'] as Map? ?? const {},
+        );
+        for (final required in requiredEntries.entries) {
+          final rows = db.select(
+            'SELECT zh_cn FROM zh_translations WHERE tag = ?',
+            [required.key],
+          );
+          if (rows.length != 1 || rows.single['zh_cn'] != required.value) {
+            throw StateError('Required translation mismatch: ${required.key}');
+          }
         }
         if (metadata['source_scope'] != 'danbooru_e621_full') {
           throw StateError('Tag catalog is not the complete merged source');

--- a/tool/tag_catalog/zh_translations.json
+++ b/tool/tag_catalog/zh_translations.json
@@ -1,0 +1,6396 @@
+{
+  "schemaVersion": 1,
+  "ffdkjBaseline": {
+    "blobSha": "98c4c94c9f17249274ca4a8b6f98966b63eedd12",
+    "tagCount": 321332
+  },
+  "mergePolicy": {
+    "translationPrecedence": [
+      "gpt",
+      "gemini",
+      "grok"
+    ],
+    "runtimePrecedence": [
+      "override",
+      "ffdkj",
+      "missing"
+    ]
+  },
+  "entries": [
+    {
+      "tag": "3d_render",
+      "zhCn": "3D渲染",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "4k",
+      "zhCn": "4K",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "8k",
+      "zhCn": "8K",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "8k_wallpaper",
+      "zhCn": "8K壁纸",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "accurate_anatomy",
+      "zhCn": "准确解剖",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "acne",
+      "zhCn": "痘痘",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "acnes",
+      "zhCn": "痘痘",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "acrylic_paint",
+      "zhCn": "丙烯画",
+      "mode": "missing",
+      "category": "material",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 原生标签含 `(medium)`；此处按基础概念规范化。"
+    },
+    {
+      "tag": "action_pose",
+      "zhCn": "动作姿势",
+      "mode": "missing",
+      "category": "pose",
+      "priority": "high",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "高动态的打斗或运动姿态"
+    },
+    {
+      "tag": "aesthetic",
+      "zhCn": "美观",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine XL 3.1 明确定义的美学等级。"
+    },
+    {
+      "tag": "aesthetic_quality",
+      "zhCn": "美学画质增强",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "high",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/qualitytags.html",
+      "notes": "NovelAI V3专用艺术美学提升词"
+    },
+    {
+      "tag": "age_spot",
+      "zhCn": "老年斑",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "ai_artifacts",
+      "zhCn": "AI痕迹",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "airbrushed",
+      "zhCn": "过度磨皮",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "amateur",
+      "zhCn": "业余",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "amazing_quality",
+      "zhCn": "惊艳质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/qualitytags/",
+      "notes": "NovelAI V5 Light、V4 Curated、Anime V3 等使用。"
+    },
+    {
+      "tag": "ambient_light",
+      "zhCn": "环境光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "通用渲染提示；类别级间接证据。"
+    },
+    {
+      "tag": "ambient_occlusion",
+      "zhCn": "环境光遮蔽",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "增强缝隙与接触面阴影真实感"
+    },
+    {
+      "tag": "amputated",
+      "zhCn": "截肢感",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "amputation",
+      "zhCn": "肢体截断",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "用于抑制异常截肢外观。"
+    },
+    {
+      "tag": "anime_screencap",
+      "zhCn": "动漫截图风格",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 官方 digital medium 标签。"
+    },
+    {
+      "tag": "artifacts",
+      "zhCn": "瑕疵",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "图像生成中指视觉伪影，不是“文物”。"
+    },
+    {
+      "tag": "artist_signature",
+      "zhCn": "画师签名",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "artist_watermark",
+      "zhCn": "画师水印",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "asymmetrical_body",
+      "zhCn": "身体不对称",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "仅指不期望的异常不对称。"
+    },
+    {
+      "tag": "asymmetrical_face",
+      "zhCn": "脸不对称",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "average_quality",
+      "zhCn": "一般质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "average_score",
+      "zhCn": "平均评分",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-4.0",
+      "notes": "Animagine XL 4.0 推荐负面中出现。"
+    },
+    {
+      "tag": "award_winning",
+      "zhCn": "获奖级",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "awful",
+      "zhCn": "糟透",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "background_focus",
+      "zhCn": "背景焦点",
+      "mode": "missing",
+      "category": "background",
+      "priority": "low",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "由 NovelAI focus 类概念延伸；模型适用性有差异。"
+    },
+    {
+      "tag": "bad",
+      "zhCn": "糟糕",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V2/V3 UC 与 Furry UC 使用；保持原词宽泛语义。"
+    },
+    {
+      "tag": "bad_arms",
+      "zhCn": "手臂错误",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "泛化手臂错误。"
+    },
+    {
+      "tag": "bad_body",
+      "zhCn": "身体畸形",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "bad_eyes",
+      "zhCn": "眼睛错误",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "泛化眼部错误。"
+    },
+    {
+      "tag": "bad_fingers",
+      "zhCn": "手指错误",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/datasets/diffusers/community-pipelines-mirror",
+      "notes": "Diffusers 社区管线示例中的动漫负面词。"
+    },
+    {
+      "tag": "bad_hands_v4",
+      "zhCn": "BadHandv4 负面嵌入",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
+      "notes": "纠正原译'坏手4'：特指SD社区BadHandv4负面模型触发词"
+    },
+    {
+      "tag": "bad_legs",
+      "zhCn": "腿部错误",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/datasets/diffusers/community-pipelines-mirror",
+      "notes": "Diffusers 社区管线示例。"
+    },
+    {
+      "tag": "bad_nails",
+      "zhCn": "指甲错误",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "手部细节负面提示。"
+    },
+    {
+      "tag": "bad_prompt",
+      "zhCn": "Bad Prompt 负面嵌入",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
+      "notes": "社区特定Negative Embedding词"
+    },
+    {
+      "tag": "bad_quality",
+      "zhCn": "差质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V4/V5 UC 的固定质量词。"
+    },
+    {
+      "tag": "bad_rendering",
+      "zhCn": "糟糕渲染",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "bad_score",
+      "zhCn": "低劣评分",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-4.0",
+      "notes": "Animagine XL 4.0 推荐负面中出现。"
+    },
+    {
+      "tag": "bad_toes",
+      "zhCn": "脚趾错误",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "泛化脚趾错误。"
+    },
+    {
+      "tag": "badhandv4",
+      "zhCn": "BadHandv4 负面嵌入",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
+      "notes": "SD常用手部修复模型触发标记"
+    },
+    {
+      "tag": "ballpoint_pen",
+      "zhCn": "圆珠笔画",
+      "mode": "missing",
+      "category": "material",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 原生标签含 `(medium)`。"
+    },
+    {
+      "tag": "banding",
+      "zhCn": "色带",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "beautiful",
+      "zhCn": "美丽",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "自然语言和标签式提示中的通用审美增强词。"
+    },
+    {
+      "tag": "beautiful_detailed_eyes",
+      "zhCn": "美丽细致的眼睛",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "beautiful_lighting",
+      "zhCn": "漂亮光影",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "beginner",
+      "zhCn": "新手画",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "best",
+      "zhCn": "最佳",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "单独出现含义弱"
+    },
+    {
+      "tag": "best_illustration",
+      "zhCn": "最佳插画",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "best_quality",
+      "zhCn": "最佳质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/qualitytags/",
+      "notes": "NovelAI Anime V1–V4/V3 等 Quality Tags。"
+    },
+    {
+      "tag": "best_shadow",
+      "zhCn": "最佳阴影",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "black_and_white",
+      "zhCn": "黑白",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "blocky",
+      "zhCn": "色块感",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "blur",
+      "zhCn": "模糊",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "blurred_background",
+      "zhCn": "背景虚化",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "景深控制自然语言提示。"
+    },
+    {
+      "tag": "blurred_foreground",
+      "zhCn": "前景模糊",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "Furry Focus UC；本身也可作摄影效果。"
+    },
+    {
+      "tag": "body_out_of_frame",
+      "zhCn": "人体超出画框",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "high",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
+      "notes": "防止身体部位被裁切"
+    },
+    {
+      "tag": "bokeh_background",
+      "zhCn": "背景虚化",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "bold_lines",
+      "zhCn": "粗线条",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "官方有 lineart/outline 等线条概念，但未直接列出 exact tag `bold lines`。"
+    },
+    {
+      "tag": "bowlegged",
+      "zhCn": "罗圈腿",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "broken_anatomy",
+      "zhCn": "身体结构损坏",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "broken_elbow",
+      "zhCn": "手肘断裂感",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "broken_fingers",
+      "zhCn": "手指断裂",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "broken_hand",
+      "zhCn": "手部损坏",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "broken_wrist",
+      "zhCn": "手腕断裂感",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "busy_background",
+      "zhCn": "背景过乱",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "c4d",
+      "zhCn": "Cinema 4D",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "low",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://www.maxon.net/en/cinema-4d",
+      "notes": "Cinema 4D 的常用简称；保留专名以避免误导。"
+    },
+    {
+      "tag": "cel_shading",
+      "zhCn": "赛璐珞阴影",
+      "mode": "missing",
+      "category": "style",
+      "priority": "high",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "边界清晰的经典动画阴影画风"
+    },
+    {
+      "tag": "cg",
+      "zhCn": "CG",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "cgi",
+      "zhCn": "电脑图形",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "character_sheet",
+      "zhCn": "角色设定表",
+      "mode": "missing",
+      "category": "meta",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "包含多视角或表情拆解的立绘模板"
+    },
+    {
+      "tag": "cinematic",
+      "zhCn": "电影感",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "notes": "SD/SDXL 高频自然语言风格词；非控制标签。"
+    },
+    {
+      "tag": "cinematic_lighting",
+      "zhCn": "电影感光照",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "通用 SD/SDXL 自然语言提示；类别级间接证据。"
+    },
+    {
+      "tag": "clean_image",
+      "zhCn": "干净画面",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "clean_lines",
+      "zhCn": "干净线条",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "与 lineart/outline 类线条控制相关。"
+    },
+    {
+      "tag": "clear",
+      "zhCn": "清晰",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "cloned_face",
+      "zhCn": "重复面孔",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "抑制重复/克隆面部。"
+    },
+    {
+      "tag": "cluttered",
+      "zhCn": "画面堆砌",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "cold_color_palette",
+      "zhCn": "冷色调色板",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "notes": "SDXL 提示示例类自然语言色彩概念。"
+    },
+    {
+      "tag": "collage_page",
+      "zhCn": "拼贴页",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "comic_panel",
+      "zhCn": "漫画分格",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "Furry UC 会抑制；正向漫画生成也可使用。"
+    },
+    {
+      "tag": "compressed",
+      "zhCn": "压缩过的",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "compression",
+      "zhCn": "压缩感",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "compression_artifacts",
+      "zhCn": "压缩瑕疵",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry V3 UC。"
+    },
+    {
+      "tag": "concept_sheet",
+      "zhCn": "设定表",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "construction_lines",
+      "zhCn": "结构辅助线",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "copyright",
+      "zhCn": "版权文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "crisp",
+      "zhCn": "清晰锐利",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "crisp_lines",
+      "zhCn": "清晰线条",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "线稿清晰度自然语言描述。"
+    },
+    {
+      "tag": "crooked_face",
+      "zhCn": "歪脸",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "crop_mark",
+      "zhCn": "裁切标记",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/qualitytags.html",
+      "notes": "去除印刷裁切线或四周留白"
+    },
+    {
+      "tag": "cropped_fingers",
+      "zhCn": "手指被裁切",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "指构图意外裁掉手指。"
+    },
+    {
+      "tag": "cropped_toes",
+      "zhCn": "脚趾被裁切",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "指构图意外裁掉脚趾。"
+    },
+    {
+      "tag": "cross_eye",
+      "zhCn": "斗鸡眼",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 社区眼部负面词。"
+    },
+    {
+      "tag": "crystal_clear",
+      "zhCn": "水晶般清晰",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "cut_off",
+      "zhCn": "被截断",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
+      "notes": "防止肢体或背景被切掉"
+    },
+    {
+      "tag": "cut_off_head",
+      "zhCn": "头被切掉",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "cut_off_legs",
+      "zhCn": "腿被切掉",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "cutoff",
+      "zhCn": "切断",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "dead_eyes",
+      "zhCn": "死鱼眼",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "deep_depth_of_field",
+      "zhCn": "大景深",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "`depth of field` 的常用细化；来源间接。"
+    },
+    {
+      "tag": "deepnegative",
+      "zhCn": "DeepNegative 负面嵌入",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "high",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
+      "notes": "SD社区广泛使用的负面Embedding标记"
+    },
+    {
+      "tag": "deformed_anatomy",
+      "zhCn": "变形人体结构",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "泛化解剖错误负面词。"
+    },
+    {
+      "tag": "deformed_body",
+      "zhCn": "身体变形",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "人体生成失败类负面概念。"
+    },
+    {
+      "tag": "deformed_face",
+      "zhCn": "面部变形",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "面部形态错误。"
+    },
+    {
+      "tag": "deformed_hands",
+      "zhCn": "手部变形",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "手部形态错误。"
+    },
+    {
+      "tag": "deformed_iris",
+      "zhCn": "畸形虹膜",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "deformed_limbs",
+      "zhCn": "肢体变形",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "社区解剖负面词。"
+    },
+    {
+      "tag": "deformed_pupils",
+      "zhCn": "畸形瞳孔",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "delicate",
+      "zhCn": "精巧",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "depth_map",
+      "zhCn": "深度图",
+      "mode": "missing",
+      "category": "background",
+      "priority": "low",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "多用于ControlNet或三维深度景深控制"
+    },
+    {
+      "tag": "detailed",
+      "zhCn": "细致",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "notes": "SDXL 常用自然语言质量词；不是模型专用控制标签。"
+    },
+    {
+      "tag": "detailed_background",
+      "zhCn": "细致背景",
+      "mode": "missing",
+      "category": "background",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "背景细节自然语言提示。"
+    },
+    {
+      "tag": "detailed_clothes",
+      "zhCn": "精细服饰",
+      "mode": "missing",
+      "category": "clothing",
+      "priority": "high",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "增强衣服质感与纹理细节"
+    },
+    {
+      "tag": "detailed_eyes",
+      "zhCn": "细致眼睛",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-charactercreation/",
+      "notes": "眼部细节增强的自然语言概念。"
+    },
+    {
+      "tag": "detailed_face",
+      "zhCn": "细致面部",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-charactercreation/",
+      "notes": "面部细节增强的通用生成提示。"
+    },
+    {
+      "tag": "detailed_hair",
+      "zhCn": "细致头发",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-charactercreation/",
+      "notes": "头发细节增强的通用生成提示。"
+    },
+    {
+      "tag": "detailed_skin",
+      "zhCn": "细致皮肤",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/Muapi/realistic-photos-detailed-skin-textures-flux",
+      "notes": "社区 Flux/SD 系资源明确使用 trained word；非通用模型控制词。"
+    },
+    {
+      "tag": "detailed_textures",
+      "zhCn": "精细纹理",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/Muapi/realistic-photos-detailed-skin-textures-flux",
+      "notes": "写实/材质生成中的常见细节概念。"
+    },
+    {
+      "tag": "diffusion_artifacts",
+      "zhCn": "扩散模型痕迹",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "digital_media",
+      "zhCn": "数字绘制",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "disconnected_body_parts",
+      "zhCn": "身体部位断开",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "抑制身体部位不自然分离。"
+    },
+    {
+      "tag": "disconnected_limbs",
+      "zhCn": "肢体断开",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "肢体连接异常。"
+    },
+    {
+      "tag": "disfigured_face",
+      "zhCn": "面部毁损变形",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "面部严重变形。"
+    },
+    {
+      "tag": "disgusting",
+      "zhCn": "恶心",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "displeasing",
+      "zhCn": "不美观",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V2/V3/Furry UC 与 Animagine 美学分级。"
+    },
+    {
+      "tag": "disproportionate",
+      "zhCn": "比例失衡",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "distorted",
+      "zhCn": "扭曲",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "distorted_anatomy",
+      "zhCn": "扭曲人体结构",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "泛化解剖错误负面词。"
+    },
+    {
+      "tag": "distorted_body",
+      "zhCn": "身体扭曲",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "人体生成失败类负面概念。"
+    },
+    {
+      "tag": "distorted_hands",
+      "zhCn": "手部扭曲",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "手部扭曲错误。"
+    },
+    {
+      "tag": "distorted_text",
+      "zhCn": "扭曲文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry V3 Heavy UC。"
+    },
+    {
+      "tag": "distracting_watermark",
+      "zhCn": "干扰性水印",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry Focus UC。"
+    },
+    {
+      "tag": "doll_like",
+      "zhCn": "假人感",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "dramatic_lighting",
+      "zhCn": "戏剧性光照",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "通用生成提示；Stability 官方资料仅属 lighting 类能力间接证据。"
+    },
+    {
+      "tag": "dramatic_shadows",
+      "zhCn": "强对比戏剧阴影",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "高对比度暗部与光影表现"
+    },
+    {
+      "tag": "dull_colors",
+      "zhCn": "色彩沉闷",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "duplicate_body",
+      "zhCn": "重复身体",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "抑制身体重复。"
+    },
+    {
+      "tag": "duplicate_face",
+      "zhCn": "重复脸",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "early",
+      "zhCn": "早期年代风格",
+      "mode": "missing",
+      "category": "model_control",
+      "priority": "low",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine temporal tag；推荐负面中也用于排除旧画风。"
+    },
+    {
+      "tag": "easynegative",
+      "zhCn": "EasyNegative",
+      "mode": "missing",
+      "category": "model_control",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/docs/diffusers/main/using-diffusers/textual_inversion_inference",
+      "notes": "广泛使用的负面 Textual Inversion embedding；必须加载对应 embedding，非普通词。"
+    },
+    {
+      "tag": "eldritch_horror",
+      "zhCn": "克苏鲁恐怖",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "elegant",
+      "zhCn": "优雅",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "embedded_text",
+      "zhCn": "内嵌文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "error",
+      "zhCn": "错误",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V2–V4 UC 与 Animagine 负面提示使用。"
+    },
+    {
+      "tag": "error_arm",
+      "zhCn": "手臂错误",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/datasets/diffusers/community-pipelines-mirror",
+      "notes": "Diffusers 社区管线示例。"
+    },
+    {
+      "tag": "error_fingers",
+      "zhCn": "手指错误",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/datasets/diffusers/community-pipelines-mirror",
+      "notes": "Diffusers 社区管线示例。"
+    },
+    {
+      "tag": "error_hands",
+      "zhCn": "手部错误",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/datasets/diffusers/community-pipelines-mirror",
+      "notes": "Diffusers 社区管线示例。"
+    },
+    {
+      "tag": "error_legs",
+      "zhCn": "腿部错误",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/datasets/diffusers/community-pipelines-mirror",
+      "notes": "Diffusers 社区管线示例。"
+    },
+    {
+      "tag": "explicit",
+      "zhCn": "露骨内容",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-4.0",
+      "notes": "Animagine XL 4.0 rating tag。"
+    },
+    {
+      "tag": "explicit_content",
+      "zhCn": "露骨内容",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "expressions",
+      "zhCn": "表情合集",
+      "mode": "missing",
+      "category": "expression",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-charactercreation/",
+      "notes": "角色设定/多视图相关标签。"
+    },
+    {
+      "tag": "exquisite",
+      "zhCn": "精致",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "extra",
+      "zhCn": "额外",
+      "mode": "override",
+      "category": "generic_negative",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "旧译“额外插画”明显错误；原词没有 illustration 语义。"
+    },
+    {
+      "tag": "extra_anatomy",
+      "zhCn": "多余人体结构",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "泛化多余结构词。"
+    },
+    {
+      "tag": "extra_body",
+      "zhCn": "多余身体",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "抑制多出的身体。"
+    },
+    {
+      "tag": "extra_digit",
+      "zhCn": "多余指趾",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "digit 在解剖语境指手指或脚趾。"
+    },
+    {
+      "tag": "extra_digit_fingers",
+      "zhCn": "多生手指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "extra_digit_on_hand",
+      "zhCn": "手上多指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "extra_feet",
+      "zhCn": "多余脚部",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "多余脚部。"
+    },
+    {
+      "tag": "extra_finger",
+      "zhCn": "多余手指",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 社区负面提示。"
+    },
+    {
+      "tag": "extra_fingers",
+      "zhCn": "多余手指",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "Stable Diffusion 社区负面提示。"
+    },
+    {
+      "tag": "extra_heads",
+      "zhCn": "多头",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "extra_limb",
+      "zhCn": "多余肢体",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "extra_limbs",
+      "zhCn": "多余肢体",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 常见人体负面提示。"
+    },
+    {
+      "tag": "extra_toes",
+      "zhCn": "多余脚趾",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "明确的脚趾数量错误。"
+    },
+    {
+      "tag": "extremely_delicate",
+      "zhCn": "极其精致",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "extremely_detailed",
+      "zhCn": "极度细致",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "fewer",
+      "zhCn": "较少",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V2/V3 UC 单独出现，表示数量偏少。"
+    },
+    {
+      "tag": "fewer_digits",
+      "zhCn": "指趾数量不足",
+      "mode": "override",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "旧译“指数异常”错误；digits 在此为 anatomical digits。"
+    },
+    {
+      "tag": "fewer_digits_on_hand",
+      "zhCn": "手上数字",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "fewer_fingers",
+      "zhCn": "手指数量不足",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "手指数不足。"
+    },
+    {
+      "tag": "fewer_than_5_fingers",
+      "zhCn": "少于五指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "fine_details",
+      "zhCn": "精细细节",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "notes": "通用扩散模型细节提示，非训练控制词。"
+    },
+    {
+      "tag": "fine_lines",
+      "zhCn": "细线条",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "绘画和线稿提示基础概念。"
+    },
+    {
+      "tag": "finely_detailed",
+      "zhCn": "精细刻画",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "fingers_too_long",
+      "zhCn": "手指过长",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "fingers_too_short",
+      "zhCn": "手指过短",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "fisheye_lens",
+      "zhCn": "鱼眼镜头",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "由官方 fisheye 构图概念规范化的摄影表达。"
+    },
+    {
+      "tag": "five_fingers",
+      "zhCn": "五指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "正面约束手"
+    },
+    {
+      "tag": "flat_colors",
+      "zhCn": "平涂色彩",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "Furry Focus UC 有复数实际写法；与 flat_color 均保留。"
+    },
+    {
+      "tag": "flat_shading",
+      "zhCn": "平涂光照",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "flawless_skin",
+      "zhCn": "无瑕皮肤",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "floating_body_parts",
+      "zhCn": "悬浮身体部位",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "抑制脱离主体悬浮的身体部分。"
+    },
+    {
+      "tag": "floating_limbs",
+      "zhCn": "悬浮肢体",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "肢体脱离主体。"
+    },
+    {
+      "tag": "floating_particles",
+      "zhCn": "漂浮粒子",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "",
+      "notes": "社区提示中可见的视觉效果短语，但本次缺少足够高质量的直接来源。"
+    },
+    {
+      "tag": "font",
+      "zhCn": "字体",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "foreground_blur",
+      "zhCn": "前景虚化",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "与官方 `blurred foreground` 概念对应。"
+    },
+    {
+      "tag": "four_fingers",
+      "zhCn": "四指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "frame",
+      "zhCn": "画框",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "full_body_pose",
+      "zhCn": "全身姿势",
+      "mode": "missing",
+      "category": "pose",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-charactercreation/",
+      "notes": "由 full body framing 延伸的自然语言提示。"
+    },
+    {
+      "tag": "fused",
+      "zhCn": "融合异常",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "fused_body_parts",
+      "zhCn": "身体部位融合",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "",
+      "notes": "概念合理，但 exact-tag 直接证据不足；`fused_limbs`、`fused_fingers`、`fused_feet` 证据更强。"
+    },
+    {
+      "tag": "fused_face",
+      "zhCn": "五官融合",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "fused_feet",
+      "zhCn": "脚部融合",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "双脚或脚部结构异常融合。"
+    },
+    {
+      "tag": "fused_fingers",
+      "zhCn": "手指融合",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "手指粘连/融合类错误。"
+    },
+    {
+      "tag": "fused_hand",
+      "zhCn": "手部融合",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "fused_hands",
+      "zhCn": "手部融合",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "手部融合类错误。"
+    },
+    {
+      "tag": "fused_legs",
+      "zhCn": "双腿黏连",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/qualitytags.html",
+      "notes": "腿部无法独立分离开的瑕疵"
+    },
+    {
+      "tag": "fused_limbs",
+      "zhCn": "肢体融合",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 常见人体负面提示。"
+    },
+    {
+      "tag": "fused_toes",
+      "zhCn": "脚趾融合",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "脚趾融合。"
+    },
+    {
+      "tag": "gan_artifacts",
+      "zhCn": "GAN伪影",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "gaudy",
+      "zhCn": "艳俗",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "global_illumination",
+      "zhCn": "全局光照",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "真实的光线漫反射效果"
+    },
+    {
+      "tag": "glossy",
+      "zhCn": "光滑有光泽",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "god_rays",
+      "zhCn": "云隙光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "从云层或树缝穿透出的光束"
+    },
+    {
+      "tag": "good_quality",
+      "zhCn": "良好质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine XL 3.1 的分级质量标签。"
+    },
+    {
+      "tag": "good_score",
+      "zhCn": "良好评分",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-4.0",
+      "notes": "Animagine XL 4.0 score tag。"
+    },
+    {
+      "tag": "gorgeous",
+      "zhCn": "华丽",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "grain",
+      "zhCn": "颗粒",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "grainy",
+      "zhCn": "颗粒感",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "graphite",
+      "zhCn": "石墨画",
+      "mode": "missing",
+      "category": "material",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 官方媒介标签。"
+    },
+    {
+      "tag": "grayscale",
+      "zhCn": "灰度",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "great_quality",
+      "zhCn": "优秀质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine XL 3.1 的分级质量标签。"
+    },
+    {
+      "tag": "great_score",
+      "zhCn": "优秀评分",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-4.0",
+      "notes": "Animagine XL 4.0 专用 score tag。"
+    },
+    {
+      "tag": "gross",
+      "zhCn": "粗劣难看",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "gross_proportions",
+      "zhCn": "严重比例失调",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 社区负面提示。"
+    },
+    {
+      "tag": "gui",
+      "zhCn": "界面",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "guide_lines",
+      "zhCn": "辅助线",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry V3 UC。"
+    },
+    {
+      "tag": "hard_lighting",
+      "zhCn": "硬光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "通用摄影/生成提示；类别级间接证据。"
+    },
+    {
+      "tag": "heavily_compressed",
+      "zhCn": "重度压缩",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "heavy_uc",
+      "zhCn": "强力负面",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "NAI UC 预设名"
+    },
+    {
+      "tag": "hideous",
+      "zhCn": "极其难看",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "high_quality",
+      "zhCn": "高质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "NovelAI 提示基础页列作质量描述。"
+    },
+    {
+      "tag": "high_resolution",
+      "zhCn": "高分辨率",
+      "mode": "missing",
+      "category": "meta",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "notes": "通用扩散提示；与 `absurdres`、`lowres` 语义层级不同。"
+    },
+    {
+      "tag": "high_score",
+      "zhCn": "高评分",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-4.0",
+      "notes": "Animagine XL 4.0 专用 score tag。"
+    },
+    {
+      "tag": "highest_quality",
+      "zhCn": "最高质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "highly_detailed",
+      "zhCn": "高度细致",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "notes": "SD/SDXL 常见自然语言增强词。"
+    },
+    {
+      "tag": "highres_fix",
+      "zhCn": "高分辨率修复",
+      "mode": "missing",
+      "category": "model_control",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
+      "notes": "SD算法中的二次放大控制术语"
+    },
+    {
+      "tag": "horrible",
+      "zhCn": "糟糕透顶",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "horror",
+      "zhCn": "恐怖主题",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "官方原生形式含 `horror (theme)`；这里规范为基础概念。"
+    },
+    {
+      "tag": "huge_head",
+      "zhCn": "头过大",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "human_focus",
+      "zhCn": "人体焦点负面",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "NAI UC 预设名"
+    },
+    {
+      "tag": "hyper_detailed",
+      "zhCn": "超精细",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "illustration",
+      "zhCn": "插画",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "in_focus",
+      "zhCn": "合焦",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "incorrect_anatomy",
+      "zhCn": "人体结构不正确",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "自然语言式扩散负面提示。"
+    },
+    {
+      "tag": "inhuman",
+      "zhCn": "非人比例",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "insanely_detailed",
+      "zhCn": "极致细节",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "interface",
+      "zhCn": "界面",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "intricate",
+      "zhCn": "繁复",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "intricate_details",
+      "zhCn": "繁复细节",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "notes": "通用 SD/SDXL 细节增强短语；来源属类别级证据。"
+    },
+    {
+      "tag": "jaggies",
+      "zhCn": "锯齿",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "japanese_text",
+      "zhCn": "日文文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "jpeg",
+      "zhCn": "JPEG压缩感",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "jpeg_compression",
+      "zhCn": "JPEG压缩",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "jpg_artifacts",
+      "zhCn": "JPEG伪影",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "key_light",
+      "zhCn": "主光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "摄影布光基础词；自然语言式提示。"
+    },
+    {
+      "tag": "kitsch",
+      "zhCn": "俗气",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "knock_kneed",
+      "zhCn": "X型腿",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "letterbox",
+      "zhCn": "黑边",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "lettering",
+      "zhCn": "字样",
+      "mode": "missing",
+      "category": "text",
+      "priority": "low",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
+      "notes": "通用文字渲染概念；模型间能力差异大。"
+    },
+    {
+      "tag": "letters",
+      "zhCn": "字母",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "light_uc",
+      "zhCn": "轻度负面",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "NAI UC 预设名"
+    },
+    {
+      "tag": "liquid_fingers",
+      "zhCn": "融化手指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "location",
+      "zhCn": "场景地点",
+      "mode": "missing",
+      "category": "background",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/qualitytags/",
+      "notes": "NovelAI V4.5 Quality Tags 会自动加入。"
+    },
+    {
+      "tag": "low",
+      "zhCn": "低",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "单独出现含义弱"
+    },
+    {
+      "tag": "low_complexity",
+      "zhCn": "低复杂度",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "",
+      "notes": "可作为抽象质量描述，但未找到证据证明是主流动漫扩散模型的稳定基础标签。"
+    },
+    {
+      "tag": "low_effort",
+      "zhCn": "低努力敷衍",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "low_quality",
+      "zhCn": "低质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI UC 和 Animagine 常用负面质量词。"
+    },
+    {
+      "tag": "low_res",
+      "zhCn": "低分辨率",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "low_resolution",
+      "zhCn": "低分辨率",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 社区负面提示常见自然语言变体；与 lowres 有独立检索价值。"
+    },
+    {
+      "tag": "low_score",
+      "zhCn": "低评分",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-4.0",
+      "notes": "Animagine XL 4.0 推荐负面中出现。"
+    },
+    {
+      "tag": "lowest_quality",
+      "zhCn": "最低质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "macro",
+      "zhCn": "微距",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "通用摄影构图词；类别级间接证据。"
+    },
+    {
+      "tag": "malformed",
+      "zhCn": "畸形",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "malformed_anatomy",
+      "zhCn": "畸形人体结构",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "泛化解剖错误负面词。"
+    },
+    {
+      "tag": "malformed_body",
+      "zhCn": "身体畸形",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "人体生成失败类负面概念。"
+    },
+    {
+      "tag": "malformed_face",
+      "zhCn": "面部畸形",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "面部结构错误。"
+    },
+    {
+      "tag": "malformed_fingers",
+      "zhCn": "手指畸形",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "社区解剖负面提示。"
+    },
+    {
+      "tag": "malformed_hands",
+      "zhCn": "手部畸形",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 常见负面提示。"
+    },
+    {
+      "tag": "malformed_legs",
+      "zhCn": "腿部畸形",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "腿部形态错误。"
+    },
+    {
+      "tag": "malformed_limbs",
+      "zhCn": "肢体畸形",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "肢体形态异常。"
+    },
+    {
+      "tag": "masterpiece",
+      "zhCn": "杰作",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/qualitytags/",
+      "notes": "NovelAI 多代 Quality Tags；Animagine 亦使用。"
+    },
+    {
+      "tag": "maya",
+      "zhCn": "Maya渲染感",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "medium_quality",
+      "zhCn": "中等质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "mid",
+      "zhCn": "中期年代风格",
+      "mode": "missing",
+      "category": "model_control",
+      "priority": "low",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine 3.1 特定 temporal tag；普通语境含义过宽。"
+    },
+    {
+      "tag": "mismatched",
+      "zhCn": "不匹配",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "missing",
+      "zhCn": "缺失",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V2/V3 UC 单独出现，不限定具体身体部位。"
+    },
+    {
+      "tag": "missing_anatomy",
+      "zhCn": "缺失人体结构",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "泛化缺失结构词。"
+    },
+    {
+      "tag": "missing_arms",
+      "zhCn": "缺少手臂",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "手臂缺失。"
+    },
+    {
+      "tag": "missing_body",
+      "zhCn": "身体缺失",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "抑制主体身体生成不完整。"
+    },
+    {
+      "tag": "missing_digit",
+      "zhCn": "缺指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "missing_eyes",
+      "zhCn": "缺少眼睛",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "眼睛缺失。"
+    },
+    {
+      "tag": "missing_feet",
+      "zhCn": "缺少脚部",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "脚部缺失。"
+    },
+    {
+      "tag": "missing_fingers",
+      "zhCn": "缺少手指",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI 旧版 Bad Anatomy UC；复数形式有独立检索价值。"
+    },
+    {
+      "tag": "missing_hands",
+      "zhCn": "缺少手部",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "手部缺失。"
+    },
+    {
+      "tag": "missing_legs",
+      "zhCn": "缺少腿部",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/datasets/diffusers/community-pipelines-mirror",
+      "notes": "Diffusers 社区管线示例。"
+    },
+    {
+      "tag": "missing_limb",
+      "zhCn": "缺肢",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "missing_limbs",
+      "zhCn": "缺失肢体",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 常见人体负面提示。"
+    },
+    {
+      "tag": "missing_toes",
+      "zhCn": "缺少脚趾",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "明确的脚趾缺失。"
+    },
+    {
+      "tag": "monochromatic",
+      "zhCn": "单色调",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "单一色彩深浅变化的配色"
+    },
+    {
+      "tag": "morbid",
+      "zhCn": "病态",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "low",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "社区负面审美提示，含义较宽泛。"
+    },
+    {
+      "tag": "more_than_5_fingers",
+      "zhCn": "超过五指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "mosaic",
+      "zhCn": "马赛克",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry V3 UC。"
+    },
+    {
+      "tag": "multiple_scenes",
+      "zhCn": "多场景",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry Focus UC。"
+    },
+    {
+      "tag": "museum_quality",
+      "zhCn": "博物馆级",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "mutated",
+      "zhCn": "突变畸形",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 社区负面提示。"
+    },
+    {
+      "tag": "mutated_fingers",
+      "zhCn": "变异手指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "mutated_hands",
+      "zhCn": "手部畸变",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 经典负面提示。"
+    },
+    {
+      "tag": "mutated_hands_and_fingers",
+      "zhCn": "变异的手和手指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "mutation_hands",
+      "zhCn": "变异手",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "mutilated",
+      "zhCn": "残缺变形",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 社区负面提示。"
+    },
+    {
+      "tag": "naked",
+      "zhCn": "赤裸",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "name",
+      "zhCn": "名称",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "nasty",
+      "zhCn": "难看恶心",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "natural_hands",
+      "zhCn": "自然的手",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "natural_lighting",
+      "zhCn": "自然光照",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "通用写实提示；类别级间接证据。"
+    },
+    {
+      "tag": "natural_pose",
+      "zhCn": "自然姿势",
+      "mode": "missing",
+      "category": "pose",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-charactercreation/",
+      "notes": "写实/角色生成常用；类别级间接证据。"
+    },
+    {
+      "tag": "neon_lighting",
+      "zhCn": "霓虹灯光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "动漫/赛博风常见；类别级间接证据。"
+    },
+    {
+      "tag": "neutral_expression",
+      "zhCn": "中性表情",
+      "mode": "missing",
+      "category": "expression",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "中性表情/无明显喜怒哀乐"
+    },
+    {
+      "tag": "newest",
+      "zhCn": "最新年代风格",
+      "mode": "missing",
+      "category": "model_control",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine XL 3.1 temporal tag，约对应 2021–2024 分组。"
+    },
+    {
+      "tag": "nib_pen",
+      "zhCn": "蘸水笔画",
+      "mode": "missing",
+      "category": "material",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 官方媒介标签。"
+    },
+    {
+      "tag": "nightmare_fuel",
+      "zhCn": "恐怖素材",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "no_text",
+      "zhCn": "无文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/qualitytags/",
+      "notes": "NovelAI V4/V4.5/V5 Quality Tags。"
+    },
+    {
+      "tag": "noise",
+      "zhCn": "噪点",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 社区常见画面瑕疵词。"
+    },
+    {
+      "tag": "noise_grain",
+      "zhCn": "噪点颗粒",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "noisy",
+      "zhCn": "有噪点",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "normal",
+      "zhCn": "普通",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "单独出现含义弱"
+    },
+    {
+      "tag": "normal_quality",
+      "zhCn": "普通质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI 旧版 Low Quality UC 与 Animagine 质量分级均出现。"
+    },
+    {
+      "tag": "not_enough_fingers",
+      "zhCn": "手指不够",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "nsfw",
+      "zhCn": "成人内容",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine 3.1/4.0 rating tag；放入负面时可用于抑制成人内容。"
+    },
+    {
+      "tag": "octane_render",
+      "zhCn": "Octane 渲染",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "超写实光影与超高细节CG风格"
+    },
+    {
+      "tag": "oil_painting",
+      "zhCn": "油画",
+      "mode": "missing",
+      "category": "material",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 官方媒介标签。"
+    },
+    {
+      "tag": "oldest",
+      "zhCn": "最早年代风格",
+      "mode": "missing",
+      "category": "model_control",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine temporal tag；常见于其推荐负面。"
+    },
+    {
+      "tag": "out_of_focus",
+      "zhCn": "失焦",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "out_of_focus_background",
+      "zhCn": "背景失焦",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "按需求可正可负"
+    },
+    {
+      "tag": "overexposed",
+      "zhCn": "过曝",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "overprocessed",
+      "zhCn": "过度处理",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "oversaturated",
+      "zhCn": "过饱和",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "oversharpened",
+      "zhCn": "过锐",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "oversmoothed",
+      "zhCn": "过滑",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "painting",
+      "zhCn": "绘画",
+      "mode": "missing",
+      "category": "material",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 官方媒介标签。"
+    },
+    {
+      "tag": "panel",
+      "zhCn": "分格",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "pastel",
+      "zhCn": "粉彩画",
+      "mode": "missing",
+      "category": "material",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 官方媒介标签。"
+    },
+    {
+      "tag": "perfect_anatomy",
+      "zhCn": "完美解剖",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "正面约束"
+    },
+    {
+      "tag": "perfect_details",
+      "zhCn": "完美细节",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "perfect_rendering",
+      "zhCn": "完美渲染",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "可理解为自然语言提示，但未取得足够可靠的模型卡/官方 exact-tag 证据。"
+    },
+    {
+      "tag": "perfect_skin",
+      "zhCn": "完美皮肤",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "pillarbox",
+      "zhCn": "两侧黑边",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "pixel_censor",
+      "zhCn": "像素打码",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "pixelation",
+      "zhCn": "像素化",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "plain_background",
+      "zhCn": "纯净背景",
+      "mode": "missing",
+      "category": "background",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "比 simple_background 更偏向无复杂纹理。"
+    },
+    {
+      "tag": "polished",
+      "zhCn": "精修",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "poor_anatomy",
+      "zhCn": "人体结构欠佳",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "社区负面提示同义变体。"
+    },
+    {
+      "tag": "poor_quality",
+      "zhCn": "劣质",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "poorly_drawn",
+      "zhCn": "画工差",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "poorly_drawn_body",
+      "zhCn": "身体画工差",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "poorly_drawn_eyes",
+      "zhCn": "眼睛绘制欠佳",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "眼部生成质量错误。"
+    },
+    {
+      "tag": "poorly_drawn_face",
+      "zhCn": "面部绘制欠佳",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 经典负面提示。"
+    },
+    {
+      "tag": "poorly_drawn_feet",
+      "zhCn": "脚部画工差",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "poorly_drawn_hands",
+      "zhCn": "手部绘制欠佳",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 经典负面提示。"
+    },
+    {
+      "tag": "poorly_drawn_mouth",
+      "zhCn": "嘴部绘制欠佳",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "嘴部生成质量错误。"
+    },
+    {
+      "tag": "poorly_rendered",
+      "zhCn": "渲染差",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "porcelain_skin",
+      "zhCn": "瓷娃娃皮肤",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "过假时"
+    },
+    {
+      "tag": "pores",
+      "zhCn": "毛孔",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "posterization",
+      "zhCn": "色调分离",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "precise_lineart",
+      "zhCn": "精准线稿",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "print_quality",
+      "zhCn": "印刷级质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "professional",
+      "zhCn": "专业",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "questionable",
+      "zhCn": "敏感内容",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "questionable_content",
+      "zhCn": "敏感内容",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "rating:explicit",
+      "zhCn": "成人分级",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "rating:general",
+      "zhCn": "全年龄分级",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "NAI / Danbooru 分级写法"
+    },
+    {
+      "tag": "rating:questionable",
+      "zhCn": "敏感分级",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "rating:sensitive",
+      "zhCn": "敏感分级",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "rating_general",
+      "zhCn": "全年龄分级",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/qualitytags/",
+      "notes": "NovelAI 原生语法 `rating:general`；数据库规范化为下划线。"
+    },
+    {
+      "tag": "ray_tracing",
+      "zhCn": "光线追踪",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "真实物理反射与折射质感"
+    },
+    {
+      "tag": "realistic_face",
+      "zhCn": "写实面部",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://stable-diffusion-art.com/realistic-people/",
+      "notes": "写实人像自然语言概念；不是固定控制标签。"
+    },
+    {
+      "tag": "realistic_rendering",
+      "zhCn": "写实渲染",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "官方支持 `realistic`/`photorealistic`，但未直接支持 exact phrase `realistic rendering`；仅为间接证据。"
+    },
+    {
+      "tag": "realistic_skin",
+      "zhCn": "真实皮肤",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "realistic_texture",
+      "zhCn": "写实纹理",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "recent",
+      "zhCn": "较新年代风格",
+      "mode": "missing",
+      "category": "model_control",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine XL 3.1 temporal tag，约对应 2018–2020。"
+    },
+    {
+      "tag": "render",
+      "zhCn": "渲染",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "repeated_text",
+      "zhCn": "重复文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry V3 Heavy UC。"
+    },
+    {
+      "tag": "retro",
+      "zhCn": "复古",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "`retro artstyle` 的通用生成表达。"
+    },
+    {
+      "tag": "rich_colors",
+      "zhCn": "浓郁色彩",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "rim_light",
+      "zhCn": "轮廓光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "high",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "勾勒人物边缘的高亮光"
+    },
+    {
+      "tag": "rim_lighting",
+      "zhCn": "轮廓光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "通用绘画/摄影提示；类别级间接证据。"
+    },
+    {
+      "tag": "rough",
+      "zhCn": "粗糙",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "rough_sketch",
+      "zhCn": "草图",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "round_face",
+      "zhCn": "圆脸",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://dav.one/using-prompts-to-modify-face-and-body-in-stable-diffusion-xl/",
+      "notes": "SDXL 面部特征提示实践中使用。"
+    },
+    {
+      "tag": "safe",
+      "zhCn": "安全级内容",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine 3.1/4.0 rating tag。"
+    },
+    {
+      "tag": "sample",
+      "zhCn": "样图水印",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "scanned",
+      "zhCn": "扫描痕迹",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "screentone",
+      "zhCn": "网点纸效果",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V5 UC 中作为不期望效果。"
+    },
+    {
+      "tag": "sensitive",
+      "zhCn": "敏感级内容",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-3.1",
+      "notes": "Animagine 3.1/4.0 rating tag。"
+    },
+    {
+      "tag": "sequence",
+      "zhCn": "连续画面",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "low",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry Focus/Furry V3 UC。"
+    },
+    {
+      "tag": "sfw",
+      "zhCn": "全年龄内容",
+      "mode": "missing",
+      "category": "rating",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/qualitytags.html",
+      "notes": "适合公开展示的非敏感画作"
+    },
+    {
+      "tag": "shallow_depth_of_field",
+      "zhCn": "浅景深",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "`depth of field` 的高频扩散提示细化；来源间接。"
+    },
+    {
+      "tag": "sharp_background",
+      "zhCn": "清晰背景",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "景深控制自然语言提示。"
+    },
+    {
+      "tag": "sharp_focus",
+      "zhCn": "清晰对焦",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "与 soft focus 相对的常见生成/摄影语义。"
+    },
+    {
+      "tag": "sharp_image",
+      "zhCn": "锐利图像",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "shine",
+      "zhCn": "光泽",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "side_lighting",
+      "zhCn": "侧光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "光向提示；类别级间接证据。"
+    },
+    {
+      "tag": "signature_text",
+      "zhCn": "签名文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "simple",
+      "zhCn": "简单",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "low",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "Furry Focus UC 中作负面；翻译仍保持原词中性语义。"
+    },
+    {
+      "tag": "simple_face",
+      "zhCn": "简化面部",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "",
+      "notes": "语义可理解，但未找到足够强的官方/模型卡证据证明 exact tag 具有稳定基础价值。"
+    },
+    {
+      "tag": "simple_illustration",
+      "zhCn": "简约插画",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/strengthening-weakening/",
+      "notes": "NovelAI 强弱化示例中的概念。"
+    },
+    {
+      "tag": "simple_shading",
+      "zhCn": "简单涂影",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "six_fingers",
+      "zhCn": "六指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "sketch_page",
+      "zhCn": "草图页",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "low",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry V3 UC。"
+    },
+    {
+      "tag": "skin_blemishes",
+      "zhCn": "皮肤瑕疵",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "skin_pores",
+      "zhCn": "皮肤毛孔",
+      "mode": "missing",
+      "category": "generic_positive",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://stable-diffusion-art.com/realistic-people/",
+      "notes": "写实 Stable Diffusion 人像提示常见细节词。"
+    },
+    {
+      "tag": "skin_spots",
+      "zhCn": "色斑",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "skin_texture",
+      "zhCn": "皮肤纹理",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "sloppy",
+      "zhCn": "潦草",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "small_image",
+      "zhCn": "小图放大",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "smooth_skin",
+      "zhCn": "光滑皮肤",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "soft",
+      "zhCn": "柔和",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "不想要糊图时"
+    },
+    {
+      "tag": "soft_lighting",
+      "zhCn": "柔和光照",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "通用生成提示；类别级间接证据。"
+    },
+    {
+      "tag": "speech",
+      "zhCn": "台词",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "stamp",
+      "zhCn": "印章",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "standard_quality",
+      "zhCn": "标准质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "偶作负面"
+    },
+    {
+      "tag": "stiff_pose",
+      "zhCn": "僵硬姿势",
+      "mode": "missing",
+      "category": "pose",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-charactercreation/",
+      "notes": "用于抑制不自然僵硬姿态；类别级间接证据。"
+    },
+    {
+      "tag": "strange_fingers",
+      "zhCn": "奇怪手指",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "stuck_fingers",
+      "zhCn": "手指黏在一起",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/qualitytags.html",
+      "notes": "手指连接未分开负面词"
+    },
+    {
+      "tag": "studio_lighting",
+      "zhCn": "影棚光照",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "写实和产品图生成常见；类别级间接证据。"
+    },
+    {
+      "tag": "studio_quality",
+      "zhCn": "棚拍级质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "stunning",
+      "zhCn": "惊艳",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "subtitle",
+      "zhCn": "字幕",
+      "mode": "missing",
+      "category": "text",
+      "priority": "low",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-charactercreation/",
+      "notes": "通用画面文字概念。"
+    },
+    {
+      "tag": "tacky",
+      "zhCn": "俗套",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "telephoto",
+      "zhCn": "长焦",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "通用摄影镜头提示；来源为摄影/构图类间接证据。"
+    },
+    {
+      "tag": "terrible",
+      "zhCn": "极差",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "text",
+      "zhCn": "文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V2/旧版 UC、Animagine 推荐负面提示。"
+    },
+    {
+      "tag": "text_overlay",
+      "zhCn": "文字叠层",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "textless",
+      "zhCn": "无字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "three_arms",
+      "zhCn": "三只手臂",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "three_legs",
+      "zhCn": "三条腿",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "thumbnail",
+      "zhCn": "缩略图感",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "tilted_horizon",
+      "zhCn": "地平线倾斜",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "tiny_head",
+      "zhCn": "头过小",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "too_high_contrast",
+      "zhCn": "对比过强",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "过强时用这个，避免和正面 high contrast 冲突"
+    },
+    {
+      "tag": "too_many_legs",
+      "zhCn": "腿数量过多",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
+      "notes": "多腿控制词"
+    },
+    {
+      "tag": "too_many_limbs",
+      "zhCn": "肢体过多",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "top_aesthetic",
+      "zhCn": "顶级美观",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "NAI V4+"
+    },
+    {
+      "tag": "top_lighting",
+      "zhCn": "顶光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stable-diffusion-3-medium",
+      "notes": "光向提示；类别级间接证据。"
+    },
+    {
+      "tag": "transparent_watermark",
+      "zhCn": "透明水印",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "trending_on_artstation",
+      "zhCn": "ArtStation热门",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "twisted_body",
+      "zhCn": "身体扭转异常",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "躯体扭曲类错误。"
+    },
+    {
+      "tag": "twisted_fingers",
+      "zhCn": "手指扭转",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "two_heads",
+      "zhCn": "双头",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "ugly",
+      "zhCn": "丑陋",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13187",
+      "notes": "Stable Diffusion 社区长期使用的通用负面审美词。"
+    },
+    {
+      "tag": "ugly_face",
+      "zhCn": "丑陋的面部",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "high",
+      "researchSources": [
+        "gemini"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
+      "notes": "防止五官走样负面控制词"
+    },
+    {
+      "tag": "uhd",
+      "zhCn": "超高清",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "ui",
+      "zhCn": "界面元素",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "ultra_detailed",
+      "zhCn": "超细致",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "ultra_hd",
+      "zhCn": "超高清",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "ultra_highres",
+      "zhCn": "超高分辨率",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "ultra_quality",
+      "zhCn": "超高质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "ultra_sharp",
+      "zhCn": "超锐利",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "unaesthetic",
+      "zhCn": "不美观",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "unappealing",
+      "zhCn": "不悦目",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "unattractive",
+      "zhCn": "不吸引人",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "uncanny",
+      "zhCn": "恐怖谷",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "underexposed",
+      "zhCn": "欠曝",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "undersaturated",
+      "zhCn": "欠饱和",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "undesired",
+      "zhCn": "不期望",
+      "mode": "missing",
+      "category": "generic_negative",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "undetailed",
+      "zhCn": "缺少细节",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "unfinished_sketch",
+      "zhCn": "未完成草稿",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "unfinished_small_objects",
+      "zhCn": "未完成的小物件",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "",
+      "notes": "语义合理，但未找到可靠 exact-tag 证据；可能来自特定负面词库的组合项。"
+    },
+    {
+      "tag": "unity",
+      "zhCn": "Unity渲染感",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "unknown_text",
+      "zhCn": "未知文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry V3 UC。"
+    },
+    {
+      "tag": "unnatural_anatomy",
+      "zhCn": "不自然人体结构",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "自然语言式扩散负面提示。"
+    },
+    {
+      "tag": "unnatural_pose",
+      "zhCn": "不自然姿势",
+      "mode": "missing",
+      "category": "pose",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "Stable Diffusion 人体负面提示。"
+    },
+    {
+      "tag": "unpolished",
+      "zhCn": "未精修",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "unreal_engine",
+      "zhCn": "虚幻引擎",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "gemini",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "次世代游戏CG质感"
+    },
+    {
+      "tag": "unusual_pupils",
+      "zhCn": "异常瞳孔",
+      "mode": "missing",
+      "category": "face_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI Furry V3 UC。"
+    },
+    {
+      "tag": "upscale",
+      "zhCn": "放大处理",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "low",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "Furry Focus UC 中作为不期望概念。"
+    },
+    {
+      "tag": "upscale_artifacts",
+      "zhCn": "超分伪影",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "url",
+      "zhCn": "网址",
+      "mode": "missing",
+      "category": "text",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "抑制画面中的网址。"
+    },
+    {
+      "tag": "username_text",
+      "zhCn": "用户名文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "username_watermark",
+      "zhCn": "用户名水印",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "very_aesthetic",
+      "zhCn": "极具美感",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/qualitytags/",
+      "notes": "NovelAI Quality Tags；Animagine 3.1 美学分级。"
+    },
+    {
+      "tag": "very_awa",
+      "zhCn": "非常美观",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "very_displeasing",
+      "zhCn": "非常不美观",
+      "mode": "missing",
+      "category": "aesthetic",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V4/V5 UC 与 Animagine 美学分级。"
+    },
+    {
+      "tag": "vibrant_colors",
+      "zhCn": "鲜艳色彩",
+      "mode": "missing",
+      "category": "color",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/image/prompts.html",
+      "notes": "高饱和度与明亮的色彩"
+    },
+    {
+      "tag": "volumetric_lighting",
+      "zhCn": "体积光",
+      "mode": "missing",
+      "category": "lighting",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://stability.ai/news-updates/stability-ais-top-3-text-to-image-models-now-available-in-amazon-bedrock",
+      "notes": "通用 3D/扩散提示；官方来源属 lighting/textures 类间接证据。"
+    },
+    {
+      "tag": "wallpaper",
+      "zhCn": "壁纸",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "washed_out",
+      "zhCn": "发灰褪色",
+      "mode": "missing",
+      "category": "color",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "watercolor",
+      "zhCn": "水彩画",
+      "mode": "missing",
+      "category": "material",
+      "priority": "high",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 官方媒介标签。"
+    },
+    {
+      "tag": "watercolor_pencil",
+      "zhCn": "水彩铅笔画",
+      "mode": "missing",
+      "category": "material",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/tutorial-artstyles/",
+      "notes": "NovelAI 官方媒介标签。"
+    },
+    {
+      "tag": "watermark_signature",
+      "zhCn": "签名水印",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "watermark_text",
+      "zhCn": "水印文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "watermarked",
+      "zhCn": "带水印",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "watermarks",
+      "zhCn": "水印",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "waxy",
+      "zhCn": "蜡感",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "waxy_skin",
+      "zhCn": "蜡感皮肤",
+      "mode": "missing",
+      "category": "rendering",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "web_screenshot",
+      "zhCn": "网页截图",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "website",
+      "zhCn": "网站",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "well_drawn_face",
+      "zhCn": "画得好的脸",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "well_drawn_hands",
+      "zhCn": "画得好的手",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "western_comic",
+      "zhCn": "欧美漫画",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "white_haze",
+      "zhCn": "白色雾霾",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI V5 Light UC 明确使用。"
+    },
+    {
+      "tag": "wide_angle",
+      "zhCn": "广角构图",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "NovelAI Basics framing 示例。"
+    },
+    {
+      "tag": "wide_angle_lens",
+      "zhCn": "广角镜头",
+      "mode": "missing",
+      "category": "photography",
+      "priority": "high",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/basics/",
+      "notes": "基于官方 wide angle framing 的摄影表达。"
+    },
+    {
+      "tag": "widescreen",
+      "zhCn": "宽屏画幅",
+      "mode": "missing",
+      "category": "artifact",
+      "priority": "low",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "Furry UC 中可作负面，本身是画幅属性。"
+    },
+    {
+      "tag": "words",
+      "zhCn": "文字",
+      "mode": "missing",
+      "category": "text",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "worst",
+      "zhCn": "最差",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "单独出现含义弱"
+    },
+    {
+      "tag": "worst_face",
+      "zhCn": "最差面部",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "worst_feet",
+      "zhCn": "最差脚部",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "worst_hands",
+      "zhCn": "最差手部",
+      "mode": "missing",
+      "category": "anatomy_error",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "worst_quality",
+      "zhCn": "最差质量",
+      "mode": "missing",
+      "category": "quality",
+      "priority": "high",
+      "researchSources": [
+        "gemini",
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://docs.novelai.net/en/image/undesiredcontent/",
+      "notes": "NovelAI 多代 UC 与 Animagine 常用负面词。"
+    },
+    {
+      "tag": "wrong_feet",
+      "zhCn": "脚部错误",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "社区同义变体。"
+    },
+    {
+      "tag": "wrong_hands",
+      "zhCn": "手部错误",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "社区同义表达。"
+    },
+    {
+      "tag": "wrong_nails",
+      "zhCn": "指甲错误",
+      "mode": "missing",
+      "category": "hand_error",
+      "priority": "low",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "社区变体。"
+    },
+    {
+      "tag": "wrong_perspective",
+      "zhCn": "透视不对",
+      "mode": "missing",
+      "category": "composition",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "wrong_toes",
+      "zhCn": "脚趾错误",
+      "mode": "missing",
+      "category": "limb_error",
+      "priority": "medium",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12572",
+      "notes": "社区同义表达。"
+    },
+    {
+      "tag": "ych",
+      "zhCn": "YCH模板图",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "year_2005",
+      "zhCn": "2005年画风",
+      "mode": "missing",
+      "category": "model_control",
+      "priority": "low",
+      "researchSources": [
+        "gpt"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-4.0",
+      "notes": "原生形式为 `year 2005`，作为 temporal control 示例。"
+    },
+    {
+      "tag": "year_2023",
+      "zhCn": "2023年画风",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": "NAI 年代标签偏质量"
+    },
+    {
+      "tag": "year_2024",
+      "zhCn": "2024年画风",
+      "mode": "missing",
+      "category": "style",
+      "priority": "medium",
+      "researchSources": [
+        "grok"
+      ],
+      "sourceUrl": "",
+      "notes": ""
+    },
+    {
+      "tag": "year_2025",
+      "zhCn": "2025年画风",
+      "mode": "missing",
+      "category": "model_control",
+      "priority": "medium",
+      "researchSources": [
+        "gpt",
+        "grok"
+      ],
+      "sourceUrl": "https://huggingface.co/cagliostrolab/animagine-xl-4.0",
+      "notes": "原生形式为 `year 2025`。"
+    }
+  ]
+}


### PR DESCRIPTION
## 改动内容

- 清洗、去重并合并 Grok、Gemini、GPT 的研究结果，加入 517 条基础中文翻译：515 条缺失补充、2 条错译覆盖。
- 将补充翻译写入唯一内置数据库 `tag_catalog.db`，按“纠错覆盖 > ffdkj > 缺失补充”的优先级查询。
- 新增独立的 `FastTagService`，统一提供中英文标签补全与批量翻译；输入 `杰...` 或 `mast...` 均可补全 `masterpiece` 并显示“杰作”。
- 提示词助手改为本地快速翻译优先，只将未命中的规范化标签分批交给 AI，并保留权重、强调与分隔语法。
- 收紧模糊匹配，避免把相近但不同的标签错误翻译；可选 ffdkj 数据异常时不影响内置补全与翻译。
- 补齐数据库构建锁、确定性校验、关键词条校验及回归测试。

## 验证结果

- `dart run tool/tag_catalog/verify_bundled_databases.dart`：通过
- 数据 Release 下载、大小、SQLite 文件头与 SHA-256 校验：通过
- `scripts/test_affected.ps1`：228 项通过
- 本地优先翻译与快速标签服务专项测试：8 项通过
- 提示词助手 API 客户端相关测试：13 项通过
- 变更文件 `flutter analyze`：无问题
- `git diff --check`：通过

## 注意事项

- 内置数据库仍只有 `assets/databases/tag_catalog.db` 一个，体积增加 20 KiB。
- 新数据库已发布为独立 prerelease：`autocomplete-data-tag-catalog-125148ac-v1`，未设为 latest。
- 本地全量测试曾运行到 5,122 项通过、2 项跳过，并暴露 52 项与本次改动无关的既有/并行 Widget 测试失败；本次受影响测试与专项回归均已通过。
