### PR TITLE
fix(generation): 修正控制栏换行阈值与生成按钮位置

### DIFF
--- a/lib/presentation/screens/generation/widgets/generation_controls/generate_button.dart
+++ b/lib/presentation/screens/generation/widgets/generation_controls/generate_button.dart
@@ -87,9 +87,19 @@ class GenerateButtonWithCost extends ConsumerWidget {
       child: !_canSkipCurrentBatch
           ? primaryButton
           : largeText
-          ? Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [skipButton, const SizedBox(height: 8), primaryButton],
+          ? LayoutBuilder(
+              builder: (context, constraints) => Column(
+                mainAxisSize: MainAxisSize.min,
+                // 控制栏先测量自然宽度，再分配最终宽度；测量时不能横向拉伸。
+                crossAxisAlignment: constraints.hasBoundedWidth
+                    ? CrossAxisAlignment.stretch
+                    : CrossAxisAlignment.center,
+                children: [
+                  skipButton,
+                  const SizedBox(height: 8),
+                  primaryButton,
+                ],
+              ),
             )
           : Row(
               mainAxisSize: MainAxisSize.min,

--- a/lib/presentation/screens/generation/widgets/generation_controls/generation_controls.dart
+++ b/lib/presentation/screens/generation/widgets/generation_controls/generation_controls.dart
@@ -306,25 +306,32 @@ class _RenderGenerationControlsLayout extends RenderBox
     List<RenderBox> right,
     double width,
   ) {
-    _position(primary, 0, 0);
-    if (left.isEmpty && right.isEmpty) return primary.size.height;
-    var y = primary.size.height + _runSpacing;
+    if (left.isEmpty && right.isEmpty) {
+      _position(primary, 0, 0);
+      return primary.size.height;
+    }
+
+    // 主按钮排在操作图标之后，换行后仍留在控制条最下方，与单行版式位置一致。
     final leftWidth = _groupWidth(left);
     final rightWidth = _groupWidth(right);
+    final double actionsBottom;
     if (leftWidth + rightWidth + _primarySpacing <= width) {
       final height = [...left, ...right].fold<double>(
         0,
         (maximum, action) =>
             action.size.height > maximum ? action.size.height : maximum,
       );
-      _positionGroup(left, 0, height, y: y);
-      _positionGroup(right, width - rightWidth, height, y: y);
-      return y + height;
+      _positionGroup(left, 0, height);
+      _positionGroup(right, width - rightWidth, height);
+      actionsBottom = height;
+    } else {
+      var y = _layoutGroupRuns(left, width, 0, alignRight: false);
+      if (left.isNotEmpty && right.isNotEmpty) y += _runSpacing;
+      actionsBottom = _layoutGroupRuns(right, width, y, alignRight: true);
     }
 
-    y = _layoutGroupRuns(left, width, y, alignRight: false);
-    if (left.isNotEmpty && right.isNotEmpty) y += _runSpacing;
-    return _layoutGroupRuns(right, width, y, alignRight: true);
+    _position(primary, 0, actionsBottom + _runSpacing);
+    return actionsBottom + _runSpacing + primary.size.height;
   }
 
   double _layoutGroupRuns(

--- a/lib/presentation/screens/generation/widgets/generation_controls/generation_controls.dart
+++ b/lib/presentation/screens/generation/widgets/generation_controls/generation_controls.dart
@@ -207,7 +207,6 @@ class _RenderGenerationControlsLayout extends RenderBox
   static const double _itemSpacing = 2;
   static const double _primarySpacing = 8;
   static const double _runSpacing = 8;
-  static const double _minimumPrimaryWidth = 160;
 
   @override
   void setupParentData(RenderBox child) {
@@ -248,10 +247,15 @@ class _RenderGenerationControlsLayout extends RenderBox
       return;
     }
 
+    // 主按钮的标签不会收缩，压窄就溢出。先用无界约束量出它真正需要的宽度，
+    // 只有连这点宽度都留不出时才换行；固定下限会在大字号下裁掉标签。
+    primaryChild.layout(const BoxConstraints(), parentUsesSize: true);
+    final minimumPrimaryWidth = primaryChild.size.width;
+
     final leftWidth = _groupWidth(left);
     final rightWidth = _groupWidth(right);
     final naturalWidth =
-        leftWidth + rightWidth + _minimumPrimaryWidth + _primarySpacing * 2;
+        leftWidth + rightWidth + minimumPrimaryWidth + _primarySpacing * 2;
     final layoutWidth = constraints.hasBoundedWidth
         ? constraints.maxWidth
         : naturalWidth;
@@ -368,84 +372,13 @@ class _RenderGenerationControlsLayout extends RenderBox
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
-    final availableWidth = constraints.hasBoundedWidth
-        ? constraints.maxWidth
-        : 100000.0;
-    final actionConstraints = BoxConstraints(maxWidth: availableWidth);
-    final left = <Size>[];
-    final right = <Size>[];
-    RenderBox? primaryChild;
-
-    RenderBox? child = firstChild;
-    while (child != null) {
-      final parentData = child.parentData! as _GenerationControlsParentData;
-      switch (parentData.group) {
-        case _GenerationControlGroup.left:
-          final childSize = child.getDryLayout(actionConstraints);
-          if (!childSize.isEmpty) left.add(childSize);
-        case _GenerationControlGroup.primary:
-          primaryChild = child;
-        case _GenerationControlGroup.right:
-          final childSize = child.getDryLayout(actionConstraints);
-          if (!childSize.isEmpty) right.add(childSize);
-      }
-      child = parentData.nextSibling;
-    }
-
-    if (primaryChild == null) return constraints.smallest;
-    final leftWidth = _dryGroupWidth(left);
-    final rightWidth = _dryGroupWidth(right);
-    final singleRowWidth =
-        leftWidth + rightWidth + _minimumPrimaryWidth + _primarySpacing * 2;
-    final width = constraints.hasBoundedWidth
-        ? constraints.maxWidth
-        : singleRowWidth;
-    final useSingleRow = singleRowWidth <= width;
-    final primaryWidth = useSingleRow
-        ? width - leftWidth - rightWidth - _primarySpacing * 2
-        : width;
-    final primarySize = primaryChild.getDryLayout(
-      BoxConstraints.tightFor(width: primaryWidth),
+    // 主按钮内部的 ThemedButton 用 LayoutBuilder 决定标签能否收缩，无法参与 dry layout。
+    assert(
+      debugCannotComputeDryLayout(
+        reason: '主按钮内部的 LayoutBuilder 不支持 dry layout',
+      ),
     );
-    if (useSingleRow) {
-      final height = [...left, primarySize, ...right].fold<double>(
-        0,
-        (maximum, childSize) =>
-            childSize.height > maximum ? childSize.height : maximum,
-      );
-      return constraints.constrain(Size(width, height));
-    }
-
-    final leftAndRightFit = leftWidth + rightWidth + _primarySpacing <= width;
-    if (leftAndRightFit) {
-      final actionsHeight = [...left, ...right].fold<double>(
-        0,
-        (maximum, action) => action.height > maximum ? action.height : maximum,
-      );
-      return constraints.constrain(
-        Size(width, primarySize.height + _runSpacing + actionsHeight),
-      );
-    }
-    var height = primarySize.height;
-    if (left.isNotEmpty) {
-      height += _runSpacing + _dryRunsHeight(left, width);
-    }
-    if (right.isNotEmpty) {
-      height += _runSpacing + _dryRunsHeight(right, width);
-    }
-    return constraints.constrain(Size(width, height));
-  }
-
-  double _dryRunsHeight(List<Size> children, double width) {
-    final runs = _buildRuns<Size>(children, width, (child) => child.width);
-    return runs.fold<double>(0, (height, run) {
-          final runHeight = run.fold<double>(
-            0,
-            (maximum, child) => child.height > maximum ? child.height : maximum,
-          );
-          return height + runHeight;
-        }) +
-        _runSpacing * (runs.length - 1);
+    return Size.zero;
   }
 
   List<List<T>> _buildRuns<T>(
@@ -473,12 +406,6 @@ class _RenderGenerationControlsLayout extends RenderBox
     }
     if (run.isNotEmpty) runs.add(run);
     return runs;
-  }
-
-  double _dryGroupWidth(List<Size> children) {
-    if (children.isEmpty) return 0;
-    return children.fold<double>(0, (sum, child) => sum + child.width) +
-        _itemSpacing * (children.length - 1);
   }
 
   @override

--- a/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
+++ b/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
@@ -348,6 +348,36 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets(
+    'large-text batch controls keep cancel and skip reachable at each width',
+    (tester) async {
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      for (final width in [320.0, 475.0, 600.0, 840.0, 1180.0, 1600.0]) {
+        final notifier = await _pumpLargeTextBatchControls(tester, width);
+        notifier.setBatchGenerating();
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull, reason: 'width=$width');
+        final primary = tester.getRect(
+          find.byKey(const ValueKey('generation-footer-primary-action')),
+        );
+        final bounds = tester.getRect(
+          find.byKey(const ValueKey('generation-footer-adaptive-layout')),
+        );
+        expect(bounds.inflate(0.01).contains(primary.topLeft), isTrue);
+        expect(bounds.inflate(0.01).contains(primary.bottomRight), isTrue);
+        final skip = find.text('跳过当前批次 1/2');
+        expect(skip.hitTestable(), findsOneWidget);
+        expect(find.text('取消').hitTestable(), findsOneWidget);
+        await tester.tap(skip);
+        expect(notifier.skipCount, 1);
+        await tester.tap(find.text('取消'));
+        expect(notifier.cancelCount, 1);
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull, reason: 'width=$width');
+        await tester.pumpWidget(const SizedBox.shrink());
+      }
+    },
+  );
   testWidgets('preparing footer offers a cancel entry instead of a dead tap', (
     tester,
   ) async {
@@ -718,6 +748,68 @@ void main() {
   });
 }
 
