### PR TITLE
perf(图库): 后台解析元数据并减少重复读取与资源占用

### DIFF
--- a/lib/core/utils/read_image_dimensions.dart
+++ b/lib/core/utils/read_image_dimensions.dart
@@ -1,0 +1,19 @@
+import 'dart:ui' as ui;
+
+/// Reads encoded dimensions without retaining the native buffer or descriptor.
+Future<ui.Size> readImageDimensions(
+  String path, {
+  Future<ui.ImmutableBuffer> Function(String)? createBuffer,
+  Future<ui.ImageDescriptor> Function(ui.ImmutableBuffer)? createDescriptor,
+}) async {
+  ui.ImmutableBuffer? buffer;
+  ui.ImageDescriptor? descriptor;
+  try {
+    buffer = await (createBuffer ?? ui.ImmutableBuffer.fromFilePath)(path);
+    descriptor = await (createDescriptor ?? ui.ImageDescriptor.encoded)(buffer);
+    return ui.Size(descriptor.width.toDouble(), descriptor.height.toDouble());
+  } finally {
+    descriptor?.dispose();
+    buffer?.dispose();
+  }
+}

--- a/lib/data/services/image_metadata_service.dart
+++ b/lib/data/services/image_metadata_service.dart
@@ -7,6 +7,7 @@ import 'package:hive/hive.dart';
 import '../../core/utils/app_logger.dart';
 import '../models/gallery/nai_image_metadata.dart';
 import 'metadata/cache_manager.dart';
+import 'metadata/background_metadata_parser.dart';
 import 'metadata/hash_calculator.dart';
 import 'metadata/preloader.dart';
 import 'metadata/unified_metadata_parser.dart';
