### PR TITLE
perf(generation): 流式预览按请求复用源图与蒙版快照

### DIFF
--- a/lib/presentation/providers/generation/stream_preview_snapshot.dart
+++ b/lib/presentation/providers/generation/stream_preview_snapshot.dart
@@ -1,0 +1,141 @@
+import 'dart:typed_data';
+
+import '../../../data/models/image/image_params.dart';
+import '../../../data/models/image/image_stream_chunk.dart';
+
+/// 流式生成期间保留的最新预览帧，失败或取消时据此合成历史快照。
+class RememberedStreamPreview {
+  const RememberedStreamPreview({
+    required this.bytes,
+    required this.params,
+    this.focusedPreviewPlacement,
+  });
+
+  final Uint8List bytes;
+  final ImageParams params;
+  final FocusedStreamPreviewPlacement? focusedPreviewPlacement;
+}
+
+/// 一次请求的源图与蒙版副本，供该请求的所有预览帧共用。
+///
+/// 副本让快照不受调用方后续改动原缓冲的影响；复用判定走对象身份，
+/// 避免逐帧比对整幅图像。
+class StreamPreviewSourceSnapshot {
+  StreamPreviewSourceSnapshot._({
+    required Uint8List sourceOrigin,
+    required Uint8List? maskOrigin,
+    required this.sourceImage,
+    required this.maskImage,
+  }) : _sourceOrigin = sourceOrigin,
+       _maskOrigin = maskOrigin;
+
+  factory StreamPreviewSourceSnapshot.copyOf(
+    FocusedStreamPreviewPlacement placement,
+  ) {
+    final mask = placement.maskImage;
+    return StreamPreviewSourceSnapshot._(
+      sourceOrigin: placement.sourceImage,
+      maskOrigin: mask,
+      sourceImage: Uint8List.fromList(placement.sourceImage),
+      maskImage: mask == null ? null : Uint8List.fromList(mask),
+    );
+  }
+
+  final Uint8List _sourceOrigin;
+  final Uint8List? _maskOrigin;
+  final Uint8List sourceImage;
+  final Uint8List? maskImage;
+
+  FocusedStreamPreviewPlacement? _adopted;
+
+  bool ownsBuffersOf(FocusedStreamPreviewPlacement placement) =>
+      identical(_sourceOrigin, placement.sourceImage) &&
+      identical(_maskOrigin, placement.maskImage);
+
+  /// 用快照缓冲重建 [placement]，裁剪比例不变时直接返回上一帧的实例。
+  FocusedStreamPreviewPlacement adopt(FocusedStreamPreviewPlacement placement) {
+    final adopted = _adopted;
+    if (adopted != null &&
+        adopted.xPercent == placement.xPercent &&
+        adopted.yPercent == placement.yPercent &&
+        adopted.widthPercent == placement.widthPercent &&
+        adopted.heightPercent == placement.heightPercent) {
+      return adopted;
+    }
+    return _adopted = FocusedStreamPreviewPlacement(
+      sourceImage: sourceImage,
+      maskImage: maskImage,
+      xPercent: placement.xPercent,
+      yPercent: placement.yPercent,
+      widthPercent: placement.widthPercent,
+      heightPercent: placement.heightPercent,
+    );
+  }
+}
+
+/// 按 `runId` 与图号保管流式预览帧，并按请求复用同一份源图与蒙版快照。
+///
+/// 预览帧逐帧替换；源图与蒙版只在首帧或缓冲换新时复制一次。快照绑定 run，
+/// 帧全部消费完即释放，不跨 run 复用。
+class StreamPreviewSnapshotStore {
+  final Map<String, RememberedStreamPreview> _previews =
+      <String, RememberedStreamPreview>{};
+  StreamPreviewSourceSnapshot? _snapshot;
+  int? _snapshotRunId;
+
+  bool get isEmpty => _previews.isEmpty;
+
+  /// 当前保留的源图/蒙版快照；无保留帧时为 `null`。
+  StreamPreviewSourceSnapshot? get retainedSnapshot => _snapshot;
+
+  void remember({
+    required int runId,
+    required int imageNumber,
+    required Uint8List bytes,
+    required ImageParams params,
+    FocusedStreamPreviewPlacement? placement,
+  }) {
+    if (bytes.isEmpty) return;
+    _previews[_keyFor(runId, imageNumber)] = RememberedStreamPreview(
+      bytes: bytes,
+      params: params,
+      focusedPreviewPlacement: placement == null
+          ? null
+          : _snapshotFor(runId, placement).adopt(placement),
+    );
+  }
+
+  RememberedStreamPreview? preview(int runId, int imageNumber) =>
+      _previews[_keyFor(runId, imageNumber)];
+
+  void release(int runId, int imageNumber) {
+    _previews.remove(_keyFor(runId, imageNumber));
+    if (_previews.isEmpty) _dropSnapshot();
+  }
+
+  void clear() {
+    _previews.clear();
+    _dropSnapshot();
+  }
+
+  StreamPreviewSourceSnapshot _snapshotFor(
+    int runId,
+    FocusedStreamPreviewPlacement placement,
+  ) {
+    final current = _snapshot;
+    if (current != null &&
+        _snapshotRunId == runId &&
+        current.ownsBuffersOf(placement)) {
+      return current;
+    }
+    _snapshotRunId = runId;
+    return _snapshot = StreamPreviewSourceSnapshot.copyOf(placement);
+  }
+
+  void _dropSnapshot() {
+    _snapshot = null;
+    _snapshotRunId = null;
+  }
+
+  String _keyFor(int runId, int imageNumber) => '$runId:$imageNumber';
+}

