### PR TITLE
fix(generation): 导入尺寸保留原图并让聚焦重绘跟随源图

### DIFF
--- a/lib/core/utils/nai_resolution_adapter.dart
+++ b/lib/core/utils/nai_resolution_adapter.dart
@@ -63,6 +63,38 @@ class NaiResolutionAdapter {
     );
   }
 
+  /// 计算导入后应使用的请求分辨率。
+  ///
+  /// 面积在上限内时保持原尺寸只做 64 对齐，超限时收敛到最接近的合法尺寸；
+  /// SD 族旧模型没有高分辨率可用，仍走官网基准边。
+  static ({int width, int height, double scaleFactor}) findImportResolution(
+    int sourceWidth,
+    int sourceHeight, {
+    int? currentWidth,
+    int? currentHeight,
+    bool isStableDiffusionFamily = false,
+  }) {
+    final reused = _reuseCurrentRequestSize(
+      sourceWidth,
+      sourceHeight,
+      currentWidth: currentWidth,
+      currentHeight: currentHeight,
+    );
+    if (reused != null) return reused;
+
+    if (isStableDiffusionFamily) {
+      return findOfficialImportResolution(
+        sourceWidth,
+        sourceHeight,
+        currentWidth: currentWidth,
+        currentHeight: currentHeight,
+        isStableDiffusionFamily: true,
+      );
+    }
+
+    return findClosestResolution(sourceWidth, sourceHeight);
+  }
+
   /// 按当前 NovelAI Web 的 Image2Image 导入逻辑计算目标分辨率。
   ///
   /// 官网逻辑会先把横图临时转为竖向计算，再在两个基准边
