### PR TITLE
fix(tag-library): 词库导入改用逐条计划决定 ID 与命名

### DIFF
--- a/lib/data/models/tag_library/import_plan.dart
+++ b/lib/data/models/tag_library/import_plan.dart
@@ -1,0 +1,162 @@
+import 'import_models.dart';
+import 'tag_library_category.dart';
+import 'tag_library_entry.dart';
+
+/// 单个导入项的动作
+enum TagLibraryImportAction {
+  /// 保留本地数据，不写入包内版本
+  skip,
+
+  /// 无冲突，按新身份写入
+  create,
+
+  /// 加后缀后按新身份写入
+  rename,
+
+  /// 删除现有项后写入包内版本
+  overwrite,
+}
+
+/// 导入项类型
+enum TagLibraryImportItemKind { category, entry }
+
+/// 分类的逐条导入计划
+class TagLibraryCategoryImportPlan {
+  const TagLibraryCategoryImportPlan({
+    required this.source,
+    required this.action,
+    required this.targetId,
+    required this.targetName,
+    this.targetParentId,
+    this.replacedCategoryId,
+    this.reassignedId = false,
+  });
+
+  final TagLibraryCategory source;
+  final TagLibraryImportAction action;
+
+  /// 跳过时为可供子项引用的现有分类 ID；本地已无同名分类时为 null
+  final String? targetId;
+  final String targetName;
+
+  /// 已按分类映射解析的父级 ID
+  final String? targetParentId;
+
+  /// 覆盖时先删除的现有分类 ID
+  final String? replacedCategoryId;
+
+  /// 包内 ID 与本次不删除的本地分类冲突，已改用新 ID
+  final bool reassignedId;
+
+  bool get isApplied => action != TagLibraryImportAction.skip;
+}
+
+/// 条目的逐条导入计划
+class TagLibraryEntryImportPlan {
+  const TagLibraryEntryImportPlan({
+    required this.source,
+    required this.action,
+    required this.targetId,
+    required this.targetName,
+    this.targetCategoryId,
+    this.replacedEntryId,
+    this.reassignedId = false,
+  });
+
+  final TagLibraryEntry source;
+  final TagLibraryImportAction action;
+
+  /// 跳过时为命中的现有条目 ID；本地已无同名条目时为 null
+  final String? targetId;
+  final String targetName;
+
+  /// 已按分类映射解析的所属分类 ID
+  final String? targetCategoryId;
+
+  /// 覆盖时先删除的现有条目 ID
+  final String? replacedEntryId;
+
+  /// 包内 ID 与本次不删除的本地条目冲突，已改用新 ID
+  final bool reassignedId;
+
+  bool get isApplied => action != TagLibraryImportAction.skip;
+
+  /// 预览图落盘使用的条目 ID，决定缩略图目录内的目标文件名
+  String? get thumbnailEntryId => isApplied ? targetId : null;
+}
+
+/// 一次导入的完整计划，写入前已确定全部目标身份与引用
+class TagLibraryImportPlan {
+  TagLibraryImportPlan({
+    required this.preview,
+    required List<TagLibraryCategoryImportPlan> categories,
+    required List<TagLibraryEntryImportPlan> entries,
+  }) : categories = List.unmodifiable(categories),
+       entries = List.unmodifiable(entries),
+       categoryIdMapping = Map.unmodifiable(<String, String>{
+         for (final item in categories)
+           if (item.targetId != null) item.source.id: item.targetId!,
+       });
+
+  final ImportPreview preview;
+  final List<TagLibraryCategoryImportPlan> categories;
+  final List<TagLibraryEntryImportPlan> entries;
+
+  /// 包内分类 ID -> 本地目标分类 ID
+  final Map<String, String> categoryIdMapping;
+
+  int get skippedCount =>
+      _countCategories(TagLibraryImportAction.skip) +
+      _countEntries(TagLibraryImportAction.skip);
+
+  int get overwrittenCount =>
+      _countCategories(TagLibraryImportAction.overwrite) +
+      _countEntries(TagLibraryImportAction.overwrite);
+
+  int get renamedCount =>
+      _countCategories(TagLibraryImportAction.rename) +
+      _countEntries(TagLibraryImportAction.rename);
+
+  /// 覆盖分类沿用现有统计口径，只计入 overwrittenCount
+  int get importedCategoryCount =>
+      _countCategories(TagLibraryImportAction.create) +
+      _countCategories(TagLibraryImportAction.rename);
+
+  int get importedEntryCount => entries.where((e) => e.isApplied).length;
+
+  int _countCategories(TagLibraryImportAction action) =>
+      categories.where((item) => item.action == action).length;
+
+  int _countEntries(TagLibraryImportAction action) =>
+      entries.where((item) => item.action == action).length;
+}
+
+/// 应用计划时被拒绝的项：目标 ID 在当前数据中已被占用
+class TagLibraryImportRejection {
+  const TagLibraryImportRejection({
+    required this.kind,
+    required this.sourceId,
+    required this.targetId,
+  });
+
+  final TagLibraryImportItemKind kind;
+  final String sourceId;
+  final String targetId;
+}
+
+/// 计划应用结果
+class TagLibraryImportApplyResult {
+  TagLibraryImportApplyResult({
+    required List<String> appliedCategoryIds,
+    required List<String> appliedEntryIds,
+    required List<TagLibraryImportRejection> rejected,
+  }) : appliedCategoryIds = List.unmodifiable(appliedCategoryIds),
+       appliedEntryIds = List.unmodifiable(appliedEntryIds),
+       rejected = List.unmodifiable(rejected);
+
+  final List<String> appliedCategoryIds;
+  final List<String> appliedEntryIds;
+  final List<TagLibraryImportRejection> rejected;
+
+  bool get success => rejected.isEmpty;
+}

