### PR TITLE
perf(gallery): 批量标签与收藏改为按批次读取原状态

### DIFF
--- a/lib/data/services/bulk_gallery_store.dart
+++ b/lib/data/services/bulk_gallery_store.dart
@@ -1,0 +1,59 @@
+import '../../core/database/datasources/gallery_data_source.dart';
+
+/// 批量操作使用的画廊读写面：只暴露按批次读取原状态与逐图写入所需的方法
+abstract interface class BulkGalleryStore {
+  Future<Map<String, int?>> getImageIdsByPaths(List<String> filePaths);
+  Future<Map<int, List<String>>> getTagsByImageIds(List<int> imageIds);
+  Future<Map<int, bool>> getFavoritesByImageIds(List<int> imageIds);
+  Future<int> upsertImage({
+    required String filePath,
+    required String fileName,
+    required int fileSize,
+    required DateTime createdAt,
+    required DateTime modifiedAt,
+  });
+  Future<void> setImageTags(int imageId, List<String> tags);
+  Future<bool> toggleFavorite(int imageId);
+}
+
+/// GalleryDataSource 上的实现
+class GalleryDataSourceBulkStore implements BulkGalleryStore {
+  const GalleryDataSourceBulkStore(this._dataSource);
+
+  final GalleryDataSource _dataSource;
+
+  @override
+  Future<Map<String, int?>> getImageIdsByPaths(List<String> filePaths) =>
+      _dataSource.getImageIdsByPaths(filePaths);
+
+  @override
+  Future<Map<int, List<String>>> getTagsByImageIds(List<int> imageIds) =>
+      _dataSource.getTagsByImageIds(imageIds);
+
+  @override
+  Future<Map<int, bool>> getFavoritesByImageIds(List<int> imageIds) =>
+      _dataSource.getFavoritesByImageIds(imageIds);
+
+  @override
+  Future<int> upsertImage({
+    required String filePath,
+    required String fileName,
+    required int fileSize,
+    required DateTime createdAt,
+    required DateTime modifiedAt,
+  }) => _dataSource.upsertImage(
+    filePath: filePath,
+    fileName: fileName,
+    fileSize: fileSize,
+    createdAt: createdAt,
+    modifiedAt: modifiedAt,
+  );
+
+  @override
+  Future<void> setImageTags(int imageId, List<String> tags) =>
+      _dataSource.setImageTags(imageId, tags);
+
+  @override
+  Future<bool> toggleFavorite(int imageId) =>
+      _dataSource.toggleFavorite(imageId);
+}