--- a/lib/presentation/providers/image_generation_provider.dart
+++ b/lib/presentation/providers/image_generation_provider.dart
@@ -45,6 +45,7 @@ import 'generation/generation_result_lifecycle_service.dart';
 import 'generation/generation_settings_notifiers.dart';
 import 'generation/image_generation_coordinator.dart';
 import 'generation/image_workflow_controller.dart';
+import 'generation/stream_preview_snapshot.dart';
 import 'image_save_settings_provider.dart';
 import 'local_gallery_provider.dart';
 import 'prompt_config_provider.dart';
@@ -70,18 +71,6 @@ export 'generation/retry_policy_notifier.dart';
 
 part 'image_generation_provider.g.dart';
 
-class _RememberedStreamPreview {
-  const _RememberedStreamPreview({
-    required this.bytes,
-    required this.params,
-    this.focusedPreviewPlacement,
-  });
-
-  final Uint8List bytes;
-  final ImageParams params;
-  final FocusedStreamPreviewPlacement? focusedPreviewPlacement;
-}
-
 @Riverpod(keepAlive: true)
 class ImageGenerationNotifier extends _$ImageGenerationNotifier {
   Future<void>? _historyRestoreInFlight;
@@ -95,7 +84,8 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
   GenerationRunHandle? _activeRun;
   ImageGenerationCoordinator? _coordinator;
   final Map<String, String?> _persistedHistoryFilePaths = <String, String?>{};
-  final Map<String, _RememberedStreamPreview> _streamPreviews = {};
+  final StreamPreviewSnapshotStore _streamPreviews =
+      StreamPreviewSnapshotStore();
   final Set<String> _failedSnapshotKeys = {};
   ImageComparisonSource? _activeComparisonSource;
   FixedTagUsageSnapshot? _activeFixedTagUsageSnapshot;
@@ -109,6 +99,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
       _lifecycleEpoch++;
       _generationInvocationStarting = false;
       _activeComparisonSource = null;
+      _streamPreviews.clear();
       final invocationSettled = _generationInvocationSettled;
       _generationInvocationSettled = null;
       if (invocationSettled != null && !invocationSettled.isCompleted) {
@@ -607,14 +598,14 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
           clearStreamPreview: true,
         );
         for (var i = 0; i < max(images.length, params.nSamples); i++) {
-          _streamPreviews.remove(_snapshotKey(event.runId, startImage + i));
+          _streamPreviews.release(event.runId, startImage + i);
         }
         _saveVibeEncodings(vibeEncodings);
         _retainHistoryCaches();
       case GenerationRequestSkipped(:final startImage, :final requestSize):
         _appendFailedSnapshots(event.runId);
         for (var i = 0; i < requestSize; i++) {
-          _streamPreviews.remove(_snapshotKey(event.runId, startImage + i));
+          _streamPreviews.release(event.runId, startImage + i);
         }
         state = state.copyWith(clearStreamPreview: true);
       case GenerationRequestFailed(:final error, :final isTerminal):
@@ -633,6 +624,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
       case GenerationCompleted(:final params):
         final images = List<GeneratedImage>.from(state.currentImages);
         _activeComparisonSource = null;
+        _streamPreviews.clear();
         state = state.copyWith(
           status: GenerationStatus.completed,
           displayImages: images,
@@ -656,6 +648,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         }
       case GenerationCancelled():
         _appendFailedSnapshots(event.runId);
+        _streamPreviews.clear();
         _activeComparisonSource = null;
         state = state.copyWith(
           status: GenerationStatus.cancelled,
@@ -666,6 +659,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         );
       case GenerationFailed(:final error):
         _appendFailedSnapshots(event.runId);
+        _streamPreviews.clear();
         _activeComparisonSource = null;
         state = state.copyWith(
           status: GenerationStatus.error,
@@ -678,6 +672,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     }
   }
 
