### PR TITLE
refactor(fixed-tags): 侧栏条目改用常驻行内操作

### DIFF
--- a/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
+++ b/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
@@ -27,14 +27,15 @@ const _linkDetachDistance = 36.0;
 
 double _gridCardHeight(BuildContext context) {
   final scaledLabelSize = MediaQuery.textScalerOf(context).scale(14);
-  final usesActionMenu =
+  // 触屏命中区把链接锚点和操作行整体撑高，大字号同样需要额外余量。
+  final needsRoomyCard =
       context.interactionPolicy.shouldExposeTouchAlternatives ||
       scaledLabelSize >= 20;
 
   // Grid previews can contain up to five scaled text lines. Grow the fixed
   // extent with the text scaler so asynchronous translations cannot outgrow it.
   final scaledTextGrowth = (scaledLabelSize - 14).clamp(0.0, double.infinity);
-  final baseHeight = usesActionMenu ? 210.0 : 180.0;
+  final baseHeight = needsRoomyCard ? 210.0 : 180.0;
   return baseHeight + scaledTextGrowth * 6;
 }
 

--- a/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
+++ b/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
@@ -9,12 +9,11 @@ import '../../../../data/models/tag_library/tag_library_entry.dart';
 import '../../../adaptive/interaction_policy.dart';
 import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/thumbnail_display.dart';
+import '../../../widgets/common/tile_action_button.dart';
 import '../../../widgets/common/translated_tag_text.dart';
 import '../../../widgets/tag_library/tag_library_entry_hover_preview.dart';
 
 typedef SidebarDragHandleBuilder = Widget Function(Widget child);
-
-enum _SidebarEntryAction { copy, edit, delete }
 
 /// A fixed-tag row or preview card.
 ///
@@ -55,11 +54,11 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
   bool get _hasThumbnail =>
       !widget.isListMode && (widget.libraryEntry?.hasThumbnail ?? false);
 
-  bool get _showActionMenu =>
+  // 操作按钮常驻，未聚焦时压暗，让行高和文本宽度不随指针移动跳变。
+  bool get _actionsHighlighted =>
       _isHovering ||
       _isFocused ||
-      context.interactionPolicy.shouldExposeTouchAlternatives ||
-      MediaQuery.textScalerOf(context).scale(14) >= 20;
+      !context.interactionPolicy.precisePointerAvailable;
 
   @override
   Widget build(BuildContext context) {
@@ -114,25 +113,43 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
   }
 
   Widget _buildListContent(ThemeData theme) {
+    final leading = [
+      _buildStatusDot(),
+      const SizedBox(width: 7),
+      if (widget.linkAnchor != null) ...[
+        widget.linkAnchor!,
+        const SizedBox(width: 4),
+      ],
+    ];
+    final label = _buildDragRegion(
+      _buildText(theme, maxLines: 1, includeWeight: true),
+    );
+    // 大字号下行内操作会把名称和权重挤没，整体换到第二行而不是收进菜单。
+    final stacksActions = MediaQuery.textScalerOf(context).scale(14) >= 20;
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-      child: Row(
-        children: [
-          _buildStatusDot(),
-          const SizedBox(width: 7),
-          if (widget.linkAnchor != null) ...[
-            widget.linkAnchor!,
-            const SizedBox(width: 4),
-          ],
-          Expanded(
-            child: _buildDragRegion(
-              _buildText(theme, maxLines: 1, includeWeight: true),
+      child: stacksActions
+          ? Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(children: [...leading, Expanded(child: label)]),
+                const SizedBox(height: 4),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: _buildActions(theme),
+                ),
+              ],
+            )
+          : Row(
+              children: [
+                ...leading,
+                Expanded(child: label),
+                const SizedBox(width: 6),
+                _buildActions(theme),
+              ],
             ),
-          ),
-          const SizedBox(width: 6),
-          if (_showActionMenu) ...[_buildActionMenu(theme)],
-        ],
-      ),
     );
   }
 
@@ -163,7 +180,7 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
                   children: [
                     if (widget.linkAnchor != null) widget.linkAnchor!,
                     const Spacer(),
-                    _buildActionMenu(theme),
+                    _buildActions(theme),
                   ],
                 ),
               ],
@@ -220,9 +237,10 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
                 ),
               ),
             ),
