### PR TITLE
perf(upscale): 图生图超分改读图像头获取宽高

### DIFF
--- a/lib/presentation/screens/generation/widgets/img2img_upscale_coordinator.dart
+++ b/lib/presentation/screens/generation/widgets/img2img_upscale_coordinator.dart
@@ -2,10 +2,10 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:image/image.dart' as img;
 
 import '../../../../core/comfyui/seedvr2_support.dart';
 import '../../../../core/utils/app_logger.dart';
+import '../../../../core/utils/nai_resolution_adapter.dart';
 import '../../../../data/models/image/image_params.dart';
 import '../../../providers/comfyui/comfyui_provider.dart';
 import '../../../providers/generation/image_workflow_controller.dart';
@@ -111,12 +111,13 @@ final class Img2ImgUpscaleCoordinator {
         Img2ImgUpscaleFailure.seedVr2ModelUnavailable,
       );
     }
-    final decodedSource = img.decodeImage(source);
-    if (decodedSource == null) {
+    final sourceSize = NaiResolutionAdapter.readImageSize(source);
+    if (sourceSize == null) {
       return const Img2ImgUpscaleRejected(
         Img2ImgUpscaleFailure.sourceDecodeFailed,
       );
     }
+    final (sourceWidth, sourceHeight) = sourceSize;
 
     late final String templateId;
     late final Map<String, dynamic> values;
@@ -145,13 +146,13 @@ final class Img2ImgUpscaleCoordinator {
           : Img2ImgUpscaleKind.seedVr2Legacy;
       final resolution = tiled
           ? calculateComfySeedvr2TiledTargetResolution(
-              sourceWidth: decodedSource.width,
-              sourceHeight: decodedSource.height,
+              sourceWidth: sourceWidth,
+              sourceHeight: sourceHeight,
               scale: settings.comfyScale,
             )
           : calculateComfySeedvr2TargetResolution(
-              sourceWidth: decodedSource.width,
-              sourceHeight: decodedSource.height,
+              sourceWidth: sourceWidth,
+              sourceHeight: sourceHeight,
               scale: settings.comfyScale,
             );
       templateId = tiled
@@ -184,11 +185,10 @@ final class Img2ImgUpscaleCoordinator {
       return const Img2ImgUpscaleRejected(Img2ImgUpscaleFailure.noResult);
     }
     final bytes = results.last;
-    final decoded = img.decodeImage(bytes);
-    final width =
-        decoded?.width ?? (decodedSource.width * settings.comfyScale).round();
+    final outputSize = NaiResolutionAdapter.readImageSize(bytes);
+    final width = outputSize?.$1 ?? (sourceWidth * settings.comfyScale).round();
     final height =
-        decoded?.height ?? (decodedSource.height * settings.comfyScale).round();
+        outputSize?.$2 ?? (sourceHeight * settings.comfyScale).round();
     await _register(
       bytes,
       params,
@@ -215,19 +215,19 @@ final class Img2ImgUpscaleCoordinator {
         Img2ImgUpscaleFailure.regularModelUnavailable,
       );
     }
-    final decodedSource = img.decodeImage(source);
-    if (decodedSource == null) {
+    final sourceSize = NaiResolutionAdapter.readImageSize(source);
+    if (sourceSize == null) {
       return const Img2ImgUpscaleRejected(
         Img2ImgUpscaleFailure.sourceDecodeFailed,
       );
     }
     final width = math.max(
       1,
-      (decodedSource.width * workflow.upscale.comfyScale).round(),
+      (sourceSize.$1 * workflow.upscale.comfyScale).round(),
     );
     final height = math.max(
       1,
-      (decodedSource.height * workflow.upscale.comfyScale).round(),
+      (sourceSize.$2 * workflow.upscale.comfyScale).round(),
     );
     final results = await _execute(comfyModelUpscaleTemplateId, source, {
       'upscale_model': model,
@@ -238,9 +238,9 @@ final class Img2ImgUpscaleCoordinator {
       return const Img2ImgUpscaleRejected(Img2ImgUpscaleFailure.noResult);
     }
     final bytes = results.last;
-    final decoded = img.decodeImage(bytes);
-    final outputWidth = decoded?.width ?? width;
-    final outputHeight = decoded?.height ?? height;
+    final outputSize = NaiResolutionAdapter.readImageSize(bytes);
+    final outputWidth = outputSize?.$1 ?? width;
+    final outputHeight = outputSize?.$2 ?? height;
     await _register(bytes, params, source, outputWidth, outputHeight);
     return Img2ImgUpscaleSuccess(
       kind: Img2ImgUpscaleKind.regular,
@@ -254,8 +254,8 @@ final class Img2ImgUpscaleCoordinator {
     Uint8List source,
     ImageWorkflowState workflow,
   ) async {
-    final decodedSource = img.decodeImage(source);
-    if (decodedSource == null) {
+    final sourceSize = NaiResolutionAdapter.readImageSize(source);
+    if (sourceSize == null) {
       return const Img2ImgUpscaleRejected(
         Img2ImgUpscaleFailure.sourceDecodeFailed,
       );
@@ -268,13 +268,13 @@ final class Img2ImgUpscaleCoordinator {
       return const Img2ImgUpscaleRejected(Img2ImgUpscaleFailure.noResult);
     }
     final bytes = results.last;
-    final decoded = img.decodeImage(bytes);
+    final outputSize = NaiResolutionAdapter.readImageSize(bytes);
     final width =
-        decoded?.width ??
-        math.max(8, ((decodedSource.width * scale) / 8).round() * 8);
+        outputSize?.$1 ??
+        math.max(8, ((sourceSize.$1 * scale) / 8).round() * 8);
     final height =
-        decoded?.height ??
-        math.max(8, ((decodedSource.height * scale) / 8).round() * 8);
+        outputSize?.$2 ??
+        math.max(8, ((sourceSize.$2 * scale) / 8).round() * 8);
     await _register(bytes, params, source, width, height);
     return Img2ImgUpscaleSuccess(
       kind: Img2ImgUpscaleKind.rtx,

--- a/test/presentation/screens/generation/widgets/img2img_upscale_coordinator_test.dart
+++ b/test/presentation/screens/generation/widgets/img2img_upscale_coordinator_test.dart
@@ -1,0 +1,382 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:nai_launcher/core/comfyui/seedvr2_support.dart';
+import 'package:nai_launcher/data/models/image/image_params.dart';
+import 'package:nai_launcher/presentation/providers/comfyui/comfyui_provider.dart';
+import 'package:nai_launcher/presentation/providers/generation/image_workflow_controller.dart';
+import 'package:nai_launcher/presentation/providers/image_generation_provider.dart';
+import 'package:nai_launcher/presentation/providers/image_save_settings_provider.dart';
+import 'package:nai_launcher/presentation/screens/generation/widgets/img2img_upscale_coordinator.dart';
+
+const _coordinatorPath =
+    'lib/presentation/screens/generation/widgets/img2img_upscale_coordinator.dart';
+
+const _regularModel = '4x-UltraSharp.pth';
+const _legacySeedvr2Model = 'seedvr2_ema_3b_fp8_e4m3fn.safetensors';
+
+const _legacyCapabilities = ComfySeedvr2Capabilities(
+  legacyNodesAvailable: true,
+  legacyModels: [_legacySeedvr2Model],
+);
+
+void main() {
+  final png = _png(320, 200);
+  final jpeg = Uint8List.fromList(
+    img.encodeJpg(img.Image(width: 320, height: 200)),
+  );
+  final webp = _losslessWebp(320, 200);
+  final unreadable = Uint8List.fromList([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+  group('Img2ImgUpscaleCoordinator source sizing', () {
+    test('every comfy module reads the same size from one source', () async {
+      final sizes = <ComfyUpscaleModule, (int?, int?)>{};
+      for (final module in ComfyUpscaleModule.values) {
+        final harness = _Harness(
+          source: png,
+          module: module,
+          scale: 1.0,
+          results: [unreadable],
+        );
+        addTearDown(harness.dispose);
+
+        final result = await harness.run();
+
+        expect(result, isA<Img2ImgUpscaleSuccess>(), reason: module.name);
+        sizes[module] = (harness.registeredWidth, harness.registeredHeight);
+      }
+
+      expect(sizes.values.toSet(), equals({(320, 200)}));
+    });
+
+    test('reads png, jpeg and webp headers without decoding pixels', () async {
+      for (final source in <String, Uint8List>{
+        'png': png,
+        'jpeg': jpeg,
+        'webp': webp,
+      }.entries) {
+        final harness = _Harness(
+          source: source.value,
+          module: ComfyUpscaleModule.regular,
+          scale: 1.0,
+          results: [unreadable],
+        );
+        addTearDown(harness.dispose);
+
+        await harness.run();
+
+        expect(harness.paramValues?['target_width'], 320, reason: source.key);
+        expect(harness.paramValues?['target_height'], 200, reason: source.key);
+        expect(harness.registeredWidth, 320, reason: source.key);
+        expect(harness.registeredHeight, 200, reason: source.key);
+      }
+    });
+
+    test(
+      'seedvr2 target resolution follows the source shortest side',
+      () async {
+        final harness = _Harness(
+          source: png,
+          module: ComfyUpscaleModule.seedvr2,
+          scale: 1.5,
+          results: [unreadable],
+        );
+        addTearDown(harness.dispose);
+
+        await harness.run();
+
+        expect(harness.paramValues?['target_resolution'], 300);
+      },
+    );
+
+    test('rejects a source whose header cannot be parsed', () async {
+      for (final module in ComfyUpscaleModule.values) {
+        final harness = _Harness(
+          source: unreadable,
+          module: module,
+          scale: 1.5,
+          results: [png],
+        );
+        addTearDown(harness.dispose);
+
+        final result = await harness.run();
+
+        expect(
+          result,
+          isA<Img2ImgUpscaleRejected>().having(
+            (rejected) => rejected.reason,
+            'reason',
+            Img2ImgUpscaleFailure.sourceDecodeFailed,
+          ),
+          reason: module.name,
+        );
+        expect(harness.registeredWidth, isNull, reason: module.name);
+      }
+    });
+  });
+
+  group('Img2ImgUpscaleCoordinator output sizing', () {
+    test('reports no result for empty and missing backend output', () async {
+      for (final results in <List<Uint8List>?>[null, const []]) {
+        for (final module in ComfyUpscaleModule.values) {
+          final harness = _Harness(
+            source: png,
+            module: module,
+            scale: 1.5,
+            results: results,
+          );
+          addTearDown(harness.dispose);
+
+          final result = await harness.run();
+
+          expect(
+            result,
+            isA<Img2ImgUpscaleRejected>().having(
+              (rejected) => rejected.reason,
+              'reason',
+              Img2ImgUpscaleFailure.noResult,
+            ),
+            reason: module.name,
+          );
+        }
+      }
+    });
+
+    test('uses the output header when it is readable', () async {
+      for (final module in ComfyUpscaleModule.values) {
+        final harness = _Harness(
+          source: png,
+          module: module,
+          scale: 1.5,
+          results: [_png(640, 400)],
+        );
+        addTearDown(harness.dispose);
+
+        final result = await harness.run();
+
+        expect(
+          result,
+          isA<Img2ImgUpscaleSuccess>()
+              .having((success) => success.width, 'width', 640)
+              .having((success) => success.height, 'height', 400),
+          reason: module.name,
+        );
+        expect(harness.registeredWidth, 640, reason: module.name);
+        expect(harness.registeredHeight, 400, reason: module.name);
+      }
+    });
+
+    test('falls back to per-module scaling for unreadable output', () async {
+      const expected = {
+        ComfyUpscaleModule.seedvr2: (480, 300),
+        ComfyUpscaleModule.regular: (480, 300),
+        ComfyUpscaleModule.rtx: (480, 304),
+      };
+
+      for (final module in ComfyUpscaleModule.values) {
+        final harness = _Harness(
+          source: png,
+          module: module,
+          scale: 1.5,
+          results: [unreadable],
+        );
+        addTearDown(harness.dispose);
+
+        await harness.run();
+
+        expect(
+          (harness.registeredWidth, harness.registeredHeight),
+          expected[module],
+          reason: module.name,
+        );
+      }
+    });
+  });
+
+  test('upscale coordinator never decodes full frames', () {
+    final source = File(_coordinatorPath).readAsStringSync();
+
+    expect(source, isNot(contains('decodeImage(')));
+    expect(source, isNot(contains('package:image/image.dart')));
+    expect(source, contains('NaiResolutionAdapter.readImageSize'));
+  });
+}
+
+final class _Harness {
+  _Harness({
+    required Uint8List source,
+    required ComfyUpscaleModule module,
+    required double scale,
+    required List<Uint8List>? results,
+  }) : _task = _StubComfyTask(results),
+       _registrar = _RecordingImageGenerationNotifier() {
+    final settings = UpscaleWorkflowSettings(
+      comfyModule: module,
+      comfyScale: scale,
+      comfyRegularModel: _regularModel,
+      comfySeedvr2LegacyModel: _legacySeedvr2Model,
+      seedvr2Engine: ComfySeedvr2Engine.legacy,
+    );
+    _container = ProviderContainer(
+      overrides: [
+        generationParamsNotifierProvider.overrideWith(
+          () => _StubGenerationParams(ImageParams(sourceImage: source)),
+        ),
+        imageWorkflowControllerProvider.overrideWith(
+          () => _StubWorkflowController(
+            ImageWorkflowState(
+              mode: ImageWorkflowMode.upscale,
+              upscale: settings,
+            ),
+          ),
+        ),
+        comfyUISeedvr2ModelsProvider.overrideWith(
+          () => _StubSeedvr2Models(const [
+            _regularModel,
+            _legacySeedvr2Model,
+          ], _legacyCapabilities),
+        ),
+        comfyUITaskProvider.overrideWith(() => _task),
+        imageGenerationNotifierProvider.overrideWith(() => _registrar),
+        imageSaveSettingsNotifierProvider.overrideWith(
+          _StubImageSaveSettings.new,
+        ),
+      ],
+    );
+    // 两个 ComfyUI provider 是 autoDispose，订阅住才能保证桩 Notifier 只挂载一次。
+    _subscriptions = [
+      _container.listen(comfyUITaskProvider, (_, _) {}),
+      _container.listen(comfyUISeedvr2ModelsProvider, (_, _) {}),
+    ];
+  }
+
+  final _StubComfyTask _task;
+  final _RecordingImageGenerationNotifier _registrar;
+  late final ProviderContainer _container;
+  late final List<ProviderSubscription<Object?>> _subscriptions;
+
+  Map<String, dynamic>? get paramValues => _task.paramValues;
+  int? get registeredWidth => _registrar.width;
+  int? get registeredHeight => _registrar.height;
+
+  Future<Img2ImgUpscaleResult> run() =>
+      _container.read(img2ImgUpscaleCoordinatorProvider).run();
+
+  void dispose() {
+    for (final subscription in _subscriptions) {
+      subscription.close();
+    }
+    _container.dispose();
+  }
+}
+
+final class _StubGenerationParams extends GenerationParamsNotifier {
+  _StubGenerationParams(this._params);
+
+  final ImageParams _params;
+
+  @override
+  ImageParams build() => _params;
+}
+
+final class _StubWorkflowController extends ImageWorkflowController {
+  _StubWorkflowController(this._state);
+
+  final ImageWorkflowState _state;
+
+  @override
+  ImageWorkflowState build() => _state;
+}
+
+final class _StubSeedvr2Models extends ComfyUISeedvr2Models {
+  _StubSeedvr2Models(this._models, this._capabilities);
+
+  final List<String> _models;
+  final ComfySeedvr2Capabilities _capabilities;
+
+  @override
+  ComfySeedvr2Capabilities get capabilities => _capabilities;
+
+  @override
+  List<String> build() => _models;
+}
+
+final class _StubComfyTask extends ComfyUITask {
+  _StubComfyTask(this._results);
+
+  final List<Uint8List>? _results;
+  Map<String, dynamic>? paramValues;
+
+  @override
+  ComfyUITaskState build() => const ComfyUITaskState();
+
+  @override
+  Future<List<Uint8List>?> execute({
+    required String templateId,
+    Map<String, Uint8List> inputImages = const {},
+    Map<String, dynamic> paramValues = const {},
+  }) async {
+    this.paramValues = paramValues;
+    return _results;
+  }
+}
+
+final class _RecordingImageGenerationNotifier extends ImageGenerationNotifier {
+  int? width;
+  int? height;
+
+  @override
+  ImageGenerationState build() => const ImageGenerationState();
+
+  @override
+  Future<String?> registerExternalImage(
+    Uint8List imageBytes, {
+    required ImageParams params,
+    int? width,
+    int? height,
+    Uint8List? comparisonSourceImage,
+    bool saveToLocal = false,
+    String? saveDirectoryPath,
+    bool syncToGalleryIndex = true,
+    bool addToDisplay = false,
+    bool replaceCurrentDisplay = false,
+    bool embedNaiMetadata = true,
+  }) async {
+    this.width = width;
+    this.height = height;
+    return null;
+  }
+}
+
+final class _StubImageSaveSettings extends ImageSaveSettingsNotifier {
+  @override
+  ImageSaveSettings build() => const ImageSaveSettings();
+}
+
+Uint8List _png(int width, int height) =>
+    Uint8List.fromList(img.encodePng(img.Image(width: width, height: height)));
+
+/// 最小 VP8L 无损 WebP：1 字节签名后紧跟 14 位宽、14 位高、1 位 alpha、3 位版本。
+Uint8List _losslessWebp(int width, int height) {
+  const payloadSize = 16;
+  final builder = BytesBuilder()
+    ..add(ascii.encode('RIFF'))
+    ..add(_uint32Le(4 + 8 + payloadSize))
+    ..add(ascii.encode('WEBP'))
+    ..add(ascii.encode('VP8L'))
+    ..add(_uint32Le(payloadSize))
+    ..addByte(0x2f)
+    ..add(_uint32Le((width - 1) | ((height - 1) << 14)))
+    ..add(Uint8List(payloadSize - 5));
+  return builder.toBytes();
+}
+
+Uint8List _uint32Le(int value) {
+  final bytes = Uint8List(4);
+  ByteData.view(bytes.buffer).setUint32(0, value, Endian.little);
+  return bytes;
+}


### PR DESCRIPTION
## 用户可见变化

图生图超分启动更快、峰值内存更低，出图结果不变。

## 问题

三个 ComfyUI 超分后端此前对输入和输出各做一次 `img.decodeImage`，只为取 width/height，却在主 isolate 上完整解码像素并分配整帧缓冲。

## 改动

六处统一改用 `NaiResolutionAdapter.readImageSize`，只解析编码头。输入读不到尺寸仍返回 `sourceDecodeFailed`，输出读不到尺寸仍走各后端原有的回退换算。

## 验证

- `flutter analyze` —— 零问题
- `scripts/run_flutter_tests.ps1` —— 5524 通过 / 1 跳过 / 0 失败（集成分支）
- `flutter build windows --release` 并启动产物人工验收
- 新增 `img2img_upscale_coordinator_test.dart`（382 行）

无生成文件、LFS 或 assets 变更。