+  // 预览帧字节由解码与协调层逐帧新建，不会被复用，直接持有即可。
   void _rememberPreview(
     int runId,
     int imageNumber,
@@ -685,19 +680,12 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     ImageParams params,
     FocusedStreamPreviewPlacement? placement,
   ) {
-    if (bytes.isEmpty) return;
-    _streamPreviews[_snapshotKey(
-      runId,
-      imageNumber,
-    )] = _RememberedStreamPreview(
-      bytes: Uint8List.fromList(bytes),
+    _streamPreviews.remember(
+      runId: runId,
+      imageNumber: imageNumber,
+      bytes: bytes,
       params: params,
-      focusedPreviewPlacement: placement?.copyWith(
-        sourceImage: Uint8List.fromList(placement.sourceImage),
-        maskImage: placement.maskImage == null
-            ? null
-            : Uint8List.fromList(placement.maskImage!),
-      ),
+      placement: placement,
     );
   }
 
@@ -711,7 +699,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
         : const <int>[];
     for (final number in numbers.reversed) {
       final key = _snapshotKey(runId, number);
-      final preview = _streamPreviews[key];
+      final preview = _streamPreviews.preview(runId, number);
       if (preview == null || !_failedSnapshotKeys.add(key)) continue;
       final bytes = _materializePreview(preview);
       final size =
@@ -735,12 +723,12 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
           ...state.history,
         ].take(GenerationResultLifecycleService.historyLimit).toList(),
       );
-      _streamPreviews.remove(key);
+      _streamPreviews.release(runId, number);
     }
     _retainHistoryCaches();
   }
 