--- a/lib/data/services/tag_library_import_planner.dart
+++ b/lib/data/services/tag_library_import_planner.dart
@@ -1,0 +1,219 @@
+import 'package:uuid/uuid.dart';
+
+import '../models/tag_library/import_models.dart';
+import '../models/tag_library/import_plan.dart';
+import '../models/tag_library/tag_library_category.dart';
+import '../models/tag_library/tag_library_entry.dart';
+
+typedef _Draft<T> = ({
+  T source,
+  String sourceId,
+  String sourceName,
+  TagLibraryImportAction action,
+  String? matchedId,
+});
+
+typedef _Target = ({String? id, bool reassigned});
+
+/// 按每个分类与条目自身的冲突解决方案生成导入计划
+class TagLibraryImportPlanner {
+  const TagLibraryImportPlanner({this.newId = _uuidV4});
+
+  final String Function() newId;
+
+  static String _uuidV4() => const Uuid().v4();
+
+  /// [conflicts] 为界面展示给用户的冲突，决定每项对应的现有数据
+  TagLibraryImportPlan plan({
+    required ImportPreview preview,
+    required Set<String> selectedEntryIds,
+    required Set<String> selectedCategoryIds,
+    required List<ImportConflict> conflicts,
+    required Map<String, ConflictResolution> conflictResolutions,
+    required List<TagLibraryEntry> existingEntries,
+    required List<TagLibraryCategory> existingCategories,
+    required String renameSuffix,
+  }) {
+    final existingCategoryIds = existingCategories.map((c) => c.id).toSet();
+    final existingEntryIds = existingEntries.map((e) => e.id).toSet();
+
+    final categoryPlans = _planCategories(
+      sources: preview.categories
+          .where((c) => selectedCategoryIds.contains(c.id))
+          .toList(),
+      matchedIds: _matchedIds(
+        conflicts.where((c) => c.isCategoryConflict),
+        existingCategoryIds,
+      ),
+      conflictResolutions: conflictResolutions,
+      existingIds: existingCategoryIds,
+      renameSuffix: renameSuffix,
+    );
+
+    return TagLibraryImportPlan(
+      preview: preview,
+      categories: categoryPlans,
+      entries: _planEntries(
+        sources: preview.entries
+            .where((e) => selectedEntryIds.contains(e.id))
+            .toList(),
+        matchedIds: _matchedIds(
+          conflicts.where((c) => c.isEntryConflict),
+          existingEntryIds,
+        ),
+        conflictResolutions: conflictResolutions,
+        existingIds: existingEntryIds,
+        categoryIdMapping: <String, String>{
+          for (final item in categoryPlans)
+            if (item.targetId != null) item.source.id: item.targetId!,
+        },
+        renameSuffix: renameSuffix,
+      ),
+    );
+  }
+
+  List<TagLibraryCategoryImportPlan> _planCategories({
+    required List<TagLibraryCategory> sources,
+    required Map<String, String> matchedIds,
+    required Map<String, ConflictResolution> conflictResolutions,
+    required Set<String> existingIds,
+    required String renameSuffix,
+  }) {
+    final drafts = [
+      for (final source in sources)
+        _draft(
+          source: source,
+          sourceId: source.id,
+          sourceName: source.name,
+          matchedId: matchedIds[source.id],
+          resolution: conflictResolutions[source.id],
+        ),
+    ];
+    final targets = _assignTargets(drafts, existingIds);
+    // 父级引用必须先于子级解析，包内顺序不保证父在子前
+    final mapping = <String, String>{
+      for (var i = 0; i < drafts.length; i++)
+        if (targets[i].id != null) drafts[i].sourceId: targets[i].id!,
+    };
+
+    return [
+      for (var i = 0; i < drafts.length; i++)
+        TagLibraryCategoryImportPlan(
+          source: drafts[i].source,
+          action: drafts[i].action,
+          targetId: targets[i].id,
+          targetName: _targetName(drafts[i], renameSuffix),
+          targetParentId: _mapped(mapping, drafts[i].source.parentId),
+          replacedCategoryId: _replacedId(drafts[i]),
+          reassignedId: targets[i].reassigned,
+        ),
+    ];
+  }
+
+  List<TagLibraryEntryImportPlan> _planEntries({
+    required List<TagLibraryEntry> sources,
+    required Map<String, String> matchedIds,
+    required Map<String, ConflictResolution> conflictResolutions,
+    required Set<String> existingIds,
+    required Map<String, String> categoryIdMapping,
+    required String renameSuffix,
+  }) {
+    final drafts = [
+      for (final source in sources)
+        _draft(
+          source: source,
+          sourceId: source.id,
+          sourceName: source.name,
+          matchedId: matchedIds[source.id],
+          resolution: conflictResolutions[source.id],
+        ),
+    ];
+    final targets = _assignTargets(drafts, existingIds);
+
+    return [
+      for (var i = 0; i < drafts.length; i++)
+        TagLibraryEntryImportPlan(
+          source: drafts[i].source,
+          action: drafts[i].action,
+          targetId: targets[i].id,
+          targetName: _targetName(drafts[i], renameSuffix),
+          targetCategoryId: _mapped(
+            categoryIdMapping,
+            drafts[i].source.categoryId,
+          ),
+          replacedEntryId: _replacedId(drafts[i]),
+          reassignedId: targets[i].reassigned,
+        ),
+    ];
+  }
+
+  /// 先扣掉本次会被删除的本地 ID，再逐项占位，确保写入前目标身份互不冲突
+  List<_Target> _assignTargets<T>(
+    List<_Draft<T>> drafts,
+    Set<String> existingIds,
+  ) {
+    final replacedIds = <String>{
+      for (final draft in drafts)
+        if (draft.action == TagLibraryImportAction.overwrite &&
+            draft.matchedId != null)
+          draft.matchedId!,
+    };
+    final taken = existingIds.difference(replacedIds);
+    return [for (final draft in drafts) _assignTarget(draft, taken)];
+  }
+
+  _Target _assignTarget<T>(_Draft<T> draft, Set<String> taken) {
+    if (draft.action == TagLibraryImportAction.skip) {
+      return (id: draft.matchedId, reassigned: false);
+    }
+    final keepsSourceId = draft.action == TagLibraryImportAction.overwrite;
+    if (keepsSourceId && taken.add(draft.sourceId)) {
+      return (id: draft.sourceId, reassigned: false);
+    }
+    final generated = newId();
+    taken.add(generated);
+    return (id: generated, reassigned: keepsSourceId);
+  }
+
+  _Draft<T> _draft<T>({
+    required T source,
+    required String sourceId,
+    required String sourceName,
+    required String? matchedId,
+    required ConflictResolution? resolution,
+  }) => (
+    source: source,
+    sourceId: sourceId,
+    sourceName: sourceName,
+    action: switch (resolution) {
+      ConflictResolution.skip => TagLibraryImportAction.skip,
+      ConflictResolution.rename => TagLibraryImportAction.rename,
+      ConflictResolution.overwrite when matchedId != null =>
+        TagLibraryImportAction.overwrite,
+      ConflictResolution.overwrite => TagLibraryImportAction.create,
+      null => TagLibraryImportAction.create,
+    },
+    matchedId: matchedId,
+  );
+
+  /// 冲突记录来自选择文件时的快照，对应数据已被删除时视为无冲突
+  Map<String, String> _matchedIds(
+    Iterable<ImportConflict> conflicts,
+    Set<String> existingIds,
+  ) => <String, String>{
+    for (final conflict in conflicts)
+      if (existingIds.contains(conflict.existingId))
+        conflict.importId: conflict.existingId,
+  };
+
+  String _targetName<T>(_Draft<T> draft, String suffix) =>
+      draft.action == TagLibraryImportAction.rename
+      ? '${draft.sourceName}$suffix'
+      : draft.sourceName;
+
+  String? _replacedId<T>(_Draft<T> draft) =>
+      draft.action == TagLibraryImportAction.overwrite ? draft.matchedId : null;
+
+  String? _mapped(Map<String, String> mapping, String? sourceId) =>
+      sourceId == null ? null : mapping[sourceId];
+}

--- a/lib/data/services/tag_library_io_service.dart
+++ b/lib/data/services/tag_library_io_service.dart
@@ -5,6 +5,7 @@ import 'package:archive/archive.dart';
 import 'package:path/path.dart' as path;
 
 import '../models/tag_library/import_models.dart';
+import '../models/tag_library/import_plan.dart';
 import '../models/tag_library/tag_library_category.dart';
 import '../models/tag_library/tag_library_entry.dart';
 import 'tag_library_portable_thumbnail_store.dart';
@@ -280,32 +281,20 @@ class TagLibraryIOService {
     return conflicts;
   }
 
-  /// 执行导入
+  /// 按计划落盘预览图，条目的身份与引用由计划决定
   Future<ImportResult> executeImport({
     required File zipFile,
-    required ImportPreview preview,
-    required Set<String> selectedEntryIds,
-    required Set<String> selectedCategoryIds,
-    required Map<String, ConflictResolution> conflictResolutions,
-    required List<TagLibraryEntry> existingEntries,
-    required List<TagLibraryCategory> existingCategories,
+    required TagLibraryImportPlan plan,
     void Function(double progress, String message)? onProgress,
   }) async {
-    var importedEntries = 0;
-    var importedCategories = 0;
-    var skippedConflicts = 0;
-    var overwrittenCount = 0;
-    var renamedCount = 0;
-    final errors = <String>[];
-
     final bytes = await zipFile.readAsBytes();
     final archive = ZipDecoder().decodeBytes(bytes);
 
-    // 归档与预览都由调用方提供，落盘前必须重新校验而不是沿用解析阶段的结论
+    // 归档与计划都由调用方提供，落盘前必须重新校验而不是沿用解析阶段的结论
     final thumbnailMembers = _preflightArchive(archive);
     _verifyIdentifiers(
-      entries: preview.entries,
-      categories: preview.categories,
+      entries: plan.preview.entries,
+      categories: plan.preview.categories,
     );
 
     // 获取应用文档目录用于保存预览图
@@ -315,119 +304,70 @@ class TagLibraryIOService {
       await thumbnailsDir.create(recursive: true);
     }
 
-    final totalSteps = selectedEntryIds.length + selectedCategoryIds.length;
+    final totalSteps = plan.categories.length + plan.entries.length;
+    final progressBase = totalSteps == 0 ? 1 : totalSteps;
     var currentStep = 0;
 
-    // 创建分类 ID 映射（旧 ID -> 新 ID）
-    final categoryIdMapping = <String, String>{};
-
-    // 导入分类
-    for (final category in preview.categories) {
-      if (!selectedCategoryIds.contains(category.id)) continue;
-
+    for (final item in plan.categories) {
       onProgress?.call(
-        currentStep / totalSteps,
-        '导入分类: ${category.displayName}',
+        currentStep / progressBase,
+        '导入分类: ${item.source.displayName}',
       );
-
-      final resolution = conflictResolutions[category.id];
-      if (resolution == ConflictResolution.skip) {
-        skippedConflicts++;
-        // 找到现有分类的 ID 用于映射
-        final existing = existingCategories
-            .cast<TagLibraryCategory?>()
-            .firstWhere(
-              (c) =>
-                  c?.name.toLowerCase() == category.name.toLowerCase() &&
-                  c?.parentId == category.parentId,
-              orElse: () => null,
-            );
-        if (existing != null) {
-          categoryIdMapping[category.id] = existing.id;
-        }
-      } else if (resolution == ConflictResolution.overwrite) {
-        overwrittenCount++;
-        categoryIdMapping[category.id] = category.id;
-      } else {
-        // 新建或重命名
-        String newName = category.name;
-        if (resolution == ConflictResolution.rename) {
-          newName = '${category.name} (导入)';
-          renamedCount++;
-        }
-        final newCategory = TagLibraryCategory.create(
-          name: newName,
-          parentId: category.parentId != null
-              ? categoryIdMapping[category.parentId]
-              : null,
-        );
-        categoryIdMapping[category.id] = newCategory.id;
-        importedCategories++;
-      }
-
       currentStep++;
     }
 
     // 存储更新后的条目（key: 原始条目ID, value: 更新后的条目）
     final updatedEntries = <String, TagLibraryEntry>{};
 
-    // 导入条目
-    for (final entry in preview.entries) {
-      if (!selectedEntryIds.contains(entry.id)) continue;
-
-      onProgress?.call(currentStep / totalSteps, '导入条目: ${entry.displayName}');
-
-      final resolution = conflictResolutions[entry.id];
-      if (resolution == ConflictResolution.skip) {
-        skippedConflicts++;
-        currentStep++;
-        continue;
-      }
-
-      // 提取预览图并更新缩略图路径
-      String? newThumbnailPath;
-      if (entry.hasThumbnail) {
-        final member = thumbnailMembers[entry.id];
-        if (member != null) {
-          final ext = path.url.extension(member.name).toLowerCase();
-          _verifyThumbnailTarget(thumbnailsDir, entry.id, ext);
-          newThumbnailPath = await importPortableThumbnail(
-            entry.id,
-            ext,
-            Stream.value(member.content as List<int>),
-          );
-        }
-      }
-
-      // 创建更新后的条目（使用新的缩略图路径）
-      final updatedEntry = entry.copyWith(
-        thumbnail:
-            newThumbnailPath ??
-            _retainedThumbnail(thumbnailsDir, entry.thumbnail),
+    for (final item in plan.entries) {
+      onProgress?.call(
+        currentStep / progressBase,
+        '导入条目: ${item.source.displayName}',
       );
-      updatedEntries[entry.id] = updatedEntry;
-
-      if (resolution == ConflictResolution.overwrite) {
-        overwrittenCount++;
-      } else if (resolution == ConflictResolution.rename) {
-        renamedCount++;
-      }
-
-      importedEntries++;
       currentStep++;
+
+      final targetId = item.thumbnailEntryId;
+      if (targetId == null) continue;
+
+      updatedEntries[item.source.id] = item.source.copyWith(
+        thumbnail: await _importThumbnail(
+          entry: item.source,
+          targetId: targetId,
+          thumbnailMembers: thumbnailMembers,
+          thumbnailsDir: thumbnailsDir,
+        ),
+      );
     }
 
     onProgress?.call(1.0, '导入完成');
 
     return ImportResult(
-      importedEntries: importedEntries,
-      importedCategories: importedCategories,
-      skippedConflicts: skippedConflicts,
-      overwrittenCount: overwrittenCount,
-      renamedCount: renamedCount,
-      errors: errors,
-      success: errors.isEmpty,
+      importedEntries: plan.importedEntryCount,
+      importedCategories: plan.importedCategoryCount,
+      skippedConflicts: plan.skippedCount,
+      overwrittenCount: plan.overwrittenCount,
+      renamedCount: plan.renamedCount,
       updatedEntries: updatedEntries,
+    );
+  }
+
+  /// 预览图写入目标条目自己的 ID，避免与包内 ID 相同的本地条目互相覆盖
+  Future<String?> _importThumbnail({
+    required TagLibraryEntry entry,
+    required String targetId,
+    required Map<String, ArchiveFile> thumbnailMembers,
+    required Directory thumbnailsDir,
+  }) async {
+    final member = entry.hasThumbnail ? thumbnailMembers[entry.id] : null;
+    if (member == null) {
+      return _retainedThumbnail(thumbnailsDir, entry.thumbnail);
+    }
+    final extension = path.url.extension(member.name).toLowerCase();
+    _verifyThumbnailTarget(thumbnailsDir, targetId, extension);
+    return importPortableThumbnail(
+      targetId,
+      extension,
+      Stream.value(member.content as List<int>),
     );
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3366,6 +3366,12 @@
       "count": {}
     }
   },
+  "tagLibrary_importRejectedCount": "{count} not imported",
+  "@tagLibrary_importRejectedCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
   "tagLibrary_unknownCategory": "Unknown Category",
   "tagLibrary_selectEntryToUpdate": "Select Entry to Update",
   "tagLibrary_updatePreview": "Update Preview",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3315,6 +3315,12 @@
       "count": {}
     }
   },
