### PR TITLE
fix(tag-library): 校验词库包成员与条目 ID 阻断预览图路径穿越

### DIFF
--- a/lib/data/services/tag_library_io_service.dart
+++ b/lib/data/services/tag_library_io_service.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:path/path.dart' as path;
-import 'package:path_provider/path_provider.dart';
 
 import '../models/tag_library/import_models.dart';
 import '../models/tag_library/tag_library_category.dart';
@@ -15,6 +14,10 @@ class TagLibraryIOService {
   TagLibraryIOService({TagLibraryPortableThumbnailStore? portableThumbnails})
     : _portableThumbnails =
           portableThumbnails ?? const TagLibraryPortableThumbnailStore();
+
+  static const _thumbnailsPrefix = 'thumbnails/';
+
+  static final _driveLetterPattern = RegExp(r'^[A-Za-z]:');
 
   final TagLibraryPortableThumbnailStore _portableThumbnails;
 
@@ -157,6 +160,8 @@ class TagLibraryIOService {
       throw Exception('无法解压词库文件：${e.toString()}');
     }
 
+    _preflightArchive(archive);
+
     // 读取 manifest
     final manifestFile = archive.findFile('manifest.json');
     if (manifestFile == null) {
@@ -203,9 +208,11 @@ class TagLibraryIOService {
       }
     }
 
+    _verifyIdentifiers(entries: entries, categories: categories);
+
     // 检查是否有预览图
     final hasThumbnails = archive.files.any(
-      (f) => f.name.startsWith('thumbnails/'),
+      (f) => f.name.startsWith(_thumbnailsPrefix),
     );
 
     return ImportPreview(
@@ -294,11 +301,16 @@ class TagLibraryIOService {
     final bytes = await zipFile.readAsBytes();
     final archive = ZipDecoder().decodeBytes(bytes);
 
-    // 获取应用文档目录用于保存预览图
-    final appDir = await getApplicationDocumentsDirectory();
-    final thumbnailsDir = Directory(
-      path.join(appDir.path, 'tag_library_thumbnails'),
+    // 归档与预览都由调用方提供，落盘前必须重新校验而不是沿用解析阶段的结论
+    final thumbnailMembers = _preflightArchive(archive);
+    _verifyIdentifiers(
+      entries: preview.entries,
+      categories: preview.categories,
     );
+
+    // 获取应用文档目录用于保存预览图
+    final thumbnailsDir =
+        await TagLibraryPortableThumbnailStore.resolveDirectory();
     if (!await thumbnailsDir.exists()) {
       await thumbnailsDir.create(recursive: true);
     }
@@ -375,20 +387,23 @@ class TagLibraryIOService {
       // 提取预览图并更新缩略图路径
       String? newThumbnailPath;
       if (entry.hasThumbnail) {
-        for (final file in archive.files) {
-          if (file.name.startsWith('thumbnails/${entry.id}')) {
-            final ext = path.extension(file.name);
-            newThumbnailPath = path.join(thumbnailsDir.path, '${entry.id}$ext');
-            final thumbnailFile = File(newThumbnailPath);
-            await thumbnailFile.writeAsBytes(file.content as List<int>);
-            break;
-          }
+        final member = thumbnailMembers[entry.id];
+        if (member != null) {
+          final ext = path.url.extension(member.name).toLowerCase();
+          _verifyThumbnailTarget(thumbnailsDir, entry.id, ext);
+          newThumbnailPath = await importPortableThumbnail(
+            entry.id,
+            ext,
+            Stream.value(member.content as List<int>),
+          );
         }
       }
 
       // 创建更新后的条目（使用新的缩略图路径）
       final updatedEntry = entry.copyWith(
-        thumbnail: newThumbnailPath ?? entry.thumbnail,
+        thumbnail:
+            newThumbnailPath ??
+            _retainedThumbnail(thumbnailsDir, entry.thumbnail),
       );
       updatedEntries[entry.id] = updatedEntry;
 
@@ -423,4 +438,111 @@ class TagLibraryIOService {
         '${now.year}${now.month.toString().padLeft(2, '0')}${now.day.toString().padLeft(2, '0')}';
     return 'tag_library_export_$dateStr.zip';
   }
+
+  /// 校验归档成员，返回按条目 ID 索引的预览图成员
+  static Map<String, ArchiveFile> _preflightArchive(Archive archive) {
+    final names = <String>{};
+    final thumbnails = <String, ArchiveFile>{};
+
+    for (final file in archive.files) {
+      final name = file.name;
+      if (file.isSymbolicLink) {
+        throw FormatException('词库文件包含符号链接：${_excerpt(name)}');
+      }
+      if (!file.isFile) {
+        throw FormatException('词库文件包含非文件条目：${_excerpt(name)}');
+      }
+      if (!_isSafeMemberPath(name)) {
+        throw FormatException('词库文件包含不安全路径：${_excerpt(name)}');
+      }
+      if (!names.add(name.toLowerCase())) {
+        throw FormatException('词库文件包含重复条目：${_excerpt(name)}');
+      }
+      if (!name.startsWith(_thumbnailsPrefix)) continue;
+
+      final entryId = _thumbnailEntryId(name);
+      if (entryId == null) {
+        throw FormatException('词库文件包含无效预览图：${_excerpt(name)}');
+      }
+      if (thumbnails.containsKey(entryId)) {
+        throw FormatException('词库文件为同一条目包含多张预览图：${_excerpt(name)}');
+      }
+      thumbnails[entryId] = file;
+    }
+
+    return thumbnails;
+  }
+
+  /// 解析 `thumbnails/<条目 ID><扩展名>`，不符合精确形式时返回 null
+  static String? _thumbnailEntryId(String memberName) {
+    final relative = memberName.substring(_thumbnailsPrefix.length);
+    if (relative.contains('/')) return null;
+    if (!TagLibraryPortableThumbnailStore.isSupportedExtension(
+      path.url.extension(relative),
+    )) {
+      return null;
+    }
+    final entryId = path.url.basenameWithoutExtension(relative);
+    return TagLibraryPortableThumbnailStore.isValidEntryId(entryId)
+        ? entryId
+        : null;
+  }
+
+  static bool _isSafeMemberPath(String value) {
+    if (value.isEmpty || value.contains('\\')) return false;
+    if (value.startsWith('/') || _driveLetterPattern.hasMatch(value)) {
+      return false;
+    }
+    if (value.codeUnits.any((unit) => unit < 0x20 || unit == 0x7f)) {
+      return false;
+    }
+    return value
+        .split('/')
+        .every((part) => part.isNotEmpty && part != '.' && part != '..');
+  }
+
+  static void _verifyIdentifiers({
+    required List<TagLibraryEntry> entries,
+    required List<TagLibraryCategory> categories,
+  }) {
+    for (final category in categories) {
+      _verifyIdentifier(category.id, '分类 ID');
+      final parentId = category.parentId;
+      if (parentId != null) _verifyIdentifier(parentId, '父分类 ID');
+    }
+    for (final entry in entries) {
+      _verifyIdentifier(entry.id, '条目 ID');
+      final categoryId = entry.categoryId;
+      if (categoryId != null) _verifyIdentifier(categoryId, '条目所属分类 ID');
+    }
+  }
+
+  static void _verifyIdentifier(String value, String label) {
+    if (!TagLibraryPortableThumbnailStore.isValidEntryId(value)) {
+      throw FormatException('词库文件包含非法$label：${_excerpt(value)}');
+    }
+  }
+
+  static void _verifyThumbnailTarget(
+    Directory thumbnailsDir,
+    String entryId,
+    String extension,
+  ) {
+    final root = path.normalize(thumbnailsDir.absolute.path);
+    final target = path.normalize(path.join(root, '$entryId$extension'));
+    if (!path.isWithin(root, target)) {
+      throw FormatException('预览图写入路径越界：${_excerpt(entryId)}');
+    }
+  }
+
+  /// 包内条目自带的缩略图路径来自导出机器，只有仍位于本机缩略图目录内才保留
+  static String? _retainedThumbnail(Directory thumbnailsDir, String? value) {
+    if (value == null || value.isEmpty) return null;
+    final root = path.normalize(thumbnailsDir.absolute.path);
+    final normalized = path.normalize(path.absolute(value));
+    return path.isWithin(root, normalized) ? normalized : null;
+  }
+
+  static String _excerpt(String value) =>
+      value.length <= 64 ? value : '${value.substring(0, 64)}…';
 }

--- a/lib/data/services/tag_library_portable_thumbnail_store.dart
+++ b/lib/data/services/tag_library_portable_thumbnail_store.dart
@@ -29,25 +29,38 @@ class PortableThumbnailMutation {
 class TagLibraryPortableThumbnailStore {
   const TagLibraryPortableThumbnailStore();
 
+  static const directoryName = 'tag_library_thumbnails';
+
+  static final _entryIdPattern = RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]{0,191}$');
+  static final _extensionPattern = RegExp(r'^\.(png|jpe?g|webp|gif|bmp)$');
+
+  static bool isValidEntryId(String value) => _entryIdPattern.hasMatch(value);
+
+  static bool isSupportedExtension(String value) =>
+      _extensionPattern.hasMatch(value.toLowerCase());
+
+  static Future<Directory> resolveDirectory() async {
+    final appDir = await getApplicationDocumentsDirectory();
+    return Directory(p.join(appDir.path, directoryName));
+  }
+
   Future<PortableThumbnailMutation> stage(
     String entryId, {
     required String? extension,
     required Stream<List<int>>? bytes,
     String? existingPath,
   }) async {
-    if (!RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]{0,191}$').hasMatch(entryId)) {
+    if (!isValidEntryId(entryId)) {
       throw const FormatException('Invalid tag library entry ID');
     }
     final safeExtension = extension?.toLowerCase();
-    if (safeExtension != null &&
-        !RegExp(r'^\.(png|jpe?g|webp|gif|bmp)$').hasMatch(safeExtension)) {
+    if (safeExtension != null && !isSupportedExtension(safeExtension)) {
       throw const FormatException('Unsupported tag library thumbnail');
     }
     if ((safeExtension == null) != (bytes == null)) {
       throw ArgumentError('Thumbnail extension and bytes must match');
     }
-    final appDir = await getApplicationDocumentsDirectory();
-    final directory = Directory(p.join(appDir.path, 'tag_library_thumbnails'));
+    final directory = await resolveDirectory();
     await directory.create(recursive: true);
     final target = safeExtension == null
         ? null
@@ -59,10 +72,7 @@ class TagLibraryPortableThumbnailStore {
       await for (final entity in directory.list())
         if (entity is File &&
             p.basenameWithoutExtension(entity.path) == entryId &&
-            RegExp(
-              r'^\.(png|jpe?g|webp|gif|bmp)$',
-              caseSensitive: false,
-            ).hasMatch(p.extension(entity.path)))
+            isSupportedExtension(p.extension(entity.path)))
           p.normalize(entity.path): entity,
     };
     final backups = <File, File>{};

--- a/test/data/services/tag_library_io_service_import_security_test.dart
+++ b/test/data/services/tag_library_io_service_import_security_test.dart
@@ -1,0 +1,404 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/tag_library/import_models.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_category.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
+import 'package:nai_launcher/data/services/tag_library_io_service.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+const _entryId = '11111111-1111-4111-8111-111111111111';
+const _otherEntryId = '33333333-3333-4333-8333-333333333333';
+const _categoryId = '22222222-2222-4222-8222-222222222222';
+const _pngBytes = <int>[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory documents;
+  late Directory workspace;
+  late PathProviderPlatform previousPlatform;
+  late TagLibraryIOService service;
+
+  setUp(() async {
+    documents = await Directory.systemTemp.createTemp('tag-library-docs-');
+    workspace = await Directory.systemTemp.createTemp('tag-library-package-');
+    previousPlatform = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _PathProvider(documents.path);
+    service = TagLibraryIOService();
+  });
+
+  tearDown(() async {
+    PathProviderPlatform.instance = previousPlatform;
+    await documents.delete(recursive: true);
+    await workspace.delete(recursive: true);
+  });
+
+  Directory thumbnailsRoot() =>
+      Directory(p.join(documents.path, 'tag_library_thumbnails'));
+
+  List<String> documentEntryNames() =>
+      documents.listSync().map((e) => p.basename(e.path)).toList()..sort();
+
+  List<String> thumbnailNames() {
+    final root = thumbnailsRoot();
+    if (!root.existsSync()) return const [];
+    return root.listSync().map((e) => p.basename(e.path)).toList()..sort();
+  }
+
+  Future<ImportResult> runImport(File package, ImportPreview preview) =>
+      service.executeImport(
+        zipFile: package,
+        preview: preview,
+        selectedEntryIds: preview.entries.map((e) => e.id).toSet(),
+        selectedCategoryIds: preview.categories.map((c) => c.id).toSet(),
+        conflictResolutions: const {},
+        existingEntries: const [],
+        existingCategories: const [],
+      );
+
+  group('归档成员校验', () {
+    test('拒绝穿越缩略图目录的成员并且不落盘', () async {
+      final entry = _entry(id: _entryId, thumbnail: '/exported/thumb.png');
+      final package = _writePackage(workspace, [
+        _manifest(),
+        _json('entries/$_entryId.json', entry.toJson()),
+        _binary('thumbnails/../escaped.png', _pngBytes),
+      ]);
+
+      await expectLater(
+        service.parseImportFile(package),
+        throwsA(isA<FormatException>()),
+      );
+      await expectLater(
+        runImport(package, _preview(entries: [entry])),
+        throwsA(isA<FormatException>()),
+      );
+      expect(File(p.join(documents.path, 'escaped.png')).existsSync(), isFalse);
+      expect(thumbnailNames(), isEmpty);
+    });
+
+    test('拒绝绝对路径成员', () async {
+      final package = _writePackage(workspace, [
+        _manifest(entryCount: 0),
+        _binary('/etc/escaped.png', _pngBytes),
+      ]);
+
+      await expectLater(
+        service.parseImportFile(package),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('拒绝仅大小写不同的重复成员', () async {
+      final entry = _entry(id: _entryId, thumbnail: '/exported/thumb.png');
+      final package = _writePackage(workspace, [
+        _manifest(),
+        _json('entries/$_entryId.json', entry.toJson()),
+        _binary('thumbnails/$_entryId.png', _pngBytes),
+        _binary('thumbnails/${_entryId.toUpperCase()}.PNG', _pngBytes),
+      ]);
+
+      await expectLater(
+        service.parseImportFile(package),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('拒绝同一条目携带多张预览图', () async {
+      final entry = _entry(id: _entryId, thumbnail: '/exported/thumb.png');
+      final package = _writePackage(workspace, [
+        _manifest(),
+        _json('entries/$_entryId.json', entry.toJson()),
+        _binary('thumbnails/$_entryId.png', _pngBytes),
+        _binary('thumbnails/$_entryId.jpg', _pngBytes),
+      ]);
+
+      await expectLater(
+        service.parseImportFile(package),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('拒绝符号链接成员', () async {
+      final entry = _entry(id: _entryId, thumbnail: '/exported/thumb.png');
+      final package = _writePackage(workspace, [
+        _manifest(),
+        _json('entries/$_entryId.json', entry.toJson()),
+        _binary('thumbnails/$_entryId.png', utf8.encode('../../escaped.png')),
+      ], symbolicLinkMember: 'thumbnails/$_entryId.png');
+
+      await expectLater(
+        service.parseImportFile(package),
+        throwsA(isA<FormatException>()),
+      );
+      await expectLater(
+        runImport(package, _preview(entries: [entry])),
+        throwsA(isA<FormatException>()),
+      );
+      expect(thumbnailNames(), isEmpty);
+    });
+
+    test('拒绝伪装成预览图的可执行文件与文本', () async {
+      for (final extension in const ['.exe', '.txt']) {
+        final entry = _entry(id: _entryId, thumbnail: '/exported/thumb.png');
+        final package = _writePackage(workspace, [
+          _manifest(),
+          _json('entries/$_entryId.json', entry.toJson()),
+          _binary('thumbnails/$_entryId$extension', _pngBytes),
+        ], fileName: 'payload$extension.zip');
+
+        await expectLater(
+          service.parseImportFile(package),
+          throwsA(isA<FormatException>()),
+          reason: '扩展名 $extension 应被拒绝',
+        );
+        await expectLater(
+          runImport(package, _preview(entries: [entry])),
+          throwsA(isA<FormatException>()),
+          reason: '扩展名 $extension 应被拒绝',
+        );
+      }
+      expect(thumbnailNames(), isEmpty);
+    });
+  });
+
+  group('标识符校验', () {
+    test('拒绝穿越目录的条目 ID 且不写出目录外文件', () async {
+      final entry = _entry(id: '../escaped', thumbnail: '/exported/thumb.png');
+      final package = _writePackage(workspace, [
+        _manifest(),
+        _json('entries/payload.json', entry.toJson()),
+        _binary('thumbnails/$_entryId.png', _pngBytes),
+      ]);
+
+      await expectLater(
+        service.parseImportFile(package),
+        throwsA(isA<FormatException>()),
+      );
+      await expectLater(
+        runImport(package, _preview(entries: [entry])),
+        throwsA(isA<FormatException>()),
+      );
+      expect(File(p.join(documents.path, 'escaped.png')).existsSync(), isFalse);
+      expect(documentEntryNames(), isEmpty);
+    });
+
+    test('拒绝含盘符与反斜杠的条目 ID', () async {
+      for (final id in const [
+        r'C:\Windows\Temp\escaped',
+        'C:/Windows/Temp/escaped',
+        r'..\escaped',
+      ]) {
+        final entry = _entry(id: id, thumbnail: '/exported/thumb.png');
+        final package = _writePackage(workspace, [
+          _manifest(),
+          _json('entries/payload.json', entry.toJson()),
+        ], fileName: 'package-${id.hashCode}.zip');
+
+        await expectLater(
+          service.parseImportFile(package),
+          throwsA(isA<FormatException>()),
+          reason: 'ID $id 应被拒绝',
+        );
+        await expectLater(
+          runImport(package, _preview(entries: [entry])),
+          throwsA(isA<FormatException>()),
+          reason: 'ID $id 应被拒绝',
+        );
+      }
+      expect(documentEntryNames(), isEmpty);
+    });
+
+    test('拒绝非法的分类 ID 与引用', () async {
+      final category = TagLibraryCategory(
+        id: _categoryId,
+        name: '分类',
+        parentId: '../escaped',
+        createdAt: DateTime.utc(2026),
+      );
+      final entry = _entry(id: _entryId, categoryId: '../escaped');
+      final package = _writePackage(workspace, [
+        _manifest(categoryCount: 1),
+        _json('categories.json', [category.toJson()]),
+        _json('entries/$_entryId.json', entry.toJson()),
+      ]);
+
+      await expectLater(
+        service.parseImportFile(package),
+        throwsA(isA<FormatException>()),
+      );
+      await expectLater(
+        runImport(package, _preview(entries: [entry], categories: [category])),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('预览图定位', () {
+    test('同名前缀成员不会被当作该条目的预览图', () async {
+      final entry = _entry(id: 'abc', thumbnail: '/exported/thumb.png');
+      final package = _writePackage(workspace, [
+        _manifest(),
+        _json('entries/abc.json', entry.toJson()),
+        _binary('thumbnails/abcd.png', _pngBytes),
+      ]);
+
+      final preview = await service.parseImportFile(package);
+      final result = await runImport(package, preview);
+
+      expect(result.success, isTrue);
+      expect(result.updatedEntries['abc']!.thumbnail, isNull);
+      expect(thumbnailNames(), isEmpty);
+    });
+
+    test('正常预览图落在缩略图目录内且内容一致', () async {
+      final entry = _entry(
+        id: _entryId,
+        thumbnail: '/exported/tag_library_thumbnails/$_entryId.png',
+      );
+      final package = _writePackage(workspace, [
+        _manifest(),
+        _json('entries/$_entryId.json', entry.toJson()),
+        _binary('thumbnails/$_entryId.png', _pngBytes),
+      ]);
+
+      final preview = await service.parseImportFile(package);
+      final result = await runImport(package, preview);
+
+      final imported = result.updatedEntries[_entryId]!.thumbnail!;
+      expect(result.success, isTrue);
+      expect(p.isWithin(thumbnailsRoot().path, imported), isTrue);
+      expect(File(imported).readAsBytesSync(), _pngBytes);
+      expect(thumbnailNames(), ['$_entryId.png']);
+      expect(documentEntryNames(), ['tag_library_thumbnails']);
+    });
+
+    test('包内未携带预览图时丢弃导出机器的外部路径', () async {
+      final foreign = _entry(
+        id: _entryId,
+        thumbnail: p.join(workspace.path, 'foreign.png'),
+      );
+      final local = _entry(
+        id: _otherEntryId,
+        thumbnail: p.join(thumbnailsRoot().path, '$_otherEntryId.png'),
+      );
+      final package = _writePackage(workspace, [
+        _manifest(entryCount: 2),
+        _json('entries/$_entryId.json', foreign.toJson()),
+        _json('entries/$_otherEntryId.json', local.toJson()),
+      ]);
+
+      final preview = await service.parseImportFile(package);
+      final result = await runImport(package, preview);
+
+      expect(result.updatedEntries[_entryId]!.thumbnail, isNull);
+      expect(
+        result.updatedEntries[_otherEntryId]!.thumbnail,
+        p.join(thumbnailsRoot().path, '$_otherEntryId.png'),
+      );
+    });
+  });
+}
+
+TagLibraryEntry _entry({
+  required String id,
+  String? thumbnail,
+  String? categoryId,
+}) => TagLibraryEntry(
+  id: id,
+  name: '条目',
+  content: '1girl',
+  thumbnail: thumbnail,
+  categoryId: categoryId,
+  createdAt: DateTime.utc(2026),
+  updatedAt: DateTime.utc(2026),
+);
+
+ImportPreview _preview({
+  List<TagLibraryEntry> entries = const [],
+  List<TagLibraryCategory> categories = const [],
+}) => ImportPreview(
+  version: '1.0',
+  exportDate: DateTime.utc(2026),
+  entries: entries,
+  categories: categories,
+  hasThumbnails: true,
+);
+
+ArchiveFile _manifest({int entryCount = 1, int categoryCount = 0}) =>
+    _json('manifest.json', {
+      'version': '1.0',
+      'exportDate': DateTime.utc(2026).toIso8601String(),
+      'appVersion': '1.0.0',
+      'entryCount': entryCount,
+      'categoryCount': categoryCount,
+      'includeThumbnails': true,
+    });
+
+ArchiveFile _json(String name, Object? value) =>
+    _binary(name, utf8.encode(jsonEncode(value)));
+
+ArchiveFile _binary(String name, List<int> bytes) =>
+    ArchiveFile(name, bytes.length, bytes);
+
+File _writePackage(
+  Directory directory,
+  List<ArchiveFile> files, {
+  String fileName = 'library.zip',
+  String? symbolicLinkMember,
+}) {
+  final archive = Archive();
+  for (final file in files) {
+    archive.addFile(file);
+  }
+  var bytes = Uint8List.fromList(ZipEncoder().encode(archive)!);
+  if (symbolicLinkMember != null) {
+    bytes = _markSymbolicLink(bytes, symbolicLinkMember);
+  }
+  return File(p.join(directory.path, fileName))..writeAsBytesSync(bytes);
+}
+
+// ZipEncoder 只写 MS-DOS 归档，符号链接位必须直接改中央目录的 versionMadeBy 与外部属性
+Uint8List _markSymbolicLink(Uint8List zip, String memberName) {
+  final data = ByteData.sublistView(zip);
+  var directoryEnd = zip.length - 22;
+  while (directoryEnd >= 0 &&
+      data.getUint32(directoryEnd, Endian.little) != 0x06054b50) {
+    directoryEnd--;
+  }
+  if (directoryEnd < 0) {
+    throw StateError('未找到中央目录结尾记录');
+  }
+
+  final count = data.getUint16(directoryEnd + 10, Endian.little);
+  var offset = data.getUint32(directoryEnd + 16, Endian.little);
+  for (var index = 0; index < count; index++) {
+    final nameLength = data.getUint16(offset + 28, Endian.little);
+    final extraLength = data.getUint16(offset + 30, Endian.little);
+    final commentLength = data.getUint16(offset + 32, Endian.little);
+    final name = utf8.decode(
+      zip.sublist(offset + 46, offset + 46 + nameLength),
+    );
+    if (name == memberName) {
+      data.setUint16(offset + 4, (3 << 8) | 20, Endian.little);
+      data.setUint32(offset + 38, 0xa1ff0000, Endian.little);
+      return zip;
+    }
+    offset += 46 + nameLength + extraLength + commentLength;
+  }
+  throw StateError('未找到归档成员：$memberName');
+}
+
+class _PathProvider extends PathProviderPlatform {
+  _PathProvider(this.path);
+
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}


### PR DESCRIPTION
## 用户可见变化

导入他人分享的词库包时，恶意构造的包不再能把文件写到缩略图目录之外。不合规的包会被整包拒绝并给出错误，而不是部分写入。正常导出的包行为不变。

## 问题

包内 `entries/*.json` 的条目 ID 被直接拼进缩略图写入路径，归档成员又用前缀匹配定位，构造 `../` 或带盘符的 ID 即可写到任意位置，扩展名也不受限制。

## 改动

- 解析和执行导入前统一预检归档成员：拒绝符号链接、非文件条目、绝对路径、`..` 段、反斜杠、盘符、控制字符，以及仅大小写不同的重复成员
- 条目与分类的 ID 及 `categoryId`/`parentId` 引用改用与缩略图存储一致的白名单，不合规拒绝整个包
- 预览图改用精确成员名 `thumbnails/<id><扩展名>` 定位，扩展名限定 png/jpg/jpeg/webp/gif/bmp，写入走缩略图存储的原子写并在写入前断言目标位于缩略图根目录内
- 包内没有预览图时丢弃指向导出机器的外部路径，只保留仍在本机缩略图目录内的路径

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（在包含本分支的集成分支上执行）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `test/data/services/tag_library_io_service_import_security_test.dart`（404 行）覆盖各类穿越构造

无生成文件、LFS 或 assets 变更。