-  Uint8List _materializePreview(_RememberedStreamPreview preview) {
+  Uint8List _materializePreview(RememberedStreamPreview preview) {
     final placement = preview.focusedPreviewPlacement;
     if (placement == null || !placement.isValid) return preview.bytes;
     final source = img.decodeImage(placement.sourceImage);
@@ -835,6 +823,7 @@ class ImageGenerationNotifier extends _$ImageGenerationNotifier {
     _generationInvocationStarting = false;
     _activeComparisonSource = null;
     _appendFailedSnapshots(runId);
+    _streamPreviews.clear();
     final coordinator = _coordinator;
     final handle = _activeRun;
     if (coordinator != null && handle != null) coordinator.cancel(handle);

--- a/test/presentation/providers/generation/stream_preview_snapshot_test.dart
+++ b/test/presentation/providers/generation/stream_preview_snapshot_test.dart
@@ -1,0 +1,424 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:image/image.dart' as img;
+import 'package:mocktail/mocktail.dart';
+import 'package:nai_launcher/core/constants/storage_keys.dart';
+import 'package:nai_launcher/data/datasources/remote/nai_image_generation_api_service.dart';
+import 'package:nai_launcher/data/models/image/image_params.dart';
+import 'package:nai_launcher/data/models/image/image_stream_chunk.dart';
+import 'package:nai_launcher/presentation/providers/auth_provider.dart';
+import 'package:nai_launcher/presentation/providers/generation/stream_preview_snapshot.dart';
+import 'package:nai_launcher/presentation/providers/image_generation_provider.dart';
+import 'package:nai_launcher/presentation/providers/notification_settings_provider.dart';
+
+class MockNAIImageGenerationApiService extends Mock
+    implements NAIImageGenerationApiService {}
+
+class _AuthenticatedAuthNotifier extends AuthNotifier {
+  @override
+  AuthState build() => const AuthState(status: AuthStatus.authenticated);
+}
+
+Future<void> _pumpUntil(bool Function() condition, {String? reason}) async {
+  for (var i = 0; i < 400; i++) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+  fail(reason ?? 'Condition not met within timeout');
+}
+
+void main() {
+  late Directory hiveTempDir;
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    registerFallbackValue(const ImageParams());
+    hiveTempDir = await Directory.systemTemp.createTemp('nai_launcher_hive_');
+    Hive.init(hiveTempDir.path);
+    await Hive.openBox(StorageKeys.settingsBox);
+    await Hive.openBox(StorageKeys.historyBox);
+    await Hive.openBox(StorageKeys.statisticsCacheBox);
+  });
+
+  setUp(() async {
+    await Hive.box(
+      StorageKeys.settingsBox,
+    ).put(StorageKeys.imagesPerRequest, 1);
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (await hiveTempDir.exists()) {
+      await hiveTempDir.delete(recursive: true);
+    }
+  });
+
+  group('StreamPreviewSnapshotStore', () {
+    test('同一请求的多帧共用一次复制出的源图与蒙版', () {
+      final store = StreamPreviewSnapshotStore();
+      final source = _solidImageBytes(width: 8, height: 8, value: 30);
+      final mask = _solidImageBytes(width: 8, height: 8, value: 90);
+      final placement = _placement(source: source, mask: mask);
+
+      store.remember(
+        runId: 1,
+        imageNumber: 1,
+        bytes: _solidImageBytes(width: 4, height: 4, value: 1),
+        params: const ImageParams(),
+        placement: placement,
+      );
+      final snapshot = store.retainedSnapshot;
+      final firstPlacement = store.preview(1, 1)!.focusedPreviewPlacement!;
+
+      for (var frame = 2; frame <= 5; frame++) {
+        store.remember(
+          runId: 1,
+          imageNumber: 1,
+          bytes: _solidImageBytes(width: 4, height: 4, value: frame),
+          params: const ImageParams(),
+          placement: _placement(source: source, mask: mask),
+        );
+      }
+      final lastPlacement = store.preview(1, 1)!.focusedPreviewPlacement!;
+
+      expect(store.retainedSnapshot, same(snapshot));
+      expect(lastPlacement, same(firstPlacement));
+      expect(lastPlacement.sourceImage, isNot(same(source)));
+      expect(lastPlacement.sourceImage, orderedEquals(source));
+      expect(lastPlacement.maskImage, isNot(same(mask)));
+      expect(lastPlacement.maskImage, orderedEquals(mask));
+    });
+
+    test('同一请求的多张图共用同一份快照', () {
+      final store = StreamPreviewSnapshotStore();
+      final source = _solidImageBytes(width: 8, height: 8, value: 30);
+      final bytes = _solidImageBytes(width: 4, height: 4, value: 1);
+
+      store.remember(
+        runId: 1,
+        imageNumber: 1,
+        bytes: bytes,
+        params: const ImageParams(),
+        placement: _placement(source: source),
+      );
+      store.remember(
+        runId: 1,
+        imageNumber: 2,
+        bytes: bytes,
+        params: const ImageParams(),
+        placement: _placement(source: source),
+      );
+
+      expect(
+        store.preview(1, 2)!.focusedPreviewPlacement!.sourceImage,
+        same(store.preview(1, 1)!.focusedPreviewPlacement!.sourceImage),
+      );
+    });
+
+    test('源缓冲换成新对象时重建快照', () {
+      final store = StreamPreviewSnapshotStore();
+      final first = _solidImageBytes(width: 8, height: 8, value: 30);
+      final second = Uint8List.fromList(first);
+      final bytes = _solidImageBytes(width: 4, height: 4, value: 1);
+
+      store.remember(
+        runId: 1,
+        imageNumber: 1,
+        bytes: bytes,
+        params: const ImageParams(),
+        placement: _placement(source: first),
+      );
+      final firstSnapshot = store.retainedSnapshot;
+      store.remember(
+        runId: 1,
+        imageNumber: 1,
+        bytes: bytes,
+        params: const ImageParams(),
+        placement: _placement(source: second),
+      );
+
+      expect(store.retainedSnapshot, isNot(same(firstSnapshot)));
+    });
+
+    test('不同 run 不共用快照', () {
+      final store = StreamPreviewSnapshotStore();
+      final source = _solidImageBytes(width: 8, height: 8, value: 30);
+      final placement = _placement(source: source);
+      final bytes = _solidImageBytes(width: 4, height: 4, value: 1);
+
+      store.remember(
+        runId: 1,
+        imageNumber: 1,
+        bytes: bytes,
+        params: const ImageParams(),
+        placement: placement,
+      );
+      store.remember(
+        runId: 2,
+        imageNumber: 1,
+        bytes: bytes,
+        params: const ImageParams(),
+        placement: placement,
+      );
+
+      final firstRun = store.preview(1, 1)!.focusedPreviewPlacement!;
+      final secondRun = store.preview(2, 1)!.focusedPreviewPlacement!;
+      expect(secondRun.sourceImage, isNot(same(firstRun.sourceImage)));
+      expect(secondRun.sourceImage, orderedEquals(firstRun.sourceImage));
+    });
+
+    test('帧全部释放后快照随之释放', () {
+      final store = StreamPreviewSnapshotStore();
+      final source = _solidImageBytes(width: 8, height: 8, value: 30);
+      final bytes = _solidImageBytes(width: 4, height: 4, value: 1);
+
+      store.remember(
+        runId: 1,
+        imageNumber: 1,
+        bytes: bytes,
+        params: const ImageParams(),
+        placement: _placement(source: source),
+      );
+      store.remember(
+        runId: 1,
+        imageNumber: 2,
+        bytes: bytes,
+        params: const ImageParams(),
+        placement: _placement(source: source),
+      );
+      final released = store
+          .preview(1, 1)!
+          .focusedPreviewPlacement!
+          .sourceImage;
+
+      store.release(1, 1);
+      expect(store.isEmpty, isFalse);
+      expect(store.retainedSnapshot, isNotNull);
+
+      store.release(1, 2);
+      expect(store.isEmpty, isTrue);
+      expect(store.retainedSnapshot, isNull);
+      expect(store.preview(1, 1), isNull);
+
+      store.remember(
+        runId: 1,
+        imageNumber: 1,
+        bytes: bytes,
+        params: const ImageParams(),
+        placement: _placement(source: source),
+      );
+      expect(
+        store.preview(1, 1)!.focusedPreviewPlacement!.sourceImage,
+        isNot(same(released)),
+      );
+    });
+
+    test('clear 释放全部帧与快照', () {
+      final store = StreamPreviewSnapshotStore();
+      store.remember(
+        runId: 1,
+        imageNumber: 1,
+        bytes: _solidImageBytes(width: 4, height: 4, value: 1),
+        params: const ImageParams(),
+        placement: _placement(
+          source: _solidImageBytes(width: 8, height: 8, value: 30),
+        ),
+      );
+
+      store.clear();
+
+      expect(store.isEmpty, isTrue);
+      expect(store.retainedSnapshot, isNull);
+    });
+
+    test('空预览帧不被保留', () {
+      final store = StreamPreviewSnapshotStore();
+      store.remember(
+        runId: 1,
+        imageNumber: 1,
+        bytes: Uint8List(0),
+        params: const ImageParams(),
+        placement: _placement(
+          source: _solidImageBytes(width: 8, height: 8, value: 30),
+        ),
+      );
+
+      expect(store.preview(1, 1), isNull);
+      expect(store.retainedSnapshot, isNull);
+    });
+  });
+
+  test('取消生成的历史快照不受预览后原始源缓冲改动影响', () async {
+    final mockApiService = MockNAIImageGenerationApiService();
+    final stream = StreamController<ImageStreamChunk>();
+    var streamCall = 0;
+    final source = _rgbImageBytes(
+      width: 256,
+      height: 256,
+      red: 10,
+      green: 20,
+      blue: 30,
+    );
+    final preview = _rgbImageBytes(
+      width: 128,
+      height: 128,
+      red: 200,
+      green: 210,
+      blue: 220,
+    );
+    final compositeMask = img.Image(width: 128, height: 128, numChannels: 4);
+    img.fill(compositeMask, color: img.ColorRgba8(0, 0, 0, 0));
+    img.fillRect(
+      compositeMask,
+      x1: 32,
+      y1: 32,
+      x2: 95,
+      y2: 95,
+      color: img.ColorRgba8(255, 255, 255, 255),
+    );
+    compositeMask.setPixelRgba(16, 16, 128, 128, 128, 128);
+    final mask = Uint8List.fromList(img.encodePng(compositeMask));
+    final placement = FocusedStreamPreviewPlacement(
+      sourceImage: source,
+      maskImage: mask,
+      xPercent: 0.25,
+      yPercent: 0.25,
+      widthPercent: 0.5,
+      heightPercent: 0.5,
+    );
+
+    when(
+      () => mockApiService.generateImage(
+        any(),
+        onProgress: any(named: 'onProgress'),
+        focusedInpaintEnabled: any(named: 'focusedInpaintEnabled'),
+        minimumContextMegaPixels: any(named: 'minimumContextMegaPixels'),
+        focusedSelectionRect: any(named: 'focusedSelectionRect'),
+      ),
+    ).thenAnswer((_) async => (<Uint8List>[], <int, String>{}));
+    when(
+      () => mockApiService.generateImageStream(
+        any(),
+        focusedInpaintEnabled: any(named: 'focusedInpaintEnabled'),
+        minimumContextMegaPixels: any(named: 'minimumContextMegaPixels'),
+        focusedSelectionRect: any(named: 'focusedSelectionRect'),
+      ),
+    ).thenAnswer((_) {
+      streamCall += 1;
+      return stream.stream;
+    });
+    when(() => mockApiService.cancelGeneration(any())).thenReturn(null);
+
+    final container = ProviderContainer(
+      overrides: [
+        authNotifierProvider.overrideWith(_AuthenticatedAuthNotifier.new),
+        naiImageGenerationApiServiceProvider.overrideWithValue(mockApiService),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container
+        .read(notificationSettingsNotifierProvider.notifier)
+        .setSoundEnabled(false);
+
+    final notifier = container.read(imageGenerationNotifierProvider.notifier);
+    final rawMask = img.Image(width: 256, height: 256, numChannels: 4);
+    img.fill(rawMask, color: img.ColorRgba8(0, 0, 0, 255));
+    rawMask.setPixelRgba(128, 128, 255, 255, 255, 255);
+    final params = container
+        .read(generationParamsNotifierProvider)
+        .copyWith(
+          prompt: 'snapshot reuse',
+          action: ImageGenerationAction.infill,
+          model: 'nai-diffusion-4-5-full-inpainting',
+          width: 256,
+          height: 256,
+          sourceImage: source,
+          maskImage: Uint8List.fromList(img.encodePng(rawMask)),
+        );
+
+    final generation = notifier.generate(params);
+    await _pumpUntil(
+      () => streamCall == 1,
+      reason: 'stream request was not started',
+    );
+    stream.add(
+      ImageStreamChunk.progress(
+        progress: 0.5,
+        currentStep: 14,
+        totalSteps: 28,
+        previewImage: preview,
+        focusedPreviewPlacement: placement,
+      ),
+    );
+    await _pumpUntil(
+      () => container.read(imageGenerationNotifierProvider).hasStreamPreview,
+      reason: 'stream preview was not published before cancellation',
+    );
+
+    source.fillRange(0, source.length, 0);
+    mask.fillRange(0, mask.length, 0);
+
+    notifier.cancel();
+    await stream.close();
+    await generation;
+
+    final state = container.read(imageGenerationNotifierProvider);
+    expect(state.status, GenerationStatus.cancelled);
+    expect(state.history, hasLength(1));
+    final snapshot = img.decodeImage(state.history.single.bytes)!;
+    expect((snapshot.width, snapshot.height), (256, 256));
+    expect(_rgb(snapshot, 0, 0), (10, 20, 30));
+    expect(_rgb(snapshot, 128, 128), (200, 210, 220));
+    final softPixel = _rgb(snapshot, 80, 80);
+    expect(softPixel.$1, inInclusiveRange(100, 110));
+    expect(softPixel.$2, inInclusiveRange(110, 120));
+    expect(softPixel.$3, inInclusiveRange(120, 130));
+  });
+}
+
+FocusedStreamPreviewPlacement _placement({
+  required Uint8List source,
+  Uint8List? mask,
+}) {
+  return FocusedStreamPreviewPlacement(
+    sourceImage: source,
+    maskImage: mask,
+    xPercent: 0.25,
+    yPercent: 0.25,
+    widthPercent: 0.5,
+    heightPercent: 0.5,
+  );
+}
+
+Uint8List _solidImageBytes({
+  required int width,
+  required int height,
+  required int value,
+}) {
+  final image = img.Image(width: width, height: height);
+  img.fill(image, color: img.ColorRgb8(value, value, value));
+  return Uint8List.fromList(img.encodePng(image));
+}
+
+Uint8List _rgbImageBytes({
+  required int width,
+  required int height,
+  required int red,
+  required int green,
+  required int blue,
+}) {
+  final image = img.Image(width: width, height: height, numChannels: 4);
+  img.fill(image, color: img.ColorRgba8(red, green, blue, 255));
+  return Uint8List.fromList(img.encodePng(image));
+}
+
+(int, int, int) _rgb(img.Image image, int x, int y) {
+  final pixel = image.getPixel(x, y);
+  return (pixel.r.toInt(), pixel.g.toInt(), pixel.b.toInt());
+}


### PR DESCRIPTION
## 用户可见变化

流式预览刷新时的内存占用与拷贝开销下降，预览画面与取消行为不变。

## 问题

预览帧原先逐帧把源图、蒙版和预览字节各复制一份，重绘时每步都在复制两块整幅图缓冲。

## 改动

改为按请求建立一次不可变快照，用源缓冲对象身份判定复用，缓冲换新或换 run 才重建；帧全部释放、请求结束、取消或失败时释放快照。预览字节由解码与协调层逐帧新建，不再重复复制。

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（集成分支）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `stream_preview_snapshot_test.dart`（424 行）

无生成文件、LFS 或 assets 变更。