+  "tagLibrary_importRejectedCount": "{count} は未インポート",
+  "@tagLibrary_importRejectedCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
   "tagLibrary_unknownCategory": "不明なカテゴリ",
   "tagLibrary_selectEntryToUpdate": "更新するエントリを選択してください",
   "tagLibrary_updatePreview": "プレビューを更新",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13084,6 +13084,12 @@ abstract class AppLocalizations {
   /// **'{count} skipped'**
   String tagLibrary_skippedCount(Object count);
 
+  /// No description provided for @tagLibrary_importRejectedCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} not imported'**
+  String tagLibrary_importRejectedCount(Object count);
+
   /// No description provided for @tagLibrary_unknownCategory.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7370,6 +7370,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String tagLibrary_importRejectedCount(Object count) {
+    return '$count not imported';
+  }
+
+  @override
   String get tagLibrary_unknownCategory => 'Unknown Category';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -7196,6 +7196,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String tagLibrary_importRejectedCount(Object count) {
+    return '$count は未インポート';
+  }
+
+  @override
   String get tagLibrary_unknownCategory => '不明なカテゴリ';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7078,6 +7078,11 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String tagLibrary_importRejectedCount(Object count) {
+    return '$count 未导入';
+  }
+
+  @override
   String get tagLibrary_unknownCategory => '未知分类';
 
   @override
@@ -20929,6 +20934,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String tagLibrary_skippedCount(Object count) {
     return '$count 跳過';
+  }
+
+  @override
+  String tagLibrary_importRejectedCount(Object count) {
+    return '$count 未匯入';
   }
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3389,6 +3389,12 @@
       "count": {}
     }
   },
+  "tagLibrary_importRejectedCount": "{count} 未导入",
+  "@tagLibrary_importRejectedCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
   "tagLibrary_unknownCategory": "未知分类",
   "tagLibrary_selectEntryToUpdate": "选择要更新的词条",
   "tagLibrary_updatePreview": "更新预览图",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3402,6 +3402,12 @@
       "count": {}
     }
   },
+  "tagLibrary_importRejectedCount": "{count} 未匯入",
+  "@tagLibrary_importRejectedCount": {
+    "placeholders": {
+      "count": {}
+    }
+  },
   "tagLibrary_unknownCategory": "未知分類",
   "tagLibrary_selectEntryToUpdate": "選擇要更新的詞條",
   "tagLibrary_updatePreview": "更新預覽圖",

--- a/lib/presentation/providers/tag_library_page_provider.dart
+++ b/lib/presentation/providers/tag_library_page_provider.dart
@@ -5,6 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../core/storage/local_storage_service.dart';
 import '../../core/utils/app_logger.dart';
+import '../../data/models/tag_library/import_plan.dart';
 import '../../data/models/tag_library/tag_library_category.dart';
 import '../../data/models/tag_library/tag_library_entry.dart';
 import 'fixed_tags_provider.dart';
@@ -234,7 +235,7 @@ class TagLibraryPageNotifier extends _$TagLibraryPageNotifier {
   }
 
   /// 保存分类到存储
