### PR TITLE
fix(generation): 挡住准备期的重复提交并给出可取消反馈

### DIFF
--- a/lib/presentation/providers/generation/generation_models.dart
+++ b/lib/presentation/providers/generation/generation_models.dart
@@ -257,6 +257,9 @@ class ImageGenerationState {
   final int? displayWidth;
   final int? displayHeight;
 
+  /// 一次生成调用是否仍在进行：从点击到整条调用结算（含读盘、编码、跑批与收尾）。
+  final bool isSubmitting;
+
   const ImageGenerationState({
     this.status = GenerationStatus.idle,
     this.currentImages = const [],
@@ -273,6 +276,7 @@ class ImageGenerationState {
     this.displayImages = const [],
     this.displayWidth,
     this.displayHeight,
+    this.isSubmitting = false,
   });
 
   ImageGenerationState copyWith({
@@ -293,6 +297,7 @@ class ImageGenerationState {
     List<GeneratedImage>? displayImages,
     int? displayWidth,
     int? displayHeight,
+    bool? isSubmitting,
   }) {
     return ImageGenerationState(
       status: status ?? this.status,
@@ -317,10 +322,18 @@ class ImageGenerationState {
       displayImages: displayImages ?? this.displayImages,
       displayWidth: displayWidth ?? this.displayWidth,
       displayHeight: displayHeight ?? this.displayHeight,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
     );
   }
 
   bool get isGenerating => status == GenerationStatus.generating;
+
+  /// 已提交但还没开跑：读盘、Vibe 编码、随机词都发生在这一段。
+  bool get isPreparing => isSubmitting && !isGenerating;
+
+  /// 忙区间，用于挡住重复提交、队列启动与 Krita 插队。
+  bool get isBusy => isSubmitting || isGenerating;
+
   bool get hasImages => displayImages.isNotEmpty;
 
   /// 是否有流式预览图像

--- a/lib/presentation/providers/generation/generation_params_notifier.dart
+++ b/lib/presentation/providers/generation/generation_params_notifier.dart
@@ -765,20 +765,25 @@ class GenerationParamsNotifier extends _$GenerationParamsNotifier {
   }
 
   Future<void> _restoreGenerationState() async {
-    final restored = await _persistence.restore();
-    if (_isDisposed) return;
-    _hasAppliedGenerationStateRestore = restored.isTerminal;
-    if (!restored.shouldApply) return;
+    // 恢复失败不能沿 Future.wait 冒泡进 generate()，否则整次生成会无声中断。
+    try {
+      final restored = await _persistence.restore();
+      if (_isDisposed) return;
+      _hasAppliedGenerationStateRestore = restored.isTerminal;
+      if (!restored.shouldApply) return;
 
-    state = state.copyWith(
-      vibeReferencesV4: _vibeReferences.normalize(
-        restored.vibeReferences,
-        currentModel: state.model,
-      ),
-      preciseReferences: restored.preciseReferences,
-      normalizeVibeStrength: restored.normalizeVibeStrength,
-    );
-    if (restored.shouldRewrite) unawaited(saveGenerationState());
+      state = state.copyWith(
+        vibeReferencesV4: _vibeReferences.normalize(
+          restored.vibeReferences,
+          currentModel: state.model,
+        ),
+        preciseReferences: restored.preciseReferences,
+        normalizeVibeStrength: restored.normalizeVibeStrength,
+      );
+      if (restored.shouldRewrite) unawaited(saveGenerationState());
+    } catch (error, stackTrace) {
+      AppLogger.e('恢复生成状态失败', error, stackTrace, 'GenerationParams');
+    }
   }
 
   // ==================== 多角色参数 (V4 模型) ====================

--- a/lib/presentation/providers/image_generation_provider.dart
+++ b/lib/presentation/providers/image_generation_provider.dart
@@ -86,7 +86,6 @@ class _RememberedStreamPreview {
 class ImageGenerationNotifier extends _$ImageGenerationNotifier {
   Future<void>? _historyRestoreInFlight;
   bool _hasRestoredHistory = false;
-  bool _generationInvocationStarting = false;
   Completer<void>? _generationInvocationSettled;
   int _invocationCounter = 0;
   int _activeInvocationId = 0;
@@ -107,7 +106,6 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     ref.onDispose(() {
       _isDisposed = true;
       _lifecycleEpoch++;
-      _generationInvocationStarting = false;
       _activeComparisonSource = null;
       final invocationSettled = _generationInvocationSettled;
       _generationInvocationSettled = null;
@@ -123,6 +121,15 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
 
   bool _isCurrentLifecycle(int epoch) =>
       !_isDisposed && epoch == _lifecycleEpoch;
+
+  /// copyWith 省略 errorMessage 等于清空，切换提交标志时必须原样带回。
+  void _setSubmitting(bool value) {
+    if (state.isSubmitting == value) return;
+    state = state.copyWith(
+      isSubmitting: value,
+      errorMessage: state.errorMessage,
+    );
+  }
 
   GenerationResultLifecycleService _lifecycle() {
     final gallery = ref.read(localGalleryNotifierProvider.notifier);
@@ -278,10 +285,10 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     bool preserveCharacterSnapshot = false,
     GenerationFocusedSnapshot? focusedOverride,
   }) async {
-    if (_isDisposed || _generationInvocationStarting || state.isGenerating) {
+    if (_isDisposed || state.isBusy) {
       return;
     }
-    _generationInvocationStarting = true;
+    _setSubmitting(true);
     final invocationSettled = Completer<void>();
     _generationInvocationSettled = invocationSettled;
     final epoch = _lifecycleEpoch;
@@ -401,9 +408,10 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         await _reduce(event, epoch);
       }
     } finally {
+      // 归属判断不可省：被取消后新一次提交已经接管标志，这里不能替它复位。
       if (_isCurrentLifecycle(epoch) && _activeInvocationId == invocationId) {
         _activeInvocationId = 0;
-        _generationInvocationStarting = false;
+        _setSubmitting(false);
         _activeComparisonSource = null;
         _activeFixedTagUsageSnapshot = null;
       }
@@ -832,19 +840,21 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     if (_isDisposed) return;
     final runId = _activeRunId;
     _activeInvocationId = 0;
-    _generationInvocationStarting = false;
     _activeComparisonSource = null;
     _appendFailedSnapshots(runId);
     final coordinator = _coordinator;
     final handle = _activeRun;
     if (coordinator != null && handle != null) coordinator.cancel(handle);
     _activeRunId = ++_runCounter;
+    // 图已出完、只剩落盘收尾时点取消，不该把已有结果改标成已取消。
+    final settled = state.status == GenerationStatus.completed;
     state = state.copyWith(
-      status: GenerationStatus.cancelled,
-      progress: 0,
+      status: settled ? state.status : GenerationStatus.cancelled,
+      progress: settled ? state.progress : 0,
       currentImage: 0,
       totalImages: 0,
       clearStreamPreview: true,
+      isSubmitting: false,
     );
   }
 

--- a/lib/presentation/providers/krita/krita_bridge_notifier.dart
+++ b/lib/presentation/providers/krita/krita_bridge_notifier.dart
@@ -298,7 +298,7 @@ final kritaBridgeNotifierProvider =
               ref.read(generationStreamPreviewSettingsProvider),
           send: server.send,
           isUiGenerating: () =>
-              ref.read(imageGenerationNotifierProvider).isGenerating,
+              ref.read(imageGenerationNotifierProvider).isBusy,
           authGuard: () =>
               requireAuthenticatedAction(ref, AuthPromptReason.kritaBridge),
           generateStream: (request) {

--- a/lib/presentation/providers/queue_execution_provider.dart
+++ b/lib/presentation/providers/queue_execution_provider.dart
@@ -346,7 +346,7 @@ class QueueExecutionNotifier extends _$QueueExecutionNotifier {
     final isKritaGenerating =
         PlatformCapabilities.current.supportsKritaBridge &&
         ref.read(kritaBridgeNotifierProvider).isBridgeGenerating;
-    if (generationState.isGenerating || isKritaGenerating) {
+    if (generationState.isBusy || isKritaGenerating) {
       return QueueStartResult.busy;
     }
 
@@ -445,7 +445,7 @@ class QueueExecutionNotifier extends _$QueueExecutionNotifier {
       await generationNotifier.waitUntilGenerationInvocationSettled();
 
       if (state.status != QueueExecutionStatus.ready) return;
-      if (ref.read(imageGenerationNotifierProvider).isGenerating ||
+      if (ref.read(imageGenerationNotifierProvider).isBusy ||
           (PlatformCapabilities.current.supportsKritaBridge &&
               ref.read(kritaBridgeNotifierProvider).isBridgeGenerating)) {
         return;

--- a/lib/presentation/screens/generation/desktop_layout.dart
+++ b/lib/presentation/screens/generation/desktop_layout.dart
@@ -78,13 +78,14 @@ class _DesktopGenerationLayoutState
         PlatformCapabilities.current.supportsKritaBridge &&
         ref.watch(kritaBridgeNotifierProvider).isBridgeGenerating;
     final isLauncherGenerating = generationState.isGenerating;
-    final isGenerating = isLauncherGenerating || isKritaGenerating;
+    // 提交后到开跑之间同样不能再次触发，否则快捷键会被静默吞掉。
+    final isBusy = generationState.isBusy || isKritaGenerating;
 
     // 定义快捷键动作映射（使用 ShortcutIds 常量）
     final shortcuts = <String, VoidCallback>{
       // 生成图像
       ShortcutIds.generateImage: () {
-        if (!isGenerating && !cooldownState.isActive) {
+        if (!isBusy && !cooldownState.isActive) {
           unawaited(generateWithProtection(context, ref));
         }
       },

--- a/lib/presentation/screens/generation/handlers/generation_action_handlers.dart
+++ b/lib/presentation/screens/generation/handlers/generation_action_handlers.dart
@@ -20,6 +20,7 @@ Future<void> generateWithProtection(BuildContext context, WidgetRef ref) async {
     return;
   }
   if (currentParams.prompt.isEmpty) {
+    AppToast.warning(context, context.l10n.generation_pleaseInputPrompt);
     return;
   }
   final confirmed = await AssetProtectionGuard.confirmHighAnlasCost(

--- a/lib/presentation/screens/generation/mobile_generation_chrome.dart
+++ b/lib/presentation/screens/generation/mobile_generation_chrome.dart
@@ -16,6 +16,7 @@ import 'mobile_generation_gestures.dart';
 import 'mobile_generation_view_data.dart';
 import 'widgets/history_panel.dart';
 import 'widgets/parameter_panel.dart';
+import 'widgets/generation_controls/generate_button.dart';
 import 'widgets/generation_controls/random_mode_toggle.dart';
 
 class MobileGenerationChrome extends ConsumerWidget {
@@ -289,6 +290,11 @@ class _MobileGenerateButton extends StatelessWidget {
       generationState.currentImage > 0 &&
       generationState.totalImages > generationState.currentImage;
 
+  /// 已提交但还没开跑，此时按钮必须立刻反馈，否则点击会被静默吞掉。
+  bool get _isPreparing => generationState.isPreparing;
+
+  bool get _showCancelAction => showCancel || _isPreparing;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -300,15 +306,16 @@ class _MobileGenerateButton extends StatelessWidget {
         onPrimaryContainer: theme.colorScheme.onError,
       ),
     );
-    final isLoading = isGenerating && !showCancel;
+    // Krita 占用时启动器自身没有可取消的任务，只能转圈禁用等待。
+    final isLoading = isGenerating && !_showCancelAction;
     final primaryButton = AnimatedTheme(
-      data: showCancel ? cancelTheme : theme,
+      data: _showCancelAction ? cancelTheme : theme,
       duration: MediaQuery.disableAnimationsOf(context)
           ? Duration.zero
           : const Duration(milliseconds: 160),
       curve: Curves.easeOut,
       child: ThemedButton(
-        onPressed: showCancel
+        onPressed: _showCancelAction
             ? onCancel
             : requiresLogin
             ? onGenerate
@@ -317,7 +324,7 @@ class _MobileGenerateButton extends StatelessWidget {
             : onGenerate,
         isLoading: isLoading,
         label: IndexedStack(
-          index: showCancel ? 1 : 0,
+          index: _showCancelAction ? 1 : 0,
           alignment: Alignment.center,
           children: [
             Row(
@@ -356,7 +363,10 @@ class _MobileGenerateButton extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                const Icon(Icons.stop_circle_outlined),
+                if (_isPreparing)
+                  const GenerateButtonSpinner()
+                else
+                  const Icon(Icons.stop_circle_outlined),
                 const SizedBox(width: 8),
                 Flexible(
                   child: Text(

--- a/lib/presentation/screens/generation/web_style_layout.dart
+++ b/lib/presentation/screens/generation/web_style_layout.dart
@@ -67,11 +67,12 @@ class _WebStyleGenerationLayoutState
         PlatformCapabilities.current.supportsKritaBridge &&
         ref.watch(kritaBridgeNotifierProvider).isBridgeGenerating;
     final isLauncherGenerating = generationState.isGenerating;
-    final isGenerating = isLauncherGenerating || isKritaGenerating;
+    // 提交后到开跑之间同样不能再次触发，否则快捷键会被静默吞掉。
+    final isBusy = generationState.isBusy || isKritaGenerating;
 
     final shortcuts = <String, VoidCallback>{
       ShortcutIds.generateImage: () {
-        if (!isGenerating && !cooldownState.isActive) {
+        if (!isBusy && !cooldownState.isActive) {
           unawaited(generateWithProtection(context, ref));
         }
       },

--- a/lib/presentation/screens/generation/widgets/generation_controls/generate_button.dart
+++ b/lib/presentation/screens/generation/widgets/generation_controls/generate_button.dart
@@ -42,6 +42,11 @@ class GenerateButtonWithCost extends ConsumerWidget {
       generationState.currentImage > 0 &&
       generationState.totalImages > generationState.currentImage;
 
+  /// 已提交但还没开跑，此时按钮必须立刻反馈，否则点击会被静默吞掉。
+  bool get _isPreparing => generationState.isPreparing;
+
+  bool get _showCancelAction => showCancel || _isPreparing;
+
   String _progressText() =>
       '${generationState.currentImage}/${generationState.totalImages}';
 
@@ -103,9 +108,10 @@ class GenerateButtonWithCost extends ConsumerWidget {
         onPrimaryContainer: theme.colorScheme.onError,
       ),
     );
-    final isLoading = isGenerating && !showCancel;
+    // Krita 占用时启动器自身没有可取消的任务，只能转圈禁用等待。
+    final isLoading = isGenerating && !_showCancelAction;
 
-    final buttonTheme = showCancel ? cancelTheme : theme;
+    final buttonTheme = _showCancelAction ? cancelTheme : theme;
     final effectiveTheme = compact
         ? buttonTheme.copyWith(
             filledButtonTheme: FilledButtonThemeData(
@@ -131,7 +137,7 @@ class GenerateButtonWithCost extends ConsumerWidget {
           : const Duration(milliseconds: 160),
       curve: Curves.easeOut,
       child: ThemedButton(
-        onPressed: showCancel
+        onPressed: _showCancelAction
             ? onCancel
             : requiresLogin
             ? onGenerate
@@ -140,7 +146,7 @@ class GenerateButtonWithCost extends ConsumerWidget {
             : onGenerate,
         isLoading: isLoading,
         label: IndexedStack(
-          index: showCancel ? 1 : 0,
+          index: _showCancelAction ? 1 : 0,
           alignment: Alignment.center,
           children: [
             Row(
@@ -168,7 +174,10 @@ class GenerateButtonWithCost extends ConsumerWidget {
             Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Icon(Icons.stop_circle_outlined),
+                if (_isPreparing)
+                  const GenerateButtonSpinner()
+                else
+                  const Icon(Icons.stop_circle_outlined),
                 const SizedBox(width: 8),
                 Text(context.l10n.common_cancel),
               ],
@@ -176,6 +185,22 @@ class GenerateButtonWithCost extends ConsumerWidget {
           ],
         ),
         style: ThemedButtonStyle.filled,
+      ),
+    );
+  }
+}
+
+/// 跟随按钮前景色的小转圈，供准备期的可取消态复用。
+class GenerateButtonSpinner extends StatelessWidget {
+  const GenerateButtonSpinner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: 16,
+      child: CircularProgressIndicator(
+        strokeWidth: 2,
+        color: IconTheme.of(context).color,
       ),
     );
   }

--- a/test/presentation/providers/generation/image_generation_submit_guard_test.dart
+++ b/test/presentation/providers/generation/image_generation_submit_guard_test.dart
@@ -1,0 +1,226 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:image/image.dart' as img;
+import 'package:mocktail/mocktail.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/data/datasources/remote/nai_generation_transport.dart';
+import 'package:nai_launcher/data/datasources/remote/nai_image_generation_api_service.dart';
+import 'package:nai_launcher/data/models/image/image_params.dart';
+import 'package:nai_launcher/data/models/image/image_stream_chunk.dart';
+import 'package:nai_launcher/presentation/providers/auth_provider.dart';
+import 'package:nai_launcher/presentation/providers/image_generation_provider.dart';
+import 'package:nai_launcher/presentation/providers/image_save_settings_provider.dart';
+import 'package:nai_launcher/presentation/providers/notification_settings_provider.dart';
+
+class _MockApiService extends Mock implements NAIImageGenerationApiService {}
+
+class _AuthenticatedAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => const AuthState(status: AuthStatus.authenticated);
+}
+
+void main() {
+  late Directory hiveTempDir;
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    registerFallbackValue(const ImageParams());
+    registerFallbackValue(NaiGenerationCancellationLease());
+    hiveTempDir = await Directory.systemTemp.createTemp('nai_launcher_hive_');
+    Hive.init(hiveTempDir.path);
+    await Hive.openBox(StorageKeys.settingsBox);
+    await Hive.openBox(StorageKeys.historyBox);
+    await Hive.openBox(StorageKeys.statisticsCacheBox);
+  });
+
+  setUp(() async {
+    await Hive.box(
+      StorageKeys.settingsBox,
+    ).put(StorageKeys.imagesPerRequest, 1);
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (await hiveTempDir.exists()) {
+      await hiveTempDir.delete(recursive: true);
+    }
+  });
+
+  test('preparation is visible and a second tap cannot start a run', () async {
+    // 用真实 controller：取消后要靠 close() 收掉订阅，否则 await 不回来。
+    final stream = StreamController<ImageStreamChunk>();
+    var streamCall = 0;
+    final api = _stubApi(
+      onStream: () {
+        streamCall += 1;
+        return stream.stream;
+      },
+    );
+    final container = await _createContainer(api);
+
+    final notifier = container.read(imageGenerationNotifierProvider.notifier);
+    final params = container
+        .read(generationParamsNotifierProvider)
+        .copyWith(prompt: '1girl', width: 512, height: 768);
+
+    final generation = notifier.generate(params);
+
+    // 点击返回的同一时刻状态就必须对外可见，否则按钮会继续吞掉点击。
+    final armed = container.read(imageGenerationNotifierProvider);
+    expect(armed.isSubmitting, isTrue);
+    expect(armed.isPreparing, isTrue);
+    expect(armed.isGenerating, isFalse);
+    expect(armed.isBusy, isTrue);
+
+    await notifier.generate(params);
+    await _pumpUntil(
+      () => streamCall == 1,
+      reason: 'the first submission never reached the API',
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(streamCall, 1);
+
+    notifier.cancel();
+    await stream.close();
+    await generation;
+    expect(
+      container.read(imageGenerationNotifierProvider).isSubmitting,
+      isFalse,
+    );
+  });
+
+  test('cancel during preparation releases the guard synchronously', () async {
+    final api = _stubApi(onStream: _neverEmits);
+    final container = await _createContainer(api);
+
+    final notifier = container.read(imageGenerationNotifierProvider.notifier);
+    final params = container
+        .read(generationParamsNotifierProvider)
+        .copyWith(prompt: '1girl', width: 512, height: 768);
+
+    final generation = notifier.generate(params);
+    expect(container.read(imageGenerationNotifierProvider).isPreparing, isTrue);
+
+    notifier.cancel();
+
+    final released = container.read(imageGenerationNotifierProvider);
+    expect(released.isSubmitting, isFalse);
+    expect(released.isBusy, isFalse);
+
+    await generation;
+  });
+
+  test('failed run releases the guard and keeps the error message', () async {
+    final api = _stubApi(
+      onStream: () =>
+          Stream.value(ImageStreamChunk.error('API_ERROR_500|stream failed')),
+    );
+    final container = await _createContainer(api);
+
+    final notifier = container.read(imageGenerationNotifierProvider.notifier);
+    final params = container
+        .read(generationParamsNotifierProvider)
+        .copyWith(prompt: '1girl', width: 512, height: 768);
+
+    await notifier.generate(params);
+
+    final state = container.read(imageGenerationNotifierProvider);
+    expect(state.isSubmitting, isFalse);
+    expect(state.isBusy, isFalse);
+    expect(state.status, GenerationStatus.error);
+    // copyWith 省略 errorMessage 等于清空，释放守卫时不能顺手吞掉失败原因。
+    expect(state.errorMessage, contains('stream failed'));
+  });
+
+  test('completed run releases the guard for the next submission', () async {
+    final image = Uint8List.fromList(
+      img.encodePng(img.Image(width: 512, height: 768)),
+    );
+    var streamCall = 0;
+    final api = _stubApi(
+      onStream: () {
+        streamCall += 1;
+        return Stream.value(ImageStreamChunk.complete(image));
+      },
+    );
+    final container = await _createContainer(api);
+
+    final notifier = container.read(imageGenerationNotifierProvider.notifier);
+    final params = container
+        .read(generationParamsNotifierProvider)
+        .copyWith(prompt: '1girl', width: 512, height: 768);
+
+    await notifier.generate(params);
+
+    final completed = container.read(imageGenerationNotifierProvider);
+    expect(completed.status, GenerationStatus.completed);
+    expect(completed.isSubmitting, isFalse);
+    expect(completed.isPreparing, isFalse);
+    expect(completed.isBusy, isFalse);
+
+    await notifier.generate(params);
+    expect(streamCall, 2);
+  });
+}
+
+/// 停在请求发出后永不返回，模拟服务端仍在跑的生成。
+Stream<ImageStreamChunk> _neverEmits() =>
+    Completer<ImageStreamChunk>().future.asStream();
+
+Future<void> _pumpUntil(bool Function() condition, {String? reason}) async {
+  for (var i = 0; i < 400; i++) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+  fail(reason ?? 'Condition not met within timeout');
+}
+
+_MockApiService _stubApi({
+  required Stream<ImageStreamChunk> Function() onStream,
+}) {
+  final api = _MockApiService();
+  when(
+    () => api.generateImage(
+      any(),
+      onProgress: any(named: 'onProgress'),
+      focusedInpaintEnabled: any(named: 'focusedInpaintEnabled'),
+      minimumContextMegaPixels: any(named: 'minimumContextMegaPixels'),
+      focusedSelectionRect: any(named: 'focusedSelectionRect'),
+      cancellationLease: null,
+    ),
+  ).thenAnswer((_) async => (<Uint8List>[], <int, String>{}));
+  when(
+    () => api.generateImageStream(
+      any(),
+      focusedInpaintEnabled: any(named: 'focusedInpaintEnabled'),
+      minimumContextMegaPixels: any(named: 'minimumContextMegaPixels'),
+      focusedSelectionRect: any(named: 'focusedSelectionRect'),
+      cancellationLease: null,
+    ),
+  ).thenAnswer((_) => onStream());
+  when(() => api.cancelGeneration(any())).thenReturn(null);
+  return api;
+}
+
+Future<ProviderContainer> _createContainer(_MockApiService api) async {
+  final container = ProviderContainer(
+    overrides: [
+      authNotifierProvider.overrideWith(_AuthenticatedAuthNotifier.new),
+      naiImageGenerationApiServiceProvider.overrideWithValue(api),
+    ],
+  );
+  addTearDown(container.dispose);
+  await container
+      .read(notificationSettingsNotifierProvider.notifier)
+      .setSoundEnabled(false);
+  await container
+      .read(imageSaveSettingsNotifierProvider.notifier)
+      .setAutoSave(false);
+  return container;
+}

--- a/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
+++ b/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
@@ -340,6 +340,83 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('preparing footer offers a cancel entry instead of a dead tap', (
+    tester,
+  ) async {
+    final storage = _MemoryLocalStorageService({
+      StorageKeys.autoSaveImages: false,
+      StorageKeys.showRandomPromptTools: true,
+    });
+    late ProviderContainer container;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authNotifierProvider.overrideWith(_AuthenticatedAuthNotifier.new),
+          imageGenerationNotifierProvider.overrideWith(
+            _TestImageGenerationNotifier.new,
+          ),
+          localStorageServiceProvider.overrideWith((ref) => storage),
+          kritaBridgeNotifierProvider.overrideWith(
+            (ref) => _TestKritaBridgeNotifier(),
+          ),
+          replicationQueueNotifierProvider.overrideWith(
+            _TestReplicationQueueNotifier.new,
+          ),
+          queueExecutionNotifierProvider.overrideWith(
+            _TestQueueExecutionNotifier.new,
+          ),
+          subscriptionNotifierProvider.overrideWith(
+            _TestSubscriptionNotifier.new,
+          ),
+          estimatedCostProvider.overrideWith((ref) => 0),
+          isFreeGenerationProvider.overrideWith((ref) => true),
+        ],
+        child: Consumer(
+          builder: (context, ref, _) {
+            container = ProviderScope.containerOf(context);
+            return const MaterialApp(
+              locale: Locale('zh'),
+              supportedLocales: AppLocalizations.supportedLocales,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              home: Scaffold(
+                body: Align(
+                  alignment: Alignment.topLeft,
+                  child: SizedBox(
+                    width: 475,
+                    height: 180,
+                    child: GenerationControls(compact: true),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('生成'), findsOneWidget);
+
+    final notifier =
+        container.read(imageGenerationNotifierProvider.notifier)
+            as _TestImageGenerationNotifier;
+    notifier.setPreparing();
+    // 转圈是无限动画，只能定量 pump，不能 pumpAndSettle。
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('取消'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byIcon(Icons.stop_circle_outlined), findsNothing);
+
+    await tester.tap(find.text('取消'));
+    await tester.pump();
+
+    expect(notifier.cancelCount, 1);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('batch settings desktop form follows its content height', (
     tester,
   ) async {
@@ -513,6 +590,8 @@ class _UnauthenticatedAuthNotifier extends AuthNotifier {
 }
 
 class _TestImageGenerationNotifier extends ImageGenerationNotifier {
+  int cancelCount = 0;
+
   @override
   ImageGenerationState build() => const ImageGenerationState();
 
@@ -520,6 +599,16 @@ class _TestImageGenerationNotifier extends ImageGenerationNotifier {
     state = ImageGenerationState(
       status: value ? GenerationStatus.generating : GenerationStatus.idle,
     );
+  }
+
+  void setPreparing() {
+    state = const ImageGenerationState(isSubmitting: true);
+  }
+
+  @override
+  void cancel() {
+    cancelCount += 1;
+    state = const ImageGenerationState();
   }
 }
 


### PR DESCRIPTION
## 用户可见变化

点击生成到真正开跑之间要读盘、编码 Vibe 参考图、抽随机词，这段窗口里按钮此前既不转圈也不可点，再次点击和生成快捷键都被静默吞掉。现在按钮立刻变成可点的「取消」并显示转圈，这期间重复点击或按快捷键不会重复起任务。

另外两处：图已出完、只剩落盘收尾时点取消，不再把已出的图改标成「已取消」；提示词为空点生成会给出提示，不再什么都不发生。

## 改动

- `ImageGenerationState` 增加 `isSubmitting`，派生 `isPreparing` 与 `isBusy`，取代原先只有 notifier 自己可见的调用起始标志
- 重复提交、队列启动、Krita 插队与桌面/官网式布局的生成快捷键统一改判 `isBusy`
- 准备期按钮显示转圈并可取消，与生成中的取消共用同一分支
- 恢复生成状态的异常不再沿 `Future.wait` 冒泡中断整次生成

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（集成分支）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `image_generation_submit_guard_test.dart`（准备期可见且二次点击不启动、准备期取消同步释放守卫、失败释放守卫且保留错误文案、完成释放守卫）与一条按钮 widget 测试

无生成文件、LFS 或 assets 变更。