--- a/lib/data/services/bulk_image_state_service.dart
+++ b/lib/data/services/bulk_image_state_service.dart
@@ -1,0 +1,354 @@
+import 'dart:io';
+
+import '../../core/utils/app_logger.dart';
+import '../../core/utils/bulk_tag_edit_utils.dart';
+import 'bulk_gallery_store.dart';
+import 'bulk_operation_types.dart';
+
+const String _logTag = 'BulkImageStateService';
+
+/// 批量标签与收藏的原状态批读和按计划写入
+///
+/// 读取阶段按批次一次取回图片 ID 与原状态，写入阶段只按已确定的目标执行。
+class BulkImageStateService {
+  const BulkImageStateService(this._store);
+
+  final BulkGalleryStore _store;
+
+  /// 单批读取的图片数量，上限受 SQLite 变量数量约束
+  static const int readBatchSize = 200;
+
+  /// 批量增删标签，读回的原标签同时作为撤销快照与写入输入
+  Future<BulkTagEditOutcome> editTags(
+    List<String> imagePaths, {
+    required List<String> tagsToAdd,
+    required List<String> tagsToRemove,
+    BulkProgressCallback? onProgress,
+  }) async {
+    final resolved = await _resolveImageIds(imagePaths);
+    final currentTags = await _readInBatches(
+      resolved.idsByPath.values.toList(),
+      _store.getTagsByImageIds,
+    );
+
+    final planned = _plan<List<String>>(resolved, (path, imageId) {
+      final failure = currentTags.failures[imageId];
+      if (failure != null) return _PlannedItem<List<String>>.failed(failure);
+      return _PlannedItem<List<String>>.target(
+        imageId,
+        applyBulkTagChanges(
+          currentTags.values[imageId] ?? const <String>[],
+          tagsToAdd: tagsToAdd,
+          tagsToRemove: tagsToRemove,
+        ),
+      );
+    });
+
+    final result = await _writePlanned<List<String>>(
+      orderedPaths: imagePaths,
+      planned: planned,
+      write: _store.setImageTags,
+      describeFailure: _describeTagFailure,
+      logLabel: 'Metadata edit',
+      onProgress: onProgress,
+    );
+
+    final succeeded = result.successfulItems.toSet();
+    return BulkTagEditOutcome(
+      result: result,
+      previous: [
+        for (final path in succeeded)
+          BulkTagAssignment(
+            path: path,
+            tags:
+                currentTags.values[resolved.idsByPath[path]] ??
+                const <String>[],
+          ),
+      ],
+      applied: [
+        for (final path in succeeded)
+          BulkTagAssignment(path: path, tags: planned[path]!.target!),
+      ],
+    );
+  }
+
+  /// 按显式目标写入标签，供撤销/重做回放，不再读取当前标签
+  Future<BulkOperationResult> applyTagAssignments(
+    List<BulkTagAssignment> assignments, {
+    BulkProgressCallback? onProgress,
+  }) async {
+    final orderedPaths = [for (final item in assignments) item.path];
+    final targets = {for (final item in assignments) item.path: item.tags};
+
+    final resolved = await _resolveImageIds(orderedPaths);
+    final planned = _plan<List<String>>(
+      resolved,
+      (path, imageId) =>
+          _PlannedItem<List<String>>.target(imageId, targets[path]!),
+    );
+
+    return _writePlanned<List<String>>(
+      orderedPaths: orderedPaths,
+      planned: planned,
+      write: _store.setImageTags,
+      describeFailure: _describeTagFailure,
+      logLabel: 'Metadata edit',
+      onProgress: onProgress,
+    );
+  }
+
+  /// 批量设置收藏，读回的原状态同时作为撤销快照与切换依据
+  Future<BulkFavoriteOutcome> setFavorites(
+    List<String> imagePaths, {
+    required bool isFavorite,
+    BulkProgressCallback? onProgress,
+  }) => _applyFavorites([
+    for (final path in imagePaths)
+      BulkFavoriteAssignment(path: path, isFavorite: isFavorite),
+  ], onProgress: onProgress);
+
+  /// 按显式目标写入收藏状态，供撤销/重做回放
+  Future<BulkOperationResult> applyFavoriteAssignments(
+    List<BulkFavoriteAssignment> assignments, {
+    BulkProgressCallback? onProgress,
+  }) async {
+    final outcome = await _applyFavorites(assignments, onProgress: onProgress);
+    return outcome.result;
+  }
+
+  Future<BulkFavoriteOutcome> _applyFavorites(
+    List<BulkFavoriteAssignment> assignments, {
+    BulkProgressCallback? onProgress,
+  }) async {
+    final orderedPaths = [for (final item in assignments) item.path];
+    final targets = {
+      for (final item in assignments) item.path: item.isFavorite,
+    };
+
+    final resolved = await _resolveImageIds(orderedPaths);
+    final currentFavorites = await _readInBatches(
+      resolved.idsByPath.values.toList(),
+      _store.getFavoritesByImageIds,
+    );
+
+    final planned = _plan<bool>(resolved, (path, imageId) {
+      final failure = currentFavorites.failures[imageId];
+      if (failure != null) return _PlannedItem<bool>.failed(failure);
+      return _PlannedItem<bool>.target(imageId, targets[path]!);
+    });
+
+    final result = await _writePlanned<bool>(
+      orderedPaths: orderedPaths,
+      planned: planned,
+      write: (imageId, target) async {
+        if ((currentFavorites.values[imageId] ?? false) != target) {
+          await _store.toggleFavorite(imageId);
+        }
+      },
+      describeFailure: _describeFavoriteFailure,
+      logLabel: 'Toggle favorite',
+      onProgress: onProgress,
+    );
+
+    final succeeded = result.successfulItems.toSet();
+    return BulkFavoriteOutcome(
+      result: result,
+      previous: [
+        for (final path in succeeded)
+          BulkFavoriteAssignment(
+            path: path,
+            isFavorite:
+                currentFavorites.values[resolved.idsByPath[path]] ?? false,
+          ),
+      ],
+      applied: [
+        for (final path in succeeded)
+          BulkFavoriteAssignment(path: path, isFavorite: targets[path]!),
+      ],
+    );
+  }
+
+  Future<_ResolvedPaths> _resolveImageIds(List<String> paths) async {
+    final idsByPath = <String, int>{};
+    final failures = <String, Object>{};
+    final unindexed = <String>[];
+
+    for (final chunk in _chunk(paths.toSet().toList(), readBatchSize)) {
+      try {
+        final ids = await _store.getImageIdsByPaths(chunk);
+        for (final path in chunk) {
+          final id = ids[path];
+          if (id == null) {
+            unindexed.add(path);
+          } else {
+            idsByPath[path] = id;
+          }
+        }
+      } catch (e) {
+        for (final path in chunk) {
+          failures[path] = e;
+        }
+      }
+    }
+
+    // 未索引图片必须先读取文件属性建立记录，这一步无法合批。
+    for (final path in unindexed) {
+      try {
+        idsByPath[path] = await _indexImage(path);
+      } catch (e) {
+        failures[path] = e;
+      }
+    }
+
+    return _ResolvedPaths(idsByPath: idsByPath, failures: failures);
+  }
+
+  Future<int> _indexImage(String path) async {
+    final file = File(path);
+    if (!await file.exists()) {
+      throw Exception('File not found');
+    }
+
+    final stat = await file.stat();
+    return _store.upsertImage(
+      filePath: path,
+      fileName: path.split(Platform.pathSeparator).last,
+      fileSize: stat.size,
+      createdAt: stat.changed,
+      modifiedAt: stat.modified,
+    );
+  }
+
+  Future<_BatchRead<T>> _readInBatches<T>(
+    List<int> imageIds,
+    Future<Map<int, T>> Function(List<int> imageIds) read,
+  ) async {
+    final values = <int, T>{};
+    final failures = <int, Object>{};
+
+    for (final chunk in _chunk(imageIds, readBatchSize)) {
+      try {
+        values.addAll(await read(chunk));
+      } catch (e) {
+        for (final id in chunk) {
+          failures[id] = e;
+        }
+      }
+    }
+
+    return _BatchRead(values: values, failures: failures);
+  }
+
+  Map<String, _PlannedItem<T>> _plan<T>(
+    _ResolvedPaths resolved,
+    _PlannedItem<T> Function(String path, int imageId) planItem,
+  ) {
+    return {
+      for (final entry in resolved.idsByPath.entries)
+        entry.key: planItem(entry.key, entry.value),
+      for (final entry in resolved.failures.entries)
+        entry.key: _PlannedItem<T>.failed(entry.value),
+    };
+  }
+
+  Future<BulkOperationResult> _writePlanned<T>({
+    required List<String> orderedPaths,
+    required Map<String, _PlannedItem<T>> planned,
+    required Future<void> Function(int imageId, T target) write,
+    required String Function(String path, Object error) describeFailure,
+    required String logLabel,
+    BulkProgressCallback? onProgress,
+  }) async {
+    var success = 0;
+    var failed = 0;
+    final errors = <String>[];
+    final successfulItems = <String>[];
+
+    void recordFailure(String path, Object error) {
+      failed++;
+      errors.add(describeFailure(path, error));
+      AppLogger.e('$logLabel failed for $path', error, null, _logTag);
+    }
+
+    for (var i = 0; i < orderedPaths.length; i++) {
+      final path = orderedPaths[i];
+      onProgress?.call(
+        current: i,
+        total: orderedPaths.length,
+        currentItem: path,
+        isComplete: false,
+      );
+
+      final item = planned[path];
+      if (item == null || item.error != null) {
+        recordFailure(path, item?.error ?? StateError('Unplanned $path'));
+        continue;
+      }
+
+      try {
+        await write(item.imageId!, item.target as T);
+        success++;
+        successfulItems.add(path);
+        AppLogger.d(
+          '$logLabel applied for $path ($success/${orderedPaths.length})',
+          _logTag,
+        );
+      } catch (e) {
+        recordFailure(path, e);
+      }
+    }
+
+    onProgress?.call(
+      current: orderedPaths.length,
+      total: orderedPaths.length,
+      currentItem: '',
+      isComplete: true,
+    );
+
+    return (
+      success: success,
+      failed: failed,
+      errors: errors,
+      successfulItems: successfulItems,
+    );
+  }
+
+  List<List<T>> _chunk<T>(List<T> values, int size) {
+    return [
+      for (var i = 0; i < values.length; i += size)
+        values.sublist(i, (i + size).clamp(0, values.length)),
+    ];
+  }
+}
+
+String _describeTagFailure(String path, Object error) =>
+    'Failed to edit metadata for $path: $error';
+
+String _describeFavoriteFailure(String path, Object error) =>
+    'Failed to toggle favorite for $path: $error';
+
+/// 路径解析结果：已确定 imageId 的路径与解析失败的路径
+class _ResolvedPaths {
+  const _ResolvedPaths({required this.idsByPath, required this.failures});
+
+  final Map<String, int> idsByPath;
+  final Map<String, Object> failures;
+}
+
+/// 分批读取结果：单个批次失败只影响该批次内的图片
+class _BatchRead<T> {
+  const _BatchRead({required this.values, required this.failures});
+
+  final Map<int, T> values;
+  final Map<int, Object> failures;
+}
+
+/// 写入阶段的逐项计划：要么带着已确定的目标，要么带着读取阶段的失败原因
+class _PlannedItem<T> {
+  const _PlannedItem.target(this.imageId, this.target) : error = null;
+  const _PlannedItem.failed(this.error) : imageId = null, target = null;
+
+  final int? imageId;
+  final T? target;
+  final Object? error;
+}

--- a/lib/data/services/bulk_operation_service.dart
+++ b/lib/data/services/bulk_operation_service.dart
@@ -8,34 +8,32 @@ import 'package:path_provider/path_provider.dart';
 import '../../core/database/database_providers.dart';
 import '../../core/database/datasources/gallery_data_source.dart';
 import '../../core/utils/app_logger.dart';
-import '../../core/utils/bulk_tag_edit_utils.dart';
 import '../models/gallery/local_image_record.dart';
 import '../models/gallery/nai_image_metadata.dart';
+import 'bulk_gallery_store.dart';
+import 'bulk_image_state_service.dart';
+import 'bulk_operation_types.dart';
+
+export 'bulk_operation_types.dart';
 
 part 'bulk_operation_service.g.dart';