@@ -129,7 +130,8 @@ class ParseStatistics {
 /// - 详细的解析统计
 /// - 增强的错误处理
 class ImageMetadataService {
-  static final ImageMetadataService _instance = ImageMetadataService._internal();
+  static final ImageMetadataService _instance =
+      ImageMetadataService._internal();
   factory ImageMetadataService() => _instance;
   ImageMetadataService._internal();
 
@@ -214,7 +216,10 @@ class ImageMetadataService {
     // 设置超时
     final timeoutTimer = Timer(_highPriorityTimeout, () {
       if (!taskCompleter.isCompleted) {
-        AppLogger.w('[MetadataFlow] Parse timeout for: $path', 'ImageMetadataService');
+        AppLogger.w(
+          '[MetadataFlow] Parse timeout for: $path',
+          'ImageMetadataService',
+        );
         _statistics.recordTimeout();
         taskCompleter.complete(null);
       }
@@ -244,7 +249,12 @@ class ImageMetadataService {
       }
       return null;
     } catch (e, stack) {
-      AppLogger.e('[MetadataFlow] Parse error', e, stack, 'ImageMetadataService');
+      AppLogger.e(
+        '[MetadataFlow] Parse error',
+        e,
+        stack,
+        'ImageMetadataService',
+      );
       if (!taskCompleter.isCompleted) {
         taskCompleter.complete(null);
       }
@@ -311,7 +321,10 @@ class ImageMetadataService {
     final actualTimeout = timeout ?? _defaultParseTimeout;
     final timeoutTimer = Timer(actualTimeout, () {
       if (!taskCompleter.isCompleted) {
-        AppLogger.w('[MetadataFlow] Parse timeout for: $path', 'ImageMetadataService');
+        AppLogger.w(
+          '[MetadataFlow] Parse timeout for: $path',
+          'ImageMetadataService',
+        );
         _statistics.recordTimeout();
         taskCompleter.complete(null);
       }
@@ -345,7 +358,12 @@ class ImageMetadataService {
       }
       return null;
     } catch (e, stack) {
-      AppLogger.e('[MetadataFlow] Parse error', e, stack, 'ImageMetadataService');
+      AppLogger.e(
+        '[MetadataFlow] Parse error',
+        e,
+        stack,
+        'ImageMetadataService',
+      );
       if (!taskCompleter.isCompleted) {
         taskCompleter.complete(null);
       }
@@ -358,7 +376,7 @@ class ImageMetadataService {
 
   /// 从字节数组获取元数据
   Future<NaiImageMetadata?> getMetadataFromBytes(Uint8List bytes) async {
-    final hash = _hashCalculator.calculateFromBytes(bytes);
+    final hash = await _hashCalculator.calculateFromBytesInBackground(bytes);
 
     // 检查 L1 内存缓存
     final memoryCached = _cacheManager.getFromMemory(hash);
@@ -411,7 +429,7 @@ class ImageMetadataService {
   Future<MetadataParseResult> getMetadataParseResultFromBytes(
     Uint8List bytes,
   ) async {
-    final hash = _hashCalculator.calculateFromBytes(bytes);
+    final hash = await _hashCalculator.calculateFromBytesInBackground(bytes);
     final cached =
         _cacheManager.getFromMemory(hash) ??
         _cacheManager.getFromPersistent(hash);
@@ -427,7 +445,7 @@ class ImageMetadataService {
 
     final stopwatch = Stopwatch()..start();
     try {
-      final result = UnifiedMetadataParser.parseFromImage(bytes);
+      final result = await parseMetadataBytesInBackground(bytes);
       final metadata = result.success ? result.metadata : null;
       if (metadata != null && metadata.hasData) {
         try {
@@ -479,7 +497,6 @@ class ImageMetadataService {
 
   /// 从缓存获取元数据（同步检查）
   NaiImageMetadata? getCached(String path) {
-
     final hash = _hashCalculator.getHashForPath(path);
     if (hash == null) return null;
 
@@ -550,7 +567,8 @@ class ImageMetadataService {
   Box<String>? get persistentBox => _cacheManager.box;
 
   /// 获取哈希对应的所有路径
-  List<String> getPathsForHash(String hash) => _hashCalculator.getPathsForHash(hash);
+  List<String> getPathsForHash(String hash) =>
+      _hashCalculator.getPathsForHash(hash);
 
   /// 获取解析统计
   ParseStatistics get parseStatistics => _statistics;
@@ -612,7 +630,10 @@ class ImageMetadataService {
       final file = File(path);
       // 检查文件是否存在
       if (!await file.exists()) {
-        AppLogger.w('[MetadataFlow] File NOT FOUND: $path', 'ImageMetadataService');
+        AppLogger.w(
+          '[MetadataFlow] File NOT FOUND: $path',
+          'ImageMetadataService',
+        );
         _statistics.recordFailure('file_not_found', totalStopwatch.elapsed);
         return null;
       }
@@ -628,11 +649,7 @@ class ImageMetadataService {
       try {
         _checkCancelled(cancelToken);
 
-        final result = UnifiedMetadataParser.parseFromFile(
-          path,
-          useGradualRead: true,
-          useCache: true,
-        );
+        final result = await parseMetadataFileInBackground(path);
 
         parseStopwatch.stop();
 
@@ -643,7 +660,10 @@ class ImageMetadataService {
         }
       } catch (e, _) {
         parseStopwatch.stop();
-        AppLogger.w('[MetadataFlow] Unified parse error: $e', 'ImageMetadataService');
+        AppLogger.w(
+          '[MetadataFlow] Unified parse error: $e',
+          'ImageMetadataService',
+        );
         metadata = null;
       }
 
@@ -677,8 +697,16 @@ class ImageMetadataService {
       rethrow;
     } catch (e, stack) {
       totalStopwatch.stop();
-      _statistics.recordFailure('exception: ${e.runtimeType}', totalStopwatch.elapsed);
-      AppLogger.e('[MetadataFlow] Parse FAILED: $path', e, stack, 'ImageMetadataService');
+      _statistics.recordFailure(
+        'exception: ${e.runtimeType}',
+        totalStopwatch.elapsed,
+      );
+      AppLogger.e(
+        '[MetadataFlow] Parse FAILED: $path',
+        e,
+        stack,
+        'ImageMetadataService',
+      );
       return null;
     }
   }
@@ -695,19 +723,25 @@ class ImageMetadataService {
         return null;
       }
 
-      final result = UnifiedMetadataParser.parseFromImage(bytes);
+      final result = await parseMetadataBytesInBackground(bytes);
       final metadata = result.success ? result.metadata : null;
 
       if (metadata != null && metadata.hasData) {
         await _cacheManager.save(hash, metadata);
         _statistics.recordSuccess(stopwatch.elapsed);
       } else {
-        _statistics.recordFailure(result.errorMessage ?? 'unknown', stopwatch.elapsed);
+        _statistics.recordFailure(
+          result.errorMessage ?? 'unknown',
+          stopwatch.elapsed,
+        );
       }
 
       return metadata;
     } catch (e, stack) {
-      _statistics.recordFailure('exception: ${e.runtimeType}', stopwatch.elapsed);
+      _statistics.recordFailure(
+        'exception: ${e.runtimeType}',
+        stopwatch.elapsed,
+      );
       AppLogger.e('Parse bytes failed', e, stack, 'ImageMetadataService');
       return null;
     }

--- a/lib/data/services/metadata/background_metadata_parser.dart
+++ b/lib/data/services/metadata/background_metadata_parser.dart
@@ -1,0 +1,20 @@
+import 'dart:typed_data';
+
+import '../../../core/utils/isolate_pool.dart';
+import 'unified_metadata_parser.dart';
+
+Future<MetadataParseResult> parseMetadataFileInBackground(String path) =>
+    ComputeGate().runCompute(_parseFile, path, debugLabel: 'metadata-file');
+
+Future<MetadataParseResult> parseMetadataBytesInBackground(Uint8List bytes) =>
+    ComputeGate().runCompute(_parseBytes, bytes, debugLabel: 'metadata-bytes');
+
+MetadataParseResult _parseFile(String path) =>
+    UnifiedMetadataParser.parseFromFile(
+      path,
+      useGradualRead: true,
+      useCache: true,
+    );
+
+MetadataParseResult _parseBytes(Uint8List bytes) =>
+    UnifiedMetadataParser.parseFromImage(bytes);

--- a/lib/data/services/metadata/hash_calculator.dart
+++ b/lib/data/services/metadata/hash_calculator.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 
 import '../../../core/utils/app_logger.dart';
+import '../../../core/utils/isolate_pool.dart';
 
 /// 文件哈希计算器
 ///
@@ -58,6 +59,9 @@ class FileHashCalculator {
     return sha256.convert(bytes).toString();
   }
 
+  Future<String> calculateFromBytesInBackground(Uint8List bytes) =>
+      ComputeGate().runCompute(_hashBytes, bytes, debugLabel: 'metadata-hash');
+
   /// 注册路径到哈希的映射
   ///
   /// 用于在已知哈希的情况下建立映射关系
@@ -80,7 +84,10 @@ class FileHashCalculator {
       paths.add(newPath);
     }
 
-    AppLogger.d('Hash mapping updated: $oldPath -> $newPath', 'FileHashCalculator');
+    AppLogger.d(
+      'Hash mapping updated: $oldPath -> $newPath',
+      'FileHashCalculator',
+    );
   }
 
   /// 获取哈希对应的所有路径
@@ -120,9 +127,11 @@ class FileHashCalculator {
   Future<String> _calculateWithSemaphore(String filePath) async {
     await _semaphore.acquire();
     try {
-      final file = File(filePath);
-      final bytes = await file.readAsBytes();
-      final hash = sha256.convert(bytes).toString();
+      final hash = await ComputeGate().runCompute(
+        _hashFile,
+        filePath,
+        debugLabel: 'metadata-file-hash',
+      );
 
       // 更新映射
       _pathToHashMap[filePath] = hash;
@@ -135,6 +144,10 @@ class FileHashCalculator {
     }
   }
 }
+
+String _hashBytes(Uint8List bytes) => sha256.convert(bytes).toString();
+
+String _hashFile(String path) => _hashBytes(File(path).readAsBytesSync());
 
 /// 信号量（并发控制）
 class _Semaphore {

--- a/lib/presentation/widgets/common/image_card_controller.dart
+++ b/lib/presentation/widgets/common/image_card_controller.dart
@@ -24,7 +24,6 @@ class ImageCardController extends ChangeNotifier {
     );
     _lastStreamPreview = _capturedStreamPreview(data);
     showPreparedIndexBadge = data.dragPreparationReady;
-    if (data.isGenerating) _initGlowAnimation(vsync);
     _shareTransferCache = _createShareTransferCache();
   }
 
@@ -51,8 +50,6 @@ class ImageCardController extends ChangeNotifier {
 
   final AnimationController glossController;
   late final Animation<double> glossAnimation;
-  AnimationController? glowController;
-  Animation<double>? glowAnimation;
 
   ImageCardViewData get data => _data;
   ImageCardCapabilities get capabilities => _capabilities;
@@ -73,14 +70,6 @@ class ImageCardController extends ChangeNotifier {
     final oldCapabilities = _capabilities;
     _data = data;
     _capabilities = capabilities;
-
-    if (data.isGenerating && !oldData.isGenerating) {
-      _initGlowAnimation(vsync);
-    } else if (!data.isGenerating && oldData.isGenerating) {
-      glowController?.dispose();
-      glowController = null;
-      glowAnimation = null;
-    }
 
     if (data.streamPreview?.isNotEmpty == true) {
       _lastStreamPreview = _capturedStreamPreview(data);
@@ -134,29 +123,6 @@ class ImageCardController extends ChangeNotifier {
       glossController.stop();
       glossController.value = 0;
     }
-    final controller = glowController;
-    if (controller == null) return;
-    if (reducedMotion) {
-      controller.stop();
-      controller.value = 1 / 3;
-    } else if (!controller.isAnimating) {
-      controller.repeat(reverse: true);
-    }
-  }
-
-  void _initGlowAnimation(TickerProvider vsync) {
-    glowController?.dispose();
-    glowController = AnimationController(
-      duration: const Duration(milliseconds: 2000),
-      value: 1 / 3,
-      vsync: vsync,
-    );
-    if (_motionPreferenceInitialized && !_reducedMotion) {
-      glowController!.repeat(reverse: true);
-    }
-    glowAnimation = Tween<double>(begin: 0.04, end: 0.1).animate(
-      CurvedAnimation(parent: glowController!, curve: Curves.easeInOut),
-    );
   }
 
   void hoverEnter({required VoidCallback warmShareCache}) {
@@ -284,7 +250,6 @@ class ImageCardController extends ChangeNotifier {
   void dispose() {
     _disposed = true;
     glossController.dispose();
-    glowController?.dispose();
     _legacyTapResetTimer?.cancel();
     _doubleTapResetTimer?.cancel();
     final cache = _shareTransferCache;

--- a/lib/presentation/widgets/common/image_card_generating.dart
+++ b/lib/presentation/widgets/common/image_card_generating.dart
@@ -21,25 +21,16 @@ class ImageCardGenerating extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final hasPreview = data.streamPreview?.isNotEmpty == true;
-    final reducedMotion = MediaQuery.disableAnimationsOf(context);
-    return AnimatedBuilder(
-      animation: reducedMotion
-          ? const AlwaysStoppedAnimation(0.06)
-          : controller.glowAnimation ?? const AlwaysStoppedAnimation(0.06),
-      builder: (context, child) => Container(
-        decoration: BoxDecoration(
-          color: hasPreview ? null : theme.colorScheme.surface,
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: [
-            BoxShadow(
-              color: theme.colorScheme.primary.withValues(
-                alpha: controller.glowAnimation?.value ?? 0.06,
-              ),
-              blurRadius: 18,
-            ),
-          ],
-        ),
-        child: child,
+    return Container(
+      decoration: BoxDecoration(
+        color: hasPreview ? null : theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: theme.colorScheme.primary.withValues(alpha: 0.06),
+            blurRadius: 18,
+          ),
+        ],
       ),
       child: hasPreview ? _preview(context) : _loading(context, theme),
     );
@@ -74,18 +65,20 @@ class ImageCardGenerating extends StatelessWidget {
                 SizedBox(
                   width: 20,
                   height: 20,
-                  child: CircularProgressIndicator(
-                    key: const ValueKey('stream-generation-progress-ring'),
-                    value: progress > 0
-                        ? progress
-                        : MediaQuery.disableAnimationsOf(context)
-                        ? 0.72
-                        : null,
-                    strokeWidth: 2,
-                    backgroundColor: _streamProgressForeground.withValues(
-                      alpha: 0.24,
+                  child: RepaintBoundary(
+                    child: CircularProgressIndicator(
+                      key: const ValueKey('stream-generation-progress-ring'),
+                      value: progress > 0
+                          ? progress
+                          : MediaQuery.disableAnimationsOf(context)
+                          ? 0.72
+                          : null,
+                      strokeWidth: 2,
+                      backgroundColor: _streamProgressForeground.withValues(
+                        alpha: 0.24,
+                      ),
+                      color: _streamProgressForeground,
                     ),
-                    color: _streamProgressForeground,
                   ),
                 ),
                 const SizedBox(width: 8),
@@ -109,9 +102,11 @@ class ImageCardGenerating extends StatelessWidget {
     );
   }
 
-  Widget _streamPreview() => ImageCardStreamPreview(
-    previewBytes: data.streamPreview!,
-    placement: data.focusedPreviewPlacement,
+  Widget _streamPreview() => RepaintBoundary(
+    child: ImageCardStreamPreview(
+      previewBytes: data.streamPreview!,
+      placement: data.focusedPreviewPlacement,
+    ),
   );
 
   Widget _loading(BuildContext context, ThemeData theme) {
@@ -128,17 +123,19 @@ class ImageCardGenerating extends StatelessWidget {
               SizedBox(
                 width: 52,
                 height: 52,
-                child: CircularProgressIndicator(
-                  value: progress > 0
-                      ? progress
-                      : MediaQuery.disableAnimationsOf(context)
-                      ? 0.72
-                      : null,
-                  strokeWidth: 2.5,
-                  backgroundColor: theme.colorScheme.primary.withValues(
-                    alpha: 0.1,
+                child: RepaintBoundary(
+                  child: CircularProgressIndicator(
+                    value: progress > 0
+                        ? progress
+                        : MediaQuery.disableAnimationsOf(context)
+                        ? 0.72
+                        : null,
+                    strokeWidth: 2.5,
+                    backgroundColor: theme.colorScheme.primary.withValues(
+                      alpha: 0.1,
+                    ),
+                    color: theme.colorScheme.primary,
                   ),
-                  color: theme.colorScheme.primary,
                 ),
               ),
               Icon(

--- a/lib/presentation/widgets/common/image_card_stream_preview.dart
+++ b/lib/presentation/widgets/common/image_card_stream_preview.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
@@ -6,16 +7,26 @@ import 'package:flutter/material.dart';
 
 import '../../../data/models/image/image_stream_chunk.dart';
 
-/// 流式预览的持帧渲染层：新帧解码完成前继续画上一帧。
+typedef StreamPreviewImageDecoder =
+    Future<ui.Image> Function(
+      Uint8List bytes, {
+      required int? targetWidth,
+      required int? targetHeight,
+    });
+
+/// Holds the last decoded frame until its replacement is ready.
 class ImageCardStreamPreview extends StatefulWidget {
   const ImageCardStreamPreview({
     super.key,
     required this.previewBytes,
     this.placement,
+    this.imageDecoder,
   });
 
   final Uint8List previewBytes;
   final FocusedStreamPreviewPlacement? placement;
+  @visibleForTesting
+  final StreamPreviewImageDecoder? imageDecoder;
 
   @override
   State<ImageCardStreamPreview> createState() => _ImageCardStreamPreviewState();
@@ -28,18 +39,6 @@ class _ImageCardStreamPreviewState extends State<ImageCardStreamPreview> {
   bool _resolving = false;
 
   @override
-  void initState() {
-    super.initState();
-    _resolveImages();
-  }
-
-  @override
-  void didUpdateWidget(covariant ImageCardStreamPreview oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    _resolveImages();
-  }
-
-  @override
   void dispose() {
     _preview.dispose();
     _source.dispose();
@@ -49,24 +48,57 @@ class _ImageCardStreamPreviewState extends State<ImageCardStreamPreview> {
 
   @override
   Widget build(BuildContext context) {
-    return CustomPaint(
-      painter: ImageCardStreamPreviewPainter(
-        previewImage: _preview.image,
-        sourceImage: _source.image,
-        maskImage: _mask.image,
-        placement: widget.placement,
-      ),
+    final ratio = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (!constraints.biggest.isEmpty) {
+          _resolveImages(
+            constraints.hasBoundedWidth
+                ? math.max(1, (constraints.maxWidth * ratio).ceil())
+                : null,
+            constraints.hasBoundedHeight
+                ? math.max(1, (constraints.maxHeight * ratio).ceil())
+                : null,
+          );
+        }
+        return CustomPaint(
+          painter: ImageCardStreamPreviewPainter(
+            previewImage: _preview.image,
+            sourceImage: _source.image,
+            maskImage: _mask.image,
+            placement: widget.placement,
+          ),
+        );
+      },
     );
   }
 
-  void _resolveImages() {
+  void _resolveImages(int? width, int? height) {
     final placement = widget.placement;
     final composited = placement != null && placement.isValid;
-    // 缓存命中时监听器同步回调，此时正处于 initState/didUpdateWidget，不能 setState。
+    final decoder = widget.imageDecoder ?? _decodePreviewImage;
     _resolving = true;
-    _preview.resolve(widget.previewBytes, _onImageChanged);
-    _source.resolve(composited ? placement.sourceImage : null, _onImageChanged);
-    _mask.resolve(composited ? placement.maskImage : null, _onImageChanged);
+    _preview.resolve(
+      widget.previewBytes,
+      width,
+      height,
+      decoder,
+      _onImageChanged,
+    );
+    _source.resolve(
+      composited ? placement.sourceImage : null,
+      width,
+      height,
+      decoder,
+      _onImageChanged,
+    );
+    _mask.resolve(
+      composited ? placement.maskImage : null,
+      width,
+      height,
+      decoder,
+      _onImageChanged,
+    );
     _resolving = false;
   }
 
@@ -76,54 +108,138 @@ class _ImageCardStreamPreviewState extends State<ImageCardStreamPreview> {
   }
 }
 
-/// 一张经 ImageCache 解码并持有的图；换源时旧帧保留到新帧到达。
+// Transient frames bypass ImageCache. Each layer owns one displayed image and
+// at most one active decode; an incoming burst keeps only its newest request.
 class _HeldImage {
   Uint8List? _bytes;
-  ImageStream? _stream;
-  ImageStreamListener? _listener;
-  ImageInfo? _info;
+  int? _width;
+  int? _height;
+  StreamPreviewImageDecoder? _decoder;
+  ui.Image? image;
+  _PreviewDecodeRequest? _pending;
+  int _revision = 0;
+  bool _decoding = false;
+  bool _disposed = false;
 
-  ui.Image? get image => _info?.image;
-
-  void resolve(Uint8List? bytes, VoidCallback onChanged) {
-    if (identical(_bytes, bytes)) return;
+  void resolve(
+    Uint8List? bytes,
+    int? width,
+    int? height,
+    StreamPreviewImageDecoder decoder,
+    VoidCallback onChanged,
+  ) {
+    if (_disposed) return;
+    if (identical(_bytes, bytes) &&
+        _width == width &&
+        _height == height &&
+        identical(_decoder, decoder)) {
+      return;
+    }
     _bytes = bytes;
-    _stopListening();
+    _width = width;
+    _height = height;
+    _decoder = decoder;
+    final revision = ++_revision;
     if (bytes == null || bytes.isEmpty) {
-      _replaceInfo(null);
+      _pending = null;
+      image?.dispose();
+      image = null;
       onChanged();
       return;
     }
-    final stream = MemoryImage(bytes).resolve(ImageConfiguration.empty);
-    final listener = ImageStreamListener(
-      (info, _) {
-        _replaceInfo(info);
-        onChanged();
-      },
-      onError: (_, _) {},
+    _pending = _PreviewDecodeRequest(
+      bytes,
+      width,
+      height,
+      revision,
+      decoder,
+      onChanged,
     );
-    _stream = stream;
-    _listener = listener;
-    stream.addListener(listener);
+    unawaited(_drain());
+  }
+
+  Future<void> _drain() async {
+    if (_decoding || _disposed) return;
+    _decoding = true;
+    try {
+      while (!_disposed && _pending != null) {
+        final request = _pending!;
+        _pending = null;
+        final ui.Image decoded;
+        try {
+          decoded = await request.decoder(
+            request.bytes,
+            targetWidth: request.width,
+            targetHeight: request.height,
+          );
+        } catch (_) {
+          // Invalid replacement frames keep the last successfully decoded image.
+          continue;
+        }
+        if (_disposed || request.revision != _revision) {
+          decoded.dispose();
+        } else {
+          image?.dispose();
+          image = decoded;
+          request.onChanged();
+        }
+      }
+    } finally {
+      _decoding = false;
+    }
   }
 
   void dispose() {
-    _stopListening();
-    _replaceInfo(null);
+    _disposed = true;
+    _pending = null;
+    _bytes = null;
+    image?.dispose();
+    image = null;
   }
+}
 
-  void _stopListening() {
-    final stream = _stream;
-    final listener = _listener;
-    if (stream != null && listener != null) stream.removeListener(listener);
-    _stream = null;
-    _listener = null;
-  }
+class _PreviewDecodeRequest {
+  const _PreviewDecodeRequest(
+    this.bytes,
+    this.width,
+    this.height,
+    this.revision,
+    this.decoder,
+    this.onChanged,
+  );
+  final Uint8List bytes;
+  final int? width;
+  final int? height;
+  final int revision;
+  final StreamPreviewImageDecoder decoder;
+  final VoidCallback onChanged;
+}
 
-  void _replaceInfo(ImageInfo? info) {
-    if (identical(_info, info)) return;
-    _info?.dispose();
-    _info = info;
+Future<ui.Image> _decodePreviewImage(
+  Uint8List bytes, {
+  required int? targetWidth,
+  required int? targetHeight,
+}) async {
+  ui.ImmutableBuffer? buffer;
+  ui.ImageDescriptor? descriptor;
+  ui.Codec? codec;
+  try {
+    buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
+    descriptor = await ui.ImageDescriptor.encoded(buffer);
+    final requestedScale = math.max(
+      targetWidth == null ? 0.0 : targetWidth / descriptor.width,
+      targetHeight == null ? 0.0 : targetHeight / descriptor.height,
+    );
+    final scale = requestedScale <= 0 ? 1.0 : math.min(1.0, requestedScale);
+    codec = await descriptor.instantiateCodec(
+      targetWidth: math.max(1, (descriptor.width * scale).ceil()),
+      targetHeight: math.max(1, (descriptor.height * scale).ceil()),
+    );
+    return (await codec.getNextFrame()).image;
+  } finally {
+    codec?.dispose();
+    descriptor?.dispose();
+    buffer?.dispose();
   }
 }
 

--- a/lib/presentation/widgets/gallery/gallery_content_view.dart
+++ b/lib/presentation/widgets/gallery/gallery_content_view.dart
@@ -1,11 +1,10 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../../core/utils/app_logger.dart';
+import '../../../core/utils/read_image_dimensions.dart';
 import '../../../core/platform/platform_capabilities.dart';
 import '../../../core/utils/localization_extension.dart';
 import '../../../data/models/gallery/local_image_record.dart';
@@ -106,6 +105,7 @@ class GenericGalleryContentView<T> extends ConsumerStatefulWidget {
   final bool isKritaConnected;
   final String? emptyTitle;
   final String? emptySubtitle;
+  final Future<Size> Function(String)? imageDimensionsLoader;
   final IconData? emptyIcon;
 
   const GenericGalleryContentView({
@@ -134,6 +134,7 @@ class GenericGalleryContentView<T> extends ConsumerStatefulWidget {
     this.isKritaConnected = false,
     this.emptyTitle,
     this.emptySubtitle,
+    this.imageDimensionsLoader,
     this.emptyIcon,
   });
 
@@ -157,6 +158,7 @@ class _GenericGalleryContentViewState<T>
     extends ConsumerState<GenericGalleryContentView<T>>
     with TickerProviderStateMixin {
   final Map<String, double> _aspectRatioCache = {};
+  final Set<String> _pendingAspectRatios = {};
   bool _showSkeleton = false;
   final Set<int> _visibleIndices = {};
   late final AnimationController _emptyStateController;
@@ -350,16 +352,19 @@ class _GenericGalleryContentViewState<T>
   }
 
   double _getCachedAspectRatio(LocalImageRecord record) {
-    if (_aspectRatioCache.containsKey(record.path)) {
-      return _aspectRatioCache[record.path]!;
+    final key =
+        '${record.path}:${record.size}:'
+        '${record.modifiedAt.microsecondsSinceEpoch}';
+    final cached = _aspectRatioCache[key];
+    if (cached != null) return cached;
+    if (_pendingAspectRatios.add(key)) {
+      _calculateAspectRatioForRecord(record).then((value) {
+        _pendingAspectRatios.remove(key);
+        if (mounted && value != _aspectRatioCache[key]) {
+          setState(() => _aspectRatioCache[key] = value);
+        }
+      });
     }
-
-    _calculateAspectRatioForRecord(record).then((value) {
-      if (mounted && value != _aspectRatioCache[record.path]) {
-        setState(() => _aspectRatioCache[record.path] = value);
-      }
-    });
-
     return 1.0;
   }
 
@@ -372,10 +377,11 @@ class _GenericGalleryContentViewState<T>
     }
 
     try {
-      final buffer = await ui.ImmutableBuffer.fromFilePath(record.path);
-      final descriptor = await ui.ImageDescriptor.encoded(buffer);
-      if (descriptor.width > 0 && descriptor.height > 0) {
-        return descriptor.width / descriptor.height;
+      final size = await (widget.imageDimensionsLoader ?? readImageDimensions)(
+        record.path,
+      );
+      if (size.width > 0 && size.height > 0) {
+        return size.width / size.height;
       }
     } catch (e) {
       AppLogger.d(

--- a/lib/presentation/widgets/gallery/local_image_hover_preview.dart
+++ b/lib/presentation/widgets/gallery/local_image_hover_preview.dart
@@ -21,11 +21,13 @@ class LocalImageHoverPreview extends StatefulWidget {
     required this.record,
     required this.child,
     this.hoverDelay = const Duration(milliseconds: 280),
+    this.metadataLoader,
   });
 
   final LocalImageRecord record;
   final Widget child;
   final Duration hoverDelay;
+  final LocalGalleryMetadataLoader? metadataLoader;
 
   @override
   State<LocalImageHoverPreview> createState() => _LocalImageHoverPreviewState();
@@ -34,8 +36,6 @@ class LocalImageHoverPreview extends StatefulWidget {
 class _LocalImageHoverPreviewState extends State<LocalImageHoverPreview> {
   final _layerLink = LayerLink();
   late final ImageHoverPreviewController _hoverController;
-  NaiImageMetadata? _resolvedMetadata;
-  String? _resolvedMetadataPath;
 
   @override
   void initState() {
@@ -48,13 +48,10 @@ class _LocalImageHoverPreviewState extends State<LocalImageHoverPreview> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.record.path != widget.record.path) {
       _hoverController.dismissFor(oldWidget.record.path);
-      _resolvedMetadata = null;
-      _resolvedMetadataPath = null;
     }
   }
 
   void _schedulePreview() {
-    unawaited(_resolveMetadata());
     final renderObject = context.findRenderObject();
     if (renderObject is! RenderBox || !renderObject.hasSize) return;
 
@@ -73,22 +70,12 @@ class _LocalImageHoverPreviewState extends State<LocalImageHoverPreview> {
       previewSize: previewSize,
       delay: widget.hoverDelay,
       builder: (_) => LocalImageHoverPreviewCard(
-        record: _resolvedMetadataPath == widget.record.path
-            ? widget.record.copyWith(metadata: _resolvedMetadata)
-            : widget.record,
+        record: widget.record,
+        metadataLoader: widget.metadataLoader,
         maxWidth: previewSize.width,
         maxHeight: previewSize.height,
       ),
     );
-  }
-
-  Future<void> _resolveMetadata() async {
-    final path = widget.record.path;
-    if (_resolvedMetadataPath == path) return;
-    final metadata = await resolveLocalGalleryMetadata(widget.record);
-    if (!mounted || widget.record.path != path) return;
-    _resolvedMetadata = metadata;
-    _resolvedMetadataPath = path;
   }
 
   @override
@@ -117,11 +104,13 @@ class LocalImageHoverPreviewCard extends StatefulWidget {
     required this.record,
     required this.maxWidth,
     required this.maxHeight,
+    this.metadataLoader,
   });
 
   final LocalImageRecord record;
   final double maxWidth;
   final double maxHeight;
+  final LocalGalleryMetadataLoader? metadataLoader;
 
   @override
   State<LocalImageHoverPreviewCard> createState() =>
@@ -226,7 +215,10 @@ class _LocalImageHoverPreviewCardState
   Future<void> _loadMetadata() async {
     final requestId = ++_metadataRequestId;
     final path = widget.record.path;
-    final metadata = await resolveLocalGalleryMetadata(widget.record);
+    final metadata = await resolveLocalGalleryMetadata(
+      widget.record,
+      loadFromFile: widget.metadataLoader,
+    );
     if (!mounted ||
         requestId != _metadataRequestId ||
         widget.record.path != path) {

--- a/test/core/utils/read_image_dimensions_test.dart
+++ b/test/core/utils/read_image_dimensions_test.dart
@@ -1,0 +1,71 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:nai_launcher/core/utils/read_image_dimensions.dart';
+
+class _Descriptor extends Fake implements ui.ImageDescriptor {
+  bool disposed = false;
+  @override
+  int get width => 32;
+  @override
+  int get height => 48;
+  @override
+  void dispose() => disposed = true;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('dimension read releases descriptor and buffer on success', () async {
+    final buffer = await ui.ImmutableBuffer.fromUint8List(Uint8List(4));
+    addTearDown(() {
+      if (!buffer.debugDisposed) buffer.dispose();
+    });
+    final descriptor = _Descriptor();
+    final result = await readImageDimensions(
+      'synthetic',
+      createBuffer: (_) async => buffer,
+      createDescriptor: (_) async => descriptor,
+    );
+    expect(result, const ui.Size(32, 48));
+    expect(descriptor.disposed, isTrue);
+    expect(buffer.debugDisposed, isTrue);
+  });
+
+  test('dimension read releases buffer if descriptor creation fails', () async {
+    final buffer = await ui.ImmutableBuffer.fromUint8List(Uint8List(4));
+    addTearDown(() {
+      if (!buffer.debugDisposed) buffer.dispose();
+    });
+    await expectLater(
+      readImageDimensions(
+        'synthetic',
+        createBuffer: (_) async => buffer,
+        createDescriptor: (_) async =>
+            throw StateError('synthetic decode failure'),
+      ),
+      throwsStateError,
+    );
+    expect(buffer.debugDisposed, isTrue);
+  });
+
+  test(
+    'real encoded dimensions are preserved without decoding a frame',
+    () async {
+      final buffer = await ui.ImmutableBuffer.fromUint8List(
+        Uint8List.fromList(img.encodePng(img.Image(width: 17, height: 29))),
+      );
+      addTearDown(() {
+        if (!buffer.debugDisposed) buffer.dispose();
+      });
+      final result = await readImageDimensions(
+        'synthetic',
+        createBuffer: (_) async => buffer,
+      );
+      expect(result, const ui.Size(17, 29));
+      expect(buffer.debugDisposed, isTrue);
+    },
+  );
+}

--- a/test/data/services/metadata/background_metadata_parser_test.dart
+++ b/test/data/services/metadata/background_metadata_parser_test.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:nai_launcher/data/services/metadata/background_metadata_parser.dart';
+import 'package:nai_launcher/data/services/metadata/hash_calculator.dart';
+import 'package:nai_launcher/data/services/metadata/unified_metadata_parser.dart';
+
+void main() {
+  late Directory directory;
+  late Uint8List source;
+  setUpAll(() async {
+    await Directory('tool/.tmp').create(recursive: true);
+    directory = await Directory('tool/.tmp').createTemp('metadata_background_');
+    source = await UnifiedMetadataParser.embedMetadata(
+      Uint8List.fromList(
+        img.encodePng(img.Image(width: 64, height: 64, numChannels: 4)),
+      ),
+      '{"prompt":"synthetic prompt","uc":"synthetic negative","seed":42,"width":64,"height":64}',
+      useStealth: true,
+    );
+  });
+  tearDownAll(() async {
+    FileHashCalculator().clearCache();
+    await directory.delete(recursive: true);
+  });
+
+  test('background byte parser preserves metadata and input bytes', () async {
+    final original = Uint8List.fromList(source);
+    final expected = UnifiedMetadataParser.parseFromImage(source);
+    final actual = await parseMetadataBytesInBackground(source);
+    expect(actual.success, isTrue);
+    expect(actual.metadata?.toJson(), expected.metadata?.toJson());
+    expect(actual.sourceFormat, expected.sourceFormat);
+    expect(source, orderedEquals(original));
+  });
+
+  test('background file parser preserves gradual-read behavior', () async {
+    final file = File('${directory.path}/source.png');
+    await file.writeAsBytes(source);
+    final expected = UnifiedMetadataParser.parseFromFile(file.path);
+    final actual = await parseMetadataFileInBackground(file.path);
+    expect(actual.success, isTrue);
+    expect(actual.metadata?.toJson(), expected.metadata?.toJson());
+  });
+
+  test('background parser recovers a stealth-only prompt', () async {
+    final bytes = BytesBuilder()..add(source.sublist(0, 8));
+    var offset = 8;
+    final view = ByteData.sublistView(source);
+    while (offset + 12 <= source.length) {
+      final length = view.getUint32(offset);
+      final end = offset + length + 12;
+      final type = String.fromCharCodes(source.sublist(offset + 4, offset + 8));
+      if (!{'tEXt', 'iTXt', 'zTXt'}.contains(type)) {
+        bytes.add(source.sublist(offset, end));
+      }
+      offset = end;
+    }
+    final result = await parseMetadataBytesInBackground(bytes.takeBytes());
+    expect(result.success, isTrue);
+    expect(result.metadata?.prompt, 'synthetic prompt');
+  });
+
+  test('background parser retains invalid-input diagnostics', () async {
+    final invalid = Uint8List.fromList([1, 2, 3]);
+    final expected = UnifiedMetadataParser.parseFromImage(invalid);
+    final actual = await parseMetadataBytesInBackground(invalid);
+    expect(actual.success, isFalse);
+    expect(actual.errorMessage, expected.errorMessage);
+  });
+
+  test(
+    'missing file returns a failed parse rather than an uncaught error',
+    () async {
+      final result = await parseMetadataFileInBackground(
+        '${directory.path}/missing.png',
+      );
+      expect(result.success, isFalse);
+      expect(result.errorMessage, isNotEmpty);
+    },
+  );
+
+  test(
+    'background hashes match the synchronous digest and retain file deduplication',
+    () async {
+      final calculator = FileHashCalculator();
+      final expected = sha256.convert(source).toString();
+      expect(await calculator.calculateFromBytesInBackground(source), expected);
+      final file = File('${directory.path}/hash.png');
+      await file.writeAsBytes(source);
+      final count = calculator.hashComputeCount;
+      final results = await Future.wait(
+        List.generate(5, (_) => calculator.calculate(file.path)),
+      );
+      expect(results, everyElement(expected));
+      expect(calculator.hashComputeCount - count, 1);
+    },
+  );
+
+  test(
+    'foreground service routes all parses and byte hashes through background helpers',
+    () {
+      final service = File(
+        'lib/data/services/image_metadata_service.dart',
+      ).readAsStringSync();
+      expect(service, isNot(contains('UnifiedMetadataParser.parseFrom')));
+      expect(
+        service,
+        isNot(contains('_hashCalculator.calculateFromBytes(bytes)')),
+      );
+      expect(service, contains('await parseMetadataFileInBackground(path)'));
+      expect(service, contains('await parseMetadataBytesInBackground(bytes)'));
+    },
+  );
+}

--- a/test/presentation/screens/generation/preview_info_bar_test.dart
+++ b/test/presentation/screens/generation/preview_info_bar_test.dart
@@ -12,6 +12,7 @@ import 'package:nai_launcher/data/models/gallery/nai_image_metadata.dart';
 import 'package:nai_launcher/data/services/metadata/unified_metadata_parser.dart';
 import 'package:nai_launcher/l10n/app_localizations.dart';
 import 'package:nai_launcher/presentation/adaptive/interaction_policy.dart';
+import 'package:nai_launcher/presentation/providers/generation/generated_image_metadata_provider.dart';
 import 'package:nai_launcher/presentation/providers/image_generation_provider.dart';
 import 'package:nai_launcher/presentation/providers/preview_transparency_provider.dart';
 import 'package:nai_launcher/presentation/screens/generation/widgets/preview_info_bar.dart';
@@ -54,6 +55,19 @@ Future<ProviderContainer> _pumpBar(
     ],
   );
   addTearDown(container.dispose);
+  // Start real isolate work outside the widget test's fake async zone.
+  final metadataSubscription = await tester.runAsync(() async {
+    final provider = generatedImageMetadataProvider(image);
+    final subscription = container.listen(provider, (_, _) {});
+    try {
+      await container.read(provider.future).timeout(const Duration(seconds: 3));
+      return subscription;
+    } catch (_) {
+      subscription.close();
+      rethrow;
+    }
+  });
+  addTearDown(metadataSubscription!.close);
 
   Widget home = Scaffold(
     body: Center(
@@ -93,7 +107,7 @@ Future<ProviderContainer> _pumpBar(
       ),
     ),
   );
-  // 种子来自异步解析的 PNG 元数据，先让 FutureProvider 落定
+  // Paint the provider result and any layout scheduled by the first frame.
   await tester.pump();
   await tester.pump();
   return container;

--- a/test/presentation/widgets/common/image_card_stream_preview_test.dart
+++ b/test/presentation/widgets/common/image_card_stream_preview_test.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:nai_launcher/presentation/widgets/common/image_card_stream_preview.dart';
+
+void main() {
+  testWidgets('transient frames resize without populating the shared cache', (
+    tester,
+  ) async {
+    final cache = PaintingBinding.instance.imageCache;
+    cache.clear();
+    cache.clearLiveImages();
+    final bytes = Uint8List.fromList(
+      img.encodePng(img.Image(width: 512, height: 768)),
+    );
+    ui.Image? previous;
+    for (var i = 0; i < 8; i++) {
+      await tester.pumpWidget(_app(Uint8List.fromList(bytes)));
+      await _until(
+        tester,
+        () =>
+            _painter(tester).previewImage != null &&
+            !identical(_painter(tester).previewImage, previous),
+      );
+      final image = _painter(tester).previewImage!;
+      expect(image.width, 200);
+      expect(image.height, 300);
+      if (previous != null) expect(previous.debugDisposed, isTrue);
+      previous = image;
+      expect(cache.currentSizeBytes, 0);
+    }
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(previous!.debugDisposed, isTrue);
+    expect(cache.currentSizeBytes, 0);
+  });
+
+  testWidgets(
+    'burst frames keep only one decoder and the newest pending frame',
+    (tester) async {
+      final first = await tester.runAsync(() => createTestImage(cache: false));
+      final stale = await tester.runAsync(() => createTestImage(cache: false));
+      final latest = await tester.runAsync(() => createTestImage(cache: false));
+      final calls = <int>[];
+      final pending = <Completer<ui.Image>>[];
+      Future<ui.Image> decode(
+        Uint8List bytes, {
+        required int? targetWidth,
+        required int? targetHeight,
+      }) {
+        calls.add(bytes.single);
+        final completer = Completer<ui.Image>();
+        pending.add(completer);
+        return completer.future;
+      }
+
+      await tester.pumpWidget(_app(Uint8List.fromList([1]), decoder: decode));
+      pending[0].complete(first!);
+      await tester.pump();
+      expect(_painter(tester).previewImage, same(first));
+      await tester.pumpWidget(_app(Uint8List.fromList([2]), decoder: decode));
+      await tester.pumpWidget(_app(Uint8List.fromList([3]), decoder: decode));
+      await tester.pumpWidget(_app(Uint8List.fromList([4]), decoder: decode));
+      expect(calls, [1, 2]);
+      expect(_painter(tester).previewImage, same(first));
+      pending[1].complete(stale!);
+      await tester.pump();
+      expect(calls, [1, 2, 4]);
+      expect(stale.debugDisposed, isTrue);
+      expect(first.debugDisposed, isFalse);
+      pending[2].complete(latest!);
+      await tester.pump();
+      await tester.pump();
+      expect(_painter(tester).previewImage, same(latest));
+      expect(first.debugDisposed, isTrue);
+      await tester.pumpWidget(const SizedBox.shrink());
+      expect(latest.debugDisposed, isTrue);
+    },
+  );
+
+  testWidgets('disposing during decode releases its eventual image', (
+    tester,
+  ) async {
+    final image = await tester.runAsync(() => createTestImage(cache: false));
+    final completer = Completer<ui.Image>();
+    await tester.pumpWidget(
+      _app(
+        Uint8List.fromList([1]),
+        decoder:
+            (bytes, {required int? targetWidth, required int? targetHeight}) =>
+                completer.future,
+      ),
+    );
+    await tester.pumpWidget(const SizedBox.shrink());
+    completer.complete(image!);
+    await tester.pump();
+    expect(image.debugDisposed, isTrue);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('failed replacement retains its frame and later frames recover', (
+    tester,
+  ) async {
+    final first = await tester.runAsync(() => createTestImage(cache: false));
+    final last = await tester.runAsync(() => createTestImage(cache: false));
+    Future<ui.Image> decode(
+      Uint8List bytes, {
+      required int? targetWidth,
+      required int? targetHeight,
+    }) async {
+      if (bytes.single == 2) throw const FormatException('invalid frame');
+      return bytes.single == 1 ? first! : last!;
+    }
+
+    await tester.pumpWidget(_app(Uint8List.fromList([1]), decoder: decode));
+    await tester.pump();
+    await tester.pumpWidget(_app(Uint8List.fromList([2]), decoder: decode));
+    await tester.pump();
+    expect(_painter(tester).previewImage, same(first));
+    await tester.pumpWidget(_app(Uint8List.fromList([3]), decoder: decode));
+    await tester.pump();
+    expect(_painter(tester).previewImage, same(last));
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(first!.debugDisposed, isTrue);
+    expect(last!.debugDisposed, isTrue);
+  });
+
+  testWidgets('same bytes re-decode for a larger viewport and device ratio', (
+    tester,
+  ) async {
+    final bytes = Uint8List.fromList(
+      img.encodePng(img.Image(width: 512, height: 768)),
+    );
+    await tester.pumpWidget(_app(bytes));
+    await _until(tester, () => _painter(tester).previewImage != null);
+    final first = _painter(tester).previewImage!;
+    await tester.pumpWidget(_app(bytes, size: 150, ratio: 2));
+    await _until(
+      tester,
+      () => !identical(_painter(tester).previewImage, first),
+    );
+    expect(_painter(tester).previewImage!.width, 300);
+    expect(_painter(tester).previewImage!.height, 450);
+    expect(first.debugDisposed, isTrue);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}
+
+Widget _app(
+  Uint8List bytes, {
+  StreamPreviewImageDecoder? decoder,
+  double size = 200,
+  double ratio = 1,
+}) => MaterialApp(
+  home: MediaQuery(
+    data: MediaQueryData(devicePixelRatio: ratio),
+    child: Center(
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: ImageCardStreamPreview(
+          previewBytes: bytes,
+          imageDecoder: decoder,
+        ),
+      ),
+    ),
+  ),
+);
+
+ImageCardStreamPreviewPainter _painter(WidgetTester tester) =>
+    tester
+            .widget<CustomPaint>(
+              find.descendant(
+                of: find.byType(ImageCardStreamPreview),
+                matching: find.byType(CustomPaint),
+              ),
+            )
+            .painter!
+        as ImageCardStreamPreviewPainter;
+
+Future<void> _until(WidgetTester tester, bool Function() ready) async {
+  for (var i = 0; i < 50 && !ready(); i++) {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 5)),
+    );
+    await tester.pump();
+  }
+  expect(ready(), isTrue, reason: 'Native image decode must finish promptly');
+}

--- a/test/presentation/widgets/common/image_card_waiting_performance_test.dart
+++ b/test/presentation/widgets/common/image_card_waiting_performance_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/presentation/widgets/common/selectable_image_card.dart';
+
+void main() {
+  testWidgets('waiting spinner does not repaint the whole generation card', (
+    tester,
+  ) async {
+    var paints = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Center(
+            child: RepaintBoundary(
+              child: _PaintProbe(
+                onPaint: () => paints++,
+                child: const SizedBox(
+                  width: 300,
+                  height: 400,
+                  child: SelectableImageCard(
+                    isGenerating: true,
+                    imageWidth: 832,
+                    imageHeight: 1216,
+                    currentImage: 1,
+                    totalImages: 2,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+    paints = 0;
+    for (var i = 0; i < 30; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    expect(
+      tester
+          .widget<CircularProgressIndicator>(
+            find.byType(CircularProgressIndicator),
+          )
+          .value,
+      isNull,
+    );
+    expect(tester.binding.hasScheduledFrame, isTrue);
+    // The small indeterminate spinner remains active in its own paint layer.
+    print('WAITING_CARD_PAINTS $paints / 30 animation frames');
+    expect(paints, lessThanOrEqualTo(1));
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}
+
+class _PaintProbe extends SingleChildRenderObjectWidget {
+  const _PaintProbe({required this.onPaint, required super.child});
+
+  final VoidCallback onPaint;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _PaintCounter(onPaint);
+}
+
+class _PaintCounter extends RenderProxyBox {
+  _PaintCounter(this.onPaint);
+
+  final VoidCallback onPaint;
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    onPaint();
+    super.paint(context, offset);
+  }
+}

--- a/test/presentation/widgets/gallery/gallery_content_view_context_menu_test.dart
+++ b/test/presentation/widgets/gallery/gallery_content_view_context_menu_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -29,6 +31,63 @@ void main() {
         previousVisibilityUpdateInterval;
     PlatformCapabilities.debugOverride = null;
   });
+
+  testWidgets(
+    'grouped gallery coalesces pending dimension reads across rebuilds',
+    (tester) async {
+      final result = Completer<Size>();
+      var reads = 0;
+      late StateSetter rebuild;
+      final record = LocalImageRecord(
+        path: 'synthetic-pending.png',
+        size: 1,
+        modifiedAt: DateTime(2026),
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (_, setState) {
+                  rebuild = setState;
+                  return GenericGalleryContentView<LocalImageRecord>(
+                    columns: 1,
+                    itemWidth: 160,
+                    state: _GroupedGalleryState(record),
+                    selectionState: const _InactiveSelectionState(),
+                    itemBuilder: (_, __, ___, ____) => const SizedBox.shrink(),
+                    idExtractor: (item) => item.path,
+                    imageDimensionsLoader: (_) {
+                      reads++;
+                      return result.future;
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      rebuild(() {});
+      await tester.pump();
+      rebuild(() {});
+      await tester.pump();
+      final readsBeforeCompletion = reads;
+      result.complete(const Size(160, 320));
+      await tester.pump();
+      expect(readsBeforeCompletion, 1);
+      expect(
+        tester.widget<LocalImageCard3D>(find.byType(LocalImageCard3D)).height,
+        320,
+      );
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+    },
+  );
 
   testWidgets('grouped gallery forwards secondary taps to the context menu', (
     tester,

--- a/test/presentation/widgets/gallery/local_image_hover_preview_test.dart
+++ b/test/presentation/widgets/gallery/local_image_hover_preview_test.dart
@@ -12,6 +12,63 @@ import 'package:nai_launcher/presentation/widgets/gallery/local_image_hover_prev
 
 void main() {
   testWidgets(
+    'quick hover does not read metadata; sustained hover reads once',
+    (tester) async {
+      var reads = 0;
+      final record = LocalImageRecord(
+        path: 'assets/icons/tray_icon.png',
+        size: 0,
+        modifiedAt: DateTime(2026),
+        metadata: const NaiImageMetadata(
+          width: 32,
+          height: 32,
+          prompt: 'synthetic',
+        ),
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: LocalImageHoverPreview(
+                record: record,
+                metadataLoader: (_) async {
+                  reads++;
+                  return record.metadata;
+                },
+                child: const SizedBox(
+                  key: ValueKey('intent-target'),
+                  width: 100,
+                  height: 100,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(mouse.removePointer);
+      await mouse.addPointer(location: Offset.zero);
+      await mouse.moveTo(
+        tester.getCenter(find.byKey(const ValueKey('intent-target'))),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(reads, 0);
+      await mouse.moveTo(Offset.zero);
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(reads, 0);
+      await mouse.moveTo(
+        tester.getCenter(find.byKey(const ValueKey('intent-target'))),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump();
+      expect(reads, 1);
+      await mouse.moveTo(Offset.zero);
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+    },
+  );
+
+  testWidgets(
     'shows compact full-file preview inside viewport and dismisses it',
     (tester) async {
       final imageFile = File('assets/icons/tray_icon.png');


### PR DESCRIPTION
## 改动

本 PR 从 main 独立分支，仅优化已有图库/元数据路径，不依赖水印 PR，不改配色。

- 复用现有 ComputeGate，将元数据文件解析、字节解析和 SHA-256 哈希放到后台 isolate；保留统一解析器的格式支持、渐进读取、结果和错误信息。沿用已有缓存与文件哈希去重，不新增依赖或线程池。
- 本地图片悬停达到预览延迟后才读取元数据，移除预览显示前的重复读取；快速掠过不解析。
- 分组图库探测图片尺寸时，在成功/失败路径释放 ImageDescriptor 和 ImmutableBuffer；合并同一文件版本的在途探测。缓存键包含路径、大小和修改时间。
- 新增可注入的加载边界，用于确定性验证悬停意图、请求合并和原生资源释放。

## 验证

- Flutter 3.44.8 / Dart 3.12.2；未修改依赖/锁文件。
- 10 个修改/新增 Dart 文件静态分析、格式检查和 git diff --check 通过。
- 元数据解析、worker pool、缩略图缓存、图库交互、启动约束等 88 项定向回归通过。
- 先验证修复通过，再临时恢复旧行为进行反证：快速悬停测试预期 0 次读取、实际 1 次；尺寸请求合并测试预期 1 次、实际 4 次。恢复修复后全部通过。
- 原生资源测试检查 buffer.debugDisposed，并记录 descriptor.dispose 调用；覆盖成功、descriptor 创建失败和真实 PNG 尺寸读取。
- 后台解析与原解析结果一致，覆盖文本元数据、透明度隐写、无效输入、缺失文件、输入不变和 SHA-256 一致性。

## 响应性诊断

同一张合成的 1664x2432 隐写 PNG，比较未缓存的哈希加文件解析，5ms Timer 记录主 isolate 的最大事件间隔：

| 路径 | 总耗时，两次 | 主 isolate 最大间隔，两次 |
| --- | --- | --- |
| 原同步路径 | 474 / 389 ms | 462 / 377 ms |
| 后台路径 | 415 / 416 ms | 9.5 / 8.2 ms |

这是 Flutter 测试/调试环境中的事件循环诊断，不是完整应用 FPS、发布模式或生产图片语料的基准。主要收益是避免阻塞界面线程，不宣称处理吞吐量成倍提高。

## 边界

- 不修改真实用户图片或元数据，不执行生成、云同步或外部模型请求。
- 未重新打开应用；仍待 Windows 发布模式、长时间大图库浏览及 Android 实机验收，故保留 Draft。
- 全局排查还记录了启动索引扫描、失败生成预览合成和更广泛的缓存生命周期风险；本 PR 不夹带未经验证的启动/取消流程重写。
- 不包含日志、合成图片、基准文件、数据库或凭据。
