### PR TITLE
perf(ui): 两处分组网格改用惰性 sliver 布局

### DIFF
--- a/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
+++ b/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
@@ -1310,12 +1310,19 @@ class _GroupedFixedTagCollection extends StatefulWidget {
 class _GroupedFixedTagCollectionState
     extends State<_GroupedFixedTagCollection> {
   final _collapsedSectionIds = <String>{};
+  // 条目在重排后会换 index，索引无关的 key 才能让 tile 的 hover 与动画状态跟着条目走。
+  final _entryItemKeys = <String, GlobalKey>{};
 
   @override
   void didUpdateWidget(covariant _GroupedFixedTagCollection oldWidget) {
     super.didUpdateWidget(oldWidget);
     final availableIds = widget.sections.map((section) => section.id).toSet();
     _collapsedSectionIds.removeWhere((id) => !availableIds.contains(id));
+    final entryIds = <String>{
+      for (final section in widget.sections)
+        for (final entry in section.entries) entry.id,
+    };
+    _entryItemKeys.removeWhere((id, _) => !entryIds.contains(id));
   }
 
   void _setSectionCollapsed(String sectionId, bool collapsed) {
@@ -1360,45 +1367,40 @@ class _GroupedFixedTagCollectionState
       );
     }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Expanded(
-          child: SingleChildScrollView(
-            key: ValueKey('${widget.keyPrefix}-group-list'),
-            controller: widget.controller,
-            padding: const EdgeInsets.fromLTRB(6, 2, 6, 10),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                for (final section in widget.sections)
-                  Builder(
-                    builder: (context) {
-                      final isCollapsed =
-                          !widget.forceExpanded &&
-                          _collapsedSectionIds.contains(section.id);
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 6),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            _buildSectionHeader(
-                              context,
-                              section: section,
-                              isCollapsed: isCollapsed,
-                            ),
-                            if (!isCollapsed)
-                              _buildSectionEntries(context, section),
-                          ],
-                        ),
-                      );
-                    },
-                  ),
-              ],
-            ),
+    return CustomScrollView(
+      key: ValueKey('${widget.keyPrefix}-group-list'),
+      controller: widget.controller,
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(6, 2, 6, 10),
+          sliver: SliverMainAxisGroup(
+            slivers: [
+              for (final section in widget.sections)
+                _buildSectionSliver(context, section),
+            ],
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildSectionSliver(BuildContext context, _TagSection section) {
+    final isCollapsed =
+        !widget.forceExpanded && _collapsedSectionIds.contains(section.id);
+    return SliverPadding(
+      padding: const EdgeInsets.only(bottom: 6),
+      sliver: SliverMainAxisGroup(
+        slivers: [
+          SliverToBoxAdapter(
+            child: _buildSectionHeader(
+              context,
+              section: section,
+              isCollapsed: isCollapsed,
+            ),
+          ),
+          if (!isCollapsed) _buildSectionBodySliver(section),
+        ],
+      ),
     );
   }
 
@@ -1472,67 +1474,85 @@ class _GroupedFixedTagCollectionState
     );
   }
 
