### PR TITLE
fix(gallery): 让高级筛选条件在所有搜索路径生效

### DIFF
--- a/lib/core/database/datasources/gallery_data_source.dart
+++ b/lib/core/database/datasources/gallery_data_source.dart
@@ -217,6 +217,13 @@ class GalleryDataSource extends EnhancedBaseDataSource {
     int? minFileSize,
     int? maxFileSize,
     List<String>? metadataStatuses,
+    String? model,
+    String? sampler,
+    int? minSteps,
+    int? maxSteps,
+    double? minCfgScale,
+    double? maxCfgScale,
+    String? resolution,
     int limit = 100,
   }) => _query.advancedSearch(
     textQuery: textQuery,
@@ -230,6 +237,13 @@ class GalleryDataSource extends EnhancedBaseDataSource {
     minFileSize: minFileSize,
     maxFileSize: maxFileSize,
     metadataStatuses: metadataStatuses,
+    model: model,
+    sampler: sampler,
+    minSteps: minSteps,
+    maxSteps: maxSteps,
+    minCfgScale: minCfgScale,
+    maxCfgScale: maxCfgScale,
+    resolution: resolution,
     limit: limit,
   );
 

--- a/lib/core/database/datasources/gallery_query.dart
+++ b/lib/core/database/datasources/gallery_query.dart
@@ -31,6 +31,13 @@ abstract interface class GalleryQuery {
     int? minFileSize,
     int? maxFileSize,
     List<String>? metadataStatuses,
+    String? model,
+    String? sampler,
+    int? minSteps,
+    int? maxSteps,
+    double? minCfgScale,
+    double? maxCfgScale,
+    String? resolution,
     int limit = 100,
   });
   Future<List<GalleryImageRecord>> getAllImages();
@@ -54,7 +61,7 @@ class SqliteGalleryQuery implements GalleryQuery {
         .toList(growable: false);
   }
 