@@ -76,8 +108,15 @@ class NaiResolutionAdapter {
     int? currentHeight,
     bool isStableDiffusionFamily = false,
   }) {
-    final sourceAspect = sourceWidth / sourceHeight;
-    final isLandscape = sourceAspect > 1;
+    final reused = _reuseCurrentRequestSize(
+      sourceWidth,
+      sourceHeight,
+      currentWidth: currentWidth,
+      currentHeight: currentHeight,
+    );
+    if (reused != null) return reused;
+
+    final isLandscape = sourceWidth / sourceHeight > 1;
 
     var orientedWidth = sourceWidth;
     var orientedHeight = sourceHeight;
@@ -88,28 +127,6 @@ class NaiResolutionAdapter {
     }
 
     final orientedAspect = orientedWidth / orientedHeight;
-    final currentMatchesAspect =
-        currentWidth != null &&
-        currentHeight != null &&
-        currentWidth / currentHeight == sourceAspect;
-    final fitsCurrent =
-        currentWidth != null &&
-        currentHeight != null &&
-        orientedWidth <= currentWidth &&
-        orientedHeight <= currentHeight;
-
-    if (currentMatchesAspect && fitsCurrent) {
-      return (
-        width: currentWidth,
-        height: currentHeight,
-        scaleFactor: _combinedScale(
-          sourceWidth,
-          sourceHeight,
-          currentWidth,
-          currentHeight,
-        ),
-      );
-    }
 
     if (!isOfficialImportCompatible(orientedWidth, orientedHeight)) {
       final targetLongSide = isStableDiffusionFamily
@@ -248,7 +265,7 @@ class NaiResolutionAdapter {
 
     final srcW = imageSize?.$1 ?? decoded!.width;
     final srcH = imageSize?.$2 ?? decoded!.height;
-    final target = findOfficialImportResolution(
+    final target = findImportResolution(
       srcW,
       srcH,
       currentWidth: currentWidth,
@@ -302,7 +319,7 @@ class NaiResolutionAdapter {
 
     final srcW = imageSize.$1;
     final srcH = imageSize.$2;
-    final target = findOfficialImportResolution(
+    final target = findImportResolution(
       srcW,
       srcH,
       currentWidth: currentWidth,
@@ -492,6 +509,41 @@ class NaiResolutionAdapter {
   }
 
   // ==================== 内部方法 ====================
+
+  /// 源图比例与当前请求尺寸一致且不更大时，官网会沿用当前尺寸并在发送前放大源图。
+  static ({int width, int height, double scaleFactor})? _reuseCurrentRequestSize(
+    int sourceWidth,
+    int sourceHeight, {
+    required int? currentWidth,
+    required int? currentHeight,
+  }) {
+    if (currentWidth == null || currentHeight == null) return null;
+
+    final sourceAspect = sourceWidth / sourceHeight;
+    if (currentWidth / currentHeight != sourceAspect) return null;
+
+    var orientedWidth = sourceWidth;
+    var orientedHeight = sourceHeight;
+    if (sourceAspect > 1) {
+      final temp = orientedWidth;
+      orientedWidth = orientedHeight;
+      orientedHeight = temp;
+    }
+    if (orientedWidth > currentWidth || orientedHeight > currentHeight) {
+      return null;
+    }
+
+    return (
+      width: currentWidth,
+      height: currentHeight,
+      scaleFactor: _combinedScale(
+        sourceWidth,
+        sourceHeight,
+        currentWidth,
+        currentHeight,
+      ),
+    );
+  }
 
   static int _ceilToGrid(int value) {
     return math.max(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1130,6 +1130,15 @@
   },
   "editor_compressionUnavailable": "This work canvas is already below the lowest compression step.",
   "editor_compressionFocusLimited": "Higher resolutions are unavailable because the current Focused Inpaint selection would exceed the request area limit.",
+  "editor_compressionClampedToLimit": "{targetWidth}×{targetHeight} exceeds the request area limit, so {clampedWidth}×{clampedHeight} is sent instead.",
+  "@editor_compressionClampedToLimit": {
+    "placeholders": {
+      "targetWidth": {"type": "int"},
+      "targetHeight": {"type": "int"},
+      "clampedWidth": {"type": "int"},
+      "clampedHeight": {"type": "int"}
+    }
+  },
   "editor_focusRequestSummary": "Outer crop {outerWidth}×{outerHeight}, request {requestWidth}×{requestHeight}, estimated {cost} Anlas.",
   "@editor_focusRequestSummary": {
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1119,6 +1119,15 @@
   },
   "editor_compressionUnavailable": "作業キャンバスはすでに最低圧縮段階より小さいため、解像度を下げられません。",
   "editor_compressionFocusLimited": "現在の Focused Inpaint 選択範囲では、これ以上の解像度がリクエスト面積上限を超えるため、スライダー上限を制限しています。",
+  "editor_compressionClampedToLimit": "{targetWidth}×{targetHeight} はリクエストの面積上限を超えるため、実際には {clampedWidth}×{clampedHeight} で送信されます。",
+  "@editor_compressionClampedToLimit": {
+    "placeholders": {
+      "targetWidth": {"type": "int"},
+      "targetHeight": {"type": "int"},
+      "clampedWidth": {"type": "int"},
+      "clampedHeight": {"type": "int"}
+    }
+  },
   "editor_focusRequestSummary": "外側の切り抜き {outerWidth}×{outerHeight}、送信サイズ {requestWidth}×{requestHeight}、推定 {cost} Anlas。",
   "@editor_focusRequestSummary": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4923,6 +4923,17 @@ abstract class AppLocalizations {
   /// **'Higher resolutions are unavailable because the current Focused Inpaint selection would exceed the request area limit.'**
   String get editor_compressionFocusLimited;
 
+  /// No description provided for @editor_compressionClampedToLimit.
+  ///
+  /// In en, this message translates to:
+  /// **'{targetWidth}×{targetHeight} exceeds the request area limit, so {clampedWidth}×{clampedHeight} is sent instead.'**
+  String editor_compressionClampedToLimit(
+    int targetWidth,
+    int targetHeight,
+    int clampedWidth,
+    int clampedHeight,
+  );
+
   /// No description provided for @editor_focusRequestSummary.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2705,6 +2705,16 @@ class AppLocalizationsEn extends AppLocalizations {
       'Higher resolutions are unavailable because the current Focused Inpaint selection would exceed the request area limit.';
 
   @override
+  String editor_compressionClampedToLimit(
+    int targetWidth,
+    int targetHeight,
+    int clampedWidth,
+    int clampedHeight,
+  ) {
+    return '$targetWidth×$targetHeight exceeds the request area limit, so $clampedWidth×$clampedHeight is sent instead.';
+  }
+
+  @override
   String editor_focusRequestSummary(
     int outerWidth,
     int outerHeight,

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2638,6 +2638,16 @@ class AppLocalizationsJa extends AppLocalizations {
       '現在の Focused Inpaint 選択範囲では、これ以上の解像度がリクエスト面積上限を超えるため、スライダー上限を制限しています。';
 
   @override
+  String editor_compressionClampedToLimit(
+    int targetWidth,
+    int targetHeight,
+    int clampedWidth,
+    int clampedHeight,
+  ) {
+    return '$targetWidth×$targetHeight はリクエストの面積上限を超えるため、実際には $clampedWidth×$clampedHeight で送信されます。';
+  }
+
+  @override
   String editor_focusRequestSummary(
     int outerWidth,
     int outerHeight,

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2598,6 +2598,16 @@ class AppLocalizationsZh extends AppLocalizations {
       '当前 Focused Inpaint 选区在更高分辨率下会超过请求面积上限，因此滑条上限已收紧。';
 
   @override
+  String editor_compressionClampedToLimit(
+    int targetWidth,
+    int targetHeight,
+    int clampedWidth,
+    int clampedHeight,
+  ) {
+    return '所选 $targetWidth×$targetHeight 超过请求面积上限，实际会按 $clampedWidth×$clampedHeight 发送。';
+  }
+
+  @override
   String editor_focusRequestSummary(
     int outerWidth,
     int outerHeight,
@@ -16524,6 +16534,16 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String get editor_compressionFocusLimited =>
       '當前 Focused Inpaint 選區在更高解析度下會超過請求面積上限，因此滑條上限已收緊。';
+
+  @override
+  String editor_compressionClampedToLimit(
+    int targetWidth,
+    int targetHeight,
+    int clampedWidth,
+    int clampedHeight,
+  ) {
+    return '所選 $targetWidth×$targetHeight 超過請求面積上限，實際會以 $clampedWidth×$clampedHeight 傳送。';
+  }
 
   @override
   String editor_focusRequestSummary(

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1061,6 +1061,15 @@
   },
   "editor_compressionUnavailable": "当前工作画布已经低于最低压缩档，不能继续降低分辨率。",
   "editor_compressionFocusLimited": "当前 Focused Inpaint 选区在更高分辨率下会超过请求面积上限，因此滑条上限已收紧。",
+  "editor_compressionClampedToLimit": "所选 {targetWidth}×{targetHeight} 超过请求面积上限，实际会按 {clampedWidth}×{clampedHeight} 发送。",
+  "@editor_compressionClampedToLimit": {
+    "placeholders": {
+      "targetWidth": {"type": "int"},
+      "targetHeight": {"type": "int"},
+      "clampedWidth": {"type": "int"},
+      "clampedHeight": {"type": "int"}
+    }
+  },
   "editor_focusRequestSummary": "外层裁剪 {outerWidth}×{outerHeight}，实际发送 {requestWidth}×{requestHeight}，预计 {cost} Anlas。",
   "@editor_focusRequestSummary": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1068,6 +1068,15 @@
   },
   "editor_compressionUnavailable": "當前工作畫布已經低於最低壓縮檔，不能繼續降低解析度。",
   "editor_compressionFocusLimited": "當前 Focused Inpaint 選區在更高解析度下會超過請求面積上限，因此滑條上限已收緊。",
+  "editor_compressionClampedToLimit": "所選 {targetWidth}×{targetHeight} 超過請求面積上限，實際會以 {clampedWidth}×{clampedHeight} 傳送。",
+  "@editor_compressionClampedToLimit": {
+    "placeholders": {
+      "targetWidth": {"type": "int"},
+      "targetHeight": {"type": "int"},
+      "clampedWidth": {"type": "int"},
+      "clampedHeight": {"type": "int"}
+    }
+  },
   "editor_focusRequestSummary": "外層裁剪 {outerWidth}×{outerHeight}，實際傳送 {requestWidth}×{requestHeight}，預計 {cost} Anlas。",
   "@editor_focusRequestSummary": {
     "placeholders": {

--- a/lib/presentation/providers/generation/image_workflow_controller.dart
+++ b/lib/presentation/providers/generation/image_workflow_controller.dart
@@ -446,6 +446,9 @@ class ImageWorkflowState {
     bool clearBaseSnapshot = false,
     bool clearEnhanceEntryParams = false,
     bool clearFocusedSelectionRect = false,
+    // 聚焦重绘归属于当前这张源图：换图或退出重绘时开关和选区必须一起归零，
+    // 只清选区会让下一次进重绘仍带着上一张图的聚焦状态。
+    bool resetFocusedInpaint = false,
   }) {
     return ImageWorkflowState(
       mode: mode ?? this.mode,
@@ -471,11 +474,12 @@ class ImageWorkflowState {
       upscale: upscale ?? this.upscale,
       isPanelExpanded: isPanelExpanded ?? this.isPanelExpanded,
       isOutpaint: isOutpaint ?? this.isOutpaint,
-      focusedInpaintEnabled:
-          focusedInpaintEnabled ?? this.focusedInpaintEnabled,
+      focusedInpaintEnabled: resetFocusedInpaint
+          ? false
+          : (focusedInpaintEnabled ?? this.focusedInpaintEnabled),
       minimumContextMegaPixels:
           minimumContextMegaPixels ?? this.minimumContextMegaPixels,
-      focusedSelectionRect: clearFocusedSelectionRect
+      focusedSelectionRect: clearFocusedSelectionRect || resetFocusedInpaint
           ? null
           : (focusedSelectionRect ?? this.focusedSelectionRect),
     );
@@ -1055,7 +1059,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       sourceImageWidth: sourceImageSize?.$1,
       sourceImageHeight: sourceImageSize?.$2,
       isOutpaint: false,
-      clearFocusedSelectionRect: true,
+      resetFocusedInpaint: true,
     );
 
     switch (state.mode) {
@@ -1075,7 +1079,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
           mode: ImageWorkflowMode.base,
           isOutpaint: false,
           clearBaseSnapshot: true,
-          clearFocusedSelectionRect: true,
+          resetFocusedInpaint: true,
         );
         _paramsNotifier.updateAction(ImageGenerationAction.img2img);
         break;
@@ -1361,6 +1365,11 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       }
     }
 
+    // 编辑器已经明确给出输出尺寸，只在超出请求上限时收敛到最接近的合法尺寸。
+    final exactRequestSize = hasReplacementSource && importInfo == null
+        ? _clampToRequestLimits(sourceWidth!, sourceHeight!)
+        : null;
+
     _ensureBaseSizeSnapshot();
 
     final actualSourceWidth = hasReplacementSource
@@ -1391,10 +1400,10 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
     state = state.copyWith(
       mode: ImageWorkflowMode.inpaint,
       sourceWidth: hasReplacementSource
-          ? (importInfo?.width ?? sourceWidth)
+          ? (importInfo?.width ?? exactRequestSize?.width ?? sourceWidth)
           : null,
       sourceHeight: hasReplacementSource
-          ? (importInfo?.height ?? sourceHeight)
+          ? (importInfo?.height ?? exactRequestSize?.height ?? sourceHeight)
           : null,
       sourceImageWidth: hasReplacementSource ? actualSourceWidth : null,
       sourceImageHeight: hasReplacementSource ? actualSourceHeight : null,
@@ -1484,7 +1493,7 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
       mode: ImageWorkflowMode.base,
       isOutpaint: false,
       clearBaseSnapshot: shouldRestoreBaseSnapshot,
-      clearFocusedSelectionRect: clearMask,
+      resetFocusedInpaint: clearMask,
     );
     _applySourceSizeToParams();
     _paramsNotifier.updateIsOutpaint(false);
@@ -1697,6 +1706,19 @@ class ImageWorkflowController extends Notifier<ImageWorkflowState> {
     return baseModel == ImageModels.animeCurated ||
         baseModel == ImageModels.animeFull ||
         baseModel == ImageModels.furry;
+  }
+
+  ({int width, int height}) _clampToRequestLimits(int width, int height) {
+    if (NaiResolutionAdapter.isGenerationCompatible(width, height)) {
+      return (width: width, height: height);
+    }
+    final closest = NaiResolutionAdapter.findClosestResolution(width, height);
+    AppLogger.i(
+      'Editor source clamped to request limits: '
+      '${width}x$height -> ${closest.width}x${closest.height}',
+      'ImageWorkflow',
+    );
+    return (width: closest.width, height: closest.height);
   }
 
   (int, int)? _resolveImageSize(

--- a/lib/presentation/widgets/image_editor/image_editor_workspace.dart
+++ b/lib/presentation/widgets/image_editor/image_editor_workspace.dart
@@ -1959,6 +1959,22 @@ class ImageEditorWorkspaceState extends State<ImageEditorWorkspace> {
         target.height != _state.canvasSize.height.round();
   }
 
+  /// 超出请求面积上限的档位会在交接给生成页时收敛，UI 要显示实际会发送的尺寸。
+  ({int width, int height})? get _clampedRequestSize {
+    final target = _activeCompressionTarget;
+    if (NaiResolutionAdapter.isGenerationCompatible(
+      target.width,
+      target.height,
+    )) {
+      return null;
+    }
+    final closest = NaiResolutionAdapter.findClosestResolution(
+      target.width,
+      target.height,
+    );
+    return (width: closest.width, height: closest.height);
+  }
+
   bool get _compressionIsFocusLimited {
     final plan = _compressionPlan;
     return _isInpaintMode &&
@@ -2157,9 +2173,17 @@ class ImageEditorWorkspaceState extends State<ImageEditorWorkspace> {
     }
 
     final target = _activeCompressionTarget;
+    final clamped = _clampedRequestSize;
     final index = plan.indexOf(target).clamp(0, plan.targets.length - 1);
     return Tooltip(
-      message: context.l10n.editor_compressionTooltip,
+      message: clamped == null
+          ? context.l10n.editor_compressionTooltip
+          : context.l10n.editor_compressionClampedToLimit(
+              target.width,
+              target.height,
+              clamped.width,
+              clamped.height,
+            ),
       child: SizedBox(
         width: 300,
         child: Row(
@@ -2170,7 +2194,8 @@ class ImageEditorWorkspaceState extends State<ImageEditorWorkspace> {
             SizedBox(
               width: 92,
               child: Text(
-                '${target.width} x ${target.height}',
+                '${clamped?.width ?? target.width} x '
+                '${clamped?.height ?? target.height}',
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.labelMedium,
               ),
@@ -2216,6 +2241,7 @@ class ImageEditorWorkspaceState extends State<ImageEditorWorkspace> {
           final plan = _compressionPlan;
           if (plan == null) return const SizedBox.shrink();
           final target = _activeCompressionTarget;
+          final clamped = _clampedRequestSize;
           final index = plan.indexOf(target).clamp(0, plan.targets.length - 1);
           final theme = Theme.of(panelContext);
           return ListView(
@@ -2227,16 +2253,24 @@ class ImageEditorWorkspaceState extends State<ImageEditorWorkspace> {
                 context.l10n.editor_compressionSizeSummary(
                   plan.workWidth,
                   plan.workHeight,
-                  target.width,
-                  target.height,
+                  clamped?.width ?? target.width,
+                  clamped?.height ?? target.height,
                 ),
                 style: theme.textTheme.bodyMedium,
               ),
               const SizedBox(height: 4),
               Text(
-                target.isOriginal
-                    ? context.l10n.editor_compressionUncompressed
-                    : context.l10n.editor_compressionApplyOnDone,
+                switch ((clamped, target.isOriginal)) {
+                  ((final size?, _)) => context.l10n
+                      .editor_compressionClampedToLimit(
+                        target.width,
+                        target.height,
+                        size.width,
+                        size.height,
+                      ),
+                  ((_, true)) => context.l10n.editor_compressionUncompressed,
+                  ((_, false)) => context.l10n.editor_compressionApplyOnDone,
+                },
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),

--- a/test/core/utils/nai_resolution_adapter_test.dart
+++ b/test/core/utils/nai_resolution_adapter_test.dart
@@ -314,6 +314,98 @@ void main() {
       expect(working.resizeMode, NaiEditorResizeMode.passthrough);
     });
   });
+
+  group('NaiResolutionAdapter default import sizing', () {
+    test('keeps in-budget sources at their own 64-grid size', () {
+      final cases = [
+        (source: (1472, 1984), expected: (1472, 1984)),
+        (source: (1536, 2048), expected: (1536, 2048)),
+        (source: (1920, 1080), expected: (1920, 1088)),
+      ];
+
+      for (final testCase in cases) {
+        final result = NaiResolutionAdapter.findImportResolution(
+          testCase.source.$1,
+          testCase.source.$2,
+          currentWidth: 832,
+          currentHeight: 1216,
+        );
+
+        expect(
+          (result.width, result.height),
+          equals(testCase.expected),
+          reason: '${testCase.source.$1}x${testCase.source.$2}',
+        );
+      }
+    });
+
+    test('scales oversized sources down to the largest legal size', () {
+      final cases = [
+        (source: (2048, 2048), expected: (1728, 1728)),
+        (source: (2000, 3000), expected: (1408, 2112)),
+        (source: (1728, 2560), expected: (1408, 2112)),
+      ];
+
+      for (final testCase in cases) {
+        final result = NaiResolutionAdapter.findImportResolution(
+          testCase.source.$1,
+          testCase.source.$2,
+          currentWidth: 832,
+          currentHeight: 1216,
+        );
+
+        expect(
+          (result.width, result.height),
+          equals(testCase.expected),
+          reason: '${testCase.source.$1}x${testCase.source.$2}',
+        );
+        expect(
+          NaiResolutionAdapter.isGenerationCompatible(
+            result.width,
+            result.height,
+          ),
+          isTrue,
+        );
+        // 收敛后仍应贴着面积上限，而不是掉回官网的 1216/896 基准边。
+        expect(result.width * result.height, greaterThan(2900000));
+      }
+    });
+
+    test('keeps the official buckets for Stable Diffusion family models', () {
+      final result = NaiResolutionAdapter.findImportResolution(
+        4096,
+        4096,
+        currentWidth: 512,
+        currentHeight: 768,
+        isStableDiffusionFamily: true,
+      );
+
+      expect((result.width, result.height), equals((512, 512)));
+    });
+
+    test('keeps the current parameter size for a smaller same-aspect source', () {
+      final result = NaiResolutionAdapter.findImportResolution(
+        512,
+        768,
+        currentWidth: 1024,
+        currentHeight: 1536,
+      );
+
+      expect((result.width, result.height), equals((1024, 1536)));
+    });
+
+    test('describeImageForImport follows the default sizing', () {
+      final info = NaiResolutionAdapter.describeImageForImport(
+        _png(width: 2048, height: 2048),
+        currentWidth: 832,
+        currentHeight: 1216,
+      );
+
+      expect(info, isNotNull);
+      expect((info!.width, info.height), equals((1728, 1728)));
+      expect((info.originalWidth, info.originalHeight), equals((2048, 2048)));
+    });
+  });
 }
 
 Uint8List _png({required int width, required int height}) {

--- a/test/data/services/random_prompt_generator_preset_test.dart
+++ b/test/data/services/random_prompt_generator_preset_test.dart
@@ -9,7 +9,6 @@ import 'package:nai_launcher/data/models/prompt/dependency_config.dart';
 import 'package:nai_launcher/data/models/prompt/post_process_rule.dart';
 import 'package:nai_launcher/data/models/prompt/random_category.dart';
 import 'package:nai_launcher/data/models/prompt/random_preset.dart';
-import 'package:nai_launcher/data/models/prompt/random_prompt_result.dart';
 import 'package:nai_launcher/data/models/prompt/random_tag_group.dart';
 import 'package:nai_launcher/data/models/prompt/tag_category.dart';
 import 'package:nai_launcher/data/models/prompt/tag_library.dart';

--- a/test/presentation/providers/generation/image_workflow_controller_test.dart
+++ b/test/presentation/providers/generation/image_workflow_controller_test.dart
@@ -666,8 +666,8 @@ void main() {
           const Rect.fromLTWH(120, 160, 360, 420),
         );
         expect(workflow.minimumContextMegaPixels, equals(120.0));
-        expect(params.width, equals(896));
-        expect(params.height, equals(1344));
+        expect(params.width, equals(1408));
+        expect(params.height, equals(2112));
         expect(params.maskImage, isNotNull);
         expect(params.isOutpaint, isFalse);
         expect(params.action, ImageGenerationAction.infill);
@@ -1375,6 +1375,81 @@ void main() {
         expect(workflow.enhance.noise, equals(0.12));
       },
     );
+
+    test('focused inpaint should not carry over to the next source image', () {
+      final controller = container.read(
+        imageWorkflowControllerProvider.notifier,
+      );
+
+      controller.replaceSourceImage(_validImageBytes(width: 768, height: 1024));
+      controller.applyInpaintEditorResult(
+        maskImage: Uint8List.fromList([9, 9, 9]),
+        focusedInpaintEnabled: true,
+        focusedSelectionRect: const Rect.fromLTWH(120, 160, 240, 320),
+        minimumContextMegaPixels: 96,
+      );
+
+      var workflow = container.read(imageWorkflowControllerProvider);
+      expect(workflow.focusedInpaintEnabled, isTrue);
+      expect(workflow.focusedSelectionRect, isNotNull);
+
+      controller.replaceSourceImage(_validImageBytes(width: 1024, height: 768));
+
+      workflow = container.read(imageWorkflowControllerProvider);
+      expect(workflow.focusedInpaintEnabled, isFalse);
+      expect(workflow.focusedSelectionRect, isNull);
+    });
+
+    test('focused inpaint should reset when leaving inpaint for base mode', () {
+      final controller = container.read(
+        imageWorkflowControllerProvider.notifier,
+      );
+
+      controller.replaceSourceImage(_validImageBytes(width: 768, height: 1024));
+      controller.applyInpaintEditorResult(
+        maskImage: Uint8List.fromList([9, 9, 9]),
+        focusedInpaintEnabled: true,
+        focusedSelectionRect: const Rect.fromLTWH(120, 160, 240, 320),
+        minimumContextMegaPixels: 96,
+      );
+      controller.enterBaseMode(clearMask: true);
+
+      final workflow = container.read(imageWorkflowControllerProvider);
+      expect(workflow.focusedInpaintEnabled, isFalse);
+      expect(workflow.focusedSelectionRect, isNull);
+    });
+
+    test('applyInpaintEditorResult preserves a legal editor output size', () {
+      final controller = container.read(
+        imageWorkflowControllerProvider.notifier,
+      );
+      final source = _validImageBytes(width: 1344, height: 640);
+      final mask = _validMaskBytes(width: 1344, height: 640);
+
+      controller.applyInpaintEditorResult(
+        sourceImage: source,
+        sourceWidth: 1344,
+        sourceHeight: 640,
+        sourceIsOutpaint: false,
+        maskImage: mask,
+        focusedInpaintEnabled: true,
+        focusedSelectionRect: const Rect.fromLTWH(128, 64, 640, 320),
+        minimumContextMegaPixels: 88,
+      );
+
+      final workflow = container.read(imageWorkflowControllerProvider);
+      final params = container.read(generationParamsNotifierProvider);
+      expect((workflow.sourceWidth, workflow.sourceHeight), (1344, 640));
+      expect(
+        (workflow.sourceImageWidth, workflow.sourceImageHeight),
+        (1344, 640),
+      );
+      expect((params.width, params.height), (1344, 640));
+      expect(params.sourceImage, same(source));
+      expect(params.maskImage, same(mask));
+      expect(workflow.focusedInpaintEnabled, isTrue);
+    });
+
   });
 
   group('resolveSeedvr2SwapIoComponents', () {


### PR DESCRIPTION
## 用户可见变化

### 1. 导入图片保留原图尺寸

此前导入任意图片都会掉回官网基准边 1216/896，高分辨率源图被无谓降采样。现在非 SD 族模型保留原图的 64 对齐尺寸，只在超过官网面积上限时收敛到最接近的合法尺寸；SD 族旧模型没有高分辨率档位，仍走官网基准边。

`NaiResolutionAdapter` 新增 `findImportResolution` 做模型族分派，并把原先内联的「沿用当前请求尺寸」逻辑提取为 `_reuseCurrentRequestSize`，两条路径共用同一份判定。

### 2. 编辑器输出尺寸收敛到请求上限

编辑器明确给出输出尺寸的路径（`useExactSourceDimensions`）此前直接把尺寸交给生成请求，没有上限检查。现在同样收敛到请求上限，并且收敛结果会在分辨率滑条 Tooltip 和输出压缩面板显示为实际会发送的尺寸，避免用户以为发出去的是编辑器里那个更大的尺寸。

### 3. 聚焦重绘不再跨图残留

`copyWith` 的 `clearFocusedSelectionRect` 只清选区、不清 `focusedInpaintEnabled` 开关，而换源图、退出重绘回到基础模式的三处调用都只传了它。结果是换下一张图再进重绘，仍然带着上一张图的聚焦状态。新增 `resetFocusedInpaint`，让开关与选区一起归零。

### 4. 清理死导入

随机词库模式切换移除后 `random_prompt_result.dart` 已无引用，残留导入会让 `flutter analyze` 报 `unused_import`。

## 测试

新增 8 个回归测试：`NaiResolutionAdapter default import sizing` 5 个覆盖保留原图、超限收敛与 SD 族分派；`ImageWorkflowController` 3 个覆盖聚焦重绘跨图归零、退出重绘归零、编辑器合法输出尺寸保留。同步更新 1 条因保留原图尺寸而改变期望的既有断言（`(896, 1344)` -> `(1408, 2112)`）。

## 验证

- `flutter analyze lib/ test/` — No issues found!
- `flutter test`（受影响文件）— 96/96 通过
  - `test/core/utils/nai_resolution_adapter_test.dart`
  - `test/presentation/providers/generation/image_workflow_controller_test.dart`
  - `test/presentation/widgets/image_editor/image_editor_workspace_responsive_test.dart`
  - `test/presentation/widgets/image_editor/focused_selection_state_test.dart`
  - `test/data/services/random_prompt_generator_preset_test.dart`
- `flutter build windows --release` — 构建成功，已启动产物确认改动可见

已知与本 PR 无关的失败：`test/l10n/i18n_regression_test.dart` 的 ARB parity 在 main 上已经是红的。它列出的 23 个未引用键全部来自 main 自身的 `app_en.arb`，本 PR 新增的键不在其中，且已在 `image_editor_workspace.dart` 中引用。

## 生成文件与资源

- 新增 l10n 键 `editor_compressionClampedToLimit`，en/zh/ja/zh_Hant 四语齐全，四份 ARB 键数一致
- `lib/l10n/app_localizations*.dart` 为 `flutter gen-l10n` 产物，重跑生成器零 diff
- 无 assets 变更、无 LFS 对象变更、无依赖变更
