### PR TITLE
fix(fixed-tags): 面板头高度预算跟随文字缩放

### DIFF
--- a/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
+++ b/lib/presentation/screens/generation/widgets/fixed_tags_sidebar.dart
@@ -26,6 +26,44 @@ import 'sidebar_link_painter.dart';
 const _uncategorizedSectionId = '__uncategorized__';
 const _linkDetachDistance = 36.0;
 
+bool _paneHeaderUsesLargeText(BuildContext context) =>
+    MediaQuery.textScalerOf(context).scale(14) >= 28;
+
+EdgeInsets _paneHeaderPadding(BuildContext context) =>
+    _paneHeaderUsesLargeText(context)
+    ? const EdgeInsets.fromLTRB(8, 2, 4, 2)
+    : const EdgeInsets.fromLTRB(10, 8, 6, 6);
+
+double _scaledLineExtent(BuildContext context, TextStyle? style) {
+  final fontSize = MediaQuery.textScalerOf(
+    context,
+  ).scale(style?.fontSize ?? 14);
+  return fontSize * (style?.height ?? 1.45);
+}
+
+// 标题行取名称与计数徽标中较高者，徽标另算自身竖向内边距。
+double _paneHeaderTitleExtent(BuildContext context) {
+  final textTheme = Theme.of(context).textTheme;
+  return math.max(
+    _scaledLineExtent(context, textTheme.labelLarge),
+    _scaledLineExtent(context, textTheme.labelSmall) + 4,
+  );
+}
+
+// 文字缩放器可能非线性，就地按标题字号取斜率，压缩比才落在标题真实行高上。
+double _paneHeaderTextScaleFactor(BuildContext context) {
+  final fontSize = Theme.of(context).textTheme.labelLarge?.fontSize ?? 14;
+  return MediaQuery.textScalerOf(context).scale(fontSize) / fontSize;
+}
+
+// 高度预算与 _buildPaneHeader 的实际布局必须同源：预算低估会让 _buildPaneCard 的 Column 溢出。
+double _paneHeaderExtent(BuildContext context) =>
+    math.max(
+      _paneHeaderTitleExtent(context),
+      context.interactionPolicy.minimumControlExtent,
+    ) +
+    _paneHeaderPadding(context).vertical;
+
 double _gridCardHeight(BuildContext context) {
   final scaledLabelSize = MediaQuery.textScalerOf(context).scale(14);
   // 底行取链接锚点与操作按钮中较高者：前者看有无精确指针，后者看有无触摸，两条规则会错配。
@@ -338,8 +376,10 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
                 .toDouble();
         final hasPositiveEntries = fixedState.positiveEntries.isNotEmpty;
         final hasNegativeEntries = fixedState.negativeEntries.isNotEmpty;
+        // 面板头跟随文字缩放，正文下限保持定值：跟着放大会在大字号下抢走用户拖出来的分栏高度。
+        final paneHeaderMinimumHeight = _paneHeaderExtent(context);
         const populatedMinimumHeight = 138.0;
-        const emptyMinimumHeight = 64.0;
+        final emptyMinimumHeight = paneHeaderMinimumHeight;
         final desiredPositiveMinimum = !hasPositiveEntries
             ? emptyMinimumHeight
             : isListMode
@@ -348,8 +388,7 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
         final desiredNegativeMinimum = !hasNegativeEntries
             ? emptyMinimumHeight
             : populatedMinimumHeight;
-        const paneHeaderMinimumHeight = 64.0;
-        const headerMinimumTotal = paneHeaderMinimumHeight * 2;
+        final headerMinimumTotal = paneHeaderMinimumHeight * 2;
         final bodyBudget = math.max(0.0, usableHeight - headerMinimumTotal);
         final desiredPositiveBody = math.max(
           0.0,
@@ -401,6 +440,7 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
                   positiveSections,
                   libraryEntries,
                   isListMode,
+                  positiveHeight,
                 ),
               ),
               _buildNegativeResizeDivider(
@@ -416,6 +456,7 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
                   negativeSections,
                   libraryEntries,
                   isListMode,
+                  negativeHeight,
                 ),
               ),
             ],
