### PR TITLE
fix(agent-chat): 操作栏不再自带色面，并修掉设置写入的初始化竞态

### DIFF
--- a/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
+++ b/lib/presentation/agent_chat/widgets/agent_chat_messages.dart
@@ -882,31 +882,27 @@ class _AssistantActionBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Material(
+    // 两个图标与同行的时间戳一样属于消息附属信息，不承载独立层级，
+    // 因此不铺色面；按钮自身的 hover 与按压反馈已足够表达可点。
+    return Row(
       key: ValueKey('agent-assistant-message-actions-$messageIndex'),
-      color: theme.colorScheme.surfaceContainerLow,
-      borderRadius: BorderRadius.circular(12),
-      clipBehavior: Clip.antiAlias,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _MessageActionButton(
-            key: ValueKey('agent-assistant-message-copy-$messageIndex'),
-            tooltip: context.l10n.common_copy,
-            icon: Icons.copy_all_outlined,
-            largeHitArea: true,
-            onPressed: onCopy,
-          ),
-          _MessageActionButton(
-            key: ValueKey('agent-assistant-message-retry-$messageIndex'),
-            tooltip: context.l10n.common_retry,
-            icon: Icons.refresh_rounded,
-            largeHitArea: true,
-            onPressed: onRetry,
-          ),
-        ],
-      ),
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _MessageActionButton(
+          key: ValueKey('agent-assistant-message-copy-$messageIndex'),
+          tooltip: context.l10n.common_copy,
+          icon: Icons.copy_all_outlined,
+          largeHitArea: true,
+          onPressed: onCopy,
+        ),
+        _MessageActionButton(
+          key: ValueKey('agent-assistant-message-retry-$messageIndex'),
+          tooltip: context.l10n.common_retry,
+          icon: Icons.refresh_rounded,
+          largeHitArea: true,
+          onPressed: onRetry,
+        ),
+      ],
     );
   }
 }

--- a/test/presentation/agent_chat/agent_chat_notifier_edit_test.dart
+++ b/test/presentation/agent_chat/agent_chat_notifier_edit_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -111,15 +112,45 @@ Future<void> _configureRoute(ProviderContainer container) async {
   await Future<void>.delayed(const Duration(milliseconds: 20));
 }
 
