### PR TITLE
fix(generation): 主按钮的换行下限改为按自身内容推导

### DIFF
--- a/lib/presentation/screens/generation/widgets/generation_controls/generation_controls.dart
+++ b/lib/presentation/screens/generation/widgets/generation_controls/generation_controls.dart
@@ -207,7 +207,6 @@ class _RenderGenerationControlsLayout extends RenderBox
   static const double _itemSpacing = 2;
   static const double _primarySpacing = 8;
   static const double _runSpacing = 8;
-  static const double _minimumPrimaryWidth = 160;
 
   @override
   void setupParentData(RenderBox child) {
@@ -248,10 +247,15 @@ class _RenderGenerationControlsLayout extends RenderBox
       return;
     }
 
+    // 主按钮的标签不会收缩，压窄就溢出。先用无界约束量出它真正需要的宽度，
+    // 只有连这点宽度都留不出时才换行；固定下限会在大字号下裁掉标签。
+    primaryChild.layout(const BoxConstraints(), parentUsesSize: true);
+    final minimumPrimaryWidth = primaryChild.size.width;
+
     final leftWidth = _groupWidth(left);
     final rightWidth = _groupWidth(right);
     final naturalWidth =
-        leftWidth + rightWidth + _minimumPrimaryWidth + _primarySpacing * 2;
+        leftWidth + rightWidth + minimumPrimaryWidth + _primarySpacing * 2;
     final layoutWidth = constraints.hasBoundedWidth
         ? constraints.maxWidth
         : naturalWidth;
@@ -368,84 +372,13 @@ class _RenderGenerationControlsLayout extends RenderBox
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
-    final availableWidth = constraints.hasBoundedWidth
-        ? constraints.maxWidth
-        : 100000.0;
-    final actionConstraints = BoxConstraints(maxWidth: availableWidth);
-    final left = <Size>[];
-    final right = <Size>[];
-    RenderBox? primaryChild;
-
-    RenderBox? child = firstChild;
-    while (child != null) {
-      final parentData = child.parentData! as _GenerationControlsParentData;
-      switch (parentData.group) {
-        case _GenerationControlGroup.left:
-          final childSize = child.getDryLayout(actionConstraints);
-          if (!childSize.isEmpty) left.add(childSize);
-        case _GenerationControlGroup.primary:
-          primaryChild = child;
-        case _GenerationControlGroup.right:
-          final childSize = child.getDryLayout(actionConstraints);
-          if (!childSize.isEmpty) right.add(childSize);
-      }
-      child = parentData.nextSibling;
-    }
-
-    if (primaryChild == null) return constraints.smallest;
-    final leftWidth = _dryGroupWidth(left);
-    final rightWidth = _dryGroupWidth(right);
-    final singleRowWidth =
-        leftWidth + rightWidth + _minimumPrimaryWidth + _primarySpacing * 2;
-    final width = constraints.hasBoundedWidth
-        ? constraints.maxWidth
-        : singleRowWidth;
-    final useSingleRow = singleRowWidth <= width;
-    final primaryWidth = useSingleRow
-        ? width - leftWidth - rightWidth - _primarySpacing * 2
-        : width;
-    final primarySize = primaryChild.getDryLayout(
-      BoxConstraints.tightFor(width: primaryWidth),
+    // 主按钮内部的 ThemedButton 用 LayoutBuilder 决定标签能否收缩，无法参与 dry layout。
+    assert(
+      debugCannotComputeDryLayout(
+        reason: '主按钮内部的 LayoutBuilder 不支持 dry layout',
+      ),
     );
-    if (useSingleRow) {
-      final height = [...left, primarySize, ...right].fold<double>(
-        0,
-        (maximum, childSize) =>
-            childSize.height > maximum ? childSize.height : maximum,
-      );
-      return constraints.constrain(Size(width, height));
-    }
-
-    final leftAndRightFit = leftWidth + rightWidth + _primarySpacing <= width;
-    if (leftAndRightFit) {
-      final actionsHeight = [...left, ...right].fold<double>(
-        0,
-        (maximum, action) => action.height > maximum ? action.height : maximum,
-      );
-      return constraints.constrain(
-        Size(width, primarySize.height + _runSpacing + actionsHeight),
-      );
-    }
-    var height = primarySize.height;
-    if (left.isNotEmpty) {
-      height += _runSpacing + _dryRunsHeight(left, width);
-    }
-    if (right.isNotEmpty) {
-      height += _runSpacing + _dryRunsHeight(right, width);
-    }
-    return constraints.constrain(Size(width, height));
-  }
-
-  double _dryRunsHeight(List<Size> children, double width) {
-    final runs = _buildRuns<Size>(children, width, (child) => child.width);
-    return runs.fold<double>(0, (height, run) {
-          final runHeight = run.fold<double>(
-            0,
-            (maximum, child) => child.height > maximum ? child.height : maximum,
-          );
-          return height + runHeight;
-        }) +
-        _runSpacing * (runs.length - 1);
+    return Size.zero;
   }
 
   List<List<T>> _buildRuns<T>(
@@ -473,12 +406,6 @@ class _RenderGenerationControlsLayout extends RenderBox
     }
     if (run.isNotEmpty) runs.add(run);
     return runs;
