### PR TITLE
refactor(fixed-tags): 侧栏条目不再渲染标签译文并收紧网格卡片

### DIFF
--- a/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
+++ b/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
@@ -17,6 +17,7 @@ import '../../../adaptive/interaction_policy.dart';
 import '../../../themes/core/layered_surface_style.dart';
 import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/themed_confirm_dialog.dart';
+import '../../../widgets/common/tile_action_button.dart';
 import '../../../widgets/prompt/fixed_tag_edit_dialog.dart';
 import '../../../widgets/tag_library/tag_library_picker_dialog.dart';
 import 'sidebar_entry_tile.dart';
@@ -27,15 +28,17 @@ const _linkDetachDistance = 36.0;
 
 double _gridCardHeight(BuildContext context) {
   final scaledLabelSize = MediaQuery.textScalerOf(context).scale(14);
-  // 触屏命中区把链接锚点和操作行整体撑高，大字号同样需要额外余量。
-  final needsRoomyCard =
-      context.interactionPolicy.shouldExposeTouchAlternatives ||
-      scaledLabelSize >= 20;
-
-  // Grid previews can contain up to five scaled text lines. Grow the fixed
-  // extent with the text scaler so asynchronous translations cannot outgrow it.
+  // 底行取链接锚点与操作按钮中较高者：前者看有无精确指针，后者看有无触摸，两条规则会错配。
+  final footerExtent = math.max(
+    context.interactionPolicy.precisePointerAvailable ? 24.0 : 44.0,
+    TileActionButton.extentOf(context),
+  );
+  // 带缩略图的卡片最紧：正文只有一行，但正文区仅分到卡片 5/8 高度，按它标定基准。
+  const contentInsets = 20.0; // 上下内边距 15 + 正文与底行间距 5
+  const singleLineText = 36.0; // 名称 20 + 单行正文 16
+  final baseHeight =
+      (contentInsets + singleLineText + footerExtent) * 8 / 5 + 12;
   final scaledTextGrowth = (scaledLabelSize - 14).clamp(0.0, double.infinity);
-  final baseHeight = needsRoomyCard ? 210.0 : 180.0;
   return baseHeight + scaledTextGrowth * 6;
 }
 

--- a/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
+++ b/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
@@ -10,7 +10,6 @@ import '../../../adaptive/interaction_policy.dart';
 import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/thumbnail_display.dart';
 import '../../../widgets/common/tile_action_button.dart';
-import '../../../widgets/common/translated_tag_text.dart';
 import '../../../widgets/tag_library/tag_library_entry_hover_preview.dart';
 
 typedef SidebarDragHandleBuilder = Widget Function(Widget child);
@@ -245,11 +244,10 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
           ],
         ),
         if (widget.isListMode) const SizedBox(height: 1),
-        TranslatedPromptText(
+        Text(
           widget.entry.content,
-          selectable: false,
           maxLines: maxLines,
-          reserveTranslationSpace: widget.isListMode,
+          overflow: TextOverflow.ellipsis,
           style: theme.textTheme.bodySmall?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
@@ -1816,7 +1816,7 @@ void main() {
   );
 
   testWidgets(
-    'list mode reserves translated preview height without overflowing',
+    'list rows keep identical heights and never render translations',
     (tester) async {
       PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
         TargetPlatform.windows,
@@ -1861,7 +1861,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('杰作'), findsOneWidget);
+      // 只有一条能查到译文；一旦重新渲染翻译，行高就会不一致。
+      expect(find.text('杰作'), findsNothing);
       expect(tester.takeException(), isNull);
       final tileHeights = tester
           .widgetList<SidebarEntryTile>(find.byType(SidebarEntryTile))
@@ -2481,7 +2482,7 @@ void main() {
   );
 
   testWidgets(
-    'grid cards fit linked thumbnails and translated text without overflow',
+    'grid cards fit linked thumbnails and show raw prompts without overflow',
     (tester) async {
       final category = TagLibraryCategory.create(name: 'Quality');
       final positiveLibrary = TagLibraryEntry.create(
@@ -2529,10 +2530,13 @@ void main() {
         translationLookup: lookup,
       );
 
+      // 词典可用也不得渲染译文：侧栏条目只显示原文，翻译留给悬停预览。
       expect(
         find.byKey(const ValueKey('translated-prompt-translation')),
-        findsNWidgets(2),
+        findsNothing,
       );
+      expect(find.text(positiveLibrary.content), findsOneWidget);
+      expect(find.text(negativeLibrary.content), findsOneWidget);
       expect(tester.takeException(), isNull);
     },
   );


### PR DESCRIPTION
> 叠在 #266 之上，base 指向 `refactor/fixed-tags-inline-actions`。#266 合并后此 PR 的 base 会自动回落到 `main`。

## 用户可见变化

- 固定词侧栏条目下方不再显示灰色中文译文行，只保留原始提示词。条目名本就是用户自定义（多为中文），译文基本冗余却占满每一行。
- 网格卡片相应变矮：指针 180→141.6，触屏 210→178.4，`neutral` 180→172。

翻译仍保留在悬停预览面板，本 PR 不动。

## 顺带修正一处旧错配

调卡片高度时发现 `_gridCardHeight` 的分支判断和实际布局对不上。卡片底行高度是 `max(链接锚点, 操作按钮)`，而两者命中区规则不同 —— 锚点看 `precisePointerAvailable`，按钮看 `touchAvailable`。`InteractionPolicy.neutral`（两者皆 false，测试与首帧默认值）下底行是「锚点 44 + 按钮 25 = 44」，但旧的 `usesActionMenu` 只判断触摸，会走**小基准**。旧的 180 靠余量盖住了，一收紧就炸出 13px 竖向溢出。

现改为按实际底行高度推导，不再靠余量兜错配：

```dart
final footerExtent = math.max(
  context.interactionPolicy.precisePointerAvailable ? 24.0 : 44.0,
  TileActionButton.extentOf(context),
);
```

基准值来自实测（名称 20 / 正文两行 32 / 操作行 25 或 48），每种配置留 12px 余量；增长项 `* 6` 保持不变 —— 实测每 1px 字号只需 4.11px，本就是过量供给。

## 验证

- `flutter test` 侧栏套件 — 46 passed
- `flutter analyze` 改动文件零问题
- Windows release 构建通过并实机启动

## 测试改动说明

两条原本守着「译文必须出现」的测试改成守相反的不变量，避免删掉了事：

- `list rows keep identical heights and never render translations` — 保留词典 override 且只有一条能查到译文，一旦翻译回来行高就会不一致，双重哨兵
- `grid cards ... show raw prompts without overflow` — 词典可用时断言 `translated-prompt-translation` 为 `findsNothing`