+// Chat can report initialized while agent settings are still loading, and
+// settings reject every write until their own load finishes.
 Future<void> _waitForInitialized(
   ProviderContainer container,
   StateNotifierProvider<AgentChatNotifier, AgentChatState> provider,
 ) async {
-  for (var attempt = 0; attempt < 200; attempt++) {
-    if (container.read(provider).initialized) return;
-    await Future<void>.delayed(const Duration(milliseconds: 10));
+  await _waitForProviderState<AgentChatState>(
+    container,
+    provider,
+    (state) => state.initialized,
+    'AgentChatNotifier did not initialize',
+  );
+  await _waitForProviderState<AgentSettingsState>(
+    container,
+    agentSettingsProvider,
+    (state) => state.initialized,
+    'AgentSettingsNotifier did not initialize',
+  );
+  expect(container.read(agentSettingsProvider).error, isEmpty);
+}
+
+Future<void> _waitForProviderState<T>(
+  ProviderContainer container,
+  ProviderListenable<T> provider,
+  bool Function(T state) isReady,
+  String failureMessage,
+) async {
+  final ready = Completer<void>();
+  final subscription = container.listen<T>(provider, (_, next) {
+    if (isReady(next) && !ready.isCompleted) ready.complete();
+  }, fireImmediately: true);
+  try {
+    await ready.future.timeout(
+      const Duration(seconds: 5),
+      onTimeout: () => fail(failureMessage),
+    );
+  } finally {
+    subscription.close();
   }
-  fail('AgentChatNotifier did not initialize');
 }
 
 class _MemoryStorage extends LocalStorageService {

--- a/test/presentation/agent_chat/providers/agent_chat_notifier_test.dart
+++ b/test/presentation/agent_chat/providers/agent_chat_notifier_test.dart
@@ -1283,17 +1283,45 @@ AssistantMessage _assistant(Usage usage) {
   );
 }
 
+// Chat can report initialized while agent settings are still loading, and
+// settings reject every write until their own load finishes.
 Future<void> _waitForInitialized(
   ProviderContainer container,
   StateNotifierProvider<AgentChatNotifier, AgentChatState> provider,
 ) async {
-  for (var attempt = 0; attempt < 200; attempt++) {
-    if (container.read(provider).initialized) {
-      return;
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 10));
+  await _waitForProviderState<AgentChatState>(
+    container,
+    provider,
+    (state) => state.initialized,
+    'AgentChatNotifier did not initialize',
+  );
+  await _waitForProviderState<AgentSettingsState>(
+    container,
+    agentSettingsProvider,
+    (state) => state.initialized,
+    'AgentSettingsNotifier did not initialize',
+  );
+  expect(container.read(agentSettingsProvider).error, isEmpty);
+}
+
+Future<void> _waitForProviderState<T>(
+  ProviderContainer container,
+  ProviderListenable<T> provider,
+  bool Function(T state) isReady,
+  String failureMessage,
+) async {
+  final ready = Completer<void>();
+  final subscription = container.listen<T>(provider, (_, next) {
+    if (isReady(next) && !ready.isCompleted) ready.complete();
+  }, fireImmediately: true);
+  try {
+    await ready.future.timeout(
+      const Duration(seconds: 5),
+      onTimeout: () => fail(failureMessage),
+    );
+  } finally {
+    subscription.close();
   }
-  fail('AgentChatNotifier did not initialize');
 }
 
 Future<void> _waitForCondition(
@@ -1311,15 +1339,12 @@ Future<void> _waitForSkill(
   ProviderContainer container,
   StateNotifierProvider<AgentChatNotifier, AgentChatState> provider,
   String name,
-) async {
-  for (var attempt = 0; attempt < 200; attempt++) {
-    if (container.read(provider).skills.any((skill) => skill.name == name)) {
-      return;
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-  }
-  fail('AgentChatNotifier did not inject enabled Skill $name');
-}
+) => _waitForProviderState<AgentChatState>(
+  container,
+  provider,
+  (state) => state.skills.any((skill) => skill.name == name),
+  'AgentChatNotifier did not inject enabled Skill $name',
+);
 
 class _MemoryLocalStorage extends LocalStorageService {
   final Map<String, Object?> _values = {};

--- a/test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart
+++ b/test/presentation/agent_chat/widgets/agent_chat_messages_layout_test.dart
@@ -99,6 +99,19 @@ void main() {
         tester.getCenter(time).dy,
         closeTo(tester.getCenter(actions).dy, 1),
       );
+      // 操作栏与同行时间戳同属消息附属信息，不得自带色面把自己抬成独立层级。
+      // 按填充色而非部件类型断言：换一种容器铺色面同样要被挡住。
+      final filledFooterSurfaces = tester
+          .widgetList<Material>(
+            find.descendant(
+              of: find.byKey(
+                const ValueKey('agent-assistant-message-footer-1'),
+              ),
+              matching: find.byType(Material),
+            ),
+          )
+          .where((material) => (material.color?.a ?? 0) > 0);
+      expect(filledFooterSurfaces, isEmpty);
       for (final removedAction in ['helpful', 'not-helpful', 'share']) {
         expect(
           find.byKey(ValueKey('agent-assistant-message-$removedAction-1')),


### PR DESCRIPTION
## 用户可见变化

智能代理对话里，助手消息底部的复制与重试两个图标不再被一块浅色圆角胶囊包着，直接浮在消息背景上，与同行的时间戳视觉层级一致。

另含一处测试稳定性修复，无用户可见影响。

## 改动一：操作栏去掉色面

两个图标外层套着 `Material(color: surfaceContainerLow, borderRadius: 12)`，在消息背景上明显是另一块颜色。它们与同行的时间戳一样只是消息附属信息，不承载独立层级；按 `DESIGN.md` 的 Quiet Layered Utility，这里不该铺色面。

去掉外层 `Material` 改用 `Row`。图标尺寸、48×48 命中区、与时间戳的垂直对齐全部不变，按钮自身的 hover 与按压反馈仍在。

布局测试新增一条断言：脚注内不得存在带填充色的 `Material`。按填充色而非部件类型断言，换一种容器铺色面同样会被挡住。该断言做过反向验证——还原成旧实现时会失败。

## 改动二：测试初始化竞态

对话可以在智能体设置仍在加载时就报告 `initialized`，而设置在自己加载完成前会拒绝一切写入，于是只等对话 `initialized` 的用例会偶发 `StateError`。改为监听两个 provider 直到各自 `initialized`，并断言设置无加载错误；原先的 200 次轮询延时一并去掉。

## 验证

- `flutter analyze` —— 零问题
- `flutter test test/presentation/agent_chat/` —— 428 通过
- `flutter build windows --release` 并启动产物人工验收

无生成文件、LFS 或 assets 变更。