+            // 权重宽度随字号增长，留成 Flexible 兜底，任何窄行都不会溢出。
             if (includeWeight) ...[
               const SizedBox(width: 6),
-              _buildWeight(theme),
+              Flexible(child: _buildWeight(theme)),
             ],
           ],
         ),
@@ -258,6 +276,8 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
       maxScaleFactor: 1.5,
       child: Text(
         widget.entry.weight.toStringAsFixed(2),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
         style: theme.textTheme.labelSmall?.copyWith(
           color: theme.colorScheme.onSurfaceVariant,
           fontWeight: FontWeight.w700,
@@ -267,55 +287,37 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
     );
   }
 
-  Widget _buildActionMenu(ThemeData theme) {
-    final interactionPolicy = context.interactionPolicy;
-    return SizedBox.square(
-      dimension: interactionPolicy.precisePointerAvailable ? 32 : 44,
-      child: PopupMenuButton<_SidebarEntryAction>(
-        key: const ValueKey('sidebar-entry-actions-menu'),
-        tooltip: MaterialLocalizations.of(context).showMenuTooltip,
-        icon: const Icon(Icons.more_horiz_rounded, size: 18),
-        padding: EdgeInsets.zero,
-        onSelected: (action) {
-          switch (action) {
-            case _SidebarEntryAction.copy:
-              unawaited(_copyContent());
-              break;
-            case _SidebarEntryAction.edit:
-              widget.onEdit();
-              break;
-            case _SidebarEntryAction.delete:
-              widget.onDelete();
-              break;
-          }
-        },
-        itemBuilder: (context) => [
-          PopupMenuItem(
-            value: _SidebarEntryAction.copy,
-            child: ListTile(
-              leading: const Icon(Icons.copy_rounded),
-              title: Text(context.l10n.common_copy),
-            ),
+  Widget _buildActions(ThemeData theme) {
+    final resting = theme.colorScheme.onSurfaceVariant;
+    return AnimatedOpacity(
+      key: const ValueKey('sidebar-entry-actions'),
+      opacity: _actionsHighlighted ? 1 : 0.4,
+      duration: MediaQuery.disableAnimationsOf(context)
+          ? Duration.zero
+          : const Duration(milliseconds: 120),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TileActionButton(
+            icon: Icons.copy_rounded,
+            tooltip: context.l10n.common_copy,
+            color: resting,
+            hoverColor: theme.colorScheme.primary,
+            onPressed: () => unawaited(_copyContent()),
           ),
-          PopupMenuItem(
-            value: _SidebarEntryAction.edit,
-            child: ListTile(
-              leading: const Icon(Icons.edit_rounded),
-              title: Text(context.l10n.common_edit),
-            ),
+          TileActionButton(
+            icon: Icons.edit_rounded,
+            tooltip: context.l10n.common_edit,
+            color: resting,
+            hoverColor: theme.colorScheme.primary,
+            onPressed: widget.onEdit,
           ),
-          PopupMenuItem(
-            value: _SidebarEntryAction.delete,
-            child: ListTile(
-              leading: Icon(
-                Icons.delete_outline_rounded,
-                color: theme.colorScheme.error,
-              ),
-              title: Text(
-                context.l10n.common_delete,
-                style: TextStyle(color: theme.colorScheme.error),
-              ),
-            ),
+          TileActionButton(
+            icon: Icons.delete_outline_rounded,
+            tooltip: context.l10n.common_delete,
+            color: resting,
+            hoverColor: theme.colorScheme.error,
+            onPressed: widget.onDelete,
           ),
         ],
       ),

--- a/lib/presentation/widgets/common/tile_action_button.dart
+++ b/lib/presentation/widgets/common/tile_action_button.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../../adaptive/interaction_policy.dart';
+
+/// 列表条目行内的密集操作按钮。
+///
+/// 命中区按交互策略在触屏与指针之间切换，图标尺寸保持不变。
+class TileActionButton extends StatefulWidget {
+  const TileActionButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    required this.tooltip,
+    required this.color,
+    required this.hoverColor,
+  });
+
+  static const pointerExtent = 25.0;
+
+  final IconData icon;
+  final VoidCallback onPressed;
+  final String tooltip;
+  final Color color;
+  final Color hoverColor;
+
+  /// 供容器预留空间使用，避免调用方各自硬编码命中区尺寸。
+  static double extentOf(BuildContext context) {
+    final policy = context.interactionPolicy;
+    return policy.touchAvailable ? policy.minimumControlExtent : pointerExtent;
+  }
+
+  @override
+  State<TileActionButton> createState() => _TileActionButtonState();
+}
+
+class _TileActionButtonState extends State<TileActionButton> {
+  bool _hovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final interactionPolicy = context.interactionPolicy;
+    final extent = TileActionButton.extentOf(context);
+    return Tooltip(
+      message: widget.tooltip,
+      child: MouseRegion(
+        onEnter: interactionPolicy.precisePointerAvailable
+            ? (_) => setState(() => _hovering = true)
+            : null,
+        onExit: interactionPolicy.precisePointerAvailable
+            ? (_) => setState(() => _hovering = false)
+            : null,
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: widget.onPressed,
+          behavior: HitTestBehavior.opaque,
+          child: SizedBox(
+            width: extent,
+            height: extent,
+            child: Center(
+              child: Icon(
+                widget.icon,
+                size: 15,
+                color: _hovering ? widget.hoverColor : widget.color,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/prompt/fixed_tag_entry_tile.dart
+++ b/lib/presentation/widgets/prompt/fixed_tag_entry_tile.dart
@@ -6,6 +6,7 @@ import '../../../data/models/fixed_tag/fixed_tag_entry.dart';
 import '../../../data/models/fixed_tag/fixed_tag_prompt_type.dart';
 import '../../themes/core/layered_surface_style.dart';
 import '../../themes/prompt_semantic_colors.dart';
+import '../common/tile_action_button.dart';
 import '../common/translated_tag_text.dart';
 import '../common/themed_switch.dart';
 
@@ -147,14 +148,14 @@ class _FixedTagEntryTileState extends State<FixedTagEntryTile> {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _CompactIconButton(
+              TileActionButton(
                 icon: Icons.edit_outlined,
                 onPressed: widget.onEdit,
                 tooltip: context.l10n.common_edit,
                 color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
                 hoverColor: theme.colorScheme.primary,
               ),
-              _CompactIconButton(
+              TileActionButton(
                 icon: Icons.close_rounded,
                 onPressed: widget.onDelete,
                 tooltip: context.l10n.common_delete,
@@ -376,63 +377,6 @@ class _EntryBadges extends StatelessWidget {
           ),
         ],
       ],
-    );
-  }
-}
-
-class _CompactIconButton extends StatefulWidget {
-  const _CompactIconButton({
-    required this.icon,
-    required this.onPressed,
-    required this.tooltip,
-    required this.color,
-    required this.hoverColor,
-  });
-  final IconData icon;
-  final VoidCallback onPressed;
-  final String tooltip;
-  final Color color;
-  final Color hoverColor;
-
-  @override
-  State<_CompactIconButton> createState() => _CompactIconButtonState();
-}
-
-class _CompactIconButtonState extends State<_CompactIconButton> {
-  bool _hovering = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final interactionPolicy = context.interactionPolicy;
-    final extent = interactionPolicy.touchAvailable
-        ? interactionPolicy.minimumControlExtent
-        : 25.0;
-    return Tooltip(
-      message: widget.tooltip,
-      child: MouseRegion(
-        onEnter: interactionPolicy.precisePointerAvailable
-            ? (_) => setState(() => _hovering = true)
-            : null,
-        onExit: interactionPolicy.precisePointerAvailable
-            ? (_) => setState(() => _hovering = false)
-            : null,
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          onTap: widget.onPressed,
-          behavior: HitTestBehavior.opaque,
-          child: SizedBox(
-            width: extent,
-            height: extent,
-            child: Center(
-              child: Icon(
-                widget.icon,
-                size: 15,
-                color: _hovering ? widget.hoverColor : widget.color,
-              ),
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
@@ -28,6 +28,7 @@ import 'package:nai_launcher/presentation/screens/generation/widgets/fixed_tags_
 import 'package:nai_launcher/presentation/screens/generation/widgets/sidebar_entry_tile.dart';
 import 'package:nai_launcher/presentation/screens/generation/widgets/sidebar_link_painter.dart';
 import 'package:nai_launcher/presentation/themes/prompt_semantic_colors.dart';
+import 'package:nai_launcher/presentation/widgets/common/tile_action_button.dart';
 import 'package:nai_launcher/presentation/widgets/common/themed_switch.dart';
 import 'package:nai_launcher/presentation/widgets/common/themed_input.dart';
 import 'package:nai_launcher/presentation/widgets/common/thumbnail_display.dart';
@@ -2173,11 +2174,9 @@ void main() {
       ),
     );
 
-    final menu = find.byKey(const ValueKey('sidebar-entry-actions-menu'));
-    expect(menu, findsOneWidget);
-    await tester.ensureVisible(menu);
-    await tester.pumpAndSettle();
-    await tester.tap(menu);
+    final actions = find.byKey(const ValueKey('sidebar-entry-actions'));
+    expect(actions, findsOneWidget);
+    await tester.ensureVisible(actions);
     await tester.pumpAndSettle();
 
     expect(find.byIcon(Icons.copy_rounded), findsOneWidget);
@@ -2243,14 +2242,10 @@ void main() {
       await tester.pumpAndSettle();
       expect(tester.takeException(), isNull);
 
-      final entryMenu = find.byKey(
-        const ValueKey('sidebar-entry-actions-menu'),
-      );
-      await tester.ensureVisible(entryMenu);
+      final entryEdit = find.byIcon(Icons.edit_rounded);
+      await tester.ensureVisible(entryEdit);
       await tester.pumpAndSettle();
-      await tester.tap(entryMenu);
-      await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.edit_rounded));
+      await tester.tap(entryEdit);
       await tester.pumpAndSettle();
       expect(tester.takeException(), isNull);
 
@@ -2773,7 +2768,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('SidebarEntryTile pointer menu exposes every action at 320', (
+  testWidgets('SidebarEntryTile pointer actions stay live at 320', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(320, 300);
@@ -2816,25 +2811,27 @@ void main() {
     );
 
     final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await mouse.addPointer();
+    await mouse.addPointer(location: Offset.zero);
     addTearDown(mouse.removePointer);
     await mouse.moveTo(tester.getCenter(find.byType(SidebarEntryTile)));
     await tester.pumpAndSettle();
 
-    final menu = find.byKey(const ValueKey('sidebar-entry-actions-menu'));
-    expect(menu, findsOneWidget);
+    expect(find.byKey(const ValueKey('sidebar-entry-actions')), findsOneWidget);
 
-    await tester.tap(menu);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.copy_rounded));
-    await tester.pumpAndSettle();
-    await tester.tap(menu);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.edit_rounded));
-    await tester.pumpAndSettle();
-    await tester.tap(menu);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.delete_outline_rounded));
+    // 合成 touch tap 不会更新鼠标命中，测不出指针路径的回归，必须用真实鼠标。
+    for (final icon in [
+      Icons.copy_rounded,
+      Icons.edit_rounded,
+      Icons.delete_outline_rounded,
+    ]) {
+      final target = tester.getCenter(find.byIcon(icon));
+      await mouse.moveTo(target);
+      await tester.pumpAndSettle();
+      await mouse.down(target);
+      await tester.pump();
+      await mouse.up();
+      await tester.pumpAndSettle();
+    }
 
     expect(copiedText, 'copied tag');
     expect(edited, 1);
@@ -2842,7 +2839,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('SidebarEntryTile touch menu invokes edit and delete callbacks', (
+  testWidgets('SidebarEntryTile touch actions invoke edit and delete', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(320, 700);
@@ -2865,18 +2862,21 @@ void main() {
       onDelete: () => deleted++,
     );
 
-    final menu = find.byKey(const ValueKey('sidebar-entry-actions-menu'));
-    expect(menu, findsOneWidget);
+    expect(find.byKey(const ValueKey('sidebar-entry-actions')), findsOneWidget);
 
-    await tester.tap(menu);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.edit_rounded));
-    await tester.pumpAndSettle();
-
-    await tester.tap(menu);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.delete_outline_rounded));
-    await tester.pumpAndSettle();
+    // 触屏没有 hover，操作必须无条件可见且命中区不小于 44。
+    for (final icon in [Icons.edit_rounded, Icons.delete_outline_rounded]) {
+      final size = tester.getSize(
+        find.ancestor(
+          of: find.byIcon(icon),
+          matching: find.byType(TileActionButton),
+        ),
+      );
+      expect(size.width, greaterThanOrEqualTo(44));
+      expect(size.height, greaterThanOrEqualTo(44));
+      await tester.tap(find.byIcon(icon));
+      await tester.pumpAndSettle();
+    }
 
     expect(edited, 1);
     expect(deleted, 1);
@@ -2884,7 +2884,7 @@ void main() {
   });
 
   testWidgets(
-    'SidebarEntryTile 3x menu invokes copy, edit and delete without overflow',
+    'SidebarEntryTile 3x actions invoke copy, edit and delete without overflow',
     (tester) async {
       tester.view.physicalSize = const Size(320, 700);
       tester.view.devicePixelRatio = 1;
@@ -2926,24 +2926,20 @@ void main() {
         onDelete: () => deleted++,
       );
 
-      final menu = find.byKey(const ValueKey('sidebar-entry-actions-menu'));
-      expect(menu, findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('sidebar-entry-actions')),
+        findsOneWidget,
+      );
       expect(find.byType(FittedBox), findsNothing);
 
-      await tester.tap(menu);
-      await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.copy_rounded));
-      await tester.pumpAndSettle();
-
-      await tester.tap(menu);
-      await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.edit_rounded));
-      await tester.pumpAndSettle();
-
-      await tester.tap(menu);
-      await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.delete_outline_rounded));
-      await tester.pumpAndSettle();
+      for (final icon in [
+        Icons.copy_rounded,
+        Icons.edit_rounded,
+        Icons.delete_outline_rounded,
+      ]) {
+        await tester.tap(find.byIcon(icon));
+        await tester.pumpAndSettle();
+      }
 
       expect(copiedText, 'copied tag');
       expect(edited, 1);
@@ -2996,11 +2992,14 @@ void main() {
     expect(find.byIcon(Icons.remove_rounded), findsNothing);
     expect(find.byIcon(Icons.add_rounded), findsNothing);
 
-    final menu = find.byKey(const ValueKey('sidebar-entry-actions-menu'));
-    expect(menu, findsOneWidget);
-    await tester.tap(menu);
+    expect(find.byKey(const ValueKey('sidebar-entry-actions')), findsOneWidget);
+    final editCenter = tester.getCenter(find.byIcon(Icons.edit_rounded));
+    await gesture.moveTo(editCenter);
     await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.edit_rounded));
+    await gesture.down(editCenter);
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
 
     expect(edited, isTrue);
   });