-  String _escapeLikePattern(String input) {
+  static String _escapeLikePattern(String input) {
     return input
         .replaceAll('\\', '\\\\')
         .replaceAll('%', r'\%')
@@ -454,21 +461,39 @@ class SqliteGalleryQuery implements GalleryQuery {
     int? minFileSize,
     int? maxFileSize,
     List<String>? metadataStatuses,
+    String? model,
+    String? sampler,
+    int? minSteps,
+    int? maxSteps,
+    double? minCfgScale,
+    double? maxCfgScale,
+    String? resolution,
     int limit = 100,
   }) async {
+    final criteria = _AdvancedSearchCriteria(
+      dateStart: dateStart,
+      dateEnd: dateEnd,
+      favoritesOnly: favoritesOnly,
+      minWidth: minWidth,
+      minHeight: minHeight,
+      maxWidth: maxWidth,
+      maxHeight: maxHeight,
+      minFileSize: minFileSize,
+      maxFileSize: maxFileSize,
+      metadataStatuses: metadataStatuses,
+      model: model,
+      sampler: sampler,
+      minSteps: minSteps,
+      maxSteps: maxSteps,
+      minCfgScale: minCfgScale,
+      maxCfgScale: maxCfgScale,
+      resolution: resolution,
+    );
+
     // 缓存键
     final cacheKey = GalleryQueryCacheKey('advancedSearch', {
       'textQuery': textQuery,
-      'dateStart': dateStart?.millisecondsSinceEpoch,
-      'dateEnd': dateEnd?.millisecondsSinceEpoch,
-      'favoritesOnly': favoritesOnly,
-      'minWidth': minWidth,
-      'minHeight': minHeight,
-      'maxWidth': maxWidth,
-      'maxHeight': maxHeight,
-      'minFileSize': minFileSize,
-      'maxFileSize': maxFileSize,
-      'metadataStatuses': metadataStatuses?.join(','),
+      ...criteria.cacheFields,
       'limit': limit,
     });
 
@@ -504,87 +529,14 @@ class SqliteGalleryQuery implements GalleryQuery {
         }
 
         return await gateway.execute('advancedSearch', (db) async {
-          // 2. 构建查询条件
-          final conditions = <String>['i.is_deleted = 0'];
-          final args = <dynamic>[];
+          final statement = criteria.buildStatement(
+            textSearchIds: textSearchIds,
+            limit: limit,
+          );
 
-          if (favoritesOnly) {
-            conditions.add('f.image_id IS NOT NULL');
-          }
-
-          if (dateStart != null) {
-            conditions.add('i.modified_at >= ?');
-            args.add(dateStart.millisecondsSinceEpoch);
-          }
-          if (dateEnd != null) {
-            conditions.add('i.modified_at <= ?');
-            args.add(dateEnd.millisecondsSinceEpoch);
-          }
-
-          if (minWidth != null) {
-            conditions.add('i.width >= ?');
-            args.add(minWidth);
-          }
-          if (minHeight != null) {
-            conditions.add('i.height >= ?');
-            args.add(minHeight);
-          }
-          if (maxWidth != null) {
-            conditions.add('i.width <= ?');
-            args.add(maxWidth);
-          }
-          if (maxHeight != null) {
-            conditions.add('i.height <= ?');
-            args.add(maxHeight);
-          }
-
-          if (minFileSize != null) {
-            conditions.add('i.file_size >= ?');
-            args.add(minFileSize);
-          }
-          if (maxFileSize != null) {
-            conditions.add('i.file_size <= ?');
-            args.add(maxFileSize);
-          }
-
-          if (metadataStatuses != null && metadataStatuses.isNotEmpty) {
-            final statusIndices = metadataStatuses
-                .map(
-                  (s) => MetadataStatus.values.indexWhere((v) => v.name == s),
-                )
-                .where((i) => i >= 0)
-                .toList();
-            if (statusIndices.isNotEmpty) {
-              final placeholders = List.filled(
-                statusIndices.length,
-                '?',
-              ).join(',');
-              conditions.add('i.metadata_status IN ($placeholders)');
-              args.addAll(statusIndices);
-            }
-          }
-
-          if (textSearchIds != null && textSearchIds.isNotEmpty) {
-            final placeholders = List.filled(
-              textSearchIds.length,
-              '?',
-            ).join(',');
-            conditions.add('i.id IN ($placeholders)');
-            args.addAll(textSearchIds);
-          }
-
-          final whereClause = conditions.join(' AND ');
-
-          // 3. 执行查询
           final results = await db.rawQuery(
-            '''
-            SELECT i.id FROM ${GalleryTables.images} i
-            ${favoritesOnly ? 'INNER JOIN ${GalleryTables.favorites} f ON i.id = f.image_id' : 'LEFT JOIN ${GalleryTables.favorites} f ON i.id = f.image_id'}
-            WHERE $whereClause
-            ORDER BY i.modified_at DESC
-            LIMIT ?
-            ''',
-            [...args, limit],
+            statement.sql,
+            statement.arguments,
           );
 
           final ids = results.map((row) => (row['id'] as num).toInt()).toList();
@@ -924,4 +876,219 @@ class SqliteGalleryQuery implements GalleryQuery {
     }
     return counts;
   }
+}
+
+/// advancedSearch 的非文本条件及其 SQL 展开。
+class _AdvancedSearchCriteria {
+  const _AdvancedSearchCriteria({
+    this.dateStart,
+    this.dateEnd,
+    this.favoritesOnly = false,
+    this.minWidth,
+    this.minHeight,
+    this.maxWidth,
+    this.maxHeight,
+    this.minFileSize,
+    this.maxFileSize,
+    this.metadataStatuses,
+    this.model,
+    this.sampler,
+    this.minSteps,
+    this.maxSteps,
+    this.minCfgScale,
+    this.maxCfgScale,
+    this.resolution,
+  });
+
+  final DateTime? dateStart;
+  final DateTime? dateEnd;
+  final bool favoritesOnly;
+  final int? minWidth;
+  final int? minHeight;
+  final int? maxWidth;
+  final int? maxHeight;
+  final int? minFileSize;
+  final int? maxFileSize;
+  final List<String>? metadataStatuses;
+  final String? model;
+  final String? sampler;
+  final int? minSteps;
+  final int? maxSteps;
+  final double? minCfgScale;
+  final double? maxCfgScale;
+  final String? resolution;
+
+  // 扫描时宽高同时写入 images 与 metadata，旧记录可能只落其中一处。
+  static const String _widthExpression =
+      'COALESCE(NULLIF(m.width, 0), NULLIF(i.width, 0))';
+  static const String _heightExpression =
+      'COALESCE(NULLIF(m.height, 0), NULLIF(i.height, 0))';
+
+  static final RegExp _resolutionPattern = RegExp(
+    r'^(\d{1,6})\s*[x×*]\s*(\d{1,6})$',
+    caseSensitive: false,
+  );
+
+  Map<String, dynamic> get cacheFields => {
+    'dateStart': dateStart?.millisecondsSinceEpoch,
+    'dateEnd': dateEnd?.millisecondsSinceEpoch,
+    'favoritesOnly': favoritesOnly,
+    'minWidth': minWidth,
+    'minHeight': minHeight,
+    'maxWidth': maxWidth,
+    'maxHeight': maxHeight,
+    'minFileSize': minFileSize,
+    'maxFileSize': maxFileSize,
+    'metadataStatuses': metadataStatuses?.join(','),
+    'model': _normalizedText(model),
+    'sampler': _normalizedText(sampler),
+    'minSteps': minSteps,
+    'maxSteps': maxSteps,
+    'minCfgScale': minCfgScale,
+    'maxCfgScale': maxCfgScale,
+    'resolution': _normalizedText(resolution),
+  };
+
+  _AdvancedSearchStatement buildStatement({
+    required List<int>? textSearchIds,
+    required int limit,
+  }) {
+    final conditions = <String>['i.is_deleted = 0'];
+    final arguments = <Object?>[];
+
+    if (favoritesOnly) {
+      conditions.add('f.image_id IS NOT NULL');
+    }
+
+    void addComparison(String expression, Object? value) {
+      if (value == null) return;
+      conditions.add(expression);
+      arguments.add(value);
+    }
+
+    addComparison('i.modified_at >= ?', dateStart?.millisecondsSinceEpoch);
+    addComparison('i.modified_at <= ?', dateEnd?.millisecondsSinceEpoch);
+    addComparison('$_widthExpression >= ?', minWidth);
+    addComparison('$_heightExpression >= ?', minHeight);
+    addComparison('$_widthExpression <= ?', maxWidth);
+    addComparison('$_heightExpression <= ?', maxHeight);
+    addComparison('i.file_size >= ?', minFileSize);
+    addComparison('i.file_size <= ?', maxFileSize);
+    addComparison('m.steps >= ?', minSteps);
+    addComparison('m.steps <= ?', maxSteps);
+    addComparison('m.cfg_scale >= ?', minCfgScale);
+    addComparison('m.cfg_scale <= ?', maxCfgScale);
+
+    _addStatusCondition(conditions, arguments);
+    _addContainsCondition(conditions, arguments, 'm.model', model);
+    _addContainsCondition(conditions, arguments, 'm.sampler', sampler);
+    _addResolutionCondition(conditions, arguments);
+
+    if (textSearchIds != null && textSearchIds.isNotEmpty) {
+      final placeholders = List.filled(textSearchIds.length, '?').join(',');
+      conditions.add('i.id IN ($placeholders)');
+      arguments.addAll(textSearchIds);
+    }
+
+    final favoritesJoin = favoritesOnly
+        ? 'INNER JOIN ${GalleryTables.favorites} f ON i.id = f.image_id'
+        : 'LEFT JOIN ${GalleryTables.favorites} f ON i.id = f.image_id';
+    final metadataJoin = _requiresMetadataJoin
+        ? 'LEFT JOIN ${GalleryTables.metadata} m ON m.image_id = i.id'
+        : '';
+
+    return _AdvancedSearchStatement(
+      sql:
+          '''
+            SELECT i.id FROM ${GalleryTables.images} i
+            $favoritesJoin
+            $metadataJoin
+            WHERE ${conditions.join(' AND ')}
+            ORDER BY i.modified_at DESC
+            LIMIT ?
+            ''',
+      arguments: [...arguments, limit],
+    );
+  }
+
+  bool get _requiresMetadataJoin =>
+      minWidth != null ||
+      minHeight != null ||
+      maxWidth != null ||
+      maxHeight != null ||
+      minSteps != null ||
+      maxSteps != null ||
+      minCfgScale != null ||
+      maxCfgScale != null ||
+      _normalizedText(model) != null ||
+      _normalizedText(sampler) != null ||
+      _normalizedText(resolution) != null;
+
+  void _addStatusCondition(List<String> conditions, List<Object?> arguments) {
+    final statuses = metadataStatuses;
+    if (statuses == null || statuses.isEmpty) return;
+
+    final statusIndices = statuses
+        .map((status) => MetadataStatus.values.indexWhere((v) => v.name == status))
+        .where((index) => index >= 0)
+        .toList();
+    if (statusIndices.isEmpty) return;
+
+    final placeholders = List.filled(statusIndices.length, '?').join(',');
+    conditions.add('i.metadata_status IN ($placeholders)');
+    arguments.addAll(statusIndices);
+  }
+
+  void _addContainsCondition(
+    List<String> conditions,
+    List<Object?> arguments,
+    String column,
+    String? value,
+  ) {
+    final normalized = _normalizedText(value);
+    if (normalized == null) return;
+
+    conditions.add("LOWER($column) LIKE ? ESCAPE '\\'");
+    arguments.add('%${SqliteGalleryQuery._escapeLikePattern(normalized)}%');
+  }
+
+  void _addResolutionCondition(
+    List<String> conditions,
+    List<Object?> arguments,
+  ) {
+    final normalized = _normalizedText(resolution);
+    if (normalized == null) return;
+
+    final match = _resolutionPattern.firstMatch(normalized);
+    final width = match == null ? null : int.tryParse(match.group(1)!);
+    final height = match == null ? null : int.tryParse(match.group(2)!);
+
+    if (width != null && width > 0 && height != null && height > 0) {
+      conditions.add('$_widthExpression = ?');
+      conditions.add('$_heightExpression = ?');
+      arguments.add(width);
+      arguments.add(height);
+      return;
+    }
+
+    // 面板允许自由输入，无法读成 宽x高 时退化为分辨率文本包含匹配。
+    conditions.add(
+      "(CAST($_widthExpression AS TEXT) || 'x' || "
+      "CAST($_heightExpression AS TEXT)) LIKE ? ESCAPE '\\'",
+    );
+    arguments.add('%${SqliteGalleryQuery._escapeLikePattern(normalized)}%');
+  }
+
+  static String? _normalizedText(String? value) {
+    final trimmed = value?.trim().toLowerCase();
+    if (trimmed == null || trimmed.isEmpty) return null;
+    return trimmed;
+  }
+}
+
+class _AdvancedSearchStatement {
+  const _AdvancedSearchStatement({required this.sql, required this.arguments});
+
+  final String sql;
+  final List<Object?> arguments;
 }

--- a/lib/data/services/gallery/gallery_filter_service.dart
+++ b/lib/data/services/gallery/gallery_filter_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../../core/database/datasources/gallery_data_source.dart';
 import '../../../core/database/utils/lru_cache.dart';
+import '../../../core/exceptions/gallery_exceptions.dart';
 import '../../../core/utils/app_logger.dart';
 import '../../../core/utils/isolate_pool.dart';
 import '../../../core/utils/tag_normalizer.dart';
@@ -350,37 +351,11 @@ class GalleryFilterService {
       }
 
       // 执行过滤
-      List<File> filtered;
-
-      if (criteria.searchQuery.isNotEmpty) {
-        if (_hasDelimitedSearchQuery(criteria.searchQuery)) {
-          // 逗号分隔搜索使用后台 AND 过滤，避免 FTS 多词搜索的 OR 语义。
-          filtered = allFiles;
-          if (_hasDatabasePreSearchFilters(criteria)) {
-            filtered = await _searchInDatabase(
-              allFiles,
-              criteria.copyWith(searchQuery: ''),
-              cancelToken,
-            );
-          }
-          filtered = await _filterByDelimitedSearchQuery(
-            filtered,
-            criteria.searchQuery,
-            cancelToken,
-          );
-        } else {
-          // 有普通搜索关键词：使用数据库搜索
-          filtered = await _searchInDatabase(allFiles, criteria, cancelToken);
-        }
-        filtered = await _applyPostSearchFilters(
-          filtered,
-          criteria,
-          cancelToken,
-        );
-      } else {
-        // 本地过滤
-        filtered = await _applyLocalFilters(allFiles, criteria, cancelToken);
-      }
+      final filtered = await _runFilterPipeline(
+        allFiles,
+        criteria,
+        cancelToken,
+      );
 
       // 检查是否取消
       if (cancelToken.isCancelled) {
@@ -411,14 +386,96 @@ class GalleryFilterService {
     }
   }
 
-  /// 在数据库中搜索
+  /// 过滤管线：数据库批量条件 → 逗号分段搜索 → 本地路径与文件条件。
+  Future<List<File>> _runFilterPipeline(
+    List<File> allFiles,
+    FilterCriteria criteria,
+    CancelToken cancelToken,
+  ) async {
+    final plan = _planFilters(criteria);
+    var filtered = allFiles;
+
+    final databaseCriteria = plan.databaseCriteria;
+    if (databaseCriteria != null) {
+      filtered = await _searchInDatabase(
+        filtered,
+        databaseCriteria,
+        cancelToken,
+      );
+      if (cancelToken.isCancelled) return [];
+      AppLogger.d(
+        'Filter pipeline after index query: ${filtered.length} files',
+        'GalleryFilterService',
+      );
+    }
+
+    final delimitedQuery = plan.delimitedSearchQuery;
+    if (delimitedQuery != null) {
+      filtered = await _filterByDelimitedSearchQuery(
+        filtered,
+        delimitedQuery,
+        cancelToken,
+      );
+      if (cancelToken.isCancelled) return [];
+      AppLogger.d(
+        'Filter pipeline after delimited search: ${filtered.length} files',
+        'GalleryFilterService',
+      );
+    }
+
+    filtered = await _applyLocalFilters(
+      filtered,
+      criteria,
+      cancelToken,
+      applyDateRange: plan.applyLocalDateRange,
+    );
+    AppLogger.d(
+      'Filter pipeline after local filters: ${filtered.length} files',
+      'GalleryFilterService',
+    );
+
+    return filtered;
+  }
+
+  /// 把过滤条件分配到管线的各个阶段。
+  _FilterPlan _planFilters(FilterCriteria criteria) {
+    // 逗号分隔搜索改走分段 AND 匹配，避免 FTS 多词搜索的 OR 语义。
+    final isDelimited =
+        criteria.searchQuery.isNotEmpty &&
+        _hasDelimitedSearchQuery(criteria.searchQuery);
+    final databaseCriteria = isDelimited
+        ? criteria.copyWith(searchQuery: '')
+        : criteria;
+    final usesDatabase = _requiresDatabaseStage(databaseCriteria);
+
+    return _FilterPlan(
+      databaseCriteria: usesDatabase ? databaseCriteria : null,
+      delimitedSearchQuery: isDelimited ? criteria.searchQuery : null,
+      // 索引查询在跑时顺带按 modified_at 过滤；否则回到文件修改时间，
+      // 让尚未入库的图片仍能参与日期筛选。
+      applyLocalDateRange:
+          !usesDatabase &&
+          (criteria.dateStart != null || criteria.dateEnd != null),
+    );
+  }
+
+  /// 只能由索引回答的条件；日期区间不在其中，未入库图片也应能按文件时间筛选。
+  bool _requiresDatabaseStage(FilterCriteria criteria) {
+    return criteria.searchQuery.trim().isNotEmpty ||
+        criteria.showFavoritesOnly ||
+        criteria.hasAdvancedFilters ||
+        criteria.hasMetadataFilters;
+  }
+
+  /// 在数据库中批量应用索引支持的条件
   Future<List<File>> _searchInDatabase(
     List<File> allFiles,
     FilterCriteria criteria,
     CancelToken cancelToken,
   ) async {
+    if (allFiles.isEmpty) return allFiles;
+
     try {
-      // 使用高级搜索
       final imageIds = await _dataSource.advancedSearch(
         textQuery: criteria.searchQuery.toLowerCase().trim(),
         favoritesOnly: criteria.showFavoritesOnly,
@@ -433,37 +490,45 @@ class GalleryFilterService {
         metadataStatuses: criteria.metadataStatuses.isNotEmpty
             ? criteria.metadataStatuses
             : null,
+        model: criteria.filterModel,
+        sampler: criteria.filterSampler,
+        minSteps: criteria.filterMinSteps,
+        maxSteps: criteria.filterMaxSteps,
+        minCfgScale: criteria.filterMinCfg,
+        maxCfgScale: criteria.filterMaxCfg,
+        resolution: criteria.filterResolution,
         limit: max(1, allFiles.length),
       );
 
       if (cancelToken.isCancelled) return [];
 
-      // 获取图片记录
       final images = await _dataSource.getImagesByIds(imageIds);
-      final validPaths = images.map((img) => img.filePath).toSet();
+      final matchedKeys = {
+        for (final image in images) galleryFilePathKey(image.filePath),
+      };
 
-      // 只返回存在于 allFiles 中的文件
-      return allFiles.where((file) => validPaths.contains(file.path)).toList();
-    } catch (e) {
-      AppLogger.w('Search failed: $e', 'GalleryFilterService');
-      // 回退到本地过滤
-      return _applyLocalFilters(allFiles, criteria, cancelToken);
+      // 未入库的图片无法满足索引条件，这里一并排除。
+      return allFiles
+          .where((file) => matchedKeys.contains(galleryFilePathKey(file.path)))
+          .toList();
+    } catch (e, stack) {
+      throw _filterFailure(
+        criteria.cacheKey,
+        'Failed to query the gallery index',
+        e,
+        stack,
+      );
     }
   }
 
-  /// 应用本地过滤
+  /// 应用索引之外、只能在本地判定的条件
   Future<List<File>> _applyLocalFilters(
     List<File> allFiles,
     FilterCriteria criteria,
-    CancelToken cancelToken,
-  ) async {
-    var filtered = List<File>.from(allFiles);
-
-    AppLogger.d(
-      '_applyLocalFilters START: ${filtered.length} files, '
-          'tags=${criteria.selectedTags}, dateStart=${criteria.dateStart}, dateEnd=${criteria.dateEnd}, favOnly=${criteria.showFavoritesOnly}',
-      'GalleryFilterService',
-    );
+    CancelToken cancelToken, {
+    required bool applyDateRange,
+  }) async {
+    var filtered = allFiles;
 
     // 标签过滤（需要数据库查询）
     if (criteria.selectedTags.isNotEmpty) {
@@ -472,32 +537,13 @@ class GalleryFilterService {
         criteria.selectedTags,
         cancelToken,
       );
-      AppLogger.d(
-        '_applyLocalFilters after tags filter: ${filtered.length} files',
-        'GalleryFilterService',
-      );
     }
 
     if (cancelToken.isCancelled) return [];
 
-    // 日期过滤
-    if (criteria.dateStart != null || criteria.dateEnd != null) {
+    // 日期过滤（按文件修改时间）
+    if (applyDateRange) {
       filtered = await _filterByDateRange(filtered, criteria, cancelToken);
-      AppLogger.d(
-        '_applyLocalFilters after date filter: ${filtered.length} files',
-        'GalleryFilterService',
-      );
-    }
-
-    if (cancelToken.isCancelled) return [];
-
-    // 收藏过滤
-    if (criteria.showFavoritesOnly) {
-      filtered = await _filterByFavorites(filtered, cancelToken);
-      AppLogger.d(
-        '_applyLocalFilters after fav filter: ${filtered.length} files',
-        'GalleryFilterService',
-      );
     }
 
     if (cancelToken.isCancelled) return [];
@@ -509,71 +555,31 @@ class GalleryFilterService {
         criteria.categoryFolderPath!,
         cancelToken,
       );
-      AppLogger.d(
-        '_applyLocalFilters after category filter: ${filtered.length} files',
-        'GalleryFilterService',
-      );
     }
 
     if (cancelToken.isCancelled) return [];
 
     // 相簿过滤（逻辑引用集合，含子相簿）
     if (criteria.albumId != null) {
-      filtered = await _filterByAlbum(
-        filtered,
-        criteria.albumId!,
-        cancelToken,
-      );
-      AppLogger.d(
-        '_applyLocalFilters after album filter: ${filtered.length} files',
-        'GalleryFilterService',
-      );
+      filtered = await _filterByAlbum(filtered, criteria.albumId!, cancelToken);
     }
 
-    AppLogger.d(
-      '_applyLocalFilters END: ${filtered.length} files',
-      'GalleryFilterService',
-    );
     return filtered;
   }
 
-  /// 应用数据库文本搜索之后仍需叠加的本地过滤。
-  Future<List<File>> _applyPostSearchFilters(
-    List<File> files,
-    FilterCriteria criteria,
-    CancelToken cancelToken,
-  ) async {
-    var filtered = files;
-
-    if (criteria.selectedTags.isNotEmpty) {
-      filtered = await _filterByTags(
-        filtered,
-        criteria.selectedTags,
-        cancelToken,
-      );
-    }
-
-    if (cancelToken.isCancelled) return [];
-
-    if (criteria.categoryFolderPath != null) {
-      filtered = await _filterByCategory(
-        filtered,
-        criteria.categoryFolderPath!,
-        cancelToken,
-      );
-    }
-
-    if (cancelToken.isCancelled) return [];
-
-    if (criteria.albumId != null) {
-      filtered = await _filterByAlbum(
-        filtered,
-        criteria.albumId!,
-        cancelToken,
-      );
-    }
-
-    return filtered;
+  /// 条件失败时保留条件本身并向上抛出，避免静默返回未过滤结果。
+  GalleryFilterException _filterFailure(
+    String criteriaDetail,
+    String message,
+    Object error,
+    StackTrace stack,
+  ) {
+    AppLogger.e(message, error, stack, 'GalleryFilterService');
+    return GalleryFilterException(
+      filterCriteria: criteriaDetail,
+      message: message,
+      cause: error,
+    );
   }
 
   /// 按逗号分隔的搜索片段做 AND 包含匹配。
@@ -595,18 +601,21 @@ class GalleryFilterService {
       if (cancelToken.isCancelled) return [];
 
       final images = await _dataSource.getImagesByIds(imageIds);
-      final validPaths = images.map((image) => image.filePath).toSet();
+      final matchedKeys = {
+        for (final image in images) galleryFilePathKey(image.filePath),
+      };
 
       return files.where((file) {
         if (cancelToken.isCancelled) return false;
-        return validPaths.contains(file.path);
+        return matchedKeys.contains(galleryFilePathKey(file.path));
       }).toList();
-    } catch (e) {
-      AppLogger.w(
-        'Failed to filter by delimited search query: $e',
-        'GalleryFilterService',
+    } catch (e, stack) {
+      throw _filterFailure(
+        'delimitedSearch:$searchQuery',
+        'Failed to filter by delimited search query',
+        e,
+        stack,
       );
-      return files;
     }
   }
 
@@ -653,21 +662,18 @@ class GalleryFilterService {
               _normalizedTextContainsTag(metadataText, tag),
         );
       }).toList();
-    } catch (e) {
-      AppLogger.w('Failed to filter by tags: $e', 'GalleryFilterService');
-      return files;
+    } catch (e, stack) {
+      throw _filterFailure(
+        'tags:${tags.join(",")}',
+        'Failed to filter by tags',
+        e,
+        stack,
+      );
     }
   }
 
   bool _hasDelimitedSearchQuery(String value) {
     return value.contains(',') || value.contains('，');
-  }
-
-  bool _hasDatabasePreSearchFilters(FilterCriteria criteria) {
-    return criteria.dateStart != null ||
-        criteria.dateEnd != null ||
-        criteria.showFavoritesOnly ||
-        criteria.hasAdvancedFilters;
   }
 
   List<String> _parseDelimitedSearchSegments(String value) {
@@ -745,33 +751,6 @@ class GalleryFilterService {
     }
   }
 