-  }
-
-  double _dryGroupWidth(List<Size> children) {
-    if (children.isEmpty) return 0;
-    return children.fold<double>(0, (sum, child) => sum + child.width) +
-        _itemSpacing * (children.length - 1);
   }
 
   @override

--- a/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
+++ b/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
@@ -97,8 +97,9 @@ void main() {
 
       for (final scenario in const [
         (width: 320.0, textScale: 1.0, singleLine: false),
-        (width: 438.0, textScale: 1.0, singleLine: false),
-        (width: 475.0, textScale: 1.0, singleLine: false),
+        (width: 400.0, textScale: 1.0, singleLine: true),
+        (width: 438.0, textScale: 1.0, singleLine: true),
+        (width: 475.0, textScale: 1.0, singleLine: true),
         (width: 497.0, textScale: 1.0, singleLine: true),
         (width: 590.0, textScale: 1.0, singleLine: true),
         (width: 700.0, textScale: 1.0, singleLine: true),
@@ -229,7 +230,14 @@ void main() {
             closeTo(footerRect.right, 0.01),
             reason: reason,
           );
-          expect(primaryRect.width, greaterThanOrEqualTo(160), reason: reason);
+          // 主按钮不再有固定下限，下限即自身内容宽度：标签必须完整落在按钮内。
+          final labelRect = tester.getRect(find.text('生成'));
+          expect(
+            primaryRect.inflate(0.01).contains(labelRect.topLeft) &&
+                primaryRect.inflate(0.01).contains(labelRect.bottomRight),
+            isTrue,
+            reason: '$reason 主按钮被压到放不下标签',
+          );
         } else {
           expect(
             primaryRect.left,
@@ -577,6 +585,68 @@ void main() {
     expect(find.text('LOGIN_SCREEN_OPENED'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('Opus 配额徽章出现时不把生成按钮挤到单独一行', (tester) async {
+    final storage = _MemoryLocalStorageService({
+      StorageKeys.autoSaveImages: false,
+      StorageKeys.showRandomPromptTools: true,
+    });
+
+    for (final width in const [497.0, 520.0, 590.0]) {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authNotifierProvider.overrideWith(_AuthenticatedAuthNotifier.new),
+            localStorageServiceProvider.overrideWith((ref) => storage),
+            kritaBridgeNotifierProvider.overrideWith(
+              (ref) => _TestKritaBridgeNotifier(),
+            ),
+            replicationQueueNotifierProvider.overrideWith(
+              _TestReplicationQueueNotifier.new,
+            ),
+            queueExecutionNotifierProvider.overrideWith(
+              _TestQueueExecutionNotifier.new,
+            ),
+            subscriptionNotifierProvider.overrideWith(
+              _OpusSubscriptionNotifier.new,
+            ),
+            estimatedCostProvider.overrideWith((ref) => 0),
+            isFreeGenerationProvider.overrideWith((ref) => true),
+          ],
+          child: MaterialApp(
+            locale: const Locale('zh'),
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            home: Scaffold(
+              body: SizedBox(
+                width: width,
+                height: 240,
+                child: const GenerationControls(compact: true),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final reason = 'width=$width';
+      final primaryRect = tester.getRect(
+        find.byKey(const ValueKey('generation-footer-primary-action')),
+      );
+      final opusRect = tester.getRect(find.byType(OpusUsageChip));
+      final anlasRect = tester.getRect(find.byType(AnlasBalanceChip));
+
+      expect(opusRect.width, greaterThan(0), reason: reason);
+      expect(
+        anlasRect.center.dy,
+        closeTo(primaryRect.center.dy, 0.01),
+        reason: '$reason 生成按钮被挤到单独一行',
+      );
+      expect(anlasRect.right, lessThan(primaryRect.left), reason: reason);
+      expect(find.text('生成'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    }
+  });
 }
 
 class _AuthenticatedAuthNotifier extends AuthNotifier {
@@ -650,6 +720,19 @@ class _TestSubscriptionNotifier extends SubscriptionNotifier {
       tier: 1,
       active: true,
       trainingStepsLeft: TrainingStepsInfo(fixedTrainingStepsLeft: 7384),
+    ),
+  );
+}
+
+/// tier 3 且带配额，才会让 Opus 徽章真正占位（默认模型 V5 有配额上限）。
+class _OpusSubscriptionNotifier extends SubscriptionNotifier {
+  @override
+  SubscriptionState build() => const SubscriptionState.loaded(
+    UserSubscription(
+      tier: 3,
+      active: true,
+      trainingStepsLeft: TrainingStepsInfo(fixedTrainingStepsLeft: 7384),
+      usage: OpusUsageInfo(percent: 67),
     ),
   );
 }


### PR DESCRIPTION
> 堆叠在 #275（`fix/generation-submit-guard`）之上：两条改的是同一个控制条测试文件，base 指向该分支，合并后自动改指 main。

## 用户可见变化

Opus 用户切到 V5 时，生成按钮不再被顶到独占的第一行。此前左侧多出配额徽章后整条控制栏改走换行版式，按钮通栏跑到顶部，切回非 V5 又恢复单行。

## 问题

底栏用硬编码的 160px 当主按钮下限来判断能否单行。实测：非 V5 单行阈值 447，V5 因配额徽章（+95.8px）抬到 520，宽约 500 的官网式面板刚好卡在中间。

## 改动

- 先用无界约束量出主按钮真正需要的宽度当下限（`ThemedButton` 的 `LayoutBuilder` 在无界宽度下走 `MainAxisSize.min`，正好给出内容宽度），只有连这点宽度都留不出才换行。下限随字号、语言和是否显示花费徽章自动变化——按钮标签是 `IndexedStack` 里两个 `MainAxisSize.min` 的 `Row`，没有 `Flexible` 兜底，任何固定下限在大字号下都会裁标签（实测非 Opus 在 3x 字号下内容宽度 206.9，远超 160）
- `computeDryLayout` 标为不支持：主按钮内部的 `ThemedButton` 用 `LayoutBuilder` 决定标签能否收缩，本就无法参与 dry layout，原实现只会静默算出错误尺寸

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（集成分支）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `Opus 配额徽章出现时不把生成按钮挤到单独一行`（497/520/590 三档宽度）
- 既有换行矩阵按新阈值更新，并把「主按钮宽度 ≥ 160」的旧断言换成「标签必须完整落在按钮内」

无生成文件、LFS 或 assets 变更。