@@ -430,6 +471,7 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
     List<_TagSection> sections,
     List<TagLibraryEntry> libraryEntries,
     bool isListMode,
+    double paneHeight,
   ) {
     final entryCount = sections.fold<int>(
       0,
@@ -440,11 +482,13 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
       theme,
       key: const ValueKey('fixed-tags-positive-card'),
       accent: theme.colorScheme.primary,
-      header: _buildPaneHeader(
+      paneHeight: paneHeight,
+      headerBuilder: (headerExtent) => _buildPaneHeader(
         icon: Icons.add_circle_outline_rounded,
         label: context.l10n.fixedTags_positiveTitle,
         count: entryCount,
         color: theme.colorScheme.primary,
+        maxExtent: headerExtent,
         trailingBuilder: (iconOnly) => _buildGroupHeaderActions(
           keyPrefix: 'fixed-tags-positive',
           groupsKey: _positiveGroupsKey,
@@ -498,12 +542,19 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
     ThemeData theme, {
     required Key key,
     required Color accent,
-    required Widget header,
+    required double paneHeight,
+    required Widget Function(double headerExtent) headerBuilder,
     required Widget body,
   }) {
     final baseColor = sectionSurfaceColor(theme.colorScheme);
     final cardTint = theme.brightness == Brightness.dark ? 0.04 : 0.025;
     final headerTint = theme.brightness == Brightness.dark ? 0.09 : 0.065;
+    // 面板头不超过整格高度，否则下面的 Expanded 拿到 0 仍会把 Column 撑破；
+    // 下界是操作按钮命中区，压过头等于缩小操作入口。
+    final headerExtent = math.max(
+      context.interactionPolicy.minimumControlExtent,
+      math.min(_paneHeaderExtent(context), paneHeight),
+    );
     return Material(
       key: key,
       color: Color.alphaBlend(accent.withValues(alpha: cardTint), baseColor),
@@ -517,7 +568,10 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
               accent.withValues(alpha: headerTint),
               baseColor,
             ),
-            child: header,
+            child: SizedBox(
+              height: headerExtent,
+              child: headerBuilder(headerExtent),
+            ),
           ),
           Expanded(child: body),
         ],
@@ -530,26 +584,49 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
     required String label,
     required int count,
     required Color color,
+    required double maxExtent,
     Widget Function(bool iconOnly)? trailingBuilder,
   }) {
-    final usesLargeText = MediaQuery.textScalerOf(context).scale(14) >= 28;
+    final usesLargeText = _paneHeaderUsesLargeText(context);
+    final padding = _paneHeaderPadding(context);
+    final titleExtent = _paneHeaderTitleExtent(context);
+    final actionExtent = context.interactionPolicy.minimumControlExtent;
+    // 分到的高度不够时先收内边距再压标题字号，操作按钮命中区不参与压缩。
+    final verticalPadding = (maxExtent - math.max(titleExtent, actionExtent))
+        .clamp(0.0, padding.vertical)
+        .toDouble();
+    final paddingScale = padding.vertical == 0
+        ? 1.0
+        : verticalPadding / padding.vertical;
+    final contentExtent = math.max(0.0, maxExtent - verticalPadding);
+    final titleScaleFactor = _paneHeaderTextScaleFactor(context);
+    final titleMaxScaleFactor = contentExtent >= titleExtent
+        ? titleScaleFactor
+        : titleScaleFactor * contentExtent / titleExtent;
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final trailing = trailingBuilder?.call(
           constraints.maxWidth < 360 || usesLargeText,
         );
         return Padding(
-          padding: usesLargeText
-              ? const EdgeInsets.fromLTRB(8, 2, 4, 2)
-              : const EdgeInsets.fromLTRB(10, 8, 6, 6),
+          padding: EdgeInsets.fromLTRB(
+            padding.left,
+            padding.top * paddingScale,
+            padding.right,
+            padding.bottom * paddingScale,
+          ),
           child: Row(
             children: [
               Expanded(
-                child: _SectionTitle(
-                  icon: icon,
-                  label: label,
-                  count: count,
-                  color: color,
+                child: MediaQuery.withClampedTextScaling(
+                  maxScaleFactor: titleMaxScaleFactor,
+                  child: _SectionTitle(
+                    icon: icon,
+                    label: label,
+                    count: count,
+                    color: color,
+                  ),
                 ),
               ),
               if (trailing != null) trailing,
@@ -687,6 +764,7 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
     List<_TagSection> sections,
     List<TagLibraryEntry> libraryEntries,
     bool isListMode,
+    double paneHeight,
   ) {
     final entryCount = sections.fold<int>(
       0,
@@ -696,11 +774,13 @@ class _FixedTagsSidebarState extends ConsumerState<FixedTagsSidebar> {
       theme,
       key: const ValueKey('fixed-tags-negative-card'),
       accent: theme.colorScheme.error,
-      header: _buildPaneHeader(
+      paneHeight: paneHeight,
+      headerBuilder: (headerExtent) => _buildPaneHeader(
         icon: Icons.block_rounded,
         label: context.l10n.fixedTags_negativeTitle,
         count: entryCount,
         color: theme.colorScheme.error,
+        maxExtent: headerExtent,
         trailingBuilder: (iconOnly) => _buildGroupHeaderActions(
           keyPrefix: 'fixed-tags-negative',
           groupsKey: _negativeGroupsKey,

--- a/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
+++ b/test/presentation/screens/generation/widgets/fixed_tags_sidebar_test.dart
@@ -191,6 +191,57 @@ void main() {
     }
   }
 
+  for (final width in const [320.0, 600.0, 840.0]) {
+    for (final viewMode in const ['list', 'grid']) {
+      for (final scale in const [1.0, 3.0]) {
+        testWidgets(
+          '$viewMode panes at $width / ${scale}x keep headers inside the card',
+          (tester) async {
+            await _pumpSidebar(
+              tester,
+              _paneHeaderStorage(viewMode: viewMode),
+              textScale: scale,
+              viewportSize: Size(width, 620),
+            );
+
+            // 这里只断言面板头，不断言条目：正文按需构建，窄屏大字号下条目本就
+            // 落在视口之外。条目渲染由本文件其余用例覆盖。
+            _expectPaneHeadersFit(tester);
+            expect(tester.takeException(), isNull);
+          },
+        );
+      }
+    }
+  }
+
+  // 顶部卡片在 3x 下吃掉大半高度，面板头分到的高度低于自然高度时必须自己收缩。
+  testWidgets('pane headers shrink instead of overflowing a short pane', (
+    tester,
+  ) async {
+    await _pumpSidebar(
+      tester,
+      _paneHeaderStorage(),
+      textScale: 3,
+      viewportSize: const Size(320, 600),
+    );
+
+    _expectPaneHeadersFit(tester);
+    expect(tester.takeException(), isNull);
+  });
+
+  // 空面板只按面板头预算，4x 下自然高度已到 84，写死 64 就会少留 20。
+  testWidgets('empty pane reserves a text-scaled header at 4x', (tester) async {
+    await _pumpSidebar(
+      tester,
+      _paneHeaderStorage(withNegative: false),
+      textScale: 4,
+      viewportSize: const Size(320, 860),
+    );
+
+    _expectPaneHeadersFit(tester);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('select-all action follows input hit targets', (tester) async {
     tester.view.physicalSize = const Size(320, 700);
     tester.view.devicePixelRatio = 1;
@@ -3211,13 +3262,70 @@ _buildUnevenPositiveFixture() {
   return (categories: categories, entries: entries);
 }
 
+_SidebarTestStorage _paneHeaderStorage({
+  String viewMode = 'list',
+  bool withNegative = true,
+}) {
+  final category = TagLibraryCategory.create(name: '分组', sortOrder: 0);
+  final types = withNegative
+      ? FixedTagPromptType.values
+      : const [FixedTagPromptType.positive];
+  return _SidebarTestStorage(
+    fixedEntries: [
+      for (final type in types)
+        for (var index = 0; index < 6; index++)
+          FixedTagEntry.create(
+            name: '${type.name}-$index',
+            content: 'tag $index',
+            enabled: false,
+            promptType: type,
+            categoryId: category.id,
+            sortOrder: index,
+          ),
+    ],
+    categories: [category],
+    libraryEntries: const [],
+  )..fixedSidebarViewMode = viewMode;
+}
+
+// 面板头收缩后仍不得越过卡片下沿，且两侧筛选入口保持完整命中区。
+void _expectPaneHeadersFit(WidgetTester tester) {
+  for (final prefix in const ['fixed-tags-positive', 'fixed-tags-negative']) {
+    final card = find.byKey(ValueKey('$prefix-card'));
+    expect(card, findsOneWidget);
+    final header = find
+        .descendant(of: card, matching: find.byType(ColoredBox))
+        .first;
+    expect(
+      tester.getRect(header).height,
+      lessThanOrEqualTo(tester.getRect(card).height),
+      reason: '$prefix 面板头超出了卡片高度',
+    );
+
+    final action = find.byKey(ValueKey('$prefix-enabled-only'));
+    expect(action.hitTestable(), findsOneWidget);
+    expect(
+      tester.getSize(action).height,
+      greaterThanOrEqualTo(40.0),
+      reason: '$prefix 的筛选入口被压缩到命中区以下',
+    );
+  }
+}
+
 Future<void> _pumpSidebar(
   WidgetTester tester,
   _SidebarTestStorage storage, {
   double textScale = 1,
+  Size? viewportSize,
   InteractionPolicy? interactionPolicy,
   TagTranslationLookup? translationLookup,
 }) async {
+  final size = viewportSize ?? const Size(340, 620);
+  if (viewportSize != null) {
+    tester.view.physicalSize = viewportSize;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+  }
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
@@ -3240,10 +3348,10 @@ Future<void> _pumpSidebar(
         home: Scaffold(
           body: InteractionPolicyScope(
             initialPolicy: interactionPolicy,
-            child: const SizedBox(
-              width: 340,
-              height: 620,
-              child: FixedTagsSidebar(),
+            child: SizedBox(
+              width: size.width,
+              height: size.height,
+              child: const FixedTagsSidebar(),
             ),
           ),
         ),


### PR DESCRIPTION
## 用户可见变化

固定词侧栏在放大文字（2x 起）时，正负面板的标题行不再被撑破卡片。空面板也不会再出现「连面板头都装不下」的情况。筛选入口在压缩时仍保持不小于 40 的命中区。

## 问题

面板头的高度预算写死为 `64`，而它的实际高度随文字缩放变化——320 宽下实测 1x/1.5x/1.9x 都是 54、2x=44、3x=64、4x=84。预算低估时 `_buildPaneCard` 的 `Column` 直接被撑破。空面板的最小高度同样是常数，缩放后连面板头都装不下。

## 改动

- 预算改为按 `max(标题行实际行高, 操作按钮命中区) + 内边距` 实测推导；标题行取名称与计数徽标中较高者，徽标另算自身竖向内边距
- 文字缩放器可能非线性，压缩比就地按标题字号取斜率，才落在标题真实行高上
- 面板头限制在整格高度内（否则下面的 `Expanded` 拿到 0 仍会撑破 `Column`），下界是操作按钮命中区，压过头等于缩小操作入口
- 分到的高度不够时先收内边距、再压标题字号，命中区不参与压缩
- 空面板最小高度改用同一份面板头高度
- 正文最小高度**仍保持定值**：跟着放大会让空的次要面板被挤到只剩面板头，空态文案彻底看不见，还会覆盖用户拖拽持久化的分栏高度

## 与 #278 的关系

无文件区域重叠：#278 只改分组正文的构建方式，本 PR 只改面板头与高度预算，两者可独立合并。新增的矩阵不断言条目渲染，因为正文按需构建时，窄屏大字号下条目本就落在视口之外；条目渲染由同文件其余用例覆盖。

## 验证

- `flutter analyze` —— 零问题
- `flutter test .../fixed_tags_sidebar_test.dart` —— 70 通过
- 与 #278 组合后 `test/presentation/screens/generation/widgets/` 全部 243 通过
- `flutter build windows --release` 并启动产物人工验收
- 新增测试矩阵：viewMode(list/grid) × width(320/600/840) × scale(1x/3x) 断言面板头不超出卡片且筛选入口保持命中区，另加「短面板下面板头收缩而非溢出」「4x 下空面板仍预留缩放后的面板头」

无生成文件、LFS 或 assets 变更。