-
-/// Progress callback for bulk operations
-typedef BulkProgressCallback =
-    void Function({
-      required int current,
-      required int total,
-      required String currentItem,
-      required bool isComplete,
-    });
-
-/// Bulk operation result
-typedef BulkOperationResult = ({
-  int success,
-  int failed,
-  List<String> errors,
-  List<String> successfulItems,
-});
 
 /// Bulk operation service for managing batch operations on local images
 class BulkOperationService {
   final Ref _ref;
+  final BulkGalleryStore? _store;
 
-  BulkOperationService({Ref? ref}) : _ref = ref ?? _FakeRef();
+  BulkOperationService({Ref? ref, BulkGalleryStore? store})
+    : _ref = ref ?? _FakeRef(),
+      _store = store;
+
+  Future<BulkImageStateService> _stateService() async {
+    final store = _store;
+    if (store != null) return BulkImageStateService(store);
+    return BulkImageStateService(
+      GalleryDataSourceBulkStore(await _getDataSource()),
+    );
+  }
 
   /// 获取 GalleryDataSource
   Future<GalleryDataSource> _getDataSource() async {
@@ -276,28 +274,21 @@ class BulkOperationService {
   }
 
   /// 批量编辑元数据（添加/删除标签）
-  Future<BulkOperationResult> bulkEditMetadata(
+  Future<BulkTagEditOutcome> bulkEditMetadata(
     List<String> imagePaths, {
     List<String> tagsToAdd = const [],
     List<String> tagsToRemove = const [],
     BulkProgressCallback? onProgress,
   }) async {
-    final stopwatch = Stopwatch()..start();
-    var successCount = 0;
-    var failedCount = 0;
-    final errors = <String>[];
-    final successfulItems = <String>[];
-
     if (tagsToAdd.isEmpty && tagsToRemove.isEmpty) {
       AppLogger.w(
         'No tags to add or remove, skipping bulk metadata edit',
         'BulkOperationService',
       );
-      return (
-        success: 0,
-        failed: 0,
-        errors: <String>[],
-        successfulItems: <String>[],
+      return BulkTagEditOutcome(
+        result: emptyBulkOperationResult,
+        previous: const [],
+        applied: const [],
       );
     }
 
@@ -306,179 +297,77 @@ class BulkOperationService {
       'BulkOperationService',
     );
 
-    final dataSource = await _getDataSource();
-
-    for (var i = 0; i < imagePaths.length; i++) {
-      final imagePath = imagePaths[i];
-      onProgress?.call(
-        current: i,
-        total: imagePaths.length,
-        currentItem: imagePath,
-        isComplete: false,
-      );
-
-      try {
-        // 获取或创建图片ID
-        var imageId = await dataSource.getImageIdByPath(imagePath);
-
-        if (imageId == null) {
-          // 图片不在数据库中，先索引它
-          final file = File(imagePath);
-          if (await file.exists()) {
-            final stat = await file.stat();
-            final fileName = imagePath.split(Platform.pathSeparator).last;
-            imageId = await dataSource.upsertImage(
-              filePath: imagePath,
-              fileName: fileName,
-              fileSize: stat.size,
-              createdAt: stat.changed,
-              modifiedAt: stat.modified,
-            );
-          } else {
-            throw Exception('File not found');
-          }
-        }
-
-        // 获取当前标签
-        final currentTags = await dataSource.getImageTags(imageId);
-        final updatedTags = applyBulkTagChanges(
-          currentTags,
-          tagsToAdd: tagsToAdd,
-          tagsToRemove: tagsToRemove,
-        );
-
-        await dataSource.setImageTags(imageId, updatedTags);
-        successCount++;
-        successfulItems.add(imagePath);
-        AppLogger.d(
-          'Updated tags for $imagePath: ${currentTags.length} -> ${updatedTags.length} ($successCount/${imagePaths.length})',
-          'BulkOperationService',
-        );
-      } catch (e) {
-        failedCount++;
-        errors.add('Failed to edit metadata for $imagePath: $e');
-        AppLogger.e(
-          'Metadata edit failed for $imagePath',
-          e,
-          null,
-          'BulkOperationService',
-        );
-      }
-    }
-
-    onProgress?.call(
-      current: imagePaths.length,
-      total: imagePaths.length,
-      currentItem: '',
-      isComplete: true,
+    final stopwatch = Stopwatch()..start();
+    final stateService = await _stateService();
+    final outcome = await stateService.editTags(
+      imagePaths,
+      tagsToAdd: tagsToAdd,
+      tagsToRemove: tagsToRemove,
+      onProgress: onProgress,
     );
     stopwatch.stop();
+
     AppLogger.i(
-      'Bulk metadata edit completed: $successCount succeeded, $failedCount failed in ${stopwatch.elapsedMilliseconds}ms',
+      'Bulk metadata edit completed: ${outcome.result.success} succeeded, ${outcome.result.failed} failed in ${stopwatch.elapsedMilliseconds}ms',
       'BulkOperationService',
     );
 
-    return (
-      success: successCount,
-      failed: failedCount,
-      errors: errors,
-      successfulItems: successfulItems,
+    return outcome;
+  }
+
+  /// 按显式目标回放标签，供撤销/重做复用同一条写入路径
+  Future<BulkOperationResult> applyTagAssignments(
+    List<BulkTagAssignment> assignments, {
+    BulkProgressCallback? onProgress,
+  }) async {
+    if (assignments.isEmpty) return emptyBulkOperationResult;
+
+    final stateService = await _stateService();
+    return stateService.applyTagAssignments(
+      assignments,
+      onProgress: onProgress,
     );
   }
 
   /// 批量切换收藏状态
-  Future<BulkOperationResult> bulkToggleFavorite(
+  Future<BulkFavoriteOutcome> bulkToggleFavorite(
     List<String> imagePaths, {
     required bool isFavorite,
     BulkProgressCallback? onProgress,
   }) async {
-    final stopwatch = Stopwatch()..start();
-    var successCount = 0;
-    var failedCount = 0;
-    final errors = <String>[];
-    final successfulItems = <String>[];
-
     AppLogger.i(
       'Starting bulk toggle favorite: ${imagePaths.length} images -> $isFavorite',
       'BulkOperationService',
     );
 
-    final dataSource = await _getDataSource();
-
-    for (var i = 0; i < imagePaths.length; i++) {
-      final imagePath = imagePaths[i];
-      onProgress?.call(
-        current: i,
-        total: imagePaths.length,
-        currentItem: imagePath,
-        isComplete: false,
-      );
-
-      try {
-        // 获取或创建图片ID
-        var imageId = await dataSource.getImageIdByPath(imagePath);
-
-        if (imageId == null) {
-          // 图片不在数据库中，先索引它
-          final file = File(imagePath);
-          if (await file.exists()) {
-            final stat = await file.stat();
-            final fileName = imagePath.split(Platform.pathSeparator).last;
-            imageId = await dataSource.upsertImage(
-              filePath: imagePath,
-              fileName: fileName,
-              fileSize: stat.size,
-              createdAt: stat.changed,
-              modifiedAt: stat.modified,
-            );
-          } else {
-            throw Exception('File not found');
-          }
-        }
-
-        // 检查当前收藏状态
-        final currentlyFavorite = await dataSource.isFavorite(imageId);
-
-        // 只有在状态需要改变时才切换
-        if (currentlyFavorite != isFavorite) {
-          await dataSource.toggleFavorite(imageId);
-        }
-
-        successCount++;
-        successfulItems.add(imagePath);
-        AppLogger.d(
-          'Set favorite: $imagePath -> $isFavorite ($successCount/${imagePaths.length})',
-          'BulkOperationService',
-        );
-      } catch (e) {
-        failedCount++;
-        errors.add('Failed to toggle favorite for $imagePath: $e');
-        AppLogger.e(
-          'Toggle favorite failed for $imagePath',
-          e,
-          null,
-          'BulkOperationService',
-        );
-      }
-    }
-
-    onProgress?.call(
-      current: imagePaths.length,
-      total: imagePaths.length,
-      currentItem: '',
-      isComplete: true,
+    final stopwatch = Stopwatch()..start();
+    final stateService = await _stateService();
+    final outcome = await stateService.setFavorites(
+      imagePaths,
+      isFavorite: isFavorite,
+      onProgress: onProgress,
     );
     stopwatch.stop();
+
     AppLogger.i(
-      'Bulk toggle favorite completed: $successCount succeeded, $failedCount failed in ${stopwatch.elapsedMilliseconds}ms',
+      'Bulk toggle favorite completed: ${outcome.result.success} succeeded, ${outcome.result.failed} failed in ${stopwatch.elapsedMilliseconds}ms',
       'BulkOperationService',
     );
 
-    return (
-      success: successCount,
-      failed: failedCount,
-      errors: errors,
-      successfulItems: successfulItems,
+    return outcome;
+  }
+
+  /// 按显式目标回放收藏状态，供撤销/重做复用同一条写入路径
+  Future<BulkOperationResult> applyFavoriteAssignments(
+    List<BulkFavoriteAssignment> assignments, {
+    BulkProgressCallback? onProgress,
+  }) async {
+    if (assignments.isEmpty) return emptyBulkOperationResult;
+
+    final stateService = await _stateService();
+    return stateService.applyFavoriteAssignments(
+      assignments,
+      onProgress: onProgress,
     );
   }
 

--- a/lib/data/services/bulk_operation_types.dart
+++ b/lib/data/services/bulk_operation_types.dart
@@ -1,0 +1,62 @@
+/// 批量操作的进度回调
+typedef BulkProgressCallback =
+    void Function({
+      required int current,
+      required int total,
+      required String currentItem,
+      required bool isComplete,
+    });
+
+/// 批量操作结果
+typedef BulkOperationResult = ({
+  int success,
+  int failed,
+  List<String> errors,
+  List<String> successfulItems,
+});
+
+/// 空结果；每次返回新的可增长列表，调用方可以继续追加
+BulkOperationResult get emptyBulkOperationResult =>
+    (success: 0, failed: 0, errors: <String>[], successfulItems: <String>[]);
+
+/// 单张图片的目标标签
+class BulkTagAssignment {
+  const BulkTagAssignment({required this.path, required this.tags});
+
+  final String path;
+  final List<String> tags;
+}
+
+/// 单张图片的目标收藏状态
+class BulkFavoriteAssignment {
+  const BulkFavoriteAssignment({required this.path, required this.isFavorite});
+
+  final String path;
+  final bool isFavorite;
+}
+
+/// 批量标签编辑结果，附带成功项写入前后的标签供撤销/重做回放
+class BulkTagEditOutcome {
+  const BulkTagEditOutcome({
+    required this.result,
+    required this.previous,
+    required this.applied,
+  });
+
+  final BulkOperationResult result;
+  final List<BulkTagAssignment> previous;
+  final List<BulkTagAssignment> applied;
+}
+
+/// 批量收藏结果，附带成功项写入前后的收藏状态供撤销/重做回放
+class BulkFavoriteOutcome {
+  const BulkFavoriteOutcome({
+    required this.result,
+    required this.previous,
+    required this.applied,
+  });
+
+  final BulkOperationResult result;
+  final List<BulkFavoriteAssignment> previous;
+  final List<BulkFavoriteAssignment> applied;
+}

--- a/lib/presentation/providers/bulk_operation_provider.dart
+++ b/lib/presentation/providers/bulk_operation_provider.dart
@@ -4,10 +4,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/database/database_providers.dart';
-import '../../core/database/datasources/gallery_data_source.dart';
 import '../../core/utils/app_logger.dart';
-import '../../core/utils/bulk_tag_edit_utils.dart';
 import '../../data/models/gallery/local_image_record.dart';
 import '../../data/services/bulk_operation_service.dart';
 import '../../core/utils/undo_redo_history.dart';
@@ -140,222 +137,49 @@ class BulkOperationState with _$BulkOperationState {
 }
 
 /// Bulk metadata edit command for undo/redo
+///
+/// 撤销与重做都按成功项的显式目标标签回放，不再逐图读取数据库。
 class _BulkMetadataEditCommand extends HistoryCommand {
-  final Ref _ref;
-  final List<String> _imagePaths;
-  final List<String> _tagsToAdd;
-  final List<String> _tagsToRemove;
-  final Map<String, List<String>> _originalTags;
+  final BulkOperationService _service;
+  final List<BulkTagAssignment> _previous;
+  final List<BulkTagAssignment> _applied;
 
   _BulkMetadataEditCommand(
     super.description,
-    this._ref,
-    this._imagePaths,
-    this._tagsToAdd,
-    this._tagsToRemove,
-    this._originalTags,
-  );
-
-  Future<GalleryDataSource> _getDataSource() async {
-    final dbManager = await _ref.read(databaseManagerProvider.future);
-    final dataSource = dbManager.getDataSource<GalleryDataSource>('gallery');
-    if (dataSource == null) {
-      throw StateError('GalleryDataSource not found');
-    }
-    return dataSource;
-  }
+    this._service, {
+    required List<BulkTagAssignment> previous,
+    required List<BulkTagAssignment> applied,
+  }) : _previous = previous,
+       _applied = applied;
 
   @override
-  Future<void> execute() async {
-    final dataSource = await _getDataSource();
-
-    // Apply the metadata changes
-    for (final imagePath in _imagePaths) {
-      try {
-        var imageId = await dataSource.getImageIdByPath(imagePath);
-
-        // If image not in database, index it first
-        if (imageId == null) {
-          final file = File(imagePath);
-          if (await file.exists()) {
-            final stat = await file.stat();
-            final fileName = imagePath.split(Platform.pathSeparator).last;
-            imageId = await dataSource.upsertImage(
-              filePath: imagePath,
-              fileName: fileName,
-              fileSize: stat.size,
-              createdAt: stat.changed,
-              modifiedAt: stat.modified,
-            );
-          } else {
-            continue;
-          }
-        }
-
-        final currentTags = await dataSource.getImageTags(imageId);
-        final updatedTags = applyBulkTagChanges(
-          currentTags,
-          tagsToAdd: _tagsToAdd,
-          tagsToRemove: _tagsToRemove,
-        );
-
-        await dataSource.setImageTags(imageId, updatedTags);
-      } catch (e) {
-        AppLogger.e(
-          'Failed to edit metadata for $imagePath',
-          e,
-          null,
-          '_BulkMetadataEditCommand',
-        );
-      }
-    }
-  }
+  Future<void> execute() => _service.applyTagAssignments(_applied);
 
   @override
-  Future<void> undo() async {
-    final dataSource = await _getDataSource();
-
-    // Restore original tags
-    for (final imagePath in _imagePaths) {
-      try {
-        final originalTags = _originalTags[imagePath];
-        if (originalTags != null) {
-          var imageId = await dataSource.getImageIdByPath(imagePath);
-
-          if (imageId == null) {
-            final file = File(imagePath);
-            if (await file.exists()) {
-              final stat = await file.stat();
-              final fileName = imagePath.split(Platform.pathSeparator).last;
-              imageId = await dataSource.upsertImage(
-                filePath: imagePath,
-                fileName: fileName,
-                fileSize: stat.size,
-                createdAt: stat.changed,
-                modifiedAt: stat.modified,
-              );
-            } else {
-              continue;
-            }
-          }
-
-          await dataSource.setImageTags(imageId, originalTags);
-        }
-      } catch (e) {
-        AppLogger.e(
-          'Failed to undo metadata edit for $imagePath',
-          e,
-          null,
-          '_BulkMetadataEditCommand',
-        );
-      }
-    }
-  }
+  Future<void> undo() => _service.applyTagAssignments(_previous);
 }
 
 /// Bulk toggle favorite command for undo/redo
+///
+/// 撤销与重做都按成功项的显式目标收藏状态回放，不再逐图读取数据库。
 class _BulkToggleFavoriteCommand extends HistoryCommand {
-  final Ref _ref;
-  final Map<String, bool> _originalFavoriteStates;
-  final bool _newFavoriteState;
+  final BulkOperationService _service;
+  final List<BulkFavoriteAssignment> _previous;
+  final List<BulkFavoriteAssignment> _applied;
 
   _BulkToggleFavoriteCommand(
     super.description,
-    this._ref,
-    this._originalFavoriteStates,
-    this._newFavoriteState,
-  );
-
-  Future<GalleryDataSource> _getDataSource() async {
-    final dbManager = await _ref.read(databaseManagerProvider.future);
-    final dataSource = dbManager.getDataSource<GalleryDataSource>('gallery');
-    if (dataSource == null) {
-      throw StateError('GalleryDataSource not found');
-    }
-    return dataSource;
-  }
+    this._service, {
+    required List<BulkFavoriteAssignment> previous,
+    required List<BulkFavoriteAssignment> applied,
+  }) : _previous = previous,
+       _applied = applied;
 
   @override
-  Future<void> execute() async {
-    final dataSource = await _getDataSource();
-
-    for (final entry in _originalFavoriteStates.entries) {
-      try {
-        var imageId = await dataSource.getImageIdByPath(entry.key);
-
-        // If image not in database, index it first
-        if (imageId == null) {
-          final file = File(entry.key);
-          if (await file.exists()) {
-            final stat = await file.stat();
-            final fileName = entry.key.split(Platform.pathSeparator).last;
-            imageId = await dataSource.upsertImage(
-              filePath: entry.key,
-              fileName: fileName,
-              fileSize: stat.size,
-              createdAt: stat.changed,
-              modifiedAt: stat.modified,
-            );
-          } else {
-            continue;
-          }
-        }
-
-        final currentlyFavorite = await dataSource.isFavorite(imageId);
-        if (currentlyFavorite != _newFavoriteState) {
-          await dataSource.toggleFavorite(imageId);
-        }
-      } catch (e) {
-        AppLogger.e(
-          'Failed to toggle favorite for ${entry.key}',
-          e,
-          null,
-          '_BulkToggleFavoriteCommand',
-        );
-      }
-    }
-  }
+  Future<void> execute() => _service.applyFavoriteAssignments(_applied);
 
   @override
-  Future<void> undo() async {
-    final dataSource = await _getDataSource();
-
-    // Restore original favorite states
-    for (final entry in _originalFavoriteStates.entries) {
-      try {
-        var imageId = await dataSource.getImageIdByPath(entry.key);
-
-        if (imageId == null) {
-          final file = File(entry.key);
-          if (await file.exists()) {
-            final stat = await file.stat();
-            final fileName = entry.key.split(Platform.pathSeparator).last;
-            imageId = await dataSource.upsertImage(
-              filePath: entry.key,
-              fileName: fileName,
-              fileSize: stat.size,
-              createdAt: stat.changed,
-              modifiedAt: stat.modified,
-            );
-          } else {
-            continue;
-          }
-        }
-
-        final currentlyFavorite = await dataSource.isFavorite(imageId);
-        if (currentlyFavorite != entry.value) {
-          await dataSource.toggleFavorite(imageId);
-        }
-      } catch (e) {
-        AppLogger.e(
-          'Failed to undo favorite toggle for ${entry.key}',
-          e,
-          null,
-          '_BulkToggleFavoriteCommand',
-        );
-      }
-    }
-  }
+  Future<void> undo() => _service.applyFavoriteAssignments(_previous);
 }
 
 /// Provider for BulkOperationService
@@ -378,16 +202,6 @@ class BulkOperationNotifier extends _$BulkOperationNotifier {
     return const BulkOperationState();
   }
 
-  /// 获取 GalleryDataSource
-  Future<GalleryDataSource> _getDataSource() async {
-    final dbManager = await ref.read(databaseManagerProvider.future);
-    final dataSource = dbManager.getDataSource<GalleryDataSource>('gallery');
-    if (dataSource == null) {
-      throw StateError('GalleryDataSource not found');
-    }
-    return dataSource;
-  }
-
   /// Bulk delete images
   ///
   /// [imagePaths] List of image file paths to delete
@@ -397,12 +211,7 @@ class BulkOperationNotifier extends _$BulkOperationNotifier {
   /// 返回操作结果（成功数、失败数、错误列表）
   Future<BulkOperationResult> bulkDelete(List<String> imagePaths) async {
     if (imagePaths.isEmpty) {
-      return (
-        success: 0,
-        failed: 0,
-        errors: <String>[],
-        successfulItems: <String>[],
-      );
+      return emptyBulkOperationResult;
     }
 
     state = state.copyWith(
@@ -561,12 +370,7 @@ class BulkOperationNotifier extends _$BulkOperationNotifier {
     List<String> tagsToRemove = const [],
   }) async {
     if (imagePaths.isEmpty) {
-      return (
-        success: 0,
-        failed: 0,
-        errors: <String>[],
-        successfulItems: <String>[],
-      );
+      return emptyBulkOperationResult;
     }
 
     if (tagsToAdd.isEmpty && tagsToRemove.isEmpty) {
@@ -575,12 +379,7 @@ class BulkOperationNotifier extends _$BulkOperationNotifier {
           BulkOperationErrorCode.noMetadataChanges,
         ),
       );
-      return (
-        success: 0,
-        failed: 0,
-        errors: <String>[],
-        successfulItems: <String>[],
-      );
+      return emptyBulkOperationResult;
     }
 
     state = state.copyWith(
@@ -595,19 +394,7 @@ class BulkOperationNotifier extends _$BulkOperationNotifier {
     );
 
     try {
-      // Store original tags for undo
-      final dataSource = await _getDataSource();
-      final originalTags = <String, List<String>>{};
-      for (final path in imagePaths) {
-        final imageId = await dataSource.getImageIdByPath(path);
-        if (imageId != null) {
-          originalTags[path] = await dataSource.getImageTags(imageId);
-        } else {
-          originalTags[path] = [];
-        }
-      }
-
-      final result = await _service.bulkEditMetadata(
+      final outcome = await _service.bulkEditMetadata(
         imagePaths,
         tagsToAdd: tagsToAdd,
         tagsToRemove: tagsToRemove,
@@ -627,14 +414,13 @@ class BulkOperationNotifier extends _$BulkOperationNotifier {
             },
       );
 
-      if (result.successfulItems.isNotEmpty) {
+      final result = outcome.result;
+      if (outcome.previous.isNotEmpty) {
         final command = _BulkMetadataEditCommand(
-          'Edit metadata for ${result.successfulItems.length} images',
-          ref,
-          result.successfulItems,
-          tagsToAdd,
-          tagsToRemove,
-          originalTags,
+          'Edit metadata for ${outcome.previous.length} images',
+          _service,
+          previous: outcome.previous,
+          applied: outcome.applied,
         );
         _history.push(command);
       }
@@ -688,12 +474,7 @@ class BulkOperationNotifier extends _$BulkOperationNotifier {
     required bool isFavorite,
   }) async {
     if (imagePaths.isEmpty) {
-      return (
-        success: 0,
-        failed: 0,
-        errors: <String>[],
-        successfulItems: <String>[],
-      );
+      return emptyBulkOperationResult;
     }
 
     state = state.copyWith(
@@ -706,19 +487,7 @@ class BulkOperationNotifier extends _$BulkOperationNotifier {
     );
 
     try {
-      // Store original favorite states for undo
-      final dataSource = await _getDataSource();
-      final originalStates = <String, bool>{};
-      for (final path in imagePaths) {
-        final imageId = await dataSource.getImageIdByPath(path);
-        if (imageId != null) {
-          originalStates[path] = await dataSource.isFavorite(imageId);
-        } else {
-          originalStates[path] = false;
-        }
-      }
-
-      final result = await _service.bulkToggleFavorite(
+      final outcome = await _service.bulkToggleFavorite(
         imagePaths,
         isFavorite: isFavorite,
         onProgress:
@@ -737,16 +506,13 @@ class BulkOperationNotifier extends _$BulkOperationNotifier {
             },
       );
 
-      if (result.successfulItems.isNotEmpty) {
-        final successfulOriginalStates = {
-          for (final path in result.successfulItems)
-            path: originalStates[path]!,
-        };
+      final result = outcome.result;
+      if (outcome.previous.isNotEmpty) {
         final command = _BulkToggleFavoriteCommand(
-          'Toggle favorite for ${result.successfulItems.length} images to $isFavorite',
-          ref,
-          successfulOriginalStates,
-          isFavorite,
+          'Toggle favorite for ${outcome.previous.length} images to $isFavorite',
+          _service,
+          previous: outcome.previous,
+          applied: outcome.applied,
         );
         _history.push(command);
       }

--- a/test/data/services/bulk_image_state_service_test.dart
+++ b/test/data/services/bulk_image_state_service_test.dart
@@ -1,0 +1,368 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:nai_launcher/core/utils/app_logger.dart';
+import 'package:nai_launcher/data/services/bulk_gallery_store.dart';
+import 'package:nai_launcher/data/services/bulk_image_state_service.dart';
+import 'package:nai_launcher/data/services/bulk_operation_types.dart';
+
+void main() {
+  setUp(() => AppLogger.debugSetMinimumLevelForTesting(Level.off));
+  tearDown(() => AppLogger.debugSetMinimumLevelForTesting(null));
+
+  const batchSize = BulkImageStateService.readBatchSize;
+
+  group('editTags', () {
+    test('已索引图片的读取次数随批次增长而不是随图片数增长', () async {
+      const count = batchSize * 2 + 1;
+      final store = _CountingBulkGalleryStore()..indexImages(_paths(count));
+      final service = BulkImageStateService(store);
+
+      final outcome = await service.editTags(
+        _paths(count),
+        tagsToAdd: const ['added'],
+        tagsToRemove: const [],
+      );
+
+      expect(outcome.result.success, count);
+      expect(store.idLookupBatchSizes, hasLength(3));
+      expect(store.tagReadBatchSizes, hasLength(3));
+      expect(
+        store.idLookupBatchSizes.every((size) => size <= batchSize),
+        isTrue,
+      );
+      expect(
+        store.tagReadBatchSizes.every((size) => size <= batchSize),
+        isTrue,
+      );
+      expect(store.tagWrites, hasLength(count));
+    });
+
+    test('原标签一次读回后既作为写入输入也作为撤销快照', () async {
+      final store = _CountingBulkGalleryStore()
+        ..indexImages(['/a.png', '/b.png'])
+        ..setTags('/a.png', ['keep', 'drop'])
+        ..setTags('/b.png', ['drop']);
+      final service = BulkImageStateService(store);
+
+      final outcome = await service.editTags(
+        ['/a.png', '/b.png'],
+        tagsToAdd: const ['added'],
+        tagsToRemove: const ['drop'],
+      );
+
+      expect(store.tagsOf('/a.png'), ['keep', 'added']);
+      expect(store.tagsOf('/b.png'), ['added']);
+      expect(_assignmentTags(outcome.previous), {
+        '/a.png': ['keep', 'drop'],
+        '/b.png': ['drop'],
+      });
+      expect(_assignmentTags(outcome.applied), {
+        '/a.png': ['keep', 'added'],
+        '/b.png': ['added'],
+      });
+    });
+
+    test('读取失败只让该批次内的图片失败', () async {
+      const count = batchSize + 2;
+      final paths = _paths(count);
+      final store = _CountingBulkGalleryStore()..indexImages(paths);
+      store.failingTagReadIds.add(store.idOf(paths.last));
+      final service = BulkImageStateService(store);
+
+      final outcome = await service.editTags(
+        paths,
+        tagsToAdd: const ['added'],
+        tagsToRemove: const [],
+      );
+
+      expect(outcome.result.success, batchSize);
+      expect(outcome.result.failed, 2);
+      expect(outcome.result.errors.first, contains('Failed to edit metadata'));
+      expect(outcome.result.successfulItems, paths.take(batchSize).toList());
+      expect(store.tagWrites, hasLength(batchSize));
+    });
+
+    test('写入失败的图片不进入撤销快照', () async {
+      final store = _CountingBulkGalleryStore()
+        ..indexImages(['/a.png', '/b.png', '/c.png'])
+        ..setTags('/b.png', ['original']);
+      store.failingTagWriteIds.add(store.idOf('/b.png'));
+      final service = BulkImageStateService(store);
+
+      final outcome = await service.editTags(
+        ['/a.png', '/b.png', '/c.png'],
+        tagsToAdd: const ['added'],
+        tagsToRemove: const [],
+      );
+
+      expect(outcome.result.success, 2);
+      expect(outcome.result.failed, 1);
+      expect(outcome.result.successfulItems, ['/a.png', '/c.png']);
+      expect(_assignmentTags(outcome.previous).keys, ['/a.png', '/c.png']);
+      expect(_assignmentTags(outcome.applied).keys, ['/a.png', '/c.png']);
+      expect(store.tagsOf('/b.png'), ['original']);
+    });
+
+    test('进度按顺序上报并以完成态收尾', () async {
+      final store = _CountingBulkGalleryStore()
+        ..indexImages(['/a.png', '/b.png']);
+      final service = BulkImageStateService(store);
+      final events = <({int current, int total, String item, bool complete})>[];
+
+      await service.editTags(
+        ['/a.png', '/b.png'],
+        tagsToAdd: const ['added'],
+        tagsToRemove: const [],
+        onProgress:
+            ({
+              required current,
+              required total,
+              required currentItem,
+              required isComplete,
+            }) {
+              events.add((
+                current: current,
+                total: total,
+                item: currentItem,
+                complete: isComplete,
+              ));
+            },
+      );
+
+      expect(events, [
+        (current: 0, total: 2, item: '/a.png', complete: false),
+        (current: 1, total: 2, item: '/b.png', complete: false),
+        (current: 2, total: 2, item: '', complete: true),
+      ]);
+    });
+  });
+
+  group('未索引图片', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('bulk_image_state_');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test('先按文件属性建立记录，再参与批量读取与写入', () async {
+      final file = File('${tempDir.path}${Platform.pathSeparator}new.png')
+        ..writeAsBytesSync([1, 2, 3]);
+      final store = _CountingBulkGalleryStore()..indexImages(['/a.png']);
+      final service = BulkImageStateService(store);
+
+      final outcome = await service.editTags(
+        ['/a.png', file.path],
+        tagsToAdd: const ['added'],
+        tagsToRemove: const [],
+      );
+
+      expect(outcome.result.success, 2);
+      expect(store.upserts, hasLength(1));
+      expect(store.upserts.single.filePath, file.path);
+      expect(store.upserts.single.fileName, 'new.png');
+      expect(store.upserts.single.fileSize, 3);
+      expect(store.tagReadIds, contains(store.idOf(file.path)));
+      expect(store.tagsOf(file.path), ['added']);
+    });
+
+    test('文件缺失时按项失败，不影响其他图片', () async {
+      final missing = '${tempDir.path}${Platform.pathSeparator}missing.png';
+      final store = _CountingBulkGalleryStore()..indexImages(['/a.png']);
+      final service = BulkImageStateService(store);
+
+      final outcome = await service.editTags(
+        ['/a.png', missing],
+        tagsToAdd: const ['added'],
+        tagsToRemove: const [],
+      );
+
+      expect(outcome.result.success, 1);
+      expect(outcome.result.failed, 1);
+      expect(outcome.result.errors.single, contains('File not found'));
+      expect(store.upserts, isEmpty);
+    });
+
+    test('重新建立记录的图片仍读回真实收藏状态', () async {
+      final file = File('${tempDir.path}${Platform.pathSeparator}known.png')
+        ..writeAsBytesSync([1]);
+      final store = _CountingBulkGalleryStore();
+      store.favoritesForNextUpsert.add(file.path);
+      final service = BulkImageStateService(store);
+
+      final outcome = await service.setFavorites([file.path], isFavorite: true);
+
+      expect(outcome.result.success, 1);
+      expect(store.favoriteToggles, isEmpty);
+      expect(outcome.previous.single.isFavorite, isTrue);
+    });
+  });
+
+  group('setFavorites', () {
+    test('只在状态需要改变时切换，并批量读取原状态', () async {
+      const count = batchSize + 1;
+      final paths = _paths(count);
+      final store = _CountingBulkGalleryStore()..indexImages(paths);
+      store.markFavorite(paths.first);
+      final service = BulkImageStateService(store);
+
+      final outcome = await service.setFavorites(paths, isFavorite: true);
+
+      expect(outcome.result.success, count);
+      expect(store.idLookupBatchSizes, hasLength(2));
+      expect(store.favoriteReadBatchSizes, hasLength(2));
+      expect(store.favoriteToggles, hasLength(count - 1));
+      expect(store.isFavorite(paths.first), isTrue);
+      expect(outcome.previous.first.isFavorite, isTrue);
+      expect(outcome.previous.last.isFavorite, isFalse);
+    });
+  });
+
+  group('按显式目标回放', () {
+    test('applyTagAssignments 不再读取当前标签', () async {
+      final store = _CountingBulkGalleryStore()
+        ..indexImages(['/a.png'])
+        ..setTags('/a.png', ['current']);
+      final service = BulkImageStateService(store);
+
+      final result = await service.applyTagAssignments(const [
+        BulkTagAssignment(path: '/a.png', tags: ['restored']),
+      ]);
+
+      expect(result.success, 1);
+      expect(store.tagReadBatchSizes, isEmpty);
+      expect(store.idLookupBatchSizes, hasLength(1));
+      expect(store.tagsOf('/a.png'), ['restored']);
+    });
+
+    test('applyFavoriteAssignments 按目标恢复收藏状态', () async {
+      final store = _CountingBulkGalleryStore()
+        ..indexImages(['/a.png', '/b.png'])
+        ..markFavorite('/a.png');
+      final service = BulkImageStateService(store);
+
+      final result = await service.applyFavoriteAssignments(const [
+        BulkFavoriteAssignment(path: '/a.png', isFavorite: false),
+        BulkFavoriteAssignment(path: '/b.png', isFavorite: true),
+      ]);
+
+      expect(result.success, 2);
+      expect(store.isFavorite('/a.png'), isFalse);
+      expect(store.isFavorite('/b.png'), isTrue);
+      expect(store.favoriteToggles, hasLength(2));
+    });
+  });
+}
+
+List<String> _paths(int count) => [
+  for (var i = 0; i < count; i++) '/img_$i.png',
+];
+
+Map<String, List<String>> _assignmentTags(List<BulkTagAssignment> assignments) {
+  return {for (final item in assignments) item.path: item.tags};
+}
+
+class _CountingBulkGalleryStore implements BulkGalleryStore {
+  final Map<String, int> _idsByPath = {};
+  final Map<int, List<String>> _tagsById = {};
+  final Set<int> _favoriteIds = {};
+  var _nextId = 1;
+
+  final List<int> idLookupBatchSizes = [];
+  final List<int> tagReadBatchSizes = [];
+  final List<int> favoriteReadBatchSizes = [];
+  final List<int> tagReadIds = [];
+  final List<({String filePath, String fileName, int fileSize})> upserts = [];
+  final List<({int imageId, List<String> tags})> tagWrites = [];
+  final List<int> favoriteToggles = [];
+
+  final Set<int> failingTagReadIds = {};
+  final Set<int> failingTagWriteIds = {};
+
+  /// 模拟“记录被重新建立但收藏行仍在”的历史数据
+  final Set<String> favoritesForNextUpsert = {};
+
+  void indexImages(List<String> paths) {
+    for (final path in paths) {
+      final id = _nextId++;
+      _idsByPath[path] = id;
+    }
+  }
+
+  void setTags(String path, List<String> tags) {
+    _tagsById[idOf(path)] = List<String>.from(tags);
+  }
+
+  void markFavorite(String path) => _favoriteIds.add(idOf(path));
+
+  int idOf(String path) => _idsByPath[path]!;
+
+  List<String> tagsOf(String path) => _tagsById[idOf(path)] ?? const [];
+
+  bool isFavorite(String path) => _favoriteIds.contains(idOf(path));
+
+  @override
+  Future<Map<String, int?>> getImageIdsByPaths(List<String> filePaths) async {
+    idLookupBatchSizes.add(filePaths.length);
+    return {for (final path in filePaths) path: _idsByPath[path]};
+  }
+
+  @override
+  Future<Map<int, List<String>>> getTagsByImageIds(List<int> imageIds) async {
+    tagReadBatchSizes.add(imageIds.length);
+    tagReadIds.addAll(imageIds);
+    if (imageIds.any(failingTagReadIds.contains)) {
+      throw StateError('tag read failed');
+    }
+    return {
+      for (final id in imageIds)
+        id: List<String>.from(_tagsById[id] ?? const []),
+    };
+  }
+
+  @override
+  Future<Map<int, bool>> getFavoritesByImageIds(List<int> imageIds) async {
+    favoriteReadBatchSizes.add(imageIds.length);
+    return {for (final id in imageIds) id: _favoriteIds.contains(id)};
+  }
+
+  @override
+  Future<int> upsertImage({
+    required String filePath,
+    required String fileName,
+    required int fileSize,
+    required DateTime createdAt,
+    required DateTime modifiedAt,
+  }) async {
+    upserts.add((filePath: filePath, fileName: fileName, fileSize: fileSize));
+
+    final id = _idsByPath[filePath] ?? _nextId++;
+    _idsByPath[filePath] = id;
+    if (favoritesForNextUpsert.remove(filePath)) {
+      _favoriteIds.add(id);
+    }
+    return id;
+  }
+
+  @override
+  Future<void> setImageTags(int imageId, List<String> tags) async {
+    if (failingTagWriteIds.contains(imageId)) {
+      throw StateError('tag write failed');
+    }
+    tagWrites.add((imageId: imageId, tags: List<String>.from(tags)));
+    _tagsById[imageId] = List<String>.from(tags);
+  }
+
+  @override
+  Future<bool> toggleFavorite(int imageId) async {
+    favoriteToggles.add(imageId);
+    if (_favoriteIds.remove(imageId)) return false;
+    _favoriteIds.add(imageId);
+    return true;
+  }
+}

--- a/test/presentation/providers/bulk_operation_provider_test.dart
+++ b/test/presentation/providers/bulk_operation_provider_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:nai_launcher/core/utils/app_logger.dart';
+import 'package:nai_launcher/data/services/bulk_gallery_store.dart';
+import 'package:nai_launcher/data/services/bulk_image_state_service.dart';
+import 'package:nai_launcher/data/services/bulk_operation_service.dart'
+    show BulkOperationService;
+import 'package:nai_launcher/presentation/providers/bulk_operation_provider.dart';
+
+void main() {
+  setUp(() => AppLogger.debugSetMinimumLevelForTesting(Level.off));
+  tearDown(() => AppLogger.debugSetMinimumLevelForTesting(null));
+
+  const batchSize = BulkImageStateService.readBatchSize;
+
+  ProviderContainer containerWith(_RecordingBulkGalleryStore store) {
+    final container = ProviderContainer(
+      overrides: [
+        bulkOperationServiceProvider.overrideWithValue(
+          BulkOperationService(store: store),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('批量编辑标签的读取次数随批次增长而不是随图片数增长', () async {
+    const count = batchSize * 2 + 1;
+    final paths = _paths(count);
+    final store = _RecordingBulkGalleryStore()..indexImages(paths);
+    final container = containerWith(store);
+
+    final result = await container
+        .read(bulkOperationNotifierProvider.notifier)
+        .bulkEditMetadata(paths, tagsToAdd: const ['added']);
+
+    final state = container.read(bulkOperationNotifierProvider);
+    expect(result.success, count);
+    expect(store.idLookupBatchSizes, hasLength(3));
+    expect(store.tagReadBatchSizes, hasLength(3));
+    expect(state.canUndo, isTrue);
+    expect(state.lastResult?.success, count);
+  });
+
+  test('撤销与重做按显式目标回放，不再读取原标签', () async {
+    final paths = _paths(batchSize + 1);
+    final store = _RecordingBulkGalleryStore()..indexImages(paths);
+    for (final path in paths) {
+      store.setTags(path, ['original']);
+    }
+    final container = containerWith(store);
+    final notifier = container.read(bulkOperationNotifierProvider.notifier);
+
+    await notifier.bulkEditMetadata(paths, tagsToAdd: const ['added']);
+    expect(store.tagsOf(paths.first), ['original', 'added']);
+
+    final readsAfterEdit = store.tagReadBatchSizes.length;
+    await notifier.undo();
+
+    expect(store.tagsOf(paths.first), ['original']);
+    expect(store.tagReadBatchSizes, hasLength(readsAfterEdit));
+    expect(store.idLookupBatchSizes, hasLength(4));
+    expect(container.read(bulkOperationNotifierProvider).canRedo, isTrue);
+    expect(container.read(bulkOperationNotifierProvider).hasError, isFalse);
+
+    await notifier.redo();
+
+    expect(store.tagsOf(paths.first), ['original', 'added']);
+    expect(store.tagReadBatchSizes, hasLength(readsAfterEdit));
+    expect(container.read(bulkOperationNotifierProvider).canUndo, isTrue);
+    expect(container.read(bulkOperationNotifierProvider).hasError, isFalse);
+  });
+
+  test('撤销快照只包含写入成功的图片', () async {
+    final store = _RecordingBulkGalleryStore()
+      ..indexImages(['/a.png', '/b.png'])
+      ..setTags('/a.png', ['original'])
+      ..setTags('/b.png', ['original']);
+    store.failingTagWriteIds.add(store.idOf('/b.png'));
+    final container = containerWith(store);
+    final notifier = container.read(bulkOperationNotifierProvider.notifier);
+
+    final result = await notifier.bulkEditMetadata(
+      ['/a.png', '/b.png'],
+      tagsToAdd: const ['added'],
+    );
+
+    expect(result.success, 1);
+    expect(result.failed, 1);
+
+    store.failingTagWriteIds.clear();
+    store.tagWrites.clear();
+    await notifier.undo();
+
+    expect(store.tagWrites.map((write) => write.imageId), [
+      store.idOf('/a.png'),
+    ]);
+    expect(store.tagsOf('/a.png'), ['original']);
+  });
+
+  test('批量收藏的撤销与重做复用同一条写入路径', () async {
+    final paths = _paths(3);
+    final store = _RecordingBulkGalleryStore()..indexImages(paths);
+    store.markFavorite(paths.first);
+    final container = containerWith(store);
+    final notifier = container.read(bulkOperationNotifierProvider.notifier);
+
+    final result = await notifier.bulkToggleFavorite(paths, isFavorite: true);
+
+    expect(result.success, 3);
+    expect(store.favoriteToggles, hasLength(2));
+    expect(paths.every(store.isFavorite), isTrue);
+
+    await notifier.undo();
+
+    expect(store.isFavorite(paths.first), isTrue);
+    expect(store.isFavorite(paths[1]), isFalse);
+    expect(store.isFavorite(paths[2]), isFalse);
+
+    await notifier.redo();
+
+    expect(paths.every(store.isFavorite), isTrue);
+  });
+}
+
+List<String> _paths(int count) => [
+  for (var i = 0; i < count; i++) '/img_$i.png',
+];
+
+class _RecordingBulkGalleryStore implements BulkGalleryStore {
+  final Map<String, int> _idsByPath = {};
+  final Map<int, List<String>> _tagsById = {};
+  final Set<int> _favoriteIds = {};
+  var _nextId = 1;
+
+  final List<int> idLookupBatchSizes = [];
+  final List<int> tagReadBatchSizes = [];
+  final List<({int imageId, List<String> tags})> tagWrites = [];
+  final List<int> favoriteToggles = [];
+  final Set<int> failingTagWriteIds = {};
+
+  void indexImages(List<String> paths) {
+    for (final path in paths) {
+      _idsByPath[path] = _nextId++;
+    }
+  }
+
+  void setTags(String path, List<String> tags) {
+    _tagsById[idOf(path)] = List<String>.from(tags);
+  }
+
+  void markFavorite(String path) => _favoriteIds.add(idOf(path));
+
+  int idOf(String path) => _idsByPath[path]!;
+
+  List<String> tagsOf(String path) => _tagsById[idOf(path)] ?? const [];
+
+  bool isFavorite(String path) => _favoriteIds.contains(idOf(path));
+
+  @override
+  Future<Map<String, int?>> getImageIdsByPaths(List<String> filePaths) async {
+    idLookupBatchSizes.add(filePaths.length);
+    return {for (final path in filePaths) path: _idsByPath[path]};
+  }
+
+  @override
+  Future<Map<int, List<String>>> getTagsByImageIds(List<int> imageIds) async {
+    tagReadBatchSizes.add(imageIds.length);
+    return {
+      for (final id in imageIds)
+        id: List<String>.from(_tagsById[id] ?? const []),
+    };
+  }
+
+  @override
+  Future<Map<int, bool>> getFavoritesByImageIds(List<int> imageIds) async {
+    return {for (final id in imageIds) id: _favoriteIds.contains(id)};
+  }
+
+  @override
+  Future<int> upsertImage({
+    required String filePath,
+    required String fileName,
+    required int fileSize,
+    required DateTime createdAt,
+    required DateTime modifiedAt,
+  }) async {
+    final id = _idsByPath[filePath] ?? _nextId++;
+    _idsByPath[filePath] = id;
+    return id;
+  }
+
+  @override
+  Future<void> setImageTags(int imageId, List<String> tags) async {
+    if (failingTagWriteIds.contains(imageId)) {
+      throw StateError('tag write failed');
+    }
+    tagWrites.add((imageId: imageId, tags: List<String>.from(tags)));
+    _tagsById[imageId] = List<String>.from(tags);
+  }
+
+  @override
+  Future<bool> toggleFavorite(int imageId) async {
+    favoriteToggles.add(imageId);
+    if (_favoriteIds.remove(imageId)) return false;
+    _favoriteIds.add(imageId);
+    return true;
+  }
+}


### PR DESCRIPTION
## 用户可见变化

批量打标签和批量收藏更快，撤销与重做行为不变。

## 问题

批量编辑标签和批量收藏原先由 Provider 逐图读一遍原状态做撤销快照，Service 再逐图读一遍执行，撤销/重做命令又各自逐图读一次——N 张已索引图片至少要 4N 次读取才开始写入。

## 改动

原状态只按有界批次读一次，同一份结果既作为撤销快照也作为写入输入；未索引图片仍先读取文件属性建立记录，随后并入同一次批量读取。撤销与重做改为按成功项的显式目标状态回放，与执行共用同一条写入路径。

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（集成分支）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `bulk_image_state_service_test.dart`、`bulk_operation_provider_test.dart`

无生成文件、LFS 或 assets 变更。