### PR DESCRIPTION
## 用户可见变化

固定词侧栏条目的复制/编辑/删除，从「先点 `…` 展开菜单再选」改回**三个常驻行内图标**，未悬停时压暗、悬停变亮。列表与网格两种视图一致。

顺带修掉这三个选项点了没反应的问题。

## 背景

`#245` 的侧栏重构删掉了原本的行内按钮，桌面端只剩 `…` 菜单一条路。而列表模式下按钮的**存在**挂在 `_isHovering` 上：菜单一展开，modal barrier 盖住条目 → `onExit` → 按钮卸载 → `PopupMenuButtonState` 的 `showMenu(...).then((v) { if (!mounted) return; ... })` 丢弃选中值。三个选项因此全部失效。

行内按钮直接触发回调，不经 Navigator 回传，从结构上不再可能丢动作。

## 实现要点

- 抽出 `TileActionButton`，与固定词管理对话框共用同一套命中区（触屏 `minimumControlExtent` / 指针 25）与悬停语义，消掉一处同功能双实现
- 高亮条件用 `!precisePointerAvailable` 而非 `shouldExposeTouchAlternatives`：后者是「观察到触摸后永久为真」的粘性判断，用在这里会让插了鼠标的平板永远停在高亮态
- 大字号（`scale(14) >= 20`）下三个 48px 按钮会把名称挤没，操作整行换到第二行；权重徽标补 `Flexible` 兜底，任何窄行都不再溢出

## 验证

- `flutter test` 侧栏 + 固定词条目套件 — 52 passed
- `flutter analyze` 改动文件零问题
- Windows release 构建通过并实机启动

## 测试改动说明

原有 3 条断言菜单可用的测试是**假绿灯**：`tester.tap` 合成 touch 指针，不触发鼠标命中更新，永远走不到「指针移出 → 卸载」。已改用 `createGesture(kind: mouse)` 驱动。