### PR TITLE
perf(agent): 会话列表只读头行并按文件指纹复用会话名

### DIFF
--- a/lib/core/agent/harness/session/jsonl/session_jsonl_line_storage.dart
+++ b/lib/core/agent/harness/session/jsonl/session_jsonl_line_storage.dart
@@ -13,7 +13,10 @@ class SessionJsonlLineStorage {
   final io.File file;
   final int chunkSize;
 
-  Iterable<String> readCompleteLinesSync() {
+  /// Reads at most [maxLines] lines; a null bound reads to the end of file.
+  /// A non-positive bound yields nothing and touches no chunk.
+  Iterable<String> readCompleteLinesSync({int? maxLines}) {
+    if (maxLines != null && maxLines <= 0) return const [];
     if (!file.existsSync()) return const [];
     final lines = <String>[];
     final handle = file.openSync();
@@ -34,6 +37,7 @@ class SessionJsonlLineStorage {
             utf8.decode(bytes.sublist(0, length), allowMalformed: true),
           );
           start = index + 1;
+          if (maxLines != null && lines.length >= maxLines) return lines;
         }
         if (start < chunk.length) pending.add(chunk.sublist(start));
       }

--- a/lib/core/agent/harness/session/jsonl/session_jsonl_repository.dart
+++ b/lib/core/agent/harness/session/jsonl/session_jsonl_repository.dart
@@ -4,43 +4,55 @@ import 'dart:io' as io;
 import 'package:path/path.dart' as p;
 
 import '../../../../utils/app_logger.dart';
-import '../../../agent_types.dart';
 import '../session.dart';
 import 'session_jsonl_line_storage.dart';
 import 'session_jsonl_protocol.dart';
 import 'session_jsonl_storage.dart';
 
+/// 会话列表项：头行元数据加一次目录 stat 得到的文件信息。
+typedef SessionFileInfo = ({
+  SessionMetadata metadata,
+  String path,
+  DateTime modifiedAt,
+  int size,
+});
+
 /// 会话仓库：目录内一 JSONL 一会话。
 class JsonlSessionRepo implements SessionRepo {
   JsonlSessionRepo(this.baseDir);
+
+  static const _listLimit = 30;
 
   final io.Directory baseDir;
 
   io.File _fileFor(String id) =>
       io.File(p.join(baseDir.path, 'agent_chat', 'sessions', '$id.jsonl'));
 
-  Future<List<(SessionMetadata, io.File)>> _listAll() async {
+  Future<List<SessionFileInfo>> _listAll() async {
     final dir = io.Directory(p.join(baseDir.path, 'agent_chat', 'sessions'));
     if (!dir.existsSync()) {
       return const [];
     }
-    final result = <(SessionMetadata, io.File)>[];
-    final files =
-        dir
-            .listSync()
-            .whereType<io.File>()
-            .where((f) => f.path.endsWith('.jsonl'))
-            .toList()
-          ..sort(
-            (a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()),
-          );
-    for (final file in files) {
+    final candidates =
+        <(io.File, io.FileStat)>[
+          for (final entity in dir.listSync())
+            if (entity is io.File && entity.path.endsWith('.jsonl'))
+              (entity, entity.statSync()),
+        ]..sort((a, b) => b.$2.modified.compareTo(a.$2.modified));
+    final result = <SessionFileInfo>[];
+    for (final (file, stat) in candidates) {
       final metadata = _readHeader(file);
-      if (metadata != null) {
-        result.add((metadata, file));
-        if (result.length == 30) {
-          break;
-        }
+      if (metadata == null) {
+        continue;
+      }
+      result.add((
+        metadata: metadata,
+        path: file.path,
+        modifiedAt: stat.modified,
+        size: stat.size,
+      ));
+      if (result.length == _listLimit) {
+        break;
       }
     }
     return result;
@@ -48,24 +60,16 @@ class JsonlSessionRepo implements SessionRepo {
 
   SessionMetadata? _readHeader(io.File file) {
     try {
-      for (final line in SessionJsonlLineStorage(
+      final first = SessionJsonlLineStorage(
         file,
-      ).readCompleteLinesSync()) {
-        final trimmed = line.trim();
-        if (trimmed.isEmpty) {
-          continue;
-        }
-        final json = jsonDecode(trimmed);
-        final metadata = SessionJsonlProtocol.decodeHeader(json);
-        if (metadata != null) {
-          return metadata;
-        }
-        break;
+      ).readCompleteLinesSync(maxLines: 1);
+      if (first.isEmpty || first.first.isEmpty) {
+        return null;
       }
+      return SessionJsonlProtocol.decodeHeader(jsonDecode(first.first));
     } catch (_) {
       return null;
     }
-    return null;
   }
 
   @override
@@ -103,38 +107,11 @@ class JsonlSessionRepo implements SessionRepo {
   @override
   Future<List<SessionMetadata>> list() async {
     final all = await _listAll();
-    return [for (final (metadata, _) in all) metadata];
+    return [for (final item in all) item.metadata];
   }
 
-  /// 列出会话及 UI 列表名：优先 setName 持久化名，其次首条用户消息。
-  Future<List<(SessionMetadata, String, DateTime)>> listWithNames() async {
-    final all = await _listAll();
-    final result = <(SessionMetadata, String, DateTime)>[];
-    for (final (metadata, file) in all) {
-      final session = Session(JsonlSessionStorage(file, metadata));
-      var name = '';
-      try {
-        name = (await session.getName())?.trim() ?? '';
-      } catch (_) {
-        name = '';
-      }
-      if (name.isEmpty) {
-        final firstUser = await session.findEntry(
-          const EntryQuery(type: 'message'),
-        );
-        if (firstUser is MessageEntry && firstUser.message is UserMessage) {
-          final text = (firstUser.message as UserMessage).text
-              .replaceAll(RegExp(r'\s+'), ' ')
-              .trim();
-          if (text.isNotEmpty) {
-            name = text.length <= 40 ? text : '${text.substring(0, 40)}…';
-          }
-        }
-      }
-      result.add((metadata, name, file.lastModifiedSync()));
-    }
-    return result;
-  }
+  /// 只读头行的列表：不打开会话正文，调用方据文件信息决定是否回放。
+  Future<List<SessionFileInfo>> listWithFileInfo() => _listAll();
 
   @override
   Future<void> delete(SessionMetadata metadata) async {

--- a/lib/presentation/agent_chat/services/agent_chat_event_controller.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_event_controller.dart
@@ -97,7 +97,7 @@ class AgentChatEventController {
           );
           await _sessionController.persistMessage(message);
           if (isVisualUserMessage(message)) {
-            await _sessionController.autoNameSession(message);
+            await _sessionController.autoNameSession();
           }
         }
         if (message is AssistantMessage && message.usage != null) {

--- a/lib/presentation/agent_chat/services/agent_chat_session_controller.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_session_controller.dart
@@ -22,6 +22,7 @@ import '../providers/agent_chat_session_view.dart';
 import '../providers/agent_chat_state.dart';
 import '../models/agent_chat_turn_timeline.dart';
 import 'agent_chat_draft_controller.dart';
+import 'agent_chat_session_naming.dart';
 import 'agent_chat_session_recovery.dart';
 import 'agent_chat_session_summary_cache.dart';
 
@@ -900,20 +901,14 @@ class AgentChatSessionController {
     }
   }
 
-  Future<void> autoNameSession(Message message) async {
+  Future<void> autoNameSession() async {
     final currentSession = session;
-    final userMessage = visibleUserMessage(message);
-    if (currentSession == null || userMessage == null) return;
+    if (currentSession == null) return;
     try {
       final existing = await currentSession.getName();
       if (existing != null && existing.trim().isNotEmpty) return;
-      final normalized = userMessage.text
-          .replaceAll(RegExp(r'\s+'), ' ')
-          .trim();
-      if (normalized.isEmpty) return;
-      final name = normalized.length <= 40
-          ? normalized
-          : '${normalized.substring(0, 40)}…';
+      final name = await AgentChatSessionNaming.fromHistory(currentSession);
+      if (name.isEmpty) return;
       await currentSession.setName(name);
       _writeState(_readState().copyWith(sessions: await listSessions()));
     } catch (error) {

--- a/lib/presentation/agent_chat/services/agent_chat_session_controller.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_session_controller.dart
@@ -23,6 +23,7 @@ import '../providers/agent_chat_state.dart';
 import '../models/agent_chat_turn_timeline.dart';
 import 'agent_chat_draft_controller.dart';
 import 'agent_chat_session_recovery.dart';
+import 'agent_chat_session_summary_cache.dart';
 
 class AgentChatRewindCheckpoint {
   const AgentChatRewindCheckpoint({
@@ -57,6 +58,7 @@ class AgentChatSessionController {
     required void Function(AgentChatState state) writeState,
     required bool Function() isMounted,
   }) : _repository = repository,
+       _summaryCache = AgentChatSessionSummaryCache(repository: repository),
        _localStorage = localStorage,
        _draftController = draftController,
        _workspaceDir = workspaceDir,
@@ -67,6 +69,7 @@ class AgentChatSessionController {
        _isMounted = isMounted;
 
   final JsonlSessionRepo _repository;
+  final AgentChatSessionSummaryCache _summaryCache;
   final LocalStorageService _localStorage;
   final AgentChatDraftController _draftController;
   final String _workspaceDir;
@@ -116,15 +119,9 @@ class AgentChatSessionController {
 
   Future<List<AgentChatSessionSummary>> listSessions() async {
     try {
-      final raw = await _repository.listWithNames();
-      return [
-        for (final (metadata, name, updatedAt) in raw)
-          AgentChatSessionSummary(
-            metadata: metadata,
-            name: name,
-            updatedAt: updatedAt,
-          ),
-      ].take(sessionSummaryLimit).toList(growable: false);
+      return (await _summaryCache.list())
+          .take(sessionSummaryLimit)
+          .toList(growable: false);
     } catch (error) {
       AppLogger.w('list sessions failed: $error', 'AgentChat');
       return const [];

--- a/lib/presentation/agent_chat/services/agent_chat_session_naming.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_session_naming.dart
@@ -1,0 +1,33 @@
+import '../../../core/agent/harness/session/session.dart';
+import '../models/agent_chat_prompt_envelope.dart';
+
+/// The name an unnamed session is auto-named and listed with.
+///
+/// Auto-naming and the list fallback must agree, so both resolve the earliest
+/// user turn that carries visible text and share one length limit.
+abstract final class AgentChatSessionNaming {
+  static const lengthLimit = 40;
+
+  static final _whitespace = RegExp(r'\s+');
+
+  static String fromText(String text) {
+    final normalized = text.replaceAll(_whitespace, ' ').trim();
+    if (normalized.length <= lengthLimit) return normalized;
+    return '${normalized.substring(0, lengthLimit)}…';
+  }
+
+  /// Empty when the branch carries no user turn with visible text.
+  static Future<String> fromHistory(Session session) async {
+    final entries = await session.findEntriesOnBranch(
+      const EntryQuery(type: 'message', order: EntryOrder.oldestFirst),
+    );
+    for (final entry in entries) {
+      if (entry is! MessageEntry) continue;
+      final message = visibleUserMessage(entry.message);
+      if (message == null) continue;
+      final name = fromText(message.text);
+      if (name.isNotEmpty) return name;
+    }
+    return '';
+  }
+}

--- a/lib/presentation/agent_chat/services/agent_chat_session_summary_cache.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_session_summary_cache.dart
@@ -1,7 +1,7 @@
-import '../../../core/agent/agent_types.dart';
 import '../../../core/agent/harness/session/session.dart';
 import '../../../core/agent/harness/session/session_jsonl.dart';
 import '../providers/agent_chat_session_view.dart';
+import 'agent_chat_session_naming.dart';
 
 /// Session list names, reused while the backing JSONL file is unchanged.
 ///
@@ -14,8 +14,6 @@ class AgentChatSessionSummaryCache {
     Future<Session> Function(SessionMetadata metadata)? openSession,
   }) : _repository = repository,
        _openSession = openSession ?? repository.open;
-
-  static const nameLengthLimit = 40;
 
   final JsonlSessionRepo _repository;
   final Future<Session> Function(SessionMetadata metadata) _openSession;
@@ -49,7 +47,7 @@ class AgentChatSessionSummaryCache {
     return summaries;
   }
 
-  /// Persisted name first, then a summary of the first user message.
+  /// Persisted name first, then the earliest user turn.
   Future<String> _readName(SessionMetadata metadata) async {
     final Session session;
     try {
@@ -64,17 +62,11 @@ class AgentChatSessionSummaryCache {
       name = '';
     }
     if (name.isNotEmpty) return name;
-    final firstUser = await session.findEntry(
-      const EntryQuery(type: 'message'),
-    );
-    if (firstUser is! MessageEntry || firstUser.message is! UserMessage) {
+    try {
+      return await AgentChatSessionNaming.fromHistory(session);
+    } catch (_) {
       return '';
     }
-    final text = (firstUser.message as UserMessage).text
-        .replaceAll(RegExp(r'\s+'), ' ')
-        .trim();
-    if (text.isEmpty || text.length <= nameLengthLimit) return text;
-    return '${text.substring(0, nameLengthLimit)}…';
   }
 }
 

--- a/lib/presentation/agent_chat/services/agent_chat_session_summary_cache.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_session_summary_cache.dart
@@ -1,0 +1,94 @@
+import '../../../core/agent/agent_types.dart';
+import '../../../core/agent/harness/session/session.dart';
+import '../../../core/agent/harness/session/session_jsonl.dart';
+import '../providers/agent_chat_session_view.dart';
+
+/// Session list names, reused while the backing JSONL file is unchanged.
+///
+/// The list header carries no name, so a name still costs one replay. Files are
+/// fingerprinted by modification time and size because Windows timestamps are
+/// too coarse to catch an append on their own.
+class AgentChatSessionSummaryCache {
+  AgentChatSessionSummaryCache({
+    required JsonlSessionRepo repository,
+    Future<Session> Function(SessionMetadata metadata)? openSession,
+  }) : _repository = repository,
+       _openSession = openSession ?? repository.open;
+
+  static const nameLengthLimit = 40;
+
+  final JsonlSessionRepo _repository;
+  final Future<Session> Function(SessionMetadata metadata) _openSession;
+  final Map<String, _CachedName> _names = {};
+
+  Future<List<AgentChatSessionSummary>> list() async {
+    final listings = await _repository.listWithFileInfo();
+    final resolved = <String, _CachedName>{};
+    final summaries = <AgentChatSessionSummary>[];
+    for (final listing in listings) {
+      final cached = _names[listing.path];
+      final name = cached != null && cached.matches(listing)
+          ? cached.name
+          : await _readName(listing.metadata);
+      resolved[listing.path] = _CachedName(
+        name: name,
+        modifiedAt: listing.modifiedAt,
+        size: listing.size,
+      );
+      summaries.add(
+        AgentChatSessionSummary(
+          metadata: listing.metadata,
+          name: name,
+          updatedAt: listing.modifiedAt,
+        ),
+      );
+    }
+    _names
+      ..clear()
+      ..addAll(resolved);
+    return summaries;
+  }
+
+  /// Persisted name first, then a summary of the first user message.
+  Future<String> _readName(SessionMetadata metadata) async {
+    final Session session;
+    try {
+      session = await _openSession(metadata);
+    } catch (_) {
+      return '';
+    }
+    var name = '';
+    try {
+      name = (await session.getName())?.trim() ?? '';
+    } catch (_) {
+      name = '';
+    }
+    if (name.isNotEmpty) return name;
+    final firstUser = await session.findEntry(
+      const EntryQuery(type: 'message'),
+    );
+    if (firstUser is! MessageEntry || firstUser.message is! UserMessage) {
+      return '';
+    }
+    final text = (firstUser.message as UserMessage).text
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+    if (text.isEmpty || text.length <= nameLengthLimit) return text;
+    return '${text.substring(0, nameLengthLimit)}…';
+  }
+}
+
+class _CachedName {
+  const _CachedName({
+    required this.name,
+    required this.modifiedAt,
+    required this.size,
+  });
+
+  final String name;
+  final DateTime modifiedAt;
+  final int size;
+
+  bool matches(SessionFileInfo listing) =>
+      modifiedAt == listing.modifiedAt && size == listing.size;
+}

--- a/test/core/agent/harness/session/jsonl/session_jsonl_line_storage_bounded_read_test.dart
+++ b/test/core/agent/harness/session/jsonl/session_jsonl_line_storage_bounded_read_test.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/harness/session/session_jsonl.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('line_storage_bounded');
+  });
+
+  tearDown(() async {
+    if (tmp.existsSync()) {
+      await tmp.delete(recursive: true);
+    }
+  });
+
+  File write(String name, String content) {
+    final file = File('${tmp.path}${Platform.pathSeparator}$name')
+      ..writeAsStringSync(content);
+    return file;
+  }
+
+  group('SessionJsonlLineStorage bounded read', () {
+    test('stops at the bound and ignores the rest of a large file', () {
+      const header = '{"op":"header","id":"s1","createdAt":1}';
+      final noise = List.generate(
+        4000,
+        (index) => '{"op":"entry","seq":$index,"blob":"${'x' * 200}"}',
+      ).join('\n');
+      final file = write('large.jsonl', '$header\n$noise\nnot json at all');
+      expect(file.lengthSync(), greaterThan(64 * 1024));
+
+      final first = SessionJsonlLineStorage(
+        file,
+      ).readCompleteLinesSync(maxLines: 1);
+      expect(first, [header]);
+    });
+
+    test('a non-positive bound yields nothing', () {
+      final file = write('two.jsonl', '{"a":1}\n{"a":2}\n');
+      expect(
+        SessionJsonlLineStorage(file).readCompleteLinesSync(maxLines: 0),
+        isEmpty,
+      );
+      expect(
+        SessionJsonlLineStorage(file).readCompleteLinesSync(maxLines: -3),
+        isEmpty,
+      );
+    });
+
+    test('a bound above the line count returns every line', () {
+      final file = write('three.jsonl', '{"a":1}\n{"a":2}\n{"a":3}\n');
+      expect(
+        SessionJsonlLineStorage(file).readCompleteLinesSync(maxLines: 99),
+        ['{"a":1}', '{"a":2}', '{"a":3}'],
+      );
+    });
+
+    test('the bound is honoured across chunk boundaries', () {
+      final file = write('chunked.jsonl', '{"a":1}\n{"a":2}\n{"a":3}\n');
+      final storage = SessionJsonlLineStorage(file, chunkSize: 4);
+      expect(storage.readCompleteLinesSync(maxLines: 2), [
+        '{"a":1}',
+        '{"a":2}',
+      ]);
+      expect(storage.readCompleteLinesSync(), [
+        '{"a":1}',
+        '{"a":2}',
+        '{"a":3}',
+      ]);
+    });
+
+    test('a bound reached on the final newline never reads the torn tail', () {
+      final file = write('torn.jsonl', '{"a":1}\n{"a":2}\n{"a":');
+      expect(SessionJsonlLineStorage(file).readCompleteLinesSync(maxLines: 2), [
+        '{"a":1}',
+        '{"a":2}',
+      ]);
+      expect(SessionJsonlLineStorage(file).readCompleteLinesSync(), [
+        '{"a":1}',
+        '{"a":2}',
+      ]);
+    });
+
+    test('an unterminated final line is kept only when it is valid JSON', () {
+      final complete = write('complete_tail.jsonl', '{"a":1}\n{"a":2}');
+      expect(
+        SessionJsonlLineStorage(complete).readCompleteLinesSync(maxLines: 2),
+        ['{"a":1}', '{"a":2}'],
+      );
+
+      final torn = write('torn_tail.jsonl', '{"a":1}\n{"a"');
+      expect(SessionJsonlLineStorage(torn).readCompleteLinesSync(maxLines: 2), [
+        '{"a":1}',
+      ]);
+    });
+
+    test('an empty or missing file yields nothing', () {
+      final empty = write('empty.jsonl', '');
+      expect(
+        SessionJsonlLineStorage(empty).readCompleteLinesSync(maxLines: 1),
+        isEmpty,
+      );
+      final missing = File('${tmp.path}${Platform.pathSeparator}missing.jsonl');
+      expect(
+        SessionJsonlLineStorage(missing).readCompleteLinesSync(maxLines: 1),
+        isEmpty,
+      );
+    });
+
+    test('a leading blank line is returned verbatim', () {
+      final file = write('blank_first.jsonl', '\n{"a":1}\n');
+      expect(SessionJsonlLineStorage(file).readCompleteLinesSync(maxLines: 1), [
+        '',
+      ]);
+    });
+
+    test('CRLF terminators are stripped under a bound', () {
+      final file = write('crlf.jsonl', '{"a":1}\r\n{"a":2}\r\n');
+      expect(SessionJsonlLineStorage(file).readCompleteLinesSync(maxLines: 1), [
+        '{"a":1}',
+      ]);
+    });
+  });
+}

--- a/test/core/agent/harness_test.dart
+++ b/test/core/agent/harness_test.dart
@@ -630,40 +630,55 @@ void main() {
       expect(details.modifiedFiles, ['new.txt']);
     });
 
-    test(
-      'listWithNames prefers persisted name over first user message',
-      () async {
-        final repo = JsonlSessionRepo(Directory(tmp.path));
+    test('listWithFileInfo reports header metadata and file stat', () async {
+      final repo = JsonlSessionRepo(Directory(tmp.path));
+      final a = await repo.create();
+      await a.appendMessage(UserMessage.text('first message text'));
+      final b = await repo.create();
+      await b.appendMessage(UserMessage.text('derive my name please'));
 
-        // 会话 A：setName 持久化名优先。
-        final a = await repo.create();
-        await a.appendMessage(UserMessage.text('first message text'));
-        await a.setName('custom name');
+      final aId = (await a.getMetadata()).id;
+      final bId = (await b.getMetadata()).id;
+      final expectedModifiedAt = DateTime(2026, 1, 2, 3, 4, 5);
+      final aFile = File(
+        '${tmp.path}${Platform.pathSeparator}agent_chat'
+        '${Platform.pathSeparator}sessions${Platform.pathSeparator}$aId.jsonl',
+      );
+      final bFile = File(
+        '${tmp.path}${Platform.pathSeparator}agent_chat'
+        '${Platform.pathSeparator}sessions${Platform.pathSeparator}$bId.jsonl',
+      );
+      await aFile.setLastModified(expectedModifiedAt);
+      await bFile.setLastModified(expectedModifiedAt.add(const Duration(days: 1)));
 
-        // 会话 B：未命名 → 回退首条用户消息。
-        final b = await repo.create();
-        await b.appendMessage(UserMessage.text('derive my name please'));
+      final listed = await repo.listWithFileInfo();
+      expect([for (final item in listed) item.metadata.id], [bId, aId]);
+      final byId = {for (final item in listed) item.metadata.id: item};
+      expect(
+        byId[aId]!.modifiedAt.millisecondsSinceEpoch,
+        expectedModifiedAt.millisecondsSinceEpoch,
+      );
+      expect(byId[aId]!.path, aFile.path);
+      expect(byId[aId]!.size, aFile.lengthSync());
+    });
 
-        final aId = (await a.getMetadata()).id;
-        final bId = (await b.getMetadata()).id;
-        final expectedUpdatedAt = DateTime(2026, 1, 2, 3, 4, 5);
-        final aFile = File(
-          '${tmp.path}${Platform.pathSeparator}agent_chat'
-          '${Platform.pathSeparator}sessions${Platform.pathSeparator}$aId.jsonl',
-        );
-        await aFile.setLastModified(expectedUpdatedAt);
-        final named = await repo.listWithNames();
-        final names = {for (final (m, n, _) in named) m.id: n};
-        final updatedAt = {
-          for (final (metadata, _, modified) in named) metadata.id: modified,
-        };
-        expect(names[aId], 'custom name');
-        expect(names[bId], 'derive my name please');
-        expect(
-          updatedAt[aId]?.millisecondsSinceEpoch,
-          expectedUpdatedAt.millisecondsSinceEpoch,
-        );
-      },
-    );
+    test('listWithFileInfo skips files without a header first line', () async {
+      final repo = JsonlSessionRepo(Directory(tmp.path));
+      final valid = await repo.create();
+      final validId = (await valid.getMetadata()).id;
+      final sessions = Directory(
+        '${tmp.path}${Platform.pathSeparator}agent_chat'
+        '${Platform.pathSeparator}sessions',
+      );
+      File(
+        '${sessions.path}${Platform.pathSeparator}blank-first-line.jsonl',
+      ).writeAsStringSync('\n{"op":"header","id":"late","createdAt":1}\n');
+      File(
+        '${sessions.path}${Platform.pathSeparator}not-a-header.jsonl',
+      ).writeAsStringSync('{"op":"entry"}\n');
+
+      final listed = await repo.listWithFileInfo();
+      expect([for (final item in listed) item.metadata.id], [validId]);
+    });
   });
 }

--- a/test/presentation/agent_chat/services/agent_chat_session_name_fallback_test.dart
+++ b/test/presentation/agent_chat/services/agent_chat_session_name_fallback_test.dart
@@ -1,0 +1,174 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/agent_types.dart';
+import 'package:nai_launcher/core/agent/harness/harness_messages.dart';
+import 'package:nai_launcher/core/agent/harness/session/session.dart';
+import 'package:nai_launcher/core/agent/harness/session/session_jsonl.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_draft_store.dart';
+import 'package:nai_launcher/core/storage/local_storage_service.dart';
+import 'package:nai_launcher/presentation/agent_chat/models/agent_chat_prompt_envelope.dart';
+import 'package:nai_launcher/presentation/agent_chat/providers/agent_chat_state.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_chat_draft_controller.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_chat_session_controller.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_chat_session_naming.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_chat_session_summary_cache.dart';
+
+AssistantMessage _assistant(String text) => AssistantMessage(
+  content: [AssistantTextContent(text)],
+  stopReason: StopReason.stop,
+);
+
+HarnessCustomMessage _envelope(String visible) => HarnessCustomMessage(
+  customType: agentPromptEnvelopeType,
+  display: true,
+  blockContent: [
+    const UserTextContent('<resources/>'),
+    UserTextContent(visible),
+  ],
+  details: const {'visibleContentOffset': 1},
+  timestamp: 1,
+);
+
+void main() {
+  late Directory tmp;
+  late JsonlSessionRepo repo;
+  late AgentChatSessionSummaryCache cache;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('session_name_fallback');
+    repo = JsonlSessionRepo(Directory(tmp.path));
+    cache = AgentChatSessionSummaryCache(repository: repo);
+  });
+
+  tearDown(() async {
+    if (tmp.existsSync()) {
+      await tmp.delete(recursive: true);
+    }
+  });
+
+  Future<Session> createSession(List<AgentMessage> messages) async {
+    final session = await repo.create();
+    for (final message in messages) {
+      await session.appendMessage(message);
+    }
+    return session;
+  }
+
+  Future<String> listedName(Session session) async {
+    final id = (await session.getMetadata()).id;
+    final summaries = await cache.list();
+    return summaries.firstWhere((summary) => summary.id == id).name;
+  }
+
+  group('unnamed session names', () {
+    test('come from the first user message, not the latest', () async {
+      final session = await createSession([
+        UserMessage.text('first ask'),
+        _assistant('an answer'),
+        UserMessage.text('second ask'),
+      ]);
+
+      expect(await listedName(session), 'first ask');
+    });
+
+    test('skip a leading assistant message', () async {
+      final session = await createSession([
+        _assistant('a greeting before any prompt'),
+        UserMessage.text('the actual ask'),
+      ]);
+
+      expect(await listedName(session), 'the actual ask');
+    });
+
+    test('skip a leading custom message', () async {
+      final session = await createSession([
+        const HarnessCustomMessage(
+          customType: 'systemNote',
+          display: true,
+          textContent: 'restored context',
+          timestamp: 1,
+        ),
+        UserMessage.text('the actual ask'),
+      ]);
+
+      expect(await listedName(session), 'the actual ask');
+    });
+
+    test('read the visible half of a prompt envelope', () async {
+      final session = await createSession([
+        _envelope('draw a cat'),
+        _assistant('done'),
+      ]);
+
+      expect(await listedName(session), 'draw a cat');
+    });
+
+    test('skip a first user message without visible text', () async {
+      final session = await createSession([
+        UserMessage.text('   '),
+        UserMessage.text('the actual ask'),
+      ]);
+
+      expect(await listedName(session), 'the actual ask');
+    });
+
+    test('collapse whitespace across lines', () async {
+      final session = await createSession([
+        UserMessage.text('  draw\n  a cat  '),
+      ]);
+
+      expect(await listedName(session), 'draw a cat');
+    });
+
+    test('lose to a persisted name', () async {
+      final session = await createSession([UserMessage.text('first ask')]);
+      await session.setName('custom name');
+
+      expect(await listedName(session), 'custom name');
+    });
+
+    test('are truncated past the limit', () async {
+      final text = List.filled(20, 'lorem').join(' ');
+      final session = await createSession([UserMessage.text(text)]);
+
+      expect(await listedName(session), '${text.substring(0, 40)}…');
+    });
+  });
+
+  test('auto naming and the list fallback agree', () async {
+    final text = List.filled(20, 'lorem').join(' ');
+    final session = await createSession([
+      UserMessage.text(text),
+      _assistant('an answer'),
+      UserMessage.text('a much shorter follow-up'),
+    ]);
+    final localStorage = LocalStorageService();
+    var state = const AgentChatState();
+    final controller = AgentChatSessionController(
+      repository: repo,
+      localStorage: localStorage,
+      draftController: AgentChatDraftController(
+        resourceStore: AgentChatResourceDraftStore(
+          File('${tmp.path}${Platform.pathSeparator}drafts.json'),
+        ),
+        localStorage: localStorage,
+        readState: () => state,
+        writeState: (next) => state = next,
+        createResourceResolver: () => throw UnimplementedError(),
+        isMounted: () => true,
+      ),
+      workspaceDir: tmp.path,
+      buildAgent: () => throw UnimplementedError(),
+      buildSystemPrompt: () async => '',
+      readState: () => state,
+      writeState: (next) => state = next,
+      isMounted: () => true,
+    )..session = session;
+
+    await controller.autoNameSession();
+
+    expect(await session.getName(), AgentChatSessionNaming.fromText(text));
+    expect(await listedName(session), AgentChatSessionNaming.fromText(text));
+  });
+}

--- a/test/presentation/agent_chat/services/agent_chat_session_summary_cache_test.dart
+++ b/test/presentation/agent_chat/services/agent_chat_session_summary_cache_test.dart
@@ -1,0 +1,201 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/agent_types.dart';
+import 'package:nai_launcher/core/agent/harness/session/session.dart';
+import 'package:nai_launcher/core/agent/harness/session/session_jsonl.dart';
+import 'package:nai_launcher/core/agent/harness/session/session_types.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_chat_session_summary_cache.dart';
+
+void main() {
+  late Directory tmp;
+  late JsonlSessionRepo repo;
+  late List<String> opened;
+  late AgentChatSessionSummaryCache cache;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('session_summary_cache');
+    repo = JsonlSessionRepo(Directory(tmp.path));
+    opened = [];
+    cache = AgentChatSessionSummaryCache(
+      repository: repo,
+      openSession: (SessionMetadata metadata) {
+        opened.add(metadata.id);
+        return repo.open(metadata);
+      },
+    );
+  });
+
+  tearDown(() async {
+    if (tmp.existsSync()) {
+      await tmp.delete(recursive: true);
+    }
+  });
+
+  File fileFor(String id) => File(
+    '${tmp.path}${Platform.pathSeparator}agent_chat'
+    '${Platform.pathSeparator}sessions${Platform.pathSeparator}$id.jsonl',
+  );
+
+  Future<String> createSession(String text) async {
+    final session = await repo.create();
+    if (text.isNotEmpty) {
+      await session.appendMessage(UserMessage.text(text));
+    }
+    return (await session.getMetadata()).id;
+  }
+
+  group('AgentChatSessionSummaryCache', () {
+    test('replays each session once, then reuses unchanged names', () async {
+      final first = await createSession('hello there');
+      final second = await createSession('another thread');
+
+      final initial = await cache.list();
+      expect(
+        {for (final item in initial) item.id: item.name},
+        {first: 'hello there', second: 'another thread'},
+      );
+      expect(opened.toSet(), {first, second});
+
+      opened.clear();
+      final repeated = await cache.list();
+      expect(
+        {for (final item in repeated) item.id: item.name},
+        {first: 'hello there', second: 'another thread'},
+      );
+      expect(opened, isEmpty);
+    });
+
+    test('a persisted name wins over the first user message', () async {
+      final id = await createSession('first message text');
+      final session = await repo.open(
+        (await repo.list()).firstWhere((item) => item.id == id),
+      );
+      await session.setName('custom name');
+
+      final summaries = await cache.list();
+      expect(summaries.single.name, 'custom name');
+    });
+
+    test('a long first user message is truncated', () async {
+      final text = List.filled(20, 'lorem').join(' ');
+      final id = await createSession(text);
+
+      final summaries = await cache.list();
+      expect(summaries.single.id, id);
+      expect(summaries.single.name, '${text.substring(0, 40)}…');
+    });
+
+    test('an unnamed empty session lists without a name', () async {
+      await createSession('');
+      final summaries = await cache.list();
+      expect(summaries.single.name, '');
+    });
+
+    test('only the appended session is replayed again', () async {
+      final busy = await createSession('busy session');
+      final idle = await createSession('idle session');
+      final session = await repo.open(
+        (await repo.list()).firstWhere((item) => item.id == busy),
+      );
+      await session.setName('busy session');
+      await cache.list();
+      opened.clear();
+
+      await session.appendMessage(UserMessage.text('one more turn'));
+
+      final summaries = await cache.list();
+      expect(opened, [busy]);
+      expect(
+        {for (final item in summaries) item.id: item.name},
+        {busy: 'busy session', idle: 'idle session'},
+      );
+    });
+
+    test('a rename invalidates only the renamed session', () async {
+      final renamed = await createSession('before rename');
+      final untouched = await createSession('untouched');
+      await cache.list();
+      opened.clear();
+
+      final session = await repo.open(
+        (await repo.list()).firstWhere((item) => item.id == renamed),
+      );
+      await session.setName('after rename');
+
+      final summaries = await cache.list();
+      expect(opened, [renamed]);
+      expect(
+        {for (final item in summaries) item.id: item.name},
+        {renamed: 'after rename', untouched: 'untouched'},
+      );
+    });
+
+    test('a size change invalidates even when the timestamp is kept', () async {
+      final id = await createSession('original text');
+      await cache.list();
+      opened.clear();
+      final file = fileFor(id);
+      final modifiedAt = file.lastModifiedSync();
+
+      final session = await repo.open(
+        (await repo.list()).firstWhere((item) => item.id == id),
+      );
+      await session.setName('renamed while frozen');
+      await file.setLastModified(modifiedAt);
+
+      final summaries = await cache.list();
+      expect(opened, [id]);
+      expect(summaries.single.name, 'renamed while frozen');
+    });
+
+    test('a timestamp change invalidates even when the size is kept', () async {
+      final id = await createSession('external edit');
+      await cache.list();
+      opened.clear();
+      final file = fileFor(id);
+      final size = file.lengthSync();
+
+      file.writeAsStringSync(file.readAsStringSync());
+      await file.setLastModified(
+        file.lastModifiedSync().add(const Duration(minutes: 5)),
+      );
+      expect(file.lengthSync(), size);
+
+      await cache.list();
+      expect(opened, [id]);
+    });
+
+    test('a deleted session drops out of the cache', () async {
+      final kept = await createSession('kept');
+      final removed = await createSession('removed');
+      await cache.list();
+      opened.clear();
+
+      repo.deleteById(removed);
+      final afterDelete = await cache.list();
+      expect([for (final item in afterDelete) item.id], [kept]);
+      expect(opened, isEmpty);
+
+      final recreated = await createSession('recreated');
+      final afterCreate = await cache.list();
+      expect(opened, [recreated]);
+      expect(
+        {for (final item in afterCreate) item.id: item.name},
+        {kept: 'kept', recreated: 'recreated'},
+      );
+    });
+
+    test('updatedAt mirrors the listed file timestamp', () async {
+      final id = await createSession('timestamped');
+      final expected = DateTime(2026, 3, 4, 5, 6, 7);
+      await fileFor(id).setLastModified(expected);
+
+      final summaries = await cache.list();
+      expect(
+        summaries.single.updatedAt.millisecondsSinceEpoch,
+        expected.millisecondsSinceEpoch,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 用户可见变化

智能代理的会话列表加载更快。未命名会话的标题改为取首条有正文的用户消息，此前的取名规则在部分会话上会落空。

## 改动

- 列表改为每个文件只 stat 一次并只解析首行 header，会话名交由 presentation 层按 `(mtime, size)` 缓存，未变化的会话不再重放 JSONL
- 列表回退改用 `oldestFirst` 分支查询取最早一条有正文的用户消息，信封消息按可见内容解析
- 40 字截断收敛到一处，自动命名与列表回退共用同一规则

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（集成分支）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `session_jsonl_line_storage_bounded_read_test.dart`、`agent_chat_session_name_fallback_test.dart`、`agent_chat_session_summary_cache_test.dart`

无生成文件、LFS 或 assets 变更。