-  Future<void> _saveCategories() async {
+  Future<void> _saveCategories({bool rethrowError = false}) async {
     try {
       final json = jsonEncode(state.categories.map((e) => e.toJson()).toList());
       await _storage.setTagLibraryCategoriesJson(json);
@@ -245,6 +246,7 @@ class TagLibraryPageNotifier extends _$TagLibraryPageNotifier {
         stack,
         'TagLibraryPageProvider',
       );
+      if (rethrowError) rethrow;
     }
   }
 
@@ -696,120 +698,183 @@ class TagLibraryPageNotifier extends _$TagLibraryPageNotifier {
 
   // ==================== 导入导出 ====================
 
-  /// 批量导入条目
-  ///
-  /// [entries] 要导入的条目列表
-  /// [categoryIdMapping] 分类ID映射（旧ID -> 新ID）
-  /// [keepIds] 是否保留原始ID（用于替换场景）
-  /// [nameSuffix] 名称后缀（用于重命名场景）
-  /// [updatedEntries] 更新缩略图路径后的条目映射（原始ID -> 更新后的条目）
-  Future<int> importEntries(
-    List<TagLibraryEntry> entries, {
-    Map<String, String>? categoryIdMapping,
-    bool keepIds = false,
-    String? nameSuffix,
-    Map<String, TagLibraryEntry>? updatedEntries,
+  /// 按导入计划应用：先删除被覆盖项，再写入计划确定的目标身份，最后统一持久化
+  Future<TagLibraryImportApplyResult> applyImportPlan(
+    TagLibraryImportPlan plan, {
+    Map<String, TagLibraryEntry> importedEntries = const {},
   }) async {
-    final newEntries = <TagLibraryEntry>[];
-    var startSortOrder = state.entries.length;
+    final previousState = state;
+    final removedCategoryIds = _replacedCategoryIds(plan);
+    final removedEntryIds = <String>{
+      for (final item in plan.entries)
+        if (item.replacedEntryId != null) item.replacedEntryId!,
+    };
 
-    for (final entry in entries) {
-      String? mappedCategoryId;
-      if (entry.categoryId != null && categoryIdMapping != null) {
-        mappedCategoryId = categoryIdMapping[entry.categoryId];
-      }
+    final keptCategories = _categoriesWithout(removedCategoryIds);
+    final keptEntries = _entriesWithout(removedEntryIds, removedCategoryIds);
+    final categories = _importedCategories(plan, keptCategories);
+    final entries = _importedEntries(
+      plan,
+      keptEntries,
+      categoryIds: {
+        ...keptCategories.map((c) => c.id),
+        ...categories.inserted.map((c) => c.id),
+      },
+      importedEntries: importedEntries,
+    );
 
-      final newName = nameSuffix != null && nameSuffix.isNotEmpty
-          ? '${entry.name}$nameSuffix'
-          : entry.name;
-
-      // 使用更新后的条目数据（包含正确的缩略图路径）
-      final sourceEntry = updatedEntries?[entry.id] ?? entry;
-
-      if (keepIds) {
-        // 保留原始ID（替换场景）
-        newEntries.add(
-          sourceEntry.copyWith(
-            name: newName,
-            categoryId: mappedCategoryId ?? entry.categoryId,
-            sortOrder: startSortOrder++,
-            updatedAt: DateTime.now(),
-          ),
-        );
-      } else {
-        // 创建新ID（正常导入场景）
-        newEntries.add(
-          TagLibraryEntry.create(
-            name: newName,
-            content: sourceEntry.content,
-            thumbnail: sourceEntry.thumbnail,
-            tags: sourceEntry.tags,
-            categoryId: mappedCategoryId ?? entry.categoryId,
-            sortOrder: startSortOrder++,
-            isFavorite: sourceEntry.isFavorite,
-          ),
-        );
-      }
+    state = state.copyWith(
+      categories: [...keptCategories, ...categories.inserted],
+      entries: [...keptEntries, ...entries.inserted],
+      clearSelectedCategory: removedCategoryIds.contains(
+        previousState.selectedCategoryId,
+      ),
+    );
+    try {
+      await _saveCategories(rethrowError: true);
+      await _saveEntries(rethrowError: true);
+    } catch (_) {
+      state = previousState;
+      await _saveCategories();
+      await _saveEntries();
+      rethrow;
     }
 
-    state = state.copyWith(entries: [...state.entries, ...newEntries]);
-    await _saveEntries();
-
-    return newEntries.length;
+    return TagLibraryImportApplyResult(
+      appliedCategoryIds: categories.inserted.map((c) => c.id).toList(),
+      appliedEntryIds: entries.inserted.map((e) => e.id).toList(),
+      rejected: [...categories.rejected, ...entries.rejected],
+    );
   }
 
-  /// 批量导入分类
-  ///
-  /// [categories] 要导入的分类列表
-  /// [keepIds] 是否保留原始ID（用于替换场景）
-  /// [nameSuffix] 名称后缀（用于重命名场景）
-  Future<Map<String, String>> importCategories(
-    List<TagLibraryCategory> categories, {
-    bool keepIds = false,
-    String? nameSuffix,
-  }) async {
-    // 返回旧ID到新ID的映射
-    final idMapping = <String, String>{};
-    final newCategories = <TagLibraryCategory>[];
-    var startSortOrder = state.categories.length;
+  Set<String> _replacedCategoryIds(TagLibraryImportPlan plan) {
+    final ids = <String>{};
+    for (final item in plan.categories) {
+      final replaced = item.replacedCategoryId;
+      if (replaced == null) continue;
+      ids
+        ..add(replaced)
+        ..addAll(state.categories.getDescendantIds(replaced));
+    }
+    return ids;
+  }
 
-    for (final category in categories) {
-      final newName = nameSuffix != null && nameSuffix.isNotEmpty
-          ? '${category.name}$nameSuffix'
-          : category.name;
+  List<TagLibraryCategory> _categoriesWithout(Set<String> removedIds) =>
+      removedIds.isEmpty
+      ? state.categories
+      : state.categories
+            .where((c) => !removedIds.contains(c.id))
+            .toList()
+            .reindex();
 
-      if (keepIds) {
-        // 保留原始ID（替换场景）
-        final parentId = category.parentId != null
-            ? idMapping[category.parentId]
-            : null;
-        newCategories.add(
-          category.copyWith(
-            name: newName,
-            parentId: parentId,
-            sortOrder: startSortOrder++,
+  List<TagLibraryEntry> _entriesWithout(
+    Set<String> removedIds,
+    Set<String> removedCategoryIds,
+  ) {
+    final orphaned = state.entries
+        .map(
+          (e) => removedCategoryIds.contains(e.categoryId)
+              ? e.copyWith(categoryId: null, updatedAt: DateTime.now())
+              : e,
+        )
+        .toList();
+    if (removedIds.isEmpty) return orphaned;
+    return orphaned.where((e) => !removedIds.contains(e.id)).toList().reindex();
+  }
+
+  _CategoryInserts _importedCategories(
+    TagLibraryImportPlan plan,
+    List<TagLibraryCategory> kept,
+  ) {
+    final takenIds = kept.map((c) => c.id).toSet();
+    final rejected = <TagLibraryImportRejection>[];
+    final inserted = <TagLibraryCategory>[];
+    var sortOrder = kept.length;
+
+    for (final item in plan.categories) {
+      final targetId = item.targetId;
+      if (!item.isApplied || targetId == null) continue;
+      if (!takenIds.add(targetId)) {
+        rejected.add(
+          TagLibraryImportRejection(
+            kind: TagLibraryImportItemKind.category,
+            sourceId: item.source.id,
+            targetId: targetId,
           ),
         );
-        idMapping[category.id] = category.id;
-      } else {
-        // 创建新ID（正常导入场景）
-        final newCategory = TagLibraryCategory.create(
-          name: newName,
-          parentId:
-              category.parentId != null ? idMapping[category.parentId] : null,
-          sortOrder: startSortOrder++,
-        );
-        idMapping[category.id] = newCategory.id;
-        newCategories.add(newCategory);
+        continue;
       }
+      inserted.add(
+        TagLibraryCategory(
+          id: targetId,
+          name: item.targetName,
+          parentId: item.targetParentId,
+          sortOrder: sortOrder++,
+          createdAt: item.source.createdAt,
+        ),
+      );
     }
 
-    state = state.copyWith(categories: [...state.categories, ...newCategories]);
-    await _saveCategories();
+    return (
+      inserted: [
+        for (final category in inserted)
+          category.parentId == null || takenIds.contains(category.parentId)
+              ? category
+              : category.copyWith(parentId: null),
+      ],
+      rejected: rejected,
+    );
+  }
 
-    return idMapping;
+  _EntryInserts _importedEntries(
+    TagLibraryImportPlan plan,
+    List<TagLibraryEntry> kept, {
+    required Set<String> categoryIds,
+    required Map<String, TagLibraryEntry> importedEntries,
+  }) {
+    final takenIds = kept.map((e) => e.id).toSet();
+    final rejected = <TagLibraryImportRejection>[];
+    final inserted = <TagLibraryEntry>[];
+    var sortOrder = kept.length;
+
+    for (final item in plan.entries) {
+      final targetId = item.targetId;
+      if (!item.isApplied || targetId == null) continue;
+      if (!takenIds.add(targetId)) {
+        rejected.add(
+          TagLibraryImportRejection(
+            kind: TagLibraryImportItemKind.entry,
+            sourceId: item.source.id,
+            targetId: targetId,
+          ),
+        );
+        continue;
+      }
+      final categoryId = item.targetCategoryId;
+      inserted.add(
+        (importedEntries[item.source.id] ?? item.source).copyWith(
+          id: targetId,
+          name: item.targetName,
+          categoryId: categoryIds.contains(categoryId) ? categoryId : null,
+          sortOrder: sortOrder++,
+          updatedAt: DateTime.now(),
+        ),
+      );
+    }
+
+    return (inserted: inserted, rejected: rejected);
   }
 }
+
+typedef _CategoryInserts = ({
+  List<TagLibraryCategory> inserted,
+  List<TagLibraryImportRejection> rejected,
+});
+
+typedef _EntryInserts = ({
+  List<TagLibraryEntry> inserted,
+  List<TagLibraryImportRejection> rejected,
+});
 
 // ==================== 便捷 Providers ====================
 

--- a/lib/presentation/screens/tag_library_page/widgets/import_dialog.dart
+++ b/lib/presentation/screens/tag_library_page/widgets/import_dialog.dart
@@ -6,6 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nai_launcher/core/utils/localization_extension.dart';
 
 import '../../../../data/models/tag_library/import_models.dart';
+import '../../../../data/models/tag_library/import_plan.dart';
+import '../../../../data/services/tag_library_import_planner.dart';
 import '../../../../data/services/tag_library_io_service.dart';
 import '../../../adaptive/adaptive_presenter.dart';
 import '../../../adaptive/interaction_policy.dart';
@@ -722,9 +724,13 @@ class _ImportDialogState extends ConsumerState<ImportDialog> {
   }
 
   Future<void> _import() async {
-    if (_selectedFile == null || _preview == null) return;
+    final file = _selectedFile;
+    final preview = _preview;
+    if (file == null || preview == null) return;
 
     final l10n = context.l10n;
+    final state = ref.read(tagLibraryPageNotifierProvider);
+    final notifier = ref.read(tagLibraryPageNotifierProvider.notifier);
 
     setState(() {
       _isImporting = true;
@@ -733,18 +739,22 @@ class _ImportDialogState extends ConsumerState<ImportDialog> {
     });
 
     try {
-      final state = ref.read(tagLibraryPageNotifierProvider);
-      final service = TagLibraryIOService();
-
-      final result = await service.executeImport(
-        zipFile: _selectedFile!,
-        preview: _preview!,
+      final plan = const TagLibraryImportPlanner().plan(
+        preview: preview,
         selectedEntryIds: _selectedEntryIds,
         selectedCategoryIds: _selectedCategoryIds,
+        conflicts: _conflicts,
         conflictResolutions: _conflictResolutions,
         existingEntries: state.entries,
         existingCategories: state.categories,
+        renameSuffix: ' (${l10n.common_import})',
+      );
+
+      final result = await TagLibraryIOService().executeImport(
+        zipFile: file,
+        plan: plan,
         onProgress: (progress, message) {
+          if (!mounted) return;
           setState(() {
             _progress = progress;
             _progressMessage = message;
@@ -752,130 +762,14 @@ class _ImportDialogState extends ConsumerState<ImportDialog> {
         },
       );
 
-      // 导入到 provider
-      final notifier = ref.read(tagLibraryPageNotifierProvider.notifier);
-
-      // 首先处理需要替换（覆盖）的分类 - 先删除现有分类
-      for (final conflict in _conflicts.where(
-        (c) =>
-            c.isCategoryConflict &&
-            _selectedCategoryIds.contains(c.importId) &&
-            _conflictResolutions[c.importId] == ConflictResolution.overwrite,
-      )) {
-        await notifier.deleteCategory(conflict.existingId);
-      }
-
-      // 处理需要替换（覆盖）的条目 - 先删除现有条目
-      for (final conflict in _conflicts.where(
-        (c) =>
-            c.isEntryConflict &&
-            _selectedEntryIds.contains(c.importId) &&
-            _conflictResolutions[c.importId] == ConflictResolution.overwrite,
-      )) {
-        await notifier.deleteEntry(conflict.existingId);
-      }
-
-      // 筛选要导入的分类（根据冲突解决策略处理）
-      final categoriesToImport = _preview!.categories.where((c) {
-        if (!_selectedCategoryIds.contains(c.id)) return false;
-        final resolution = _conflictResolutions[c.id];
-        return resolution != ConflictResolution.skip;
-      }).toList();
-
-      // 确定是否有分类需要保留ID（替换场景）
-      final categoriesNeedKeepIds = categoriesToImport.any((c) {
-        final resolution = _conflictResolutions[c.id];
-        return resolution == ConflictResolution.overwrite;
-      });
-
-      // 确定分类是否需要添加后缀（重命名场景）
-      final categoryNameSuffix =
-          categoriesToImport.any((c) {
-            final resolution = _conflictResolutions[c.id];
-            return resolution == ConflictResolution.rename;
-          })
-          ? ' (${l10n.common_import})'
-          : null;
-
-      // 导入分类并获取 ID 映射
-      final categoryIdMapping = await notifier.importCategories(
-        categoriesToImport,
-        keepIds: categoriesNeedKeepIds,
-        nameSuffix: categoryNameSuffix,
+      final applied = await notifier.applyImportPlan(
+        plan,
+        importedEntries: result.updatedEntries,
       );
 
-      // 筛选要导入的条目（根据冲突解决策略处理）
-      final entriesToImport = _preview!.entries.where((e) {
-        if (!_selectedEntryIds.contains(e.id)) return false;
-        final resolution = _conflictResolutions[e.id];
-        return resolution != ConflictResolution.skip;
-      }).toList();
-
-      // 确定是否有条目需要保留ID（替换场景）
-      final entriesNeedKeepIds = entriesToImport.any((e) {
-        final resolution = _conflictResolutions[e.id];
-        return resolution == ConflictResolution.overwrite;
-      });
-
-      // 确定条目是否需要添加后缀（重命名场景）
-      final entryNameSuffix =
-          entriesToImport.any((e) {
-            final resolution = _conflictResolutions[e.id];
-            return resolution == ConflictResolution.rename;
-          })
-          ? ' (${l10n.common_import})'
-          : null;
-
-      // 导入条目（使用更新后的缩略图路径）
-      await notifier.importEntries(
-        entriesToImport,
-        categoryIdMapping: categoryIdMapping,
-        keepIds: entriesNeedKeepIds,
-        nameSuffix: entryNameSuffix,
-        updatedEntries: result.updatedEntries,
-      );
-
-      if (mounted) {
-        Navigator.of(context).pop();
-        final messages = <String>[];
-        if (result.importedEntries > 0) {
-          messages.add(
-            context.l10n.tagLibrary_importedEntriesCount(
-              result.importedEntries,
-            ),
-          );
-        }
-        if (result.importedCategories > 0) {
-          messages.add(
-            context.l10n.tagLibrary_importedCategoriesCount(
-              result.importedCategories,
-            ),
-          );
-        }
-        if (result.renamedCount > 0) {
-          messages.add(
-            context.l10n.tagLibrary_renamedCount(result.renamedCount),
-          );
-        }
-        if (result.overwrittenCount > 0) {
-          messages.add(
-            context.l10n.tagLibrary_overwrittenCount(result.overwrittenCount),
-          );
-        }
-        if (result.skippedConflicts > 0) {
-          messages.add(
-            context.l10n.tagLibrary_skippedCount(result.skippedConflicts),
-          );
-        }
-        AppToast.info(
-          context,
-          messages.isEmpty
-              ? context.l10n.tagLibrary_importCompleted
-              : context.l10n.tagLibrary_importSuccessSummary(
-                  messages.join(', '),
-                ),
-        );
-      }
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      AppToast.info(context, _importSummary(result, applied));
     } catch (e) {
       if (mounted) {
         setState(() => _isImporting = false);
@@ -885,6 +779,30 @@ class _ImportDialogState extends ConsumerState<ImportDialog> {
         );
       }
     }
+  }
+
+  String _importSummary(
+    ImportResult result,
+    TagLibraryImportApplyResult applied,
+  ) {
+    final l10n = context.l10n;
+    final messages = <String>[
+      if (result.importedEntries > 0)
+        l10n.tagLibrary_importedEntriesCount(result.importedEntries),
+      if (result.importedCategories > 0)
+        l10n.tagLibrary_importedCategoriesCount(result.importedCategories),
+      if (result.renamedCount > 0)
+        l10n.tagLibrary_renamedCount(result.renamedCount),
+      if (result.overwrittenCount > 0)
+        l10n.tagLibrary_overwrittenCount(result.overwrittenCount),
+      if (result.skippedConflicts > 0)
+        l10n.tagLibrary_skippedCount(result.skippedConflicts),
+      if (applied.rejected.isNotEmpty)
+        l10n.tagLibrary_importRejectedCount(applied.rejected.length),
+    ];
+    return messages.isEmpty
+        ? l10n.tagLibrary_importCompleted
+        : l10n.tagLibrary_importSuccessSummary(messages.join(', '));
   }
 }
 

--- a/test/data/services/tag_library_import_planner_test.dart
+++ b/test/data/services/tag_library_import_planner_test.dart
@@ -1,0 +1,324 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/tag_library/import_models.dart';
+import 'package:nai_launcher/data/models/tag_library/import_plan.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_category.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
+import 'package:nai_launcher/data/services/tag_library_import_planner.dart';
+
+const _suffix = ' (导入)';
+
+void main() {
+  late int counter;
+
+  setUp(() => counter = 0);
+
+  TagLibraryImportPlanner planner() =>
+      TagLibraryImportPlanner(newId: () => 'new-${++counter}');
+
+  TagLibraryImportPlan run({
+    List<TagLibraryEntry> entries = const [],
+    List<TagLibraryCategory> categories = const [],
+    List<ImportConflict> conflicts = const [],
+    Map<String, ConflictResolution> resolutions = const {},
+    List<TagLibraryEntry> existingEntries = const [],
+    List<TagLibraryCategory> existingCategories = const [],
+    Set<String>? selectedEntryIds,
+    Set<String>? selectedCategoryIds,
+  }) => planner().plan(
+    preview: _preview(entries: entries, categories: categories),
+    selectedEntryIds: selectedEntryIds ?? entries.map((e) => e.id).toSet(),
+    selectedCategoryIds:
+        selectedCategoryIds ?? categories.map((c) => c.id).toSet(),
+    conflicts: conflicts,
+    conflictResolutions: resolutions,
+    existingEntries: existingEntries,
+    existingCategories: existingCategories,
+    renameSuffix: _suffix,
+  );
+
+  group('逐条动作', () {
+    test('同一批次内跳过、重命名、覆盖与新建互不影响', () {
+      final plan = run(
+        entries: [
+          _entry(id: 'pkg-1', name: '猫'),
+          _entry(id: 'pkg-2', name: '狗'),
+          _entry(id: 'pkg-3', name: '鸟'),
+          _entry(id: 'pkg-4', name: '鱼'),
+        ],
+        conflicts: [
+          _entryConflict(importId: 'pkg-1', existingId: 'local-a'),
+          _entryConflict(importId: 'pkg-2', existingId: 'local-b'),
+          _entryConflict(importId: 'pkg-3', existingId: 'local-c'),
+        ],
+        resolutions: const {
+          'pkg-1': ConflictResolution.skip,
+          'pkg-2': ConflictResolution.rename,
+          'pkg-3': ConflictResolution.overwrite,
+        },
+        existingEntries: [
+          _entry(id: 'local-a', name: '猫'),
+          _entry(id: 'local-b', name: '狗'),
+          _entry(id: 'local-c', name: '鸟'),
+        ],
+      );
+
+      final byId = {for (final item in plan.entries) item.source.id: item};
+      expect(byId['pkg-1']!.action, TagLibraryImportAction.skip);
+      expect(byId['pkg-1']!.isApplied, isFalse);
+      expect(byId['pkg-1']!.targetId, 'local-a');
+
+      expect(byId['pkg-2']!.action, TagLibraryImportAction.rename);
+      expect(byId['pkg-2']!.targetId, 'new-1');
+      expect(byId['pkg-2']!.targetName, '狗$_suffix');
+      expect(byId['pkg-2']!.replacedEntryId, isNull);
+
+      expect(byId['pkg-3']!.action, TagLibraryImportAction.overwrite);
+      expect(byId['pkg-3']!.targetId, 'pkg-3');
+      expect(byId['pkg-3']!.targetName, '鸟');
+      expect(byId['pkg-3']!.replacedEntryId, 'local-c');
+
+      expect(byId['pkg-4']!.action, TagLibraryImportAction.create);
+      expect(byId['pkg-4']!.targetId, 'new-2');
+      expect(byId['pkg-4']!.targetName, '鱼');
+
+      expect(plan.skippedCount, 1);
+      expect(plan.renamedCount, 1);
+      expect(plan.overwrittenCount, 1);
+      expect(plan.importedEntryCount, 3);
+    });
+
+    test('未选中的条目与分类不进入计划', () {
+      final plan = run(
+        entries: [
+          _entry(id: 'pkg-1', name: '猫'),
+          _entry(id: 'pkg-2', name: '狗'),
+        ],
+        categories: [_category(id: 'cat-1', name: '角色')],
+        selectedEntryIds: {'pkg-2'},
+        selectedCategoryIds: const {},
+      );
+
+      expect(plan.entries.map((e) => e.source.id), ['pkg-2']);
+      expect(plan.categories, isEmpty);
+      expect(plan.categoryIdMapping, isEmpty);
+    });
+
+    test('冲突指向的本地数据已被删除时按新建处理', () {
+      final plan = run(
+        entries: [_entry(id: 'pkg-1', name: '猫')],
+        conflicts: [_entryConflict(importId: 'pkg-1', existingId: 'gone')],
+        resolutions: const {'pkg-1': ConflictResolution.overwrite},
+      );
+
+      expect(plan.entries.single.action, TagLibraryImportAction.create);
+      expect(plan.entries.single.targetId, 'new-1');
+      expect(plan.entries.single.replacedEntryId, isNull);
+    });
+  });
+
+  group('目标 ID', () {
+    test('覆盖自己的导出包时沿用包内 ID', () {
+      final plan = run(
+        entries: [_entry(id: 'shared', name: '猫')],
+        conflicts: [_entryConflict(importId: 'shared', existingId: 'shared')],
+        resolutions: const {'shared': ConflictResolution.overwrite},
+        existingEntries: [_entry(id: 'shared', name: '猫')],
+      );
+
+      expect(plan.entries.single.targetId, 'shared');
+      expect(plan.entries.single.replacedEntryId, 'shared');
+      expect(plan.entries.single.reassignedId, isFalse);
+    });
+
+    test('重命名即使包内 ID 与本地相同也改用新 ID', () {
+      final plan = run(
+        entries: [_entry(id: 'shared', name: '猫')],
+        conflicts: [_entryConflict(importId: 'shared', existingId: 'shared')],
+        resolutions: const {'shared': ConflictResolution.rename},
+        existingEntries: [_entry(id: 'shared', name: '猫')],
+      );
+
+      expect(plan.entries.single.targetId, 'new-1');
+      expect(plan.entries.single.targetName, '猫$_suffix');
+      expect(plan.entries.single.replacedEntryId, isNull);
+    });
+
+    test('包内 ID 被本次保留的其他本地条目占用时改用新 ID', () {
+      final plan = run(
+        entries: [_entry(id: 'shared', name: '乙')],
+        conflicts: [_entryConflict(importId: 'shared', existingId: 'local-y')],
+        resolutions: const {'shared': ConflictResolution.overwrite},
+        existingEntries: [
+          _entry(id: 'shared', name: '甲'),
+          _entry(id: 'local-y', name: '乙'),
+        ],
+      );
+
+      expect(plan.entries.single.targetId, 'new-1');
+      expect(plan.entries.single.reassignedId, isTrue);
+      expect(plan.entries.single.replacedEntryId, 'local-y');
+    });
+
+    test('分类沿用同一套 ID 规则', () {
+      final plan = run(
+        categories: [
+          _category(id: 'shared', name: '角色'),
+          _category(id: 'pkg-cat', name: '场景'),
+        ],
+        conflicts: [
+          _categoryConflict(importId: 'shared', existingId: 'shared'),
+          _categoryConflict(importId: 'pkg-cat', existingId: 'local-cat'),
+        ],
+        resolutions: const {
+          'shared': ConflictResolution.overwrite,
+          'pkg-cat': ConflictResolution.rename,
+        },
+        existingCategories: [
+          _category(id: 'shared', name: '角色'),
+          _category(id: 'local-cat', name: '场景'),
+        ],
+      );
+
+      expect(plan.categories.first.targetId, 'shared');
+      expect(plan.categories.first.replacedCategoryId, 'shared');
+      expect(plan.categories.last.targetId, 'new-1');
+      expect(plan.categories.last.targetName, '场景$_suffix');
+      expect(plan.overwrittenCount, 1);
+      expect(plan.renamedCount, 1);
+      expect(plan.importedCategoryCount, 1);
+    });
+  });
+
+  group('引用映射', () {
+    test('子分类先于父分类出现也能解析父级', () {
+      final plan = run(
+        categories: [
+          _category(id: 'c-child', name: '子', parentId: 'c-parent'),
+          _category(id: 'c-parent', name: '父'),
+        ],
+        entries: [_entry(id: 'e-1', name: '词', categoryId: 'c-child')],
+      );
+
+      expect(plan.categories.first.targetId, 'new-1');
+      expect(plan.categories.first.targetParentId, 'new-2');
+      expect(plan.categories.last.targetParentId, isNull);
+      expect(plan.entries.single.targetCategoryId, 'new-1');
+      expect(plan.categoryIdMapping, {'c-child': 'new-1', 'c-parent': 'new-2'});
+    });
+
+    test('跳过的分类映射到现有同名分类供条目引用', () {
+      final plan = run(
+        categories: [_category(id: 'pkg-cat', name: '角色')],
+        entries: [_entry(id: 'e-1', name: '词', categoryId: 'pkg-cat')],
+        conflicts: [
+          _categoryConflict(importId: 'pkg-cat', existingId: 'local-cat'),
+        ],
+        resolutions: const {'pkg-cat': ConflictResolution.skip},
+        existingCategories: [_category(id: 'local-cat', name: '角色')],
+      );
+
+      expect(plan.categories.single.isApplied, isFalse);
+      expect(plan.categoryIdMapping, {'pkg-cat': 'local-cat'});
+      expect(plan.entries.single.targetCategoryId, 'local-cat');
+    });
+
+    test('父分类未被选中时子分类落到根级', () {
+      final plan = run(
+        categories: [
+          _category(id: 'c-parent', name: '父'),
+          _category(id: 'c-child', name: '子', parentId: 'c-parent'),
+        ],
+        entries: [_entry(id: 'e-1', name: '词', categoryId: 'c-parent')],
+        selectedCategoryIds: {'c-child'},
+      );
+
+      expect(plan.categories.single.source.id, 'c-child');
+      expect(plan.categories.single.targetParentId, isNull);
+      expect(plan.entries.single.targetCategoryId, isNull);
+    });
+
+    test('分类与条目的冲突记录互不串用', () {
+      final plan = run(
+        categories: [_category(id: 'same', name: '角色')],
+        entries: [_entry(id: 'same', name: '角色')],
+        conflicts: [_entryConflict(importId: 'same', existingId: 'local-e')],
+        resolutions: const {'same': ConflictResolution.overwrite},
+        existingEntries: [_entry(id: 'local-e', name: '角色')],
+      );
+
+      expect(plan.categories.single.action, TagLibraryImportAction.create);
+      expect(plan.categories.single.replacedCategoryId, isNull);
+      expect(plan.entries.single.action, TagLibraryImportAction.overwrite);
+      expect(plan.entries.single.replacedEntryId, 'local-e');
+    });
+  });
+
+  test('缩略图目标使用条目自己的目标 ID', () {
+    final plan = run(
+      entries: [
+        _entry(id: 'pkg-1', name: '猫'),
+        _entry(id: 'pkg-2', name: '狗'),
+      ],
+      conflicts: [_entryConflict(importId: 'pkg-2', existingId: 'local-b')],
+      resolutions: const {'pkg-2': ConflictResolution.skip},
+      existingEntries: [_entry(id: 'local-b', name: '狗')],
+    );
+
+    expect(plan.entries.first.thumbnailEntryId, 'new-1');
+    expect(plan.entries.last.thumbnailEntryId, isNull);
+  });
+}
+
+ImportPreview _preview({
+  List<TagLibraryEntry> entries = const [],
+  List<TagLibraryCategory> categories = const [],
+}) => ImportPreview(
+  version: '1.0',
+  exportDate: DateTime.utc(2026),
+  entries: entries,
+  categories: categories,
+);
+
+TagLibraryEntry _entry({
+  required String id,
+  required String name,
+  String? categoryId,
+}) => TagLibraryEntry(
+  id: id,
+  name: name,
+  content: '1girl',
+  categoryId: categoryId,
+  createdAt: DateTime.utc(2026),
+  updatedAt: DateTime.utc(2026),
+);
+
+TagLibraryCategory _category({
+  required String id,
+  required String name,
+  String? parentId,
+}) => TagLibraryCategory(
+  id: id,
+  name: name,
+  parentId: parentId,
+  createdAt: DateTime.utc(2026),
+);
+
+ImportConflict _entryConflict({
+  required String importId,
+  required String existingId,
+}) => ImportConflict(
+  type: ConflictType.entry,
+  importName: importId,
+  importId: importId,
+  existingId: existingId,
+);
+
+ImportConflict _categoryConflict({
+  required String importId,
+  required String existingId,
+}) => ImportConflict(
+  type: ConflictType.category,
+  importName: importId,
+  importId: importId,
+  existingId: existingId,
+);

--- a/test/data/services/tag_library_io_service_import_security_test.dart
+++ b/test/data/services/tag_library_io_service_import_security_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nai_launcher/data/models/tag_library/import_models.dart';
 import 'package:nai_launcher/data/models/tag_library/tag_library_category.dart';
 import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
+import 'package:nai_launcher/data/services/tag_library_import_planner.dart';
 import 'package:nai_launcher/data/services/tag_library_io_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -53,12 +54,16 @@ void main() {
   Future<ImportResult> runImport(File package, ImportPreview preview) =>
       service.executeImport(
         zipFile: package,
-        preview: preview,
-        selectedEntryIds: preview.entries.map((e) => e.id).toSet(),
-        selectedCategoryIds: preview.categories.map((c) => c.id).toSet(),
-        conflictResolutions: const {},
-        existingEntries: const [],
-        existingCategories: const [],
+        plan: const TagLibraryImportPlanner().plan(
+          preview: preview,
+          selectedEntryIds: preview.entries.map((e) => e.id).toSet(),
+          selectedCategoryIds: preview.categories.map((c) => c.id).toSet(),
+          conflicts: const [],
+          conflictResolutions: const {},
+          existingEntries: const [],
+          existingCategories: const [],
+          renameSuffix: ' (导入)',
+        ),
       );
 
   group('归档成员校验', () {
@@ -274,7 +279,7 @@ void main() {
       expect(result.success, isTrue);
       expect(p.isWithin(thumbnailsRoot().path, imported), isTrue);
       expect(File(imported).readAsBytesSync(), _pngBytes);
-      expect(thumbnailNames(), ['$_entryId.png']);
+      expect(thumbnailNames(), [p.basename(imported)]);
       expect(documentEntryNames(), ['tag_library_thumbnails']);
     });
 

--- a/test/presentation/providers/tag_library_import_apply_test.dart
+++ b/test/presentation/providers/tag_library_import_apply_test.dart
@@ -1,0 +1,419 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/data/models/tag_library/import_models.dart';
+import 'package:nai_launcher/data/models/tag_library/import_plan.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_category.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_entry.dart';
+import 'package:nai_launcher/data/services/tag_library_import_planner.dart';
+import 'package:nai_launcher/data/services/tag_library_io_service.dart';
+import 'package:nai_launcher/presentation/providers/tag_library_page_provider.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+const _suffix = ' (导入)';
+const _packagedBytes = <int>[0x89, 0x50, 0x4e, 0x47, 0x01];
+const _localBytes = <int>[0x89, 0x50, 0x4e, 0x47, 0x02];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory documents;
+  late Directory workspace;
+  late PathProviderPlatform previousPlatform;
+  late TagLibraryIOService service;
+  late int counter;
+
+  setUp(() async {
+    documents = await Directory.systemTemp.createTemp('tag-library-apply-');
+    workspace = await Directory.systemTemp.createTemp('tag-library-pack-');
+    previousPlatform = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _PathProvider(documents.path);
+    service = TagLibraryIOService();
+    counter = 0;
+  });
+
+  tearDown(() async {
+    PathProviderPlatform.instance = previousPlatform;
+    await documents.delete(recursive: true);
+    await workspace.delete(recursive: true);
+  });
+
+  Directory thumbnailsRoot() =>
+      Directory(p.join(documents.path, 'tag_library_thumbnails'));
+
+  List<String> thumbnailNames() {
+    final root = thumbnailsRoot();
+    if (!root.existsSync()) return const [];
+    return root.listSync().map((e) => p.basename(e.path)).toList()..sort();
+  }
+
+  File writeLocalThumbnail(String entryId, List<int> bytes) {
+    final root = thumbnailsRoot()..createSync(recursive: true);
+    return File(p.join(root.path, '$entryId.png'))..writeAsBytesSync(bytes);
+  }
+
+  Future<ProviderContainer> seeded({
+    List<TagLibraryEntry> entries = const [],
+    List<TagLibraryCategory> categories = const [],
+  }) async {
+    final storage = _MemoryStorage();
+    await storage.setTagLibraryEntriesJson(
+      jsonEncode(entries.map((e) => e.toJson()).toList()),
+    );
+    await storage.setTagLibraryCategoriesJson(
+      jsonEncode(categories.map((c) => c.toJson()).toList()),
+    );
+    final container = ProviderContainer(
+      overrides: [localStorageServiceProvider.overrideWithValue(storage)],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  TagLibraryImportPlan planFor({
+    required ProviderContainer container,
+    required ImportPreview preview,
+    required List<ImportConflict> conflicts,
+    required Map<String, ConflictResolution> resolutions,
+  }) {
+    final state = container.read(tagLibraryPageNotifierProvider);
+    return TagLibraryImportPlanner(newId: () => 'new-${++counter}').plan(
+      preview: preview,
+      selectedEntryIds: preview.entries.map((e) => e.id).toSet(),
+      selectedCategoryIds: preview.categories.map((c) => c.id).toSet(),
+      conflicts: conflicts,
+      conflictResolutions: resolutions,
+      existingEntries: state.entries,
+      existingCategories: state.categories,
+      renameSuffix: _suffix,
+    );
+  }
+
+  test('混合批次只按各自方案改写对应条目', () async {
+    final container = await seeded(
+      entries: [
+        _entry(id: 'local-a', name: '猫', content: '本地猫'),
+        _entry(id: 'local-b', name: '狗', content: '本地狗'),
+        _entry(id: 'local-c', name: '鸟', content: '本地鸟'),
+      ],
+    );
+    final notifier = container.read(tagLibraryPageNotifierProvider.notifier);
+    final preview = _preview(
+      entries: [
+        _entry(id: 'pkg-1', name: '猫', content: '包内猫'),
+        _entry(id: 'pkg-2', name: '狗', content: '包内狗'),
+        _entry(id: 'pkg-3', name: '鸟', content: '包内鸟'),
+        _entry(id: 'pkg-4', name: '鱼', content: '包内鱼'),
+      ],
+    );
+
+    final applied = await notifier.applyImportPlan(
+      planFor(
+        container: container,
+        preview: preview,
+        conflicts: [
+          _entryConflict(importId: 'pkg-1', existingId: 'local-a'),
+          _entryConflict(importId: 'pkg-2', existingId: 'local-b'),
+          _entryConflict(importId: 'pkg-3', existingId: 'local-c'),
+        ],
+        resolutions: const {
+          'pkg-1': ConflictResolution.skip,
+          'pkg-2': ConflictResolution.rename,
+          'pkg-3': ConflictResolution.overwrite,
+        },
+      ),
+    );
+
+    final entries = container.read(tagLibraryPageNotifierProvider).entries;
+    expect(applied.success, isTrue);
+    expect(applied.appliedEntryIds, ['new-1', 'pkg-3', 'new-2']);
+    expect(entries.map((e) => e.id), [
+      'local-a',
+      'local-b',
+      'new-1',
+      'pkg-3',
+      'new-2',
+    ]);
+    expect(entries.map((e) => e.name), ['猫', '狗', '狗$_suffix', '鸟', '鱼']);
+    expect(entries.map((e) => e.content), ['本地猫', '本地狗', '包内狗', '包内鸟', '包内鱼']);
+    expect(entries.map((e) => e.sortOrder), [0, 1, 2, 3, 4]);
+  });
+
+  test('导入结果一次性持久化', () async {
+    final storage = _MemoryStorage();
+    await storage.setTagLibraryEntriesJson('[]');
+    await storage.setTagLibraryCategoriesJson('[]');
+    final container = ProviderContainer(
+      overrides: [localStorageServiceProvider.overrideWithValue(storage)],
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(tagLibraryPageNotifierProvider.notifier);
+    final preview = _preview(
+      categories: [_category(id: 'cat-1', name: '角色')],
+      entries: [_entry(id: 'pkg-1', name: '猫', categoryId: 'cat-1')],
+    );
+    final writesBefore = storage.writeCount;
+
+    await notifier.applyImportPlan(
+      planFor(
+        container: container,
+        preview: preview,
+        conflicts: const [],
+        resolutions: const {},
+      ),
+    );
+
+    final persisted =
+        jsonDecode(storage.getTagLibraryEntriesJson()!) as List<dynamic>;
+    expect(storage.writeCount - writesBefore, 2);
+    expect(persisted.single['id'], 'new-2');
+    expect(persisted.single['categoryId'], 'new-1');
+  });
+
+  test('覆盖分类会连带删除子分类并把现有条目移到根级', () async {
+    final container = await seeded(
+      categories: [
+        _category(id: 'local-cat', name: '角色'),
+        _category(id: 'local-child', name: '子', parentId: 'local-cat'),
+      ],
+      entries: [_entry(id: 'local-a', name: '猫', categoryId: 'local-child')],
+    );
+    final notifier = container.read(tagLibraryPageNotifierProvider.notifier);
+    notifier.selectCategory('local-child');
+
+    await notifier.applyImportPlan(
+      planFor(
+        container: container,
+        preview: _preview(
+          categories: [_category(id: 'pkg-cat', name: '角色')],
+        ),
+        conflicts: [
+          _categoryConflict(importId: 'pkg-cat', existingId: 'local-cat'),
+        ],
+        resolutions: const {'pkg-cat': ConflictResolution.overwrite},
+      ),
+    );
+
+    final state = container.read(tagLibraryPageNotifierProvider);
+    expect(state.categories.map((c) => c.id), ['pkg-cat']);
+    expect(state.entries.single.categoryId, isNull);
+    expect(state.selectedCategoryId, isNull);
+  });
+
+  test('目标 ID 在应用时已被占用则只拒绝该项', () async {
+    final container = await seeded(
+      entries: [_entry(id: 'local-a', name: '猫', content: '本地猫')],
+    );
+    final notifier = container.read(tagLibraryPageNotifierProvider.notifier);
+    final sources = [
+      _entry(id: 'pkg-1', name: '猫', content: '包内猫'),
+      _entry(id: 'pkg-2', name: '鱼', content: '包内鱼'),
+    ];
+
+    final applied = await notifier.applyImportPlan(
+      TagLibraryImportPlan(
+        preview: _preview(entries: sources),
+        categories: const [],
+        entries: [
+          TagLibraryEntryImportPlan(
+            source: sources.first,
+            action: TagLibraryImportAction.create,
+            targetId: 'local-a',
+            targetName: '猫',
+          ),
+          TagLibraryEntryImportPlan(
+            source: sources.last,
+            action: TagLibraryImportAction.create,
+            targetId: 'fresh',
+            targetName: '鱼',
+          ),
+        ],
+      ),
+    );
+
+    final entries = container.read(tagLibraryPageNotifierProvider).entries;
+    expect(applied.success, isFalse);
+    expect(applied.rejected.single.kind, TagLibraryImportItemKind.entry);
+    expect(applied.rejected.single.sourceId, 'pkg-1');
+    expect(applied.rejected.single.targetId, 'local-a');
+    expect(entries.map((e) => e.id), ['local-a', 'fresh']);
+    expect(entries.first.content, '本地猫');
+  });
+
+  group('预览图落盘', () {
+    late File localThumbnail;
+    late File package;
+    late TagLibraryEntry localEntry;
+
+    setUp(() async {
+      localThumbnail = writeLocalThumbnail('local-a', _packagedBytes);
+      localEntry = _entry(
+        id: 'local-a',
+        name: '猫',
+        content: '本地猫',
+        thumbnail: localThumbnail.path,
+      );
+      package = await service.exportLibrary(
+        entries: [localEntry],
+        categories: const [],
+        includeThumbnails: true,
+        outputPath: p.join(workspace.path, 'library.zip'),
+      );
+      localThumbnail.writeAsBytesSync(_localBytes);
+    });
+
+    test('覆盖时预览图写回同一条目并保留包内内容', () async {
+      final container = await seeded(entries: [localEntry]);
+      final notifier = container.read(tagLibraryPageNotifierProvider.notifier);
+      final preview = await service.parseImportFile(package);
+      final plan = planFor(
+        container: container,
+        preview: preview,
+        conflicts: await service.detectConflicts(
+          preview,
+          container.read(tagLibraryPageNotifierProvider).entries,
+          const [],
+        ),
+        resolutions: const {'local-a': ConflictResolution.overwrite},
+      );
+
+      final result = await service.executeImport(zipFile: package, plan: plan);
+      await notifier.applyImportPlan(
+        plan,
+        importedEntries: result.updatedEntries,
+      );
+
+      final entry = container
+          .read(tagLibraryPageNotifierProvider)
+          .entries
+          .single;
+      expect(entry.id, 'local-a');
+      expect(entry.thumbnail, p.join(thumbnailsRoot().path, 'local-a.png'));
+      expect(File(entry.thumbnail!).readAsBytesSync(), _packagedBytes);
+      expect(thumbnailNames(), ['local-a.png']);
+    });
+
+    test('重命名导入不会覆盖同 ID 本地条目的预览图', () async {
+      final container = await seeded(entries: [localEntry]);
+      final notifier = container.read(tagLibraryPageNotifierProvider.notifier);
+      final preview = await service.parseImportFile(package);
+      final plan = planFor(
+        container: container,
+        preview: preview,
+        conflicts: await service.detectConflicts(
+          preview,
+          container.read(tagLibraryPageNotifierProvider).entries,
+          const [],
+        ),
+        resolutions: const {'local-a': ConflictResolution.rename},
+      );
+
+      final result = await service.executeImport(zipFile: package, plan: plan);
+      await notifier.applyImportPlan(
+        plan,
+        importedEntries: result.updatedEntries,
+      );
+
+      final entries = container.read(tagLibraryPageNotifierProvider).entries;
+      expect(entries.map((e) => e.id), ['local-a', 'new-1']);
+      expect(entries.first.thumbnail, localThumbnail.path);
+      expect(localThumbnail.readAsBytesSync(), _localBytes);
+      expect(
+        entries.last.thumbnail,
+        p.join(thumbnailsRoot().path, 'new-1.png'),
+      );
+      expect(File(entries.last.thumbnail!).readAsBytesSync(), _packagedBytes);
+      expect(thumbnailNames(), ['local-a.png', 'new-1.png']);
+    });
+  });
+}
+
+ImportPreview _preview({
+  List<TagLibraryEntry> entries = const [],
+  List<TagLibraryCategory> categories = const [],
+}) => ImportPreview(
+  version: '1.0',
+  exportDate: DateTime.utc(2026),
+  entries: entries,
+  categories: categories,
+);
+
+TagLibraryEntry _entry({
+  required String id,
+  required String name,
+  String content = '1girl',
+  String? categoryId,
+  String? thumbnail,
+}) => TagLibraryEntry(
+  id: id,
+  name: name,
+  content: content,
+  categoryId: categoryId,
+  thumbnail: thumbnail,
+  createdAt: DateTime.utc(2026),
+  updatedAt: DateTime.utc(2026),
+);
+
+TagLibraryCategory _category({
+  required String id,
+  required String name,
+  String? parentId,
+}) => TagLibraryCategory(
+  id: id,
+  name: name,
+  parentId: parentId,
+  createdAt: DateTime.utc(2026),
+);
+
+ImportConflict _entryConflict({
+  required String importId,
+  required String existingId,
+}) => ImportConflict(
+  type: ConflictType.entry,
+  importName: importId,
+  importId: importId,
+  existingId: existingId,
+);
+
+ImportConflict _categoryConflict({
+  required String importId,
+  required String existingId,
+}) => ImportConflict(
+  type: ConflictType.category,
+  importName: importId,
+  importId: importId,
+  existingId: existingId,
+);
+
+class _MemoryStorage extends LocalStorageService {
+  final Map<String, Object?> _values = {};
+  int writeCount = 0;
+
+  @override
+  T? getSetting<T>(String key, {T? defaultValue}) =>
+      (_values[key] ?? defaultValue) as T?;
+
+  @override
+  Future<void> setSetting<T>(String key, T value) async {
+    writeCount++;
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> deleteSetting(String key) async {
+    _values.remove(key);
+  }
+}
+
+class _PathProvider extends PathProviderPlatform {
+  _PathProvider(this.path);
+
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+}


### PR DESCRIPTION
> 堆叠在 #270（`fix/tag-library-import-path-traversal`）之上，base 指向该分支，合并后自动改指 main。

## 用户可见变化

导入词库包时，批次里选了「覆盖」或「重命名」的项不再连累其他项：无冲突的条目保持原名，重命名项也不会与本地条目撞 ID。重新导入自己的导出包不会再覆盖本地条目已有的预览图。导入结果会汇总逐项的应用与拒绝情况。

## 问题

批次里只要有一项选覆盖或重命名，整批条目就跟着保留包内 ID 或统一加后缀；预览图又固定按包内 ID 落盘。

## 改动

- 新增导入计划：每个分类与条目按自身解决方案得出动作、目标 ID、目标名称、映射后的父级或分类、预览图目标，全部在任何写入之前确定
- 新建与重命名一律使用新 ID，覆盖沿用包内 ID；包内 ID 被本次保留的本地项占用时改用新 ID
- 分类映射只在计划中生成一次，父级先于子级解析，跳过项映射到现有同名分类
- 预览图写入条目自己的目标 ID，移除 IO 层硬编码的重命名后缀，改由界面传入
- Provider 改为按计划原子应用：先删被覆盖项再插入，统一持久化，并返回逐项结果供界面汇总

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（集成分支）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `tag_library_import_planner_test.dart`、`tag_library_import_apply_test.dart`

四语文案新增 1 个键（`tagLibrary_importRejectedCount`），`lib/l10n/app_localizations*.dart` 为 `flutter gen-l10n` 重新生成。无 LFS 或 assets 变更。
