### PR TITLE
fix(tag-library): 分类操作菜单展开后仍能派发选中项

### DIFF
--- a/lib/presentation/screens/tag_library_page/widgets/category_tree_view.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/category_tree_view.dart
@@ -489,6 +489,7 @@ class _CategoryItem extends StatefulWidget {
 class _CategoryItemState extends State<_CategoryItem> {
   bool _isHovering = false;
   bool _isEditing = false;
+  bool _isActionMenuOpen = false;
   late TextEditingController _editController;
 
   @override
@@ -509,9 +510,12 @@ class _CategoryItemState extends State<_CategoryItem> {
     // Deep imported hierarchies must retain room for the label and action menu
     // instead of pushing the row beyond a compact bottom sheet.
     final indent = (12.0 + widget.depth * 16.0).clamp(12.0, 44.0).toDouble();
+    // 菜单打开后指针被遮罩挡在行外，必须保住按钮挂载，否则选中值随按钮一起消失。
     final showActions =
         widget.onRename != null &&
-        (!context.interactionPolicy.precisePointerAvailable || _isHovering);
+        (!context.interactionPolicy.precisePointerAvailable ||
+            _isHovering ||
+            _isActionMenuOpen);
 
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovering = true),
@@ -629,10 +633,18 @@ class _CategoryItemState extends State<_CategoryItem> {
                     ),
                     if (showActions)
                       PopupMenuButton<_CategoryAction>(
+                        key: const ValueKey('category-item-actions-menu'),
                         tooltip: MaterialLocalizations.of(
                           context,
                         ).moreButtonTooltip,
-                        onSelected: _handleAction,
+                        onOpened: () =>
+                            setState(() => _isActionMenuOpen = true),
+                        onCanceled: () =>
+                            setState(() => _isActionMenuOpen = false),
+                        onSelected: (action) {
+                          setState(() => _isActionMenuOpen = false);
+                          _handleAction(action);
+                        },
                         itemBuilder: _buildActionItems,
                         icon: const Icon(Icons.more_vert, size: 20),
                       ),

--- a/test/presentation/screens/tag_library_page/widgets/category_tree_view_test.dart
+++ b/test/presentation/screens/tag_library_page/widgets/category_tree_view_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/tag_library/tag_library_category.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
 import 'package:nai_launcher/presentation/screens/tag_library_page/widgets/category_tree_view.dart';
 import 'package:nai_launcher/presentation/widgets/common/themed_divider.dart';
 import 'package:nai_launcher/presentation/widgets/gallery/gallery_sidebar.dart';
@@ -165,6 +166,77 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(createdInCategory, 'target-category');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('悬停出现的操作菜单在指针移出行后仍能派发选中项', (tester) async {
+    String? addedUnderCategory;
+    final categories = [
+      TagLibraryCategory(
+        id: 'target-category',
+        name: '目标分类',
+        createdAt: DateTime(2026),
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: InteractionPolicyScope(
+            initialPolicy: const InteractionPolicy(
+              modality: InteractionModality.pointer,
+              touchAvailable: false,
+              precisePointerAvailable: true,
+            ),
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: 320,
+                height: 320,
+                child: CategoryTreeView(
+                  categories: categories,
+                  entries: const [],
+                  selectedCategoryId: null,
+                  expandedCategoryIds: const <String>{},
+                  onExpandedCategoryIdsChanged: (_) {},
+                  onCategorySelected: (_) {},
+                  onCategoryRename: (_, _) {},
+                  onCategoryDelete: (_) {},
+                  onAddSubCategory: (id) => addedUnderCategory = id,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 必须用真实鼠标：合成 tap 不更新指针命中，测不出菜单打开后按钮被卸载的回归。
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer(location: Offset.zero);
+    addTearDown(mouse.removePointer);
+    await mouse.moveTo(tester.getCenter(find.text('目标分类')));
+    await tester.pumpAndSettle();
+
+    final menu = find.byKey(const ValueKey('category-item-actions-menu'));
+    expect(menu, findsOneWidget);
+
+    Future<void> clickAt(Offset target) async {
+      await mouse.moveTo(target);
+      await tester.pumpAndSettle();
+      await mouse.down(target);
+      await tester.pump();
+      await mouse.up();
+      await tester.pumpAndSettle();
+    }
+
+    await clickAt(tester.getCenter(menu));
+    await clickAt(tester.getCenter(find.byIcon(Icons.create_new_folder)));
+
+    expect(addedUnderCategory, 'target-category');
     expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
## 用户可见变化

词库页分类树行尾的 `⋮` 菜单，展开后点「重命名 / 添加条目 / 添加子分类 / 移到根 / 删除」全部无反应。修复后正常派发。

## 根因

`showActions` 把按钮的**存在**挂在 `_isHovering` 上。菜单一展开，modal barrier 盖住该行 → `MouseRegion.onExit` 触发 → 按钮随之卸载；`PopupMenuButtonState` 的 `showMenu(...).then((v) { if (!mounted) return; ... })` 于是静默丢弃 Navigator 回传的选中值。表现就是「菜单能开、能关、什么也没发生」。

只影响桌面（`precisePointerAvailable`）路径；右键菜单走 `_showContextMenu`，`mounted` 判定的是行 State 而非按钮，本就正常。

## 修法

菜单展开期间保住按钮挂载（`onOpened` / `onCanceled` / `onSelected` 维护 `_isActionMenuOpen`）。

## 验证

- `flutter test test/presentation/screens/tag_library_page/widgets/category_tree_view_test.dart` — 3 passed
- `flutter analyze` 改动文件零问题
- 新增回归测试已确认**能抓住该 bug**：移除修复后断言变为 `Expected: 'target-category' / Actual: <null>`

新测试必须用 `createGesture(kind: mouse)`；`tester.tap` 合成的是 touch 指针，不更新鼠标命中，覆盖不到这条路径。同理必须显式套 `InteractionPolicyScope`，默认的 `InteractionPolicy.neutral` 里 `precisePointerAvailable` 为 false，`showActions` 恒真，测不出问题。