+Future<_TestImageGenerationNotifier> _pumpLargeTextBatchControls(
+  WidgetTester tester,
+  double width,
+) async {
+  await tester.binding.setSurfaceSize(Size(width, 900));
+  final storage = _MemoryLocalStorageService({
+    StorageKeys.autoSaveImages: false,
+    StorageKeys.showRandomPromptTools: true,
+  });
+  final container = ProviderContainer(
+    overrides: [
+      authNotifierProvider.overrideWith(_AuthenticatedAuthNotifier.new),
+      imageGenerationNotifierProvider.overrideWith(
+        _TestImageGenerationNotifier.new,
+      ),
+      localStorageServiceProvider.overrideWith((ref) => storage),
+      kritaBridgeNotifierProvider.overrideWith(
+        (ref) => _TestKritaBridgeNotifier(),
+      ),
+      replicationQueueNotifierProvider.overrideWith(
+        _TestReplicationQueueNotifier.new,
+      ),
+      queueExecutionNotifierProvider.overrideWith(
+        _TestQueueExecutionNotifier.new,
+      ),
+      subscriptionNotifierProvider.overrideWith(_TestSubscriptionNotifier.new),
+      estimatedCostProvider.overrideWith((ref) => 0),
+      isFreeGenerationProvider.overrideWith((ref) => true),
+    ],
+  );
+  addTearDown(container.dispose);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(textScaler: const TextScaler.linear(3)),
+          child: child!,
+        ),
+        locale: const Locale('zh'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: width,
+              height: 800,
+              child: const GenerationControls(compact: true),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  return container.read(imageGenerationNotifierProvider.notifier)
+      as _TestImageGenerationNotifier;
+}
+
 class _AuthenticatedAuthNotifier extends AuthNotifier {
   @override
   AuthState build() => const AuthState(status: AuthStatus.authenticated);
@@ -730,6 +822,20 @@ class _UnauthenticatedAuthNotifier extends AuthNotifier {
 
 class _TestImageGenerationNotifier extends ImageGenerationNotifier {
   int cancelCount = 0;
+  int skipCount = 0;
+
+  void setBatchGenerating() {
+    state = const ImageGenerationState(
+      status: GenerationStatus.generating,
+      currentImage: 1,
+      totalImages: 2,
+    );
+  }
+
+  @override
+  void skipCurrentRequest() {
+    skipCount++;
+  }
 
   @override
   ImageGenerationState build() => const ImageGenerationState();

--- a/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
+++ b/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
@@ -251,9 +251,9 @@ void main() {
           );
           for (final rect in actionRects) {
             expect(
-              rect.top,
-              greaterThanOrEqualTo(primaryRect.bottom + 7.9),
-              reason: '$reason did not use the centered layered layout',
+              primaryRect.top,
+              greaterThanOrEqualTo(rect.bottom + 7.9),
+              reason: '$reason 主按钮换行后没有排在操作图标下方',
             );
           }
           if (scenario.textScale == 1 && scenario.width >= 438) {
@@ -643,6 +643,75 @@ void main() {
         reason: '$reason 生成按钮被挤到单独一行',
       );
       expect(anlasRect.right, lessThan(primaryRect.left), reason: reason);
+      expect(find.text('生成'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  testWidgets('官网式左栏宽度换行时生成按钮仍排在操作图标下方', (tester) async {
+    final storage = _MemoryLocalStorageService({
+      StorageKeys.autoSaveImages: false,
+      StorageKeys.showRandomPromptTools: true,
+    });
+
+    // 官网式左栏可拖 320~560、默认 400；带 Opus 徽章时这一段放不下单行。
+    for (final width in const [320.0, 360.0, 400.0]) {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authNotifierProvider.overrideWith(_AuthenticatedAuthNotifier.new),
+            localStorageServiceProvider.overrideWith((ref) => storage),
+            kritaBridgeNotifierProvider.overrideWith(
+              (ref) => _TestKritaBridgeNotifier(),
+            ),
+            replicationQueueNotifierProvider.overrideWith(
+              _TestReplicationQueueNotifier.new,
+            ),
+            queueExecutionNotifierProvider.overrideWith(
+              _TestQueueExecutionNotifier.new,
+            ),
+            subscriptionNotifierProvider.overrideWith(
+              _OpusSubscriptionNotifier.new,
+            ),
+            estimatedCostProvider.overrideWith((ref) => 0),
+            isFreeGenerationProvider.overrideWith((ref) => true),
+          ],
+          child: MaterialApp(
+            locale: const Locale('zh'),
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            home: Scaffold(
+              body: SizedBox(
+                width: width,
+                height: 240,
+                child: const GenerationControls(compact: true),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final reason = 'width=$width';
+      final primaryRect = tester.getRect(
+        find.byKey(const ValueKey('generation-footer-primary-action')),
+      );
+      final actionRects = <Finder>[
+        find.byType(OpusUsageChip),
+        find.byType(AnlasBalanceChip),
+        find.byType(RandomModeToggle),
+        find.byType(AutoSaveToggleChip),
+        find.byType(DraggableNumberInput),
+        find.byType(BatchSettingsButton),
+      ].map(tester.getRect).toList();
+
+      for (final rect in actionRects) {
+        expect(
+          primaryRect.top,
+          greaterThanOrEqualTo(rect.bottom),
+          reason: '$reason 生成按钮排到了操作图标上方',
+        );
+      }
       expect(find.text('生成'), findsOneWidget);
       expect(tester.takeException(), isNull);
     }

--- a/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
+++ b/test/presentation/screens/generation/widgets/generation_controls/generation_controls_test.dart
@@ -97,8 +97,9 @@ void main() {
 
       for (final scenario in const [
         (width: 320.0, textScale: 1.0, singleLine: false),
-        (width: 438.0, textScale: 1.0, singleLine: false),
-        (width: 475.0, textScale: 1.0, singleLine: false),
+        (width: 400.0, textScale: 1.0, singleLine: true),
+        (width: 438.0, textScale: 1.0, singleLine: true),
+        (width: 475.0, textScale: 1.0, singleLine: true),
         (width: 497.0, textScale: 1.0, singleLine: true),
         (width: 590.0, textScale: 1.0, singleLine: true),
         (width: 700.0, textScale: 1.0, singleLine: true),
@@ -229,7 +230,14 @@ void main() {
             closeTo(footerRect.right, 0.01),
             reason: reason,
           );
-          expect(primaryRect.width, greaterThanOrEqualTo(160), reason: reason);
+          // 主按钮不再有固定下限，下限即自身内容宽度：标签必须完整落在按钮内。
+          final labelRect = tester.getRect(find.text('生成'));
+          expect(
+            primaryRect.inflate(0.01).contains(labelRect.topLeft) &&
+                primaryRect.inflate(0.01).contains(labelRect.bottomRight),
+            isTrue,
+            reason: '$reason 主按钮被压到放不下标签',
+          );
         } else {
           expect(
             primaryRect.left,
@@ -577,6 +585,68 @@ void main() {
     expect(find.text('LOGIN_SCREEN_OPENED'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('Opus 配额徽章出现时不把生成按钮挤到单独一行', (tester) async {
+    final storage = _MemoryLocalStorageService({
+      StorageKeys.autoSaveImages: false,
+      StorageKeys.showRandomPromptTools: true,
+    });
+
+    for (final width in const [497.0, 520.0, 590.0]) {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authNotifierProvider.overrideWith(_AuthenticatedAuthNotifier.new),
+            localStorageServiceProvider.overrideWith((ref) => storage),
+            kritaBridgeNotifierProvider.overrideWith(
+              (ref) => _TestKritaBridgeNotifier(),
+            ),
+            replicationQueueNotifierProvider.overrideWith(
+              _TestReplicationQueueNotifier.new,
+            ),
+            queueExecutionNotifierProvider.overrideWith(
+              _TestQueueExecutionNotifier.new,
+            ),
+            subscriptionNotifierProvider.overrideWith(
+              _OpusSubscriptionNotifier.new,
+            ),
+            estimatedCostProvider.overrideWith((ref) => 0),
+            isFreeGenerationProvider.overrideWith((ref) => true),
+          ],
+          child: MaterialApp(
+            locale: const Locale('zh'),
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            home: Scaffold(
+              body: SizedBox(
+                width: width,
+                height: 240,
+                child: const GenerationControls(compact: true),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final reason = 'width=$width';
+      final primaryRect = tester.getRect(
+        find.byKey(const ValueKey('generation-footer-primary-action')),
+      );
+      final opusRect = tester.getRect(find.byType(OpusUsageChip));
+      final anlasRect = tester.getRect(find.byType(AnlasBalanceChip));
+
+      expect(opusRect.width, greaterThan(0), reason: reason);
+      expect(
+        anlasRect.center.dy,
+        closeTo(primaryRect.center.dy, 0.01),
+        reason: '$reason 生成按钮被挤到单独一行',
+      );
+      expect(anlasRect.right, lessThan(primaryRect.left), reason: reason);
+      expect(find.text('生成'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    }
+  });
 }
 
 class _AuthenticatedAuthNotifier extends AuthNotifier {
@@ -650,6 +720,19 @@ class _TestSubscriptionNotifier extends SubscriptionNotifier {
       tier: 1,
       active: true,
       trainingStepsLeft: TrainingStepsInfo(fixedTrainingStepsLeft: 7384),
+    ),
+  );
+}
+
+/// tier 3 且带配额，才会让 Opus 徽章真正占位（默认模型 V5 有配额上限）。
+class _OpusSubscriptionNotifier extends SubscriptionNotifier {
+  @override
+  SubscriptionState build() => const SubscriptionState.loaded(
+    UserSubscription(
+      tier: 3,
+      active: true,
+      trainingStepsLeft: TrainingStepsInfo(fixedTrainingStepsLeft: 7384),
+      usage: OpusUsageInfo(percent: 67),
     ),
   );
 }


### PR DESCRIPTION
## 背景

原 PR #276 的 base 是 `fix/generation-submit-guard` 而不是 `main`。父 PR #275 于 08:21 先 squash 进 main，本改动几秒后才合进那条已经合并掉的分支，merge commit 从未成为 main 的祖先。GitHub 上显示 MERGED，但代码至今不在 main（`debugCannotComputeDryLayout` 在 main 上 0 命中）。

这里把改动重新基于当前 main 提交，base 为 main，不再 stack，并补上第二个提交。

## 改动一：换行下限改为按自身内容推导

底栏用固定的 160px 当主按钮下限来判断能否单行。Opus 用户切到 V5 后左侧多出配额徽章，宽约 500 的官网式面板刚好越过阈值，整条控制栏改走换行版式；换回非 V5 又回到单行。

改为先用无界约束量出主按钮真正需要的宽度，只有连这点宽度都留不出时才换行。下限随字号、语言和是否显示花费徽章自动变化，不会在大字号下裁掉标签。

同时把 `computeDryLayout` 标为不支持：主按钮内部的 ThemedButton 用 LayoutBuilder 决定标签能否收缩，本就无法参与 dry layout，原实现只会静默算出错误尺寸。

## 改动二：换行时生成按钮排到操作图标下方

上一条只消除了「宽度够却误换行」。官网式左栏可拖 320~560、默认 400，带 Opus 配额徽章时这一段确实放不下单行，仍会换行；而换行版式此前把主按钮排在第一行，生成按钮就跳到操作图标上方，与单行版式位置相反。

改为先排操作图标、主按钮排在其后，换行后仍留在控制条最下方。

## 对两个布局的实测影响

`GenerationControls` 有两个使用点：`web_left_panel.dart:379`（官网式钉底条，`compact: true`）与 `main_workspace.dart:148`（经典布局底栏，非 compact）。逐宽度实测主按钮与余额徽章的相对位置：

| 布局 | 宽度 | 改动前 | 改动后 |
| --- | --- | --- | --- |
| 官网式（compact） | 320 / 360 / 400 | 换行，按钮在图标**上方** | 换行，按钮在图标**下方** |
| 官网式（compact） | 497 / 520 / 590 | 误换行 | 单行，按钮居中 |
| 经典（非 compact） | ≥ 500 | 单行，按钮居中 | **完全一致，未变** |
| 经典（非 compact） | < 500 | 换行，按钮在**上方** | 换行，按钮在**下方** |

经典布局的控制区宽度为窗口宽度减去左右两栏，常态在 500 以上，因此常规使用下表现不变；改动只影响它被压到极窄时的换行分支，并使其与官网式布局一致。改动一对经典布局无影响——非 compact 少了 `BatchSettingsButton` 与 `AutoSaveToggleChip` 两个控件，本就没跨过旧阈值。

## 验证

- `flutter analyze` —— No issues found
- `flutter test .../generation_controls_test.dart` —— 9 passed
- 把 `generation_controls.dart` 回退到 main 版本后重跑，2 个失败（控制栏高度 76.0，期望 24.0）
- 把换行排序回退后重跑，2 个失败（`width=320.0 生成按钮排到了操作图标上方`）
- 新增回归测试覆盖官网式左栏 320/360/400 三档宽度