### PR TITLE
fix(theme): 卡片改用主题声明的形状并收敛超大圆角

### DIFF
--- a/lib/presentation/themes/core/theme_composer.dart
+++ b/lib/presentation/themes/core/theme_composer.dart
@@ -96,10 +96,7 @@ class ThemeComposer {
 
       // 普通卡片依靠语义色面区分层级，不叠加常驻描边和阴影。
       cardTheme: CardThemeData(
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(shape.largeRadius),
-          side: BorderSide.none,
-        ),
+        shape: _borderless(shape.cardShape),
         elevation: 0,
         color: colorScheme.surfaceContainerLow,
         surfaceTintColor: Colors.transparent,
@@ -110,7 +107,7 @@ class ThemeComposer {
       // 深度层叠风格：按钮配置
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          shape: shape.buttonShape as OutlinedBorder?,
+          shape: _outlined(shape.buttonShape, shape.smallRadius),
           elevation: 0,
           shadowColor: Colors.transparent,
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
@@ -119,7 +116,7 @@ class ThemeComposer {
 
       filledButtonTheme: FilledButtonThemeData(
         style: FilledButton.styleFrom(
-          shape: shape.buttonShape as OutlinedBorder?,
+          shape: _outlined(shape.buttonShape, shape.smallRadius),
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
         ),
       ),
@@ -128,7 +125,7 @@ class ThemeComposer {
       // 避免页面上出现成排的白色空心框。
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          shape: shape.buttonShape as OutlinedBorder?,
+          shape: _outlined(shape.buttonShape, shape.smallRadius),
           side: BorderSide.none,
           foregroundColor: colorScheme.onSurfaceVariant,
           backgroundColor: colorScheme.surfaceContainerHighest,
@@ -141,7 +138,7 @@ class ThemeComposer {
 
       textButtonTheme: TextButtonThemeData(
         style: TextButton.styleFrom(
-          shape: shape.buttonShape as OutlinedBorder?,
+          shape: _outlined(shape.buttonShape, shape.smallRadius),
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
         ),
       ),
@@ -193,9 +190,7 @@ class ThemeComposer {
       dropdownMenuTheme: DropdownMenuThemeData(
         menuStyle: MenuStyle(
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(shape.menuRadius),
-            ),
+            _outlined(shape.menuShape, shape.menuRadius),
           ),
           backgroundColor: WidgetStatePropertyAll(
             colorScheme.surfaceContainerHigh,
@@ -209,9 +204,7 @@ class ThemeComposer {
       ),
 
       popupMenuTheme: PopupMenuThemeData(
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(shape.menuRadius),
-        ),
+        shape: shape.menuShape,
         color: colorScheme.surfaceContainerHigh,
         elevation: 8,
         shadowColor: Colors.black.withValues(alpha: 0.15),
@@ -221,9 +214,7 @@ class ThemeComposer {
       menuTheme: MenuThemeData(
         style: MenuStyle(
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(shape.menuRadius),
-            ),
+            _outlined(shape.menuShape, shape.menuRadius),
           ),
           backgroundColor: WidgetStatePropertyAll(
             colorScheme.surfaceContainerHigh,
@@ -350,9 +341,15 @@ class ThemeComposer {
       dividerThickness: 1,
       useDivider: true,
       controlRadius: shape.smallRadius,
-      cardRadius: shape.largeRadius,
+      cardRadius: _extractBorderRadius(
+        shape.cardShape,
+        fallbackRadius: shape.largeRadius,
+      ).topLeft.x,
       dialogRadius: shape.mediumRadius,
-      menuRadius: shape.menuRadius,
+      menuRadius: _extractBorderRadius(
+        shape.menuShape,
+        fallbackRadius: shape.menuRadius,
+      ).topLeft.x,
       fastDuration: motion.fastDuration,
       normalDuration: motion.normalDuration,
       slowDuration: motion.slowDuration,
@@ -368,12 +365,30 @@ class ThemeComposer {
   }
 
   /// Extracts BorderRadius from a ShapeBorder.
-  BorderRadius _extractBorderRadius(ShapeBorder shapeBorder) {
+  BorderRadius _extractBorderRadius(
+    ShapeBorder shapeBorder, {
+    double? fallbackRadius,
+  }) {
     if (shapeBorder is RoundedRectangleBorder) {
-      return shapeBorder.borderRadius as BorderRadius;
+      return shapeBorder.borderRadius.resolve(TextDirection.ltr);
     }
-    // Default fallback
-    return BorderRadius.circular(shape.smallRadius);
+    return BorderRadius.circular(fallbackRadius ?? shape.smallRadius);
+  }
+
+  /// 保留 preset 声明的卡片几何，只去掉常驻描边。
+  ShapeBorder _borderless(ShapeBorder shapeBorder) {
+    if (shapeBorder is OutlinedBorder) {
+      return shapeBorder.copyWith(side: BorderSide.none);
+    }
+    return shapeBorder;
+  }
+
+  /// 按钮和菜单槽位只接受 [OutlinedBorder]，其余形状退回同尺度圆角矩形。
+  OutlinedBorder _outlined(ShapeBorder shapeBorder, double fallbackRadius) {
+    if (shapeBorder is OutlinedBorder) return shapeBorder;
+    return RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(fallbackRadius),
+    );
   }
 }
 

--- a/lib/presentation/themes/core/theme_modules.dart
+++ b/lib/presentation/themes/core/theme_modules.dart
@@ -115,13 +115,13 @@ abstract class ShapeModule {
   /// Medium border radius (typically 8-12px).
   double get mediumRadius;
 
-  /// Large border radius (typically 16-24px).
+  /// Large border radius; card-scale surfaces build on it.
   double get largeRadius;
 
   /// Menu/popup border radius (typically 4px, always small for clean look).
   double get menuRadius;
 
-  /// Shape for card components.
+  /// Shape for card components. Cards clip to it; content must clear the corner.
   ShapeBorder get cardShape;
 
   /// Shape for button components.

--- a/lib/presentation/themes/modules/shape/presets/fluid_shapes.dart
+++ b/lib/presentation/themes/modules/shape/presets/fluid_shapes.dart
@@ -1,4 +1,4 @@
-/// Fluid Shapes - Extreme rounded corners (100px+)
+/// Fluid Shapes - Oversized rounded corners
 library;
 
 import 'package:flutter/material.dart';
@@ -13,8 +13,9 @@ class FluidShapes extends BaseShapeModule {
   @override
   double get mediumRadius => 32.0;
 
+  // Cards clip to this: past ~3.4x the title padding the first glyph is cut.
   @override
-  double get largeRadius => 100.0;
+  double get largeRadius => 40.0;
 
   @override
   double get menuRadius => 0.0;

--- a/lib/presentation/themes/modules/shape/presets/pill_shapes.dart
+++ b/lib/presentation/themes/modules/shape/presets/pill_shapes.dart
@@ -11,17 +11,17 @@ class PillShapes extends BaseShapeModule {
   double get smallRadius => 20.0;
 
   @override
-  double get mediumRadius => 28.0;
+  double get mediumRadius => 24.0;
 
   @override
-  double get largeRadius => 100.0; // Fully rounded
+  double get largeRadius => 28.0;
 
   @override
   double get menuRadius => 0.0;
 
   @override
   ShapeBorder get cardShape => RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(mediumRadius),
+        borderRadius: BorderRadius.circular(largeRadius),
       );
 
   @override

--- a/lib/presentation/themes/modules/shape/presets/sharp_shapes.dart
+++ b/lib/presentation/themes/modules/shape/presets/sharp_shapes.dart
@@ -21,7 +21,7 @@ class SharpShapes extends BaseShapeModule {
 
   @override
   ShapeBorder get cardShape => RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(mediumRadius),
+        borderRadius: BorderRadius.circular(largeRadius),
       );
 
   @override

--- a/test/presentation/themes/core/card_shape_content_safety_test.dart
+++ b/test/presentation/themes/core/card_shape_content_safety_test.dart
@@ -1,0 +1,120 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:nai_launcher/presentation/screens/settings/widgets/settings_card.dart';
+import 'package:nai_launcher/presentation/themes/app_theme.dart';
+import 'package:nai_launcher/presentation/themes/design_tokens.dart';
+import 'package:nai_launcher/presentation/themes/theme_extension.dart';
+
+/// 卡片圆角的内容安全守卫。
+///
+/// 卡片用 `Clip.antiAlias` 真实裁剪子树，圆角越大左上角吃掉的横向空间越多。
+/// 半径 r 在距顶边 p 处向内吃掉 `r - sqrt(r² - (r-p)²)`，要求它不超过 p，
+/// 解得 `r <= (2 + sqrt2) * p`。曾有三套主题把胶囊用的 100px 当卡片圆角，
+/// 设置页标题首字被斜切掉。
+void main() {
+  // 构建主题会触发 GoogleFonts 加载，离线环境下的异步异常会误判成测试失败。
+  TestWidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
+
+  const contentPadding = DesignTokens.spacingMd;
+  const maxSafeRadius = (2 + math.sqrt2) * contentPadding;
+
+  group('卡片圆角不裁内容', () {
+    testWidgets('所有主题的卡片圆角都在安全上限内', (tester) async {
+      for (final style in AppStyle.values) {
+        for (final brightness in Brightness.values) {
+          final corners = _cardCorners(AppTheme.getTheme(style, brightness));
+
+          for (final corner in [
+            corners.topLeft,
+            corners.topRight,
+            corners.bottomLeft,
+            corners.bottomRight,
+          ]) {
+            expect(
+              corner.x,
+              lessThanOrEqualTo(maxSafeRadius),
+              reason:
+                  '${style.name}/${brightness.name} 卡片圆角 ${corner.x} 超过 '
+                  '${maxSafeRadius.toStringAsFixed(1)}，'
+                  '${contentPadding}px 内边距处的内容会被裁掉',
+            );
+          }
+        }
+      }
+    });
+
+    testWidgets('ElevatedCard 取到的圆角与 Card 实渲形状一致', (tester) async {
+      for (final style in AppStyle.values) {
+        for (final brightness in Brightness.values) {
+          final theme = AppTheme.getTheme(style, brightness);
+
+          expect(
+            theme.extension<AppThemeExtension>()!.cardRadius,
+            _cardCorners(theme).topLeft.x,
+            reason: '${style.name}/${brightness.name}',
+          );
+        }
+      }
+    });
+
+    testWidgets('设置卡标题在最圆的主题下完整可见', (tester) async {
+      tester.view.physicalSize = const Size(1400, 900);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      // 三套曾经把标题裁掉的主题。
+      for (final style in [
+        AppStyle.fluidSaturated,
+        AppStyle.materialYou,
+        AppStyle.appleLight,
+      ]) {
+        final theme = AppTheme.getTheme(style, Brightness.dark);
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: theme,
+            home: const Scaffold(
+              body: Padding(
+                padding: EdgeInsets.all(24),
+                child: SettingsCard(
+                  title: '界面呈现',
+                  child: SizedBox(height: 240),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final card = tester.getRect(find.byType(Card));
+        final title = tester.getRect(find.text('界面呈现'));
+        final radius = _cardCorners(theme).topLeft.x;
+        final dx = title.left - card.left;
+        final dy = title.top - card.top;
+
+        expect(
+          dx,
+          greaterThanOrEqualTo(_cornerInset(radius, dy)),
+          reason:
+              '${style.name} 圆角 $radius 在 y=$dy 处吃掉 '
+              '${_cornerInset(radius, dy).toStringAsFixed(1)}px，'
+              '标题左边距只有 ${dx}px',
+        );
+      }
+    });
+  });
+}
+
+BorderRadius _cardCorners(ThemeData theme) =>
+    (theme.cardTheme.shape! as RoundedRectangleBorder).borderRadius.resolve(
+      TextDirection.ltr,
+    );
+
+/// 半径 [radius] 的圆角在距顶边 [dy] 处向内吃掉的横向距离。
+double _cornerInset(double radius, double dy) {
+  if (dy >= radius) return 0;
+  final chord = radius - dy;
+  return radius - math.sqrt(math.max(0, radius * radius - chord * chord));
+}


### PR DESCRIPTION
## 用户可见变化

切换到 **Fluid Saturated / Material You / Apple Light** 后，设置页分组标题（「界面呈现」「生成页交互」等）首字被卡片圆角斜切，卡片本身也被撑成一坨大圆角色块。这三套主题的卡片圆角收敛后标题恢复完整，卡片回到正常比例。

**手绘主题（Hand Drawn）**顺带修好：`WobblyShapes` 声明的四角不等卡片/菜单形状此前从未被消费，一直渲染成对称圆角，现在生效。

`Apple Light` / `Material You` 的 dialog 与 bottom sheet 圆角 28 → 24，对齐 DESIGN.md 里记录的数值。其余 12 套主题渲染不变。

## 根因

两层，不是一层：

1. `ThemeComposer` 从不消费 preset 声明的 `cardShape` / `menuShape`，而是用 `largeRadius` 自己重新拼形状。于是同一个 preset 里两处声明可以互相矛盾——`PillShapes.cardShape` 写的是 28px，实际渲染却是 `largeRadius` 的 100px。
2. `FluidShapes` 确实把 100px 当卡片圆角。`Card` 带 `Clip.antiAlias`，圆角是真实裁剪：半径 100 在距顶边 16px 处向内吃掉 45.7px，而设置卡标题只有 16px 左边距。

半径 r 在距顶边 p 处的内缩是 `r - sqrt(r² - (r-p)²)`，要求不超过 p，解得 **`r ≤ (2+√2)·p`**；p 取 `spacingMd`(16) 时上限 54.6px。

## 影响面

| 主题 | 卡片圆角 |
|---|---|
| `fluidSaturated` | 100 → 40 |
| `materialYou` / `appleLight` | 100 → 28 |
| `handDrawn` | 对称 16 → 非对称 16/10/15/11（声明值终于生效） |
| 其余 12 套 | 不变 |

消费端扫描：全应用只有 `SettingsCard` 真的用主题圆角裁内容（另一处 `Clip.antiAlias` 的 `Card` 自己硬编码 12px）；所有 `ElevatedCard` 调用点都显式传了 `borderRadius`，无一继承主题值。无持久化结构变化。

## 已运行的验证

- `flutter test test/presentation/themes/` — 全绿，含新增守卫测试
- `flutter test test/tool/theme_color_contrast_test.dart` — 18 passed / 1 failed，该失败是 WCAG 对比度，**干净树上同样红**，与本 PR 无关
- `flutter test test/presentation/screens/settings/ test/presentation/widgets/common/` — 改动前后基线完全一致（362 passed / 7 failed，失败清单逐条相同）
- `flutter analyze` — 全项目零问题
- `flutter build windows --release` — 构建成功并启动产物确认改动可见

守卫测试做过反向验证：把 `FluidShapes.largeRadius` 改回 100 立刻失败，报错为「圆角 100.0 超过 54.6，16.0px 内边距处的内容会被裁掉」。

## 备注

`theme_color_contrast_test.dart` 的 WCAG 失败项里包含 `fluidSaturated/light` 与 `appleLight/dark` 的 `surfaceContainerHighest/onSurfaceVariant`（3.95 / 3.76，未达 4.5）。同一批主题的配色对比度也偏弱，属于既有问题，本 PR 未处理。