-  /// 按收藏状态过滤
-  Future<List<File>> _filterByFavorites(
-    List<File> files,
-    CancelToken cancelToken,
-  ) async {
-    try {
-      final pathToIdMap = await _dataSource.getImageIdsByPaths(
-        files.map((f) => f.path).toList(),
-      );
-
-      final imageIds = pathToIdMap.values.whereType<int>().toList();
-      final favoritesMap = await _dataSource.getFavoritesByImageIds(imageIds);
-
-      return files.where((file) {
-        if (cancelToken.isCancelled) return false;
-
-        final imageId = pathToIdMap[file.path];
-        if (imageId == null) return false;
-
-        return favoritesMap[imageId] ?? false;
-      }).toList();
-    } catch (e) {
-      AppLogger.w('Failed to filter favorites: $e', 'GalleryFilterService');
-      return [];
-    }
-  }
-
   /// 按分类路径过滤
   ///
   /// 根据分类的文件夹路径过滤文件
@@ -826,6 +805,20 @@ class GalleryFilterService {
   FilterCriteria clearAllFilters(FilterCriteria current) {
     return const FilterCriteria();
   }
+}
+
+/// 过滤条件在管线各阶段的分配结果
+@immutable
+class _FilterPlan {
+  const _FilterPlan({
+    required this.databaseCriteria,
+    required this.delimitedSearchQuery,
+    required this.applyLocalDateRange,
+  });
+
+  final FilterCriteria? databaseCriteria;
+  final String? delimitedSearchQuery;
+  final bool applyLocalDateRange;
 }
 
 /// 取消令牌

