### PR TITLE
fix(prompt): 增强固定词选中状态与文字对比度

### DIFF
--- a/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
+++ b/lib/presentation/screens/generation/widgets/sidebar_entry_tile.dart
@@ -5,8 +5,11 @@ import 'package:flutter/services.dart';
 
 import '../../../../core/utils/localization_extension.dart';
 import '../../../../data/models/fixed_tag/fixed_tag_entry.dart';
+import '../../../../data/models/fixed_tag/fixed_tag_prompt_type.dart';
 import '../../../../data/models/tag_library/tag_library_entry.dart';
 import '../../../adaptive/interaction_policy.dart';
+import '../../../themes/core/layered_surface_style.dart';
+import '../../../themes/prompt_semantic_colors.dart';
 import '../../../widgets/common/app_toast.dart';
 import '../../../widgets/common/thumbnail_display.dart';
 import '../../../widgets/common/tile_action_button.dart';
@@ -62,31 +65,34 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final tile = MouseRegion(
-      onEnter: (_) {
-        if (context.interactionPolicy.precisePointerAvailable) {
-          setState(() => _isHovering = true);
-        }
-      },
-      onExit: (_) => setState(() => _isHovering = false),
-      child: Material(
-        color: _backgroundColor(theme),
-        borderRadius: BorderRadius.circular(widget.isListMode ? 6 : 10),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
+    final tile = Semantics(
+      selected: widget.entry.enabled,
+      child: MouseRegion(
+        onEnter: (_) {
+          if (context.interactionPolicy.precisePointerAvailable) {
+            setState(() => _isHovering = true);
+          }
+        },
+        onExit: (_) => setState(() => _isHovering = false),
+        child: Material(
+          color: _backgroundColor(theme),
           borderRadius: BorderRadius.circular(widget.isListMode ? 6 : 10),
-          onFocusChange: (focused) => setState(() => _isFocused = focused),
-          onTap: widget.onToggle,
-          child: AnimatedContainer(
-            duration: MediaQuery.disableAnimationsOf(context)
-                ? Duration.zero
-                : const Duration(milliseconds: 120),
-            color: _isHovering
-                ? theme.colorScheme.onSurface.withValues(alpha: 0.045)
-                : Colors.transparent,
-            child: widget.isListMode
-                ? _buildListContent(theme)
-                : _buildCardContent(theme),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(widget.isListMode ? 6 : 10),
+            onFocusChange: (focused) => setState(() => _isFocused = focused),
+            onTap: widget.onToggle,
+            child: AnimatedContainer(
+              duration: MediaQuery.disableAnimationsOf(context)
+                  ? Duration.zero
+                  : const Duration(milliseconds: 120),
+              color: _isHovering
+                  ? theme.colorScheme.onSurface.withValues(alpha: 0.045)
+                  : Colors.transparent,
+              child: widget.isListMode
+                  ? _buildListContent(theme)
+                  : _buildCardContent(theme),
+            ),
           ),
         ),
       ),
@@ -101,19 +107,20 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
   }
 
   Color _backgroundColor(ThemeData theme) {
-    if (widget.isListMode) {
-      return widget.entry.enabled
-          ? theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.55)
-          : Colors.transparent;
-    }
+    final resting = controlSurfaceColor(theme.colorScheme);
     return widget.entry.enabled
-        ? theme.colorScheme.surfaceContainerHighest
-        : theme.colorScheme.surfaceContainerHigh.withValues(alpha: 0.65);
+        ? Color.alphaBlend(_statusColor(theme).withValues(alpha: 0.22), resting)
+        : resting;
   }
+
+  Color _statusColor(ThemeData theme) =>
+      widget.entry.promptType == FixedTagPromptType.positive
+      ? theme.promptSemanticColors.positiveFixedTag
+      : theme.promptSemanticColors.negativeFixedTag;
 
   Widget _buildListContent(ThemeData theme) {
     final leading = [
-      _buildStatusDot(),
+      _buildStatusIcon(theme),
       const SizedBox(width: 7),
       if (widget.linkAnchor != null) ...[
         widget.linkAnchor!,
@@ -133,7 +140,12 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Row(children: [...leading, Expanded(child: label)]),
+                Row(
+                  children: [
+                    ...leading,
+                    Expanded(child: label),
+                  ],
+                ),
                 const SizedBox(height: 4),
                 Align(
                   alignment: Alignment.centerRight,
@@ -223,6 +235,10 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
       children: [
         Row(
           children: [
+            if (!widget.isListMode) ...[
+              _buildStatusIcon(theme),
+              const SizedBox(width: 7),
+            ],
             Expanded(
               child: Text(
                 widget.entry.displayName,
@@ -256,16 +272,13 @@ class _SidebarEntryTileState extends State<SidebarEntryTile> {
     );
   }
 
-  Widget _buildStatusDot() {
-    return Container(
-      width: 8,
-      height: 8,
-      decoration: BoxDecoration(
-        color: widget.entry.enabled
-            ? widget.categoryColor
-            : Theme.of(context).colorScheme.outline,
-        shape: BoxShape.circle,
-      ),
+  Widget _buildStatusIcon(ThemeData theme) {
+    return Icon(
+      widget.entry.enabled ? Icons.check_circle : Icons.radio_button_unchecked,
+      size: 18,
+      color: widget.entry.enabled
+          ? widget.categoryColor
+          : theme.colorScheme.onSurfaceVariant,
     );
   }
 

--- a/lib/presentation/widgets/prompt/fixed_tag_entry_tile.dart
+++ b/lib/presentation/widgets/prompt/fixed_tag_entry_tile.dart
@@ -54,7 +54,7 @@ class _FixedTagEntryTileState extends State<FixedTagEntryTile> {
     final highlighted = _hovering || _focused;
     final restingColor = controlSurfaceColor(theme.colorScheme);
     final baseColor = Color.alphaBlend(
-      promptTypeColor.withValues(alpha: entry.enabled ? 0.12 : 0.07),
+      promptTypeColor.withValues(alpha: entry.enabled ? 0.22 : 0),
       restingColor,
     );
     final tile = Material(
@@ -303,7 +303,7 @@ class _EntryLabels extends StatelessWidget {
             fontWeight: FontWeight.w500,
             color: entry.enabled
                 ? theme.colorScheme.onSurface
-                : theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                : theme.colorScheme.onSurfaceVariant,
             decoration: entry.enabled ? null : TextDecoration.lineThrough,
             decorationColor: theme.colorScheme.outline.withValues(alpha: 0.6),
             decorationThickness: 2,
@@ -320,9 +320,7 @@ class _EntryLabels extends StatelessWidget {
               selectable: false,
               style: TextStyle(
                 fontSize: 11,
-                color: entry.enabled
-                    ? theme.colorScheme.outline.withValues(alpha: 0.8)
-                    : theme.colorScheme.outline.withValues(alpha: 0.5),
+                color: theme.colorScheme.onSurfaceVariant,
                 height: 1.2,
                 decoration: entry.enabled ? null : TextDecoration.lineThrough,
                 decorationColor: theme.colorScheme.outline.withValues(

--- a/test/presentation/screens/generation/widgets/sidebar_entry_tile_test.dart
+++ b/test/presentation/screens/generation/widgets/sidebar_entry_tile_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_entry.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
+import 'package:nai_launcher/presentation/screens/generation/widgets/sidebar_entry_tile.dart';
+
+void main() {
+  for (final brightness in Brightness.values) {
+    for (final isListMode in [true, false]) {
+      testWidgets('$brightness list=$isListMode selection remains readable', (
+        tester,
+      ) async {
+        addTearDown(() => tester.view.resetPhysicalSize());
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetDevicePixelRatio);
+        final theme = ThemeData.from(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.teal,
+            brightness: brightness,
+          ),
+        );
+        for (final width in [320.0, 600.0, 840.0, 1180.0, 1600.0]) {
+          tester.view.physicalSize = Size(width, 500);
+          for (final scale in [1.0, 3.0]) {
+            Color? inactiveColor;
+            for (final enabled in [false, true]) {
+              var toggles = 0;
+              await tester.pumpWidget(
+                MaterialApp(
+                  theme: theme,
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  builder: (context, child) => MediaQuery(
+                    data: MediaQuery.of(context).copyWith(
+                      textScaler: TextScaler.linear(scale),
+                      padding: const EdgeInsets.only(bottom: 24),
+                      viewInsets: const EdgeInsets.only(bottom: 100),
+                    ),
+                    child: child!,
+                  ),
+                  home: Scaffold(
+                    body: SafeArea(
+                      child: InteractionPolicyScope(
+                        initialPolicy: const InteractionPolicy(
+                          modality: InteractionModality.touch,
+                          touchAvailable: true,
+                          precisePointerAvailable: false,
+                        ),
+                        child: SizedBox(
+                          width: width,
+                          height: isListMode ? null : 240,
+                          child: SidebarEntryTile(
+                            entry: FixedTagEntry.create(
+                              name: 'Fixed tag',
+                              content: 'blue eyes',
+                              enabled: enabled,
+                            ),
+                            categoryColor: theme.colorScheme.primary,
+                            isListMode: isListMode,
+                            onToggle: () => toggles++,
+                            onEdit: () {},
+                            onDelete: () {},
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              );
+              await tester.pump();
+              final tile = find.byType(SidebarEntryTile);
+              final selectionSemantics = tester.widget<Semantics>(
+                find
+                    .descendant(of: tile, matching: find.byType(Semantics))
+                    .first,
+              );
+              expect(selectionSemantics.properties.selected, enabled);
+              final material = tester.widget<Material>(
+                find
+                    .descendant(of: tile, matching: find.byType(Material))
+                    .first,
+              );
+              final background = material.color!;
+              if (!enabled) inactiveColor = background;
+              if (enabled) expect(background, isNot(inactiveColor));
+              expect(
+                find.byIcon(
+                  enabled ? Icons.check_circle : Icons.radio_button_unchecked,
+                ),
+                findsOneWidget,
+              );
+              for (final label in ['Fixed tag', 'blue eyes']) {
+                final text = tester.widget<Text>(find.text(label));
+                final foreground = text.style!.color!;
+                final a = foreground.computeLuminance();
+                final b = background.computeLuminance();
+                final contrast = a > b
+                    ? (a + 0.05) / (b + 0.05)
+                    : (b + 0.05) / (a + 0.05);
+                expect(contrast, greaterThanOrEqualTo(4.5));
+              }
+              expect(
+                find.byIcon(Icons.edit_rounded).hitTestable(),
+                findsOneWidget,
+              );
+              expect(
+                find.byIcon(Icons.copy_rounded).hitTestable(),
+                findsOneWidget,
+              );
+              expect(
+                find.byIcon(Icons.delete_outline_rounded).hitTestable(),
+                findsOneWidget,
+              );
+              await tester.tap(find.text('Fixed tag'));
+              expect(toggles, 1);
+              expect(tester.takeException(), isNull);
+            }
+          }
+        }
+      });
+    }
+  }
+}

--- a/test/presentation/widgets/prompt/fixed_tag_entry_tile_test.dart
+++ b/test/presentation/widgets/prompt/fixed_tag_entry_tile_test.dart
@@ -24,20 +24,14 @@ void main() {
       find.byType(AnimatedContainer),
     );
     final decoration = container.decoration! as BoxDecoration;
-    expect(
-      decoration.color,
-      Color.alphaBlend(
-        theme.promptSemanticColors.positiveFixedTag.withValues(alpha: 0.07),
-        controlSurfaceColor(theme.colorScheme),
-      ),
-    );
+    expect(decoration.color, controlSurfaceColor(theme.colorScheme));
     expect(decoration.color, isNot(theme.colorScheme.surface));
     expect(decoration.border, isNull);
     expect(decoration.boxShadow, isNull);
     expect(tester.getSize(find.byType(Switch)).width, greaterThanOrEqualTo(48));
 
     final nameStyle = tester.widget<Text>(find.text('禁用固定词')).style!;
-    expect(nameStyle.color, theme.colorScheme.onSurface.withValues(alpha: 0.5));
+    expect(nameStyle.color, theme.colorScheme.onSurfaceVariant);
     expect(nameStyle.decoration, TextDecoration.lineThrough);
     expect(
       nameStyle.decorationColor,
@@ -48,10 +42,7 @@ void main() {
     final contentStyle = tester
         .widget<Text>(find.text('1girl, blue eyes'))
         .style!;
-    expect(
-      contentStyle.color,
-      theme.colorScheme.outline.withValues(alpha: 0.5),
-    );
+    expect(contentStyle.color, theme.colorScheme.onSurfaceVariant);
     expect(contentStyle.decoration, TextDecoration.lineThrough);
     expect(
       contentStyle.decorationColor,
@@ -118,7 +109,7 @@ void main() {
     final positiveColor = await surfaceColor(positive);
     final theme = Theme.of(tester.element(find.byType(FixedTagEntryTile)));
     final expectedPositive = Color.alphaBlend(
-      theme.promptSemanticColors.positiveFixedTag.withValues(alpha: 0.12),
+      theme.promptSemanticColors.positiveFixedTag.withValues(alpha: 0.22),
       controlSurfaceColor(theme.colorScheme),
     );
     expect(positiveColor, expectedPositive);
@@ -129,7 +120,7 @@ void main() {
     );
     final expectedNegative = Color.alphaBlend(
       negativeTheme.promptSemanticColors.negativeFixedTag.withValues(
-        alpha: 0.12,
+        alpha: 0.22,
       ),
       controlSurfaceColor(negativeTheme.colorScheme),
     );


### PR DESCRIPTION
## 改动内容
固定词启用与停用的色面差异较小，固定侧边栏的列表仅有小圆点、卡片缺少明确状态图标，难以快速区分。

- 增强固定词弹窗及侧边栏的启用底色，停用状态使用中性色面。
- 侧边栏列表和卡片提供勾选/未选中图标及选中语义，保留整行切换与原有操作。
- 提高弹窗名称及提示词预览的文字对比度。

## 验证结果
- 固定词条目与侧边栏独立组件共 10 项测试通过。
- 侧边栏测试覆盖浅/深色、列表/卡片、320/600/840/1180/1600 宽度、1x/3x 字号，以及 SafeArea/IME 模拟；断言文字对比度至少 4.5:1、操作可达且无渲染异常。
- 对改动源码和测试执行 dart analyze，通过。
- git diff --check 与 scripts/verify_flutter_sources.ps1 通过。

## 注意事项
- 侧边栏整页测试因 worktree 缺少 prompt_config_provider.g.dart、database_providers.g.dart 和 random_prompt_result 生成文件而无法编译；未进行真实窗口验收。
- 无 assets、LFS 或生成文件变更。
