### PR TITLE
fix(settings): 让侧栏导航项在长短标签混排的语言下保持左缘对齐

### DIFF
--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -438,6 +438,15 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     List<_SettingsSection> sections,
   ) {
     final theme = Theme.of(context);
+    // 必须从 textTheme 派生：NavigationRail 对这两项是整体替换而非合并，
+    // 传裸 TextStyle 会把默认的 labelMedium 连同用户字体一起顶掉。
+    final selectedLabelStyle = theme.textTheme.labelMedium?.copyWith(
+      color: theme.colorScheme.primary,
+      fontWeight: FontWeight.w600,
+    );
+    final labelWidth = isExtended
+        ? _widestLabelWidth(context, sections, selectedLabelStyle)
+        : null;
 
     Widget buildRail() => NavigationRail(
       selectedIndex: sections.indexWhere((item) => item.id == _selectedSection),
@@ -446,12 +455,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       minExtendedWidth: 180,
       backgroundColor: Colors.transparent,
       selectedIconTheme: IconThemeData(color: theme.colorScheme.primary),
-      // 必须从 textTheme 派生：NavigationRail 对这两项是整体替换而非合并，
-      // 传裸 TextStyle 会把默认的 labelMedium 连同用户字体一起顶掉。
-      selectedLabelTextStyle: theme.textTheme.labelMedium?.copyWith(
-        color: theme.colorScheme.primary,
-        fontWeight: FontWeight.w600,
-      ),
+      selectedLabelTextStyle: selectedLabelStyle,
       unselectedIconTheme: IconThemeData(
         color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
       ),
@@ -459,10 +463,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
       ),
       destinations: sections.map((section) {
+        final label = Text(section.label);
         return NavigationRailDestination(
           icon: Icon(section.icon),
           selectedIcon: Icon(section.selectedIcon),
-          label: Text(section.label),
+          // NavigationRail 把目的地列按最宽一项居中，标签不等宽时窄的会整体右移。
+          label: labelWidth == null
+              ? label
+              : SizedBox(width: labelWidth, child: label),
         );
       }).toList(),
     );
@@ -489,5 +497,27 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ),
       ),
     );
+  }
+
+  /// 用选中态样式测量：它比未选中态粗一档，按未选中态取值会裁掉选中项。
+  double _widestLabelWidth(
+    BuildContext context,
+    List<_SettingsSection> sections,
+    TextStyle? style,
+  ) {
+    final textScaler = MediaQuery.textScalerOf(context);
+    final textDirection = Directionality.of(context);
+    var widest = 0.0;
+    for (final section in sections) {
+      final painter = TextPainter(
+        text: TextSpan(text: section.label, style: style),
+        textDirection: textDirection,
+        textScaler: textScaler,
+        maxLines: 1,
+      )..layout();
+      if (painter.width > widest) widest = painter.width;
+      painter.dispose();
+    }
+    return widest;
   }
 }

--- a/test/presentation/screens/settings/settings_screen_test.dart
+++ b/test/presentation/screens/settings/settings_screen_test.dart
@@ -185,9 +185,11 @@ void main() {
     await tester.binding.setSurfaceSize(const Size(1280, 900));
     await tester.pumpAndSettle();
 
-    final labels = rail.destinations
-        .map((destination) => (destination.label as Text).data)
-        .toList();
+    // 标签按等宽包装以避免导航项横向抖动，取文本要穿过包装层。
+    final labels = rail.destinations.map((destination) {
+      final label = destination.label;
+      return ((label is SizedBox ? label.child : label) as Text).data;
+    }).toList();
     expect(labels, const [
       '账户',
       '外观',
@@ -289,6 +291,77 @@ void main() {
       '集成',
     );
     expect(segmentLabels, const ['提示词助手', 'ComfyUI', 'Krita']);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('导航项在长短标签混排的语言下保持左缘对齐', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    await tester.binding.setSurfaceSize(const Size(1280, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    // 中文标签长度接近，抖动只在英文/日文这类长短悬殊的语言下暴露。
+    for (final locale in const [Locale('en'), Locale('ja')]) {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            localStorageServiceProvider.overrideWithValue(storage),
+            secureStorageServiceProvider.overrideWithValue(
+              _MemorySecureStorage(),
+            ),
+            agentSettingsProvider.overrideWith(
+              (ref) => AgentSettingsNotifier(
+                ref,
+                supportDirectory: Directory.systemTemp,
+                workspaceDirectory: Directory.systemTemp,
+                environment: const {},
+                skillCatalogService: const _EmptySkillCatalogService(),
+              ),
+            ),
+            authNotifierProvider.overrideWith(_FakeAuthNotifier.new),
+            accountManagerNotifierProvider.overrideWith(
+              _FakeAccountManagerNotifier.new,
+            ),
+            subscriptionNotifierProvider.overrideWith(
+              _FakeSubscriptionNotifier.new,
+            ),
+          ],
+          child: MaterialApp(
+            locale: locale,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const SettingsScreen(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final railFinder = find.byType(NavigationRail);
+      final iconLefts = tester
+          .widgetList<Icon>(
+            find.descendant(of: railFinder, matching: find.byType(Icon)),
+          )
+          .map(
+            (icon) => tester
+                .getTopLeft(
+                  find.descendant(
+                    of: railFinder,
+                    matching: find.byWidget(icon),
+                  ),
+                )
+                .dx,
+          )
+          .toList();
+
+      expect(iconLefts.length, 11, reason: '$locale');
+      for (final left in iconLefts) {
+        expect(
+          left,
+          closeTo(iconLefts.first, 0.01),
+          reason: '$locale 导航项图标未对齐：$iconLefts',
+        );
+      }
+      expect(tester.takeException(), isNull, reason: '$locale');
+    }
     debugDefaultTargetPlatformOverride = null;
   });
 


### PR DESCRIPTION
## 用户可见变化

英文和日文界面下，设置页侧栏 11 个导航项的图标与文字终于在同一条竖线上。此前「Backup & Restore」「Privacy & Sharing」这类长标签会把自己连同图标一起往左拽，实测图标横向偏差达 60px。中文界面行为不变。

## 问题

`NavigationRail` 把目的地列放进 `Align(Alignment(0, groupAlignment))`，列是 `MainAxisSize.min` 且默认居中对齐，于是列宽等于最宽一项、比它窄的项被整体居中。中文标签长度接近且都短于 `minExtendedWidth: 180`，每项恰好 180 所以看不出来。

## 改动

按当前语言、字体和文本缩放实测出最宽标签，把每个标签包装成等宽 `SizedBox`，所有目的地等宽后居中不再产生位移。测量使用选中态样式——它比未选中态粗一档，用未选中态测会裁掉选中项。

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（集成分支）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `导航项在长短标签混排的语言下保持左缘对齐`（en / ja 两种语言，断言 11 个图标 x 一致）。该测试做过反向验证：临时关闭修复后报出图标 x 为 `[96.25, 79.75, 79.75, 96.25, 54.75, 42.25, 36.0, 96.25, 86.0, 67.25, 96.25]`

无生成文件、LFS 或 assets 变更。