--- a/test/data/services/gallery/gallery_filter_service_criteria_coverage_test.dart
+++ b/test/data/services/gallery/gallery_filter_service_criteria_coverage_test.dart
@@ -1,0 +1,484 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:nai_launcher/core/database/connection_pool_holder.dart';
+import 'package:nai_launcher/core/database/datasources/gallery_data_source.dart';
+import 'package:nai_launcher/core/utils/app_logger.dart';
+import 'package:nai_launcher/data/models/gallery/local_image_record.dart'
+    show MetadataStatus;
+import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
+import 'package:nai_launcher/data/services/gallery/gallery_filter_service.dart';
+
+const String alphaSmall = 'alpha_small.png';
+const String betaLarge = 'beta_large.png';
+const String alphaMedium = 'alpha_medium.png';
+const String plainNoMetadata = 'plain_no_metadata.png';
+const String legacyPendingSize = 'legacy_pending_size.png';
+const String neverIndexed = 'never_indexed.png';
+
+void main() {
+  group('GalleryFilterService criteria coverage', () {
+    late Directory tempDir;
+    late GalleryDataSource dataSource;
+    late List<File> allFiles;
+
+    Future<List<String>> matchNames(FilterCriteria criteria) async {
+      final service = GalleryFilterService(dataSource);
+      final result = await service.applyFilters(allFiles, criteria);
+      return result.files.map((file) => p.basename(file.path)).toList()..sort();
+    }
+
+    setUpAll(() async {
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+      await AppLogger.initialize(isTestEnvironment: true);
+
+      tempDir = Directory.systemTemp.createTempSync('gallery_filter_criteria_');
+      await ConnectionPoolHolder.initialize(
+        dbPath: p.join(tempDir.path, 'criteria_coverage.db'),
+        maxConnections: 2,
+      );
+
+      dataSource = GalleryDataSource();
+      await dataSource.initialize();
+
+      Future<File> writeFile(String name, DateTime modifiedAt) async {
+        final file = File(p.join(tempDir.path, name));
+        await file.writeAsBytes(<int>[137, 80, 78, 71]);
+        await file.setLastModified(modifiedAt);
+        return file;
+      }
+
+      Future<File> seedImage({
+        required String name,
+        required DateTime modifiedAt,
+        required int fileSize,
+        int? width,
+        int? height,
+        NaiImageMetadata? metadata,
+        bool favorite = false,
+      }) async {
+        final file = await writeFile(name, modifiedAt);
+        final imageId = await dataSource.upsertImage(
+          filePath: file.path,
+          fileName: name,
+          fileSize: fileSize,
+          width: width,
+          height: height,
+          createdAt: modifiedAt,
+          modifiedAt: modifiedAt,
+          resolutionKey: width != null && height != null
+              ? '${width}x$height'
+              : null,
+          metadataStatus: metadata == null
+              ? MetadataStatus.none
+              : MetadataStatus.success,
+        );
+        if (metadata != null) {
+          await dataSource.upsertMetadata(imageId, metadata);
+        }
+        if (favorite) {
+          await dataSource.toggleFavorite(imageId);
+        }
+        return file;
+      }
+
+      final files = <File>[
+        await seedImage(
+          name: alphaSmall,
+          modifiedAt: DateTime(2026, 1, 10, 12),
+          fileSize: 1000,
+          width: 256,
+          height: 256,
+          favorite: true,
+          metadata: const NaiImageMetadata(
+            prompt: 'alpha scene, blue eyes',
+            negativePrompt: '',
+            seed: 1,
+            sampler: 'k_euler',
+            steps: 20,
+            scale: 5.0,
+            width: 256,
+            height: 256,
+            model: 'nai-diffusion-3',
+          ),
+        ),
+        await seedImage(
+          name: betaLarge,
+          modifiedAt: DateTime(2026, 2, 10, 12),
+          fileSize: 50000,
+          width: 1024,
+          height: 1536,
+          metadata: const NaiImageMetadata(
+            prompt: 'beta scene, blonde hair',
+            negativePrompt: '',
+            seed: 2,
+            sampler: 'k_dpmpp_2m',
+            steps: 28,
+            scale: 6.5,
+            width: 1024,
+            height: 1536,
+            model: 'nai-diffusion-4-5-full',
+          ),
+        ),
+        await seedImage(
+          name: alphaMedium,
+          modifiedAt: DateTime(2026, 3, 10, 12),
+          fileSize: 20000,
+          width: 832,
+          height: 1216,
+          metadata: const NaiImageMetadata(
+            prompt: 'alpha scene, blonde hair',
+            negativePrompt: '',
+            seed: 3,
+            sampler: 'k_euler_ancestral',
+            steps: 23,
+            scale: 5.5,
+            width: 832,
+            height: 1216,
+            model: 'nai-diffusion-4-5-full',
+          ),
+        ),
+        await seedImage(
+          name: plainNoMetadata,
+          modifiedAt: DateTime(2026, 4, 10, 12),
+          fileSize: 3000,
+        ),
+        // Image row indexed before its size was known; metadata carries it.
+        await seedImage(
+          name: legacyPendingSize,
+          modifiedAt: DateTime(2026, 5, 10, 12),
+          fileSize: 8000,
+          metadata: const NaiImageMetadata(
+            prompt: 'legacy artwork',
+            negativePrompt: '',
+            seed: 4,
+            sampler: 'legacy_sampler',
+            steps: 40,
+            scale: 5.0,
+            width: 320,
+            height: 320,
+            model: 'legacy-diffusion',
+          ),
+        ),
+        await writeFile(neverIndexed, DateTime(2026, 1, 10, 12)),
+      ];
+
+      allFiles = List<File>.unmodifiable(files);
+    });
+
+    tearDownAll(() async {
+      await dataSource.dispose();
+      await ConnectionPoolHolder.dispose();
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    group('without a search query', () {
+      test('model filter matches indexed metadata', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(filterModel: 'nai-diffusion-4-5'),
+          ),
+          [alphaMedium, betaLarge],
+        );
+        expect(
+          await matchNames(
+            const FilterCriteria(filterModel: 'nai-diffusion-3'),
+          ),
+          [alphaSmall],
+        );
+      });
+
+      test('sampler filter matches by containment', () async {
+        expect(
+          await matchNames(const FilterCriteria(filterSampler: 'k_euler')),
+          [alphaMedium, alphaSmall],
+        );
+        expect(
+          await matchNames(const FilterCriteria(filterSampler: 'k_dpmpp')),
+          [betaLarge],
+        );
+      });
+
+      test('steps range filter narrows to the matching image', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(filterMinSteps: 21, filterMaxSteps: 25),
+          ),
+          [alphaMedium],
+        );
+      });
+
+      test('cfg range filter narrows to the matching image', () async {
+        expect(await matchNames(const FilterCriteria(filterMinCfg: 6.0)), [
+          betaLarge,
+        ]);
+        expect(await matchNames(const FilterCriteria(filterMaxCfg: 5.2)), [
+          alphaSmall,
+          legacyPendingSize,
+        ]);
+      });
+
+      test('resolution filter matches width by height', () async {
+        expect(
+          await matchNames(const FilterCriteria(filterResolution: '832x1216')),
+          [alphaMedium],
+        );
+        expect(
+          await matchNames(const FilterCriteria(filterResolution: '1024x1536')),
+          [betaLarge],
+        );
+      });
+
+      test(
+        'resolution filter falls back to containment for free text',
+        () async {
+          expect(
+            await matchNames(const FilterCriteria(filterResolution: '1216')),
+            [alphaMedium],
+          );
+        },
+      );
+
+      test('dimension filters fall back to metadata size', () async {
+        expect(await matchNames(const FilterCriteria(minWidth: 300)), [
+          alphaMedium,
+          betaLarge,
+          legacyPendingSize,
+        ]);
+        expect(
+          await matchNames(const FilterCriteria(filterResolution: '320x320')),
+          [legacyPendingSize],
+        );
+      });
+
+      test('dimension filters apply without a search query', () async {
+        expect(await matchNames(const FilterCriteria(minWidth: 500)), [
+          alphaMedium,
+          betaLarge,
+        ]);
+        expect(await matchNames(const FilterCriteria(maxHeight: 300)), [
+          alphaSmall,
+        ]);
+      });
+
+      test('file size filters apply without a search query', () async {
+        expect(await matchNames(const FilterCriteria(minFileSize: 10000)), [
+          alphaMedium,
+          betaLarge,
+        ]);
+        expect(await matchNames(const FilterCriteria(maxFileSize: 5000)), [
+          alphaSmall,
+          plainNoMetadata,
+        ]);
+      });
+
+      test('metadata status filter applies without a search query', () async {
+        expect(
+          await matchNames(const FilterCriteria(metadataStatuses: ['none'])),
+          [plainNoMetadata],
+        );
+        expect(
+          await matchNames(const FilterCriteria(metadataStatuses: ['success'])),
+          [alphaMedium, alphaSmall, betaLarge, legacyPendingSize],
+        );
+      });
+
+      test('favorites filter returns the favorited image', () async {
+        expect(
+          await matchNames(const FilterCriteria(showFavoritesOnly: true)),
+          [alphaSmall],
+        );
+      });
+
+      test('metadata conditions drop images without metadata', () async {
+        expect(await matchNames(const FilterCriteria(filterMinSteps: 1)), [
+          alphaMedium,
+          alphaSmall,
+          betaLarge,
+          legacyPendingSize,
+        ]);
+      });
+
+      test('index conditions drop files that are not indexed yet', () async {
+        expect(await matchNames(const FilterCriteria(minFileSize: 1)), [
+          alphaMedium,
+          alphaSmall,
+          betaLarge,
+          legacyPendingSize,
+          plainNoMetadata,
+        ]);
+      });
+
+      test('date range keeps files that are not indexed yet', () async {
+        expect(
+          await matchNames(
+            FilterCriteria(
+              dateStart: DateTime(2026, 1, 1),
+              dateEnd: DateTime(2026, 1, 31),
+            ),
+          ),
+          [alphaSmall, neverIndexed],
+        );
+      });
+
+      test(
+        'date range combined with an index condition drops unindexed files',
+        () async {
+          expect(
+            await matchNames(
+              FilterCriteria(
+                dateStart: DateTime(2026, 1, 1),
+                dateEnd: DateTime(2026, 1, 31),
+                minFileSize: 1,
+              ),
+            ),
+            [alphaSmall],
+          );
+        },
+      );
+    });
+
+    group('with a plain search query', () {
+      test('search combines with dimension filters', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(searchQuery: 'alpha', minWidth: 500),
+          ),
+          [alphaMedium],
+        );
+      });
+
+      test('search combines with the model filter', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(
+              searchQuery: 'alpha',
+              filterModel: 'nai-diffusion-3',
+            ),
+          ),
+          [alphaSmall],
+        );
+      });
+
+      test('search combines with the steps filter', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(searchQuery: 'scene', filterMinSteps: 25),
+          ),
+          [betaLarge],
+        );
+      });
+
+      test('search combines with the resolution filter', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(
+              searchQuery: 'scene',
+              filterResolution: '832x1216',
+            ),
+          ),
+          [alphaMedium],
+        );
+      });
+    });
+
+    group('with a comma separated search query', () {
+      test('segments are matched with AND', () async {
+        expect(
+          await matchNames(const FilterCriteria(searchQuery: 'scene,blonde')),
+          [alphaMedium, betaLarge],
+        );
+      });
+
+      test('segments combine with the sampler filter', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(
+              searchQuery: 'scene,blonde',
+              filterSampler: 'k_dpmpp',
+            ),
+          ),
+          [betaLarge],
+        );
+      });
+
+      test('segments combine with the resolution filter', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(
+              searchQuery: 'scene,blonde',
+              filterResolution: '832x1216',
+            ),
+          ),
+          [alphaMedium],
+        );
+      });
+
+      test('segments combine with the cfg filter', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(
+              searchQuery: 'scene,blonde',
+              filterMinCfg: 6.0,
+            ),
+          ),
+          [betaLarge],
+        );
+      });
+    });
+
+    group('combined criteria', () {
+      test('model, steps and resolution intersect', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(
+              filterModel: 'nai-diffusion-4-5-full',
+              filterMinSteps: 25,
+              filterResolution: '1024x1536',
+            ),
+          ),
+          [betaLarge],
+        );
+      });
+
+      test('conflicting criteria return nothing', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(
+              filterModel: 'nai-diffusion-3',
+              filterResolution: '1024x1536',
+            ),
+          ),
+          isEmpty,
+        );
+      });
+
+      test('favorites intersect with metadata criteria', () async {
+        expect(
+          await matchNames(
+            const FilterCriteria(
+              showFavoritesOnly: true,
+              filterSampler: 'k_euler',
+            ),
+          ),
+          [alphaSmall],
+        );
+        expect(
+          await matchNames(
+            const FilterCriteria(
+              showFavoritesOnly: true,
+              filterSampler: 'k_dpmpp',
+            ),
+          ),
+          isEmpty,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## 用户可见变化

画廊的模型、采样器、步数、CFG、分辨率筛选现在真的生效了——此前这些条件只存在于界面状态里，从未进入查询。宽高、文件大小和元数据状态也不再要求必须先输入搜索词。索引查询失败时会明确报错，而不是静默返回一份未过滤的结果。

## 改动

- `advancedSearch` 增加 model/sampler/steps/cfg/resolution 参数，按需 JOIN metadata，并把新参数纳入查询缓存键
- 宽高与分辨率统一读取 metadata 优先、images 兜底的有效尺寸，与统计页的分辨率口径保持一致
- 过滤管线不再按「是否有搜索文字」分叉：索引条件统一走一次索引查询，逗号分隔搜索同样叠加全部条件
- 索引查询失败抛出 `GalleryFilterException`，不再静默返回未过滤结果
- 日期区间不单独触发索引查询，未入库图片仍可按文件修改时间筛选

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（集成分支）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `gallery_filter_service_criteria_coverage_test.dart`（484 行）逐条覆盖 `FilterCriteria` 的全部字段

无生成文件、LFS 或 assets 变更。