-  Widget _buildSectionEntries(BuildContext context, _TagSection section) {
-    if (widget.isListMode) {
-      return Padding(
-        key: ValueKey('${widget.keyPrefix}-group-${section.id}-body'),
-        padding: const EdgeInsets.only(top: 4),
-        child: ReorderableListView.builder(
-          key: ValueKey('${widget.keyPrefix}-group-${section.id}-entries'),
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          buildDefaultDragHandles: false,
-          itemCount: section.entries.length,
-          prototypeItem: widget.listPrototypeBuilder(section.color),
-          onReorderItem: (oldIndex, newIndex) =>
-              widget.onReorder(section.entries, oldIndex, newIndex),
-          itemBuilder: (context, index) {
-            final entry = section.entries[index];
-            return Padding(
-              key: ValueKey('${widget.keyPrefix}-entry-${entry.id}'),
-              padding: const EdgeInsets.only(bottom: 4),
-              child: widget.entryBuilder(
-                entry,
-                section.color,
-                section.entries.length > 1
-                    ? (child) => ReorderableDragStartListener(
-                        index: index,
-                        child: child,
-                      )
-                    : null,
-              ),
-            );
-          },
-        ),
-      );
-    }
+  Widget _buildSectionBodySliver(_TagSection section) {
+    return SliverPadding(
+      key: ValueKey('${widget.keyPrefix}-group-${section.id}-body'),
+      padding: const EdgeInsets.only(top: 4),
+      sliver: widget.isListMode
+          ? _buildEntryListSliver(section)
+          : _buildEntryGridSliver(section),
+    );
+  }
 
-    return LayoutBuilder(
+  Widget _buildEntryListSliver(_TagSection section) {
+    return SliverReorderableList(
+      key: ValueKey('${widget.keyPrefix}-group-${section.id}-entries'),
+      itemCount: section.entries.length,
+      prototypeItem: widget.listPrototypeBuilder(section.color),
+      proxyDecorator: _buildDragProxy,
+      onReorderItem: (oldIndex, newIndex) =>
+          widget.onReorder(section.entries, oldIndex, newIndex),
+      itemBuilder: (context, index) {
+        final entry = section.entries[index];
+        return KeyedSubtree(
+          key: _entryItemKeys.putIfAbsent(entry.id, GlobalKey.new),
+          child: Padding(
+            key: ValueKey('${widget.keyPrefix}-entry-${entry.id}'),
+            padding: const EdgeInsets.only(bottom: 4),
+            child: widget.entryBuilder(
+              entry,
+              section.color,
+              section.entries.length > 1
+                  ? (child) =>
+                        ReorderableDragStartListener(index: index, child: child)
+                  : null,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildEntryGridSliver(_TagSection section) {
+    return SliverLayoutBuilder(
       builder: (context, constraints) {
         const spacing = 7.0;
         final largeText = MediaQuery.textScalerOf(context).scale(14) >= 20;
         final minimumCardWidth = largeText ? 220.0 : 140.0;
         final columnCount =
-            ((constraints.maxWidth + spacing) / (minimumCardWidth + spacing))
+            ((constraints.crossAxisExtent + spacing) /
+                    (minimumCardWidth + spacing))
                 .floor()
                 .clamp(1, 3);
-        final cardHeight = _gridCardHeight(context);
-        return GridView.builder(
-          key: ValueKey('${widget.keyPrefix}-group-${section.id}-body'),
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          padding: const EdgeInsets.only(top: 4),
+        return SliverGrid.builder(
           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: columnCount,
             mainAxisSpacing: spacing,
             crossAxisSpacing: spacing,
-            mainAxisExtent: cardHeight,
+            mainAxisExtent: _gridCardHeight(context),
           ),
           itemCount: section.entries.length,
           itemBuilder: (context, index) =>
               widget.entryBuilder(section.entries[index], section.color, null),
         );
       },
+    );
+  }
+
+  // SliverReorderableList 不带默认拖拽装饰，抬升要自己补回来。
+  Widget _buildDragProxy(Widget child, int index, Animation<double> animation) {
+    const draggingElevation = 6.0;
+    if (MediaQuery.disableAnimationsOf(context)) {
+      return Material(elevation: draggingElevation, child: child);
+    }
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, proxyChild) => Material(
+        elevation:
+            draggingElevation * Curves.easeInOut.transform(animation.value),
+        child: proxyChild,
+      ),
+      child: child,
     );
   }
 }

--- a/lib/presentation/widgets/grouped_grid_view.dart
+++ b/lib/presentation/widgets/grouped_grid_view.dart
@@ -124,65 +124,84 @@ class GroupedGridViewState extends ConsumerState<GroupedGridView> {
 
     if (groups.isEmpty) return const SizedBox.shrink();
 
-    final theme = Theme.of(context);
+    final lastIndex = groups.length - 1;
 
-    return ListView.builder(
+    // 分组必须是同一 viewport 下的 sliver：shrinkWrap 网格拿到无界主轴约束，
+    // 会为了算高度把整组图片一次性布局出来。
+    return CustomScrollView(
       controller: _scrollController,
-      padding: const EdgeInsets.all(12),
-      itemCount: groups.length,
-      itemBuilder: (context, groupIndex) {
-        final group = groups[groupIndex];
-
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Container(
-              key: _groupKeys[group.category],
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
-              child: Row(
-                children: [
-                  Text(
-                    group.title,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                      color: theme.colorScheme.primary,
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.primaryContainer
-                          .withValues(alpha: 0.5),
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Text(
-                      '${group.images.length}',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onPrimaryContainer,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  ),
-                ],
+      slivers: [
+        for (final (index, group) in groups.indexed) ...[
+          SliverPadding(
+            padding: EdgeInsets.fromLTRB(12, index == 0 ? 12 : 0, 12, 8),
+            sliver: SliverToBoxAdapter(
+              child: _GroupHeader(
+                key: _groupKeys[group.category],
+                title: group.title,
+                count: group.images.length,
               ),
             ),
-            const SizedBox(height: 8),
-            MasonryGridView.count(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
+          ),
+          SliverPadding(
+            padding: EdgeInsets.fromLTRB(
+              12,
+              0,
+              12,
+              index == lastIndex ? 28 : 16,
+            ),
+            sliver: SliverMasonryGrid.count(
               crossAxisCount: widget.columns,
               mainAxisSpacing: 12,
               crossAxisSpacing: 12,
-              itemCount: group.images.length,
-              itemBuilder: (context, index) =>
-                  widget.buildCard(group.images[index]),
+              childCount: group.images.length,
+              itemBuilder: (context, itemIndex) =>
+                  widget.buildCard(group.images[itemIndex]),
             ),
-            const SizedBox(height: 16),
-          ],
-        );
-      },
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _GroupHeader extends StatelessWidget {
+  const _GroupHeader({super.key, required this.title, required this.count});
+
+  final String title;
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
+      child: Row(
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.primaryContainer.withValues(alpha: 0.5),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              '$count',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onPrimaryContainer,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_lazy_layout_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_lazy_layout_test.dart
@@ -1,0 +1,361 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/core/platform/platform_capabilities.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/data/models/fixed_tag/fixed_tag_entry.dart';
+import 'package:nai_launcher/data/models/tag_library/tag_library_category.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
+import 'package:nai_launcher/presentation/providers/fixed_tags_provider.dart';
+import 'package:nai_launcher/presentation/screens/generation/widgets/fixed_tags_sidebar.dart';
+import 'package:nai_launcher/presentation/screens/generation/widgets/sidebar_entry_tile.dart';
+
+const _bulkEntryCount = 200;
+const _mountedTileBudget = 24;
+
+void main() {
+  late Directory hiveDir;
+
+  setUpAll(() async {
+    hiveDir = Directory.systemTemp.createTempSync('fixed_tags_lazy_hive_');
+    Hive.init(hiveDir.path);
+    await Hive.openBox(StorageKeys.settingsBox);
+  });
+
+  setUp(() async {
+    await Hive.box(StorageKeys.settingsBox).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (await hiveDir.exists()) {
+      await hiveDir.delete(recursive: true);
+    }
+  });
+
+  testWidgets('list mode builds a bounded slice and still reaches the last '
+      'entry', (tester) async {
+    final fixture = _bulkFixture();
+    await _pumpSidebar(tester, _LazyLayoutStorage(fixture: fixture));
+
+    final mounted = find.byType(SidebarEntryTile).evaluate().length;
+    expect(mounted, greaterThan(0));
+    expect(mounted, lessThan(_mountedTileBudget));
+    _expectBuiltTilesCoverViewport(tester);
+
+    final controller = _positiveController(tester);
+    controller.jumpTo(controller.position.maxScrollExtent);
+    await tester.pumpAndSettle();
+
+    expect(find.text(fixture.entries.last.name), findsOneWidget);
+    expect(
+      find.byType(SidebarEntryTile).evaluate().length,
+      lessThan(_mountedTileBudget),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('grid mode builds a bounded slice and still reaches the last '
+      'entry', (tester) async {
+    final fixture = _bulkFixture();
+    await _pumpSidebar(
+      tester,
+      _LazyLayoutStorage(fixture: fixture, viewMode: 'grid'),
+    );
+
+    final mounted = find.byType(SidebarEntryTile).evaluate().length;
+    expect(mounted, greaterThan(0));
+    expect(mounted, lessThan(_mountedTileBudget));
+    _expectBuiltTilesCoverViewport(tester);
+
+    final controller = _positiveController(tester);
+    controller.jumpTo(controller.position.maxScrollExtent);
+    await tester.pumpAndSettle();
+
+    expect(find.text(fixture.entries.last.name), findsOneWidget);
+    expect(
+      find.byType(SidebarEntryTile).evaluate().length,
+      lessThan(_mountedTileBudget),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('collapsing a folder shrinks the scroll range', (tester) async {
+    final fixture = _bulkFixture();
+    await _pumpSidebar(tester, _LazyLayoutStorage(fixture: fixture));
+
+    final controller = _positiveController(tester);
+    final expandedExtent = controller.position.maxScrollExtent;
+    expect(expandedExtent, greaterThan(0));
+
+    final bodyKey = ValueKey(
+      'fixed-tags-positive-group-${fixture.category.id}-body',
+    );
+    expect(find.byKey(bodyKey), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(ValueKey('fixed-tags-positive-group-${fixture.category.id}')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(bodyKey), findsNothing);
+    expect(find.byType(SidebarEntryTile), findsNothing);
+    expect(controller.position.maxScrollExtent, lessThan(expandedExtent));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('reordering keeps the scroll offset stable', (tester) async {
+    PlatformCapabilities.debugOverride = PlatformCapabilities.forPlatform(
+      TargetPlatform.windows,
+    );
+    addTearDown(() => PlatformCapabilities.debugOverride = null);
+    final fixture = _bulkFixture();
+    await _pumpSidebar(tester, _LazyLayoutStorage(fixture: fixture));
+
+    final controller = _positiveController(tester);
+    final maximumExtent = controller.position.maxScrollExtent;
+    controller.jumpTo(maximumExtent / 2);
+    await tester.pumpAndSettle();
+    final offsetBeforeDrag = controller.offset;
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(FixedTagsSidebar)),
+    );
+    List<String> currentOrder() => container
+        .read(fixedTagsNotifierProvider)
+        .positiveEntries
+        .map((entry) => entry.id)
+        .toList();
+
+    // 缓存区里的条目已经建好但在视口外，拿它当拖拽起点点不中。
+    final dragged = _tileWithRoomBelow(tester);
+    final draggedRect = tester.getRect(find.byWidget(dragged));
+    final indexBeforeDrag = currentOrder().indexOf(dragged.entry.id);
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.down(tester.getCenter(find.text(dragged.entry.name)));
+    await tester.pump();
+    // 一次性大跨度 move 只够让识别器进竞技场，分步移动才会走到插入位判定。
+    for (var step = 0; step < 6; step++) {
+      await gesture.moveBy(Offset(0, draggedRect.height * 0.25));
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(
+      currentOrder().indexOf(dragged.entry.id),
+      greaterThan(indexBeforeDrag),
+    );
+    expect(controller.offset, closeTo(offsetBeforeDrag, 0.01));
+    expect(controller.position.maxScrollExtent, closeTo(maximumExtent, 0.01));
+    expect(tester.takeException(), isNull);
+  });
+
+  for (final width in const [320.0, 600.0, 840.0]) {
+    for (final viewMode in const ['list', 'grid']) {
+      for (final textScale in const [1.0, 3.0]) {
+        testWidgets(
+          '$viewMode mode at $width with ${textScale}x text avoids overflow',
+          (tester) async {
+            final fixture = _bulkFixture(entryCount: 12);
+            await _pumpSidebar(
+              tester,
+              _LazyLayoutStorage(fixture: fixture, viewMode: viewMode),
+              width: width,
+              // 3 倍文字下顶栏与面板头会吃掉大部分高度，视口要够高才测得到宽度维度。
+              height: textScale > 1 ? 1400 : 620,
+              textScale: textScale,
+            );
+
+            expect(find.byType(SidebarEntryTile), findsWidgets);
+            expect(tester.takeException(), isNull);
+
+            final controller = _positiveController(tester);
+            controller.jumpTo(controller.position.maxScrollExtent);
+            await tester.pumpAndSettle();
+
+            expect(find.text(fixture.entries.last.name), findsOneWidget);
+            expect(tester.takeException(), isNull);
+          },
+        );
+      }
+    }
+  }
+}
+
+void _expectBuiltTilesCoverViewport(WidgetTester tester) {
+  final viewport = tester.getRect(
+    find.byKey(const ValueKey('fixed-tags-positive-group-list')),
+  );
+  final bottoms = tester
+      .widgetList<SidebarEntryTile>(find.byType(SidebarEntryTile))
+      .map((tile) => tester.getRect(find.byWidget(tile)).bottom);
+  expect(bottoms.reduce(math.max), greaterThanOrEqualTo(viewport.bottom));
+}
+
+SidebarEntryTile _tileWithRoomBelow(WidgetTester tester) {
+  final viewport = tester.getRect(
+    find.byKey(const ValueKey('fixed-tags-positive-group-list')),
+  );
+  for (final tile in tester.widgetList<SidebarEntryTile>(
+    find.byType(SidebarEntryTile),
+  )) {
+    final rect = tester.getRect(find.byWidget(tile));
+    if (rect.top >= viewport.top &&
+        rect.bottom + rect.height * 1.5 <= viewport.bottom) {
+      return tile;
+    }
+  }
+  fail('no fully visible entry tile with room below it');
+}
+
+ScrollController _positiveController(WidgetTester tester) {
+  return tester
+      .widget<CustomScrollView>(
+        find.byKey(const ValueKey('fixed-tags-positive-group-list')),
+      )
+      .controller!;
+}
+
+Future<void> _pumpSidebar(
+  WidgetTester tester,
+  _LazyLayoutStorage storage, {
+  double width = 340,
+  double height = 620,
+  double textScale = 1,
+}) async {
+  tester.view.physicalSize = Size(width, height);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [localStorageServiceProvider.overrideWith((ref) => storage)],
+      child: MaterialApp(
+        locale: const Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(textScaler: TextScaler.linear(textScale)),
+          child: child!,
+        ),
+        home: Scaffold(
+          body: InteractionPolicyScope(
+            initialPolicy: const InteractionPolicy(
+              modality: InteractionModality.pointer,
+              touchAvailable: false,
+              precisePointerAvailable: true,
+            ),
+            child: SizedBox(
+              width: width,
+              height: height,
+              child: const FixedTagsSidebar(),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+_BulkFixture _bulkFixture({int entryCount = _bulkEntryCount}) {
+  final category = TagLibraryCategory.create(name: 'Bulk', sortOrder: 0);
+  return _BulkFixture(
+    category: category,
+    entries: [
+      for (var index = 0; index < entryCount; index++)
+        FixedTagEntry.create(
+          name: 'bulk-${index.toString().padLeft(3, '0')}',
+          content: 'bulk tag $index',
+          enabled: false,
+          categoryId: category.id,
+          sortOrder: index,
+        ),
+    ],
+  );
+}
+
+class _BulkFixture {
+  const _BulkFixture({required this.category, required this.entries});
+
+  final TagLibraryCategory category;
+  final List<FixedTagEntry> entries;
+}
+
+class _LazyLayoutStorage extends LocalStorageService {
+  _LazyLayoutStorage({required this.fixture, String viewMode = 'list'})
+    : _viewMode = viewMode;
+
+  final _BulkFixture fixture;
+
+  String _viewMode;
+  String _linksJson = '[]';
+  double _negativeHeight = 180.0;
+
+  @override
+  bool getFixedTagsSidebarExpanded() => true;
+
+  @override
+  double getFixedTagsSidebarWidth() => 320.0;
+
+  @override
+  String getFixedTagsSidebarViewMode() => _viewMode;
+
+  @override
+  Future<void> setFixedTagsSidebarViewMode(String mode) async {
+    _viewMode = mode;
+  }
+
+  @override
+  double getFixedTagsNegativeHeight() => _negativeHeight;
+
+  @override
+  Future<void> setFixedTagsNegativeHeight(double height) async {
+    _negativeHeight = height;
+  }
+
+  @override
+  bool getFixedTagsNegativePanelExpanded() => true;
+
+  @override
+  String? getFixedTagsJson() {
+    return jsonEncode(fixture.entries.map((entry) => entry.toJson()).toList());
+  }
+
+  @override
+  Future<void> setFixedTagsJson(String json) async {}
+
+  @override
+  String? getFixedTagLinksJson() => _linksJson;
+
+  @override
+  Future<void> setFixedTagLinksJson(String json) async {
+    _linksJson = json;
+  }
+
+  @override
+  String? getTagLibraryEntriesJson() => '[]';
+
+  @override
+  String? getTagLibraryCategoriesJson() {
+    return jsonEncode([fixture.category.toJson()]);
+  }
+
+  @override
+  bool getEnableAutocomplete() => false;
+
+  @override
+  bool getHighlightEmphasis() => false;
+}

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
@@ -2494,7 +2494,7 @@ void main() {
       const ValueKey('fixed-tags-positive-group-list'),
     );
     final controller = tester
-        .widget<SingleChildScrollView>(positiveGroupList)
+        .widget<CustomScrollView>(positiveGroupList)
         .controller!;
     controller.jumpTo(controller.position.maxScrollExtent);
     await tester.pumpAndSettle();
@@ -2525,7 +2525,7 @@ void main() {
         const ValueKey('fixed-tags-positive-group-list'),
       );
       final controller = tester
-          .widget<SingleChildScrollView>(positiveScrollView)
+          .widget<CustomScrollView>(positiveScrollView)
           .controller!;
       final initialMax = await _expectStableScrollMetrics(
         tester,
@@ -2562,7 +2562,7 @@ void main() {
         const ValueKey('fixed-tags-positive-group-list'),
       );
       final controller = tester
-          .widget<SingleChildScrollView>(positiveScrollView)
+          .widget<CustomScrollView>(positiveScrollView)
           .controller!;
       await _expectStableScrollMetrics(
         tester,
@@ -2659,7 +2659,7 @@ void main() {
     );
     expect(negativeList, findsOneWidget);
     final controller = tester
-        .widget<SingleChildScrollView>(negativeList)
+        .widget<CustomScrollView>(negativeList)
         .controller!;
     await _expectStableScrollMetrics(
       tester,

--- a/test/presentation/widgets/grouped_grid_view_test.dart
+++ b/test/presentation/widgets/grouped_grid_view_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/data/models/gallery/local_image_record.dart';
+import 'package:nai_launcher/l10n/app_localizations.dart';
+import 'package:nai_launcher/presentation/widgets/grouped_grid_view.dart';
+
+const Size _viewport = Size(600, 500);
+const double _cardHeight = 70;
+const int _columns = 3;
+
+void main() {
+  testWidgets(
+    'mounted cards stay bounded when a group holds hundreds of images',
+    (tester) async {
+      await tester.binding.setSurfaceSize(_viewport);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await _pumpGroupedGrid(tester, images: _sameDayImages(600));
+      final mountedForSixHundred = _mountedCards.evaluate().length;
+
+      await _pumpGroupedGrid(tester, images: _sameDayImages(1200));
+      final mountedForTwelveHundred = _mountedCards.evaluate().length;
+
+      expect(mountedForSixHundred, greaterThan(0));
+      expect(mountedForSixHundred, lessThan(60));
+      expect(mountedForTwelveHundred, mountedForSixHundred);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('the last image of a large group is reachable at the bottom', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(_viewport);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await _pumpGroupedGrid(tester, images: _sameDayImages(600));
+
+    const lastCardKey = ValueKey('same-day-599');
+    expect(find.byKey(lastCardKey, skipOffstage: false), findsNothing);
+
+    await _scrollToEnd(tester);
+
+    final lastCard = find.byKey(lastCardKey);
+    expect(
+      lastCard,
+      findsOneWidget,
+      reason: 'the final card must be onstage, not parked in the cache area',
+    );
+    expect(tester.getRect(lastCard).overlaps(Offset.zero & _viewport), isTrue);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'scrollToGroup pulls an offscreen group header into the viewport',
+    (tester) async {
+      await tester.binding.setSurfaceSize(_viewport);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final gridKey = GlobalKey<GroupedGridViewState>();
+      ImageDateGroup? reportedCategory;
+      final now = DateTime.now();
+
+      await _pumpGroupedGrid(
+        tester,
+        images: [
+          ..._imagesOn('today', now, 9),
+          ..._imagesOn('yesterday', now.subtract(const Duration(days: 1)), 9),
+          ..._imagesOn('earlier', now.subtract(const Duration(days: 60)), 9),
+        ],
+        gridKey: gridKey,
+        onScrollToGroup: (category) => reportedCategory = category,
+      );
+
+      final earlierHeader = find.text('Earlier');
+      expect(
+        earlierHeader,
+        findsNothing,
+        reason: 'the target group must start offscreen to prove anything',
+      );
+      expect(find.text('Earlier', skipOffstage: false), findsOneWidget);
+
+      gridKey.currentState!.scrollToGroup(ImageDateGroup.earlier);
+      await tester.pumpAndSettle();
+
+      expect(_scrollPosition(tester).pixels, greaterThan(0));
+      expect(earlierHeader, findsOneWidget);
+      expect(
+        tester.getRect(earlierHeader).overlaps(Offset.zero & _viewport),
+        isTrue,
+      );
+      expect(reportedCategory, ImageDateGroup.earlier);
+      expect(tester.takeException(), isNull);
+    },
+  );
+}
+
+// skipOffstage:false also counts the cache region: the bounded quantity is the
+// mounted card count, not the visible one.
+final Finder _mountedCards = find.byType(_ProbeCard, skipOffstage: false);
+
+List<LocalImageRecord> _sameDayImages(int count) =>
+    _imagesOn('same-day', DateTime.now(), count);
+
+List<LocalImageRecord> _imagesOn(String prefix, DateTime day, int count) {
+  return List.generate(
+    count,
+    (index) => LocalImageRecord(
+      path: '$prefix-$index',
+      size: index + 1,
+      modifiedAt: day,
+    ),
+  );
+}
+
+Future<void> _pumpGroupedGrid(
+  WidgetTester tester, {
+  required List<LocalImageRecord> images,
+  GlobalKey<GroupedGridViewState>? gridKey,
+  void Function(ImageDateGroup category)? onScrollToGroup,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: GroupedGridView(
+            key: gridKey,
+            images: images,
+            columns: _columns,
+            itemWidth: 180,
+            onScrollToGroup: onScrollToGroup,
+            buildCard: (record) => _ProbeCard(key: ValueKey(record.path)),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+ScrollPosition _scrollPosition(WidgetTester tester) =>
+    tester.state<ScrollableState>(find.byType(Scrollable)).position;
+
+Future<void> _scrollToEnd(WidgetTester tester) async {
+  final position = _scrollPosition(tester);
+  for (var attempt = 0; attempt < 50; attempt++) {
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pump();
+    if (position.pixels >= position.maxScrollExtent) break;
+  }
+  await tester.pumpAndSettle();
+}
+
+class _ProbeCard extends StatelessWidget {
+  const _ProbeCard({super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox(height: _cardHeight);
+}


### PR DESCRIPTION
## 用户可见变化

条目很多时滚动更跟手：固定词侧栏的分组，以及本地画廊的分组网格，都改为按需构建，不再一次性全部挂载。折叠、拖拽重排、间距与滚动位置的行为保持不变。

## 问题

两处都是同一个模式：分组正文是 `shrinkWrap` 的列表/网格，套在无界主轴约束里，必须把整组条目先布局出来才能算高度。固定词侧栏 200 条记录会一次挂满 200 个 tile；本地画廊的 `GroupedGridView` 同理。

## 改动

**固定词侧栏**：改成单一 `CustomScrollView` —— 分组头走 `SliverToBoxAdapter`，列表走 `SliverReorderableList`，网格走 `SliverLayoutBuilder` + `SliverGrid`。滚动控制器、分组折叠、重排回调、条目间距与 key 全部保持不变。`SliverReorderableList` 没有默认拖拽装饰，补了一个等价的抬升过渡并遵循 Reduce Motion。

**本地画廊 `GroupedGridView`**：分组改为与外层共用同一 viewport 的 sliver。

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（在包含本分支的集成分支上执行）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `fixed_tags_sidebar_lazy_layout_test.dart`（361 行）与 `grouped_grid_view_test.dart`

无生成文件、LFS 或 assets 变更。
