### PR TITLE
fix(gallery): 收藏快捷路径纳入全部过滤条件并清除残留相簿

### DIFF
--- a/lib/data/services/gallery/local_gallery_query.dart
+++ b/lib/data/services/gallery/local_gallery_query.dart
@@ -9,27 +9,13 @@ import 'local_gallery_repository.dart';
 import 'local_gallery_service.dart';
 
 bool isFavoriteOnlyFastFilter(FilterCriteria criteria) {
-  return criteria.showFavoritesOnly &&
-      criteria.searchQuery.trim().isEmpty &&
-      criteria.dateStart == null &&
-      criteria.dateEnd == null &&
-      criteria.selectedTags.isEmpty &&
-      criteria.filterModel == null &&
-      criteria.filterSampler == null &&
-      criteria.filterMinSteps == null &&
-      criteria.filterMaxSteps == null &&
-      criteria.filterMinCfg == null &&
-      criteria.filterMaxCfg == null &&
-      criteria.filterResolution == null &&
-      criteria.minWidth == null &&
-      criteria.minHeight == null &&
-      criteria.maxWidth == null &&
-      criteria.maxHeight == null &&
-      criteria.minFileSize == null &&
-      criteria.maxFileSize == null &&
-      criteria.metadataStatuses.isEmpty &&
-      criteria.categoryId == null &&
-      criteria.categoryFolderPath == null;
+  if (!criteria.showFavoritesOnly) return false;
+  // Derived from hasFilters: new fields disqualify it, a blank query does not.
+  final withoutFavorites = criteria.copyWith(
+    showFavoritesOnly: false,
+    searchQuery: criteria.searchQuery.trim(),
+  );
+  return !withoutFavorites.hasFilters;
 }
 
 /// Owns the authoritative in-memory file ordering and derived query results.

--- a/lib/presentation/providers/gallery_album_provider.dart
+++ b/lib/presentation/providers/gallery_album_provider.dart
@@ -126,6 +126,8 @@ class GalleryAlbumNotifier extends _$GalleryAlbumNotifier {
     final gallery = ref.read(localGalleryNotifierProvider.notifier);
     if (albumId == 'favorites') {
       await gallery.setSelectedCategory(null, null);
+      // 每个 setter 各触发一次过滤：先清相簿，避免中间态落在“相簿 ∩ 收藏”
+      await gallery.setSelectedAlbum(null);
       await gallery.setShowFavoritesOnly(true);
     } else if (albumId != null) {
       await gallery.setShowFavoritesOnly(false);

--- a/test/data/services/gallery/favorite_fast_filter_eligibility_test.dart
+++ b/test/data/services/gallery/favorite_fast_filter_eligibility_test.dart
@@ -1,0 +1,348 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:nai_launcher/core/database/datasources/gallery_data_source.dart';
+import 'package:nai_launcher/data/services/gallery/gallery_filter_service.dart';
+import 'package:nai_launcher/data/services/gallery/gallery_path_utils.dart';
+import 'package:nai_launcher/data/services/gallery/local_gallery_query.dart';
+import 'package:nai_launcher/data/services/gallery/local_gallery_repository.dart';
+
+void main() {
+  final root = p.join(Directory.systemTemp.path, 'favorite_fast_filter');
+  File fileAt(String name) => File(p.join(root, name));
+
+  final parentAlbumFavorite = fileAt('parent_album_favorite.png');
+  final childAlbumFavorite = fileAt('child_album_favorite.png');
+  final unfiledFavorite = fileAt('unfiled_favorite.png');
+  final albumMemberWithoutFavorite = fileAt('album_member_plain.png');
+  final allFiles = <File>[
+    parentAlbumFavorite,
+    childAlbumFavorite,
+    unfiledFavorite,
+    albumMemberWithoutFavorite,
+  ];
+  final favorites = <File>[
+    parentAlbumFavorite,
+    childAlbumFavorite,
+    unfiledFavorite,
+  ];
+
+  late _FakeLocalGalleryRepository repository;
+  late _RecordingFilterService filterService;
+  late LocalGalleryQuery query;
+
+  setUp(() {
+    repository = _FakeLocalGalleryRepository(favorites: favorites);
+    filterService = _RecordingFilterService(
+      favorites: favorites,
+      albumMembers: {
+        'album-parent': [
+          parentAlbumFavorite,
+          childAlbumFavorite,
+          albumMemberWithoutFavorite,
+        ],
+        'album-child': [childAlbumFavorite],
+      },
+    );
+    query = LocalGalleryQuery(
+      repository: repository,
+      filterService: filterService,
+    )..replaceAll(allFiles);
+  });
+
+  group('LocalGalleryQuery favorites fast path', () {
+    test('serves favorites directly when no other criteria is set', () async {
+      await query.applyFilter(const FilterCriteria(showFavoritesOnly: true));
+
+      expect(repository.queryFavoriteImagesCalls, 1);
+      expect(filterService.applyFiltersCalls, 0);
+      expect(
+        query.effectiveFiles.map((file) => file.path),
+        favorites.map((file) => file.path),
+      );
+      expect(query.filteredCount, favorites.length);
+    });
+
+    test('intersects favorites with the selected album', () async {
+      await query.applyFilter(
+        const FilterCriteria(showFavoritesOnly: true, albumId: 'album-parent'),
+      );
+
+      expect(repository.queryFavoriteImagesCalls, 0);
+      expect(filterService.applyFiltersCalls, 1);
+      expect(query.effectiveFiles.map((file) => file.path), [
+        parentAlbumFavorite.path,
+        childAlbumFavorite.path,
+      ]);
+      expect(query.filteredCount, 2);
+    });
+
+    test('intersects favorites with a sub album', () async {
+      await query.applyFilter(
+        const FilterCriteria(showFavoritesOnly: true, albumId: 'album-child'),
+      );
+
+      expect(repository.queryFavoriteImagesCalls, 0);
+      expect(query.effectiveFiles.map((file) => file.path), [
+        childAlbumFavorite.path,
+      ]);
+    });
+
+    test('keeps the favorites album on the shared filter pipeline', () async {
+      await query.applyFilter(
+        const FilterCriteria(showFavoritesOnly: true, albumId: 'favorites'),
+      );
+
+      expect(repository.queryFavoriteImagesCalls, 0);
+      expect(filterService.applyFiltersCalls, 1);
+      expect(
+        query.effectiveFiles.map((file) => file.path),
+        favorites.map((file) => file.path),
+      );
+    });
+
+    test('leaves the album filter intact without the favorites flag', () async {
+      await query.applyFilter(const FilterCriteria(albumId: 'album-parent'));
+
+      expect(repository.queryFavoriteImagesCalls, 0);
+      expect(query.effectiveFiles.map((file) => file.path), [
+        parentAlbumFavorite.path,
+        childAlbumFavorite.path,
+        albumMemberWithoutFavorite.path,
+      ]);
+    });
+  });
+
+  group('isFavoriteOnlyFastFilter eligibility', () {
+    final disqualifyingCriteria = <String, FilterCriteria>{
+      'searchQuery': const FilterCriteria(
+        showFavoritesOnly: true,
+        searchQuery: 'sky',
+      ),
+      'dateStart': FilterCriteria(
+        showFavoritesOnly: true,
+        dateStart: DateTime(2026),
+      ),
+      'dateEnd': FilterCriteria(
+        showFavoritesOnly: true,
+        dateEnd: DateTime(2026, 2),
+      ),
+      'selectedTags': const FilterCriteria(
+        showFavoritesOnly: true,
+        selectedTags: ['1girl'],
+      ),
+      'filterModel': const FilterCriteria(
+        showFavoritesOnly: true,
+        filterModel: 'nai-diffusion-4-5-full',
+      ),
+      'filterSampler': const FilterCriteria(
+        showFavoritesOnly: true,
+        filterSampler: 'k_euler_ancestral',
+      ),
+      'filterMinSteps': const FilterCriteria(
+        showFavoritesOnly: true,
+        filterMinSteps: 10,
+      ),
+      'filterMaxSteps': const FilterCriteria(
+        showFavoritesOnly: true,
+        filterMaxSteps: 28,
+      ),
+      'filterMinCfg': const FilterCriteria(
+        showFavoritesOnly: true,
+        filterMinCfg: 4.5,
+      ),
+      'filterMaxCfg': const FilterCriteria(
+        showFavoritesOnly: true,
+        filterMaxCfg: 6.5,
+      ),
+      'filterResolution': const FilterCriteria(
+        showFavoritesOnly: true,
+        filterResolution: '832x1216',
+      ),
+      'minWidth': const FilterCriteria(showFavoritesOnly: true, minWidth: 512),
+      'minHeight': const FilterCriteria(
+        showFavoritesOnly: true,
+        minHeight: 512,
+      ),
+      'maxWidth': const FilterCriteria(showFavoritesOnly: true, maxWidth: 2048),
+      'maxHeight': const FilterCriteria(
+        showFavoritesOnly: true,
+        maxHeight: 2048,
+      ),
+      'minFileSize': const FilterCriteria(
+        showFavoritesOnly: true,
+        minFileSize: 1024,
+      ),
+      'maxFileSize': const FilterCriteria(
+        showFavoritesOnly: true,
+        maxFileSize: 4096,
+      ),
+      'metadataStatuses': const FilterCriteria(
+        showFavoritesOnly: true,
+        metadataStatuses: ['success'],
+      ),
+      'categoryId': const FilterCriteria(
+        showFavoritesOnly: true,
+        categoryId: 'category-1',
+      ),
+      'categoryFolderPath': const FilterCriteria(
+        showFavoritesOnly: true,
+        categoryFolderPath: 'characters',
+      ),
+      'albumId': const FilterCriteria(
+        showFavoritesOnly: true,
+        albumId: 'album-parent',
+      ),
+    };
+
+    test('accepts only the bare favorites toggle', () {
+      expect(
+        isFavoriteOnlyFastFilter(const FilterCriteria(showFavoritesOnly: true)),
+        isTrue,
+      );
+      expect(isFavoriteOnlyFastFilter(const FilterCriteria()), isFalse);
+    });
+
+    test('treats a blank search query as no filter', () {
+      expect(
+        isFavoriteOnlyFastFilter(
+          const FilterCriteria(showFavoritesOnly: true, searchQuery: '   '),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects every other criteria field', () {
+      for (final entry in disqualifyingCriteria.entries) {
+        expect(
+          isFavoriteOnlyFastFilter(entry.value),
+          isFalse,
+          reason: '${entry.key} must disqualify the favorites fast path',
+        );
+      }
+    });
+
+    test('covers every field carried by the cache key', () {
+      final fullyPopulated = FilterCriteria(
+        searchQuery: 'sky',
+        dateStart: DateTime(2026),
+        dateEnd: DateTime(2026, 2),
+        showFavoritesOnly: true,
+        selectedTags: const ['1girl'],
+        filterModel: 'nai-diffusion-4-5-full',
+        filterSampler: 'k_euler_ancestral',
+        filterMinSteps: 10,
+        filterMaxSteps: 28,
+        filterMinCfg: 4.5,
+        filterMaxCfg: 6.5,
+        filterResolution: '832x1216',
+        minWidth: 512,
+        minHeight: 512,
+        maxWidth: 2048,
+        maxHeight: 2048,
+        minFileSize: 1024,
+        maxFileSize: 4096,
+        metadataStatuses: const ['success'],
+        categoryId: 'category-1',
+        categoryFolderPath: 'characters',
+        albumId: 'album-parent',
+      );
+
+      // cacheKey 承载 FilterCriteria 的相等性，新增字段必然出现在这里
+      expect(
+        fullyPopulated.cacheKey.split('|'),
+        hasLength(disqualifyingCriteria.length + 1),
+      );
+    });
+  });
+}
+
+Set<String> _pathKeys(Iterable<File> files) => {
+  for (final file in files) galleryFilePathKey(file.path),
+};
+
+class _FakeLocalGalleryRepository extends Mock
+    implements LocalGalleryRepository {
+  _FakeLocalGalleryRepository({required this.favorites});
+
+  final List<File> favorites;
+  int queryFavoriteImagesCalls = 0;
+
+  @override
+  Future<List<GalleryImageRecord>> queryFavoriteImages({
+    required int limit,
+  }) async {
+    queryFavoriteImagesCalls++;
+    final timestamp = DateTime(2026);
+    return favorites
+        .take(limit)
+        .map(
+          (file) => GalleryImageRecord(
+            filePath: file.path,
+            fileName: p.basename(file.path),
+            fileSize: 4,
+            modifiedAt: timestamp,
+            createdAt: timestamp,
+            indexedAt: timestamp,
+            dateYmd: 20260101,
+            isFavorite: true,
+          ),
+        )
+        .toList();
+  }
+}
+
+/// Mirrors the favorites and album stages of the shared filter pipeline.
+class _RecordingFilterService extends Mock implements GalleryFilterService {
+  _RecordingFilterService({
+    required List<File> favorites,
+    required Map<String, List<File>> albumMembers,
+  }) : _favoriteKeys = _pathKeys(favorites),
+       _albumMemberKeys = {
+         for (final entry in albumMembers.entries)
+           entry.key: _pathKeys(entry.value),
+       };
+
+  final Set<String> _favoriteKeys;
+  final Map<String, Set<String>> _albumMemberKeys;
+  int applyFiltersCalls = 0;
+
+  @override
+  Future<FilterResult> applyFilters(
+    List<File> allFiles,
+    FilterCriteria criteria, {
+    String? operationId,
+    int fileListGeneration = 0,
+  }) async {
+    applyFiltersCalls++;
+    var filtered = allFiles;
+    if (criteria.showFavoritesOnly) {
+      filtered = _retain(filtered, _favoriteKeys);
+    }
+    final albumId = criteria.albumId;
+    if (albumId != null) {
+      filtered = _retain(
+        filtered,
+        albumId == 'favorites'
+            ? _favoriteKeys
+            : _albumMemberKeys[albumId] ?? const <String>{},
+      );
+    }
+    return FilterResult(
+      files: filtered,
+      totalCount: filtered.length,
+      executionTime: Duration.zero,
+      criteria: criteria,
+    );
+  }
+
+  @override
+  void cancelFilter(String operationId) {}
+
+  List<File> _retain(List<File> files, Set<String> keys) => files
+      .where((file) => keys.contains(galleryFilePathKey(file.path)))
+      .toList();
+}

--- a/test/presentation/providers/gallery_album_provider_selection_test.dart
+++ b/test/presentation/providers/gallery_album_provider_selection_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:nai_launcher/data/models/gallery/gallery_album.dart';
+import 'package:nai_launcher/data/services/gallery/gallery_filter_service.dart';
+import 'package:nai_launcher/data/services/gallery/unified_gallery_service.dart';
+import 'package:nai_launcher/presentation/providers/gallery_album_provider.dart';
+import 'package:nai_launcher/presentation/providers/gallery_category_provider.dart';
+import 'package:nai_launcher/presentation/providers/local_gallery_provider.dart';
+
+void main() {
+  late _RecordingGalleryService service;
+  late ProviderContainer container;
+
+  setUp(() {
+    service = _RecordingGalleryService();
+    container = ProviderContainer(
+      overrides: [
+        galleryServiceProvider.overrideWith(() => _StubGalleryService(service)),
+        galleryAlbumNotifierProvider.overrideWith(_TestAlbumNotifier.new),
+        galleryCategoryNotifierProvider.overrideWith(_TestCategoryNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  GalleryAlbumNotifier albums() =>
+      container.read(galleryAlbumNotifierProvider.notifier);
+
+  FilterCriteria criteria() =>
+      container.read(localGalleryNotifierProvider).filterCriteria;
+
+  String? selectedAlbumId() =>
+      container.read(galleryAlbumNotifierProvider).selectedAlbumId;
+
+  group('GalleryAlbumNotifier.selectAlbum', () {
+    test('drops the previous album when favorites is selected', () async {
+      await albums().selectAlbum('album-a');
+      expect(criteria().albumId, 'album-a');
+
+      await albums().selectAlbum('favorites');
+
+      expect(selectedAlbumId(), 'favorites');
+      expect(criteria().albumId, isNull);
+      expect(criteria().categoryId, isNull);
+      expect(criteria().showFavoritesOnly, isTrue);
+    });
+
+    test('never narrows favorites by the previous album', () async {
+      await albums().selectAlbum('album-a');
+      await albums().selectAlbum('favorites');
+
+      expect(
+        service.applied.where(
+          (applied) => applied.showFavoritesOnly && applied.albumId != null,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('drops the favorites flag when a normal album is selected', () async {
+      await albums().selectAlbum('favorites');
+
+      await albums().selectAlbum('album-a');
+
+      expect(selectedAlbumId(), 'album-a');
+      expect(criteria().albumId, 'album-a');
+      expect(criteria().showFavoritesOnly, isFalse);
+    });
+
+    test('clears both after browsing an album', () async {
+      await albums().selectAlbum('album-a');
+
+      await albums().selectAlbum(null);
+
+      expect(selectedAlbumId(), isNull);
+      expect(criteria().albumId, isNull);
+      expect(criteria().showFavoritesOnly, isFalse);
+    });
+
+    test('clears both after browsing favorites', () async {
+      await albums().selectAlbum('favorites');
+
+      await albums().selectAlbum(null);
+
+      expect(selectedAlbumId(), isNull);
+      expect(criteria().albumId, isNull);
+      expect(criteria().showFavoritesOnly, isFalse);
+    });
+  });
+}
+
+class _RecordingGalleryService extends Mock implements LocalGalleryService {
+  final List<FilterCriteria> applied = [];
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  int get filteredCount => 0;
+
+  @override
+  int get totalCount => 0;
+
+  @override
+  FilterCriteria get currentFilter =>
+      applied.isEmpty ? const FilterCriteria() : applied.last;
+
+  @override
+  Future<void> applyFilter(FilterCriteria criteria) async {
+    applied.add(criteria);
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _StubGalleryService extends GalleryService {
+  _StubGalleryService(this.service);
+
+  final LocalGalleryService service;
+
+  @override
+  LocalGalleryService build() => service;
+
+  @override
+  Future<void> ensureInitialized() async {}
+}
+
+class _TestAlbumNotifier extends GalleryAlbumNotifier {
+  @override
+  GalleryAlbumState build() => GalleryAlbumState(
+    albums: [
+      GalleryAlbum(
+        id: 'album-a',
+        name: 'Album A',
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+      ),
+    ],
+  );
+}
+
+class _TestCategoryNotifier extends GalleryCategoryNotifier {
+  @override
+  GalleryCategoryState build() => const GalleryCategoryState();
+}


### PR DESCRIPTION
## 背景

原 PR #273 的 base 是 `fix/gallery-filter-cache-file-generation` 而不是 `main`。父 PR #272 于 08:21 先 squash 进 main，本改动之后才合进那条已经合并掉的分支，merge commit 从未成为 main 的祖先。GitHub 上显示 MERGED，但代码至今不在 main。

这里把两个提交重新基于当前 main 提交，base 为 main，不再 stack。

## 改动

- 仅收藏的快捷路径此前绕开了相簿等过滤条件，导致「相簿 ∩ 收藏」的结果被当成全部收藏返回。改为只有在除收藏开关外没有任何其他条件时才走快捷路径，其余情况一律回到共用的过滤管线。
- 选中收藏相簿时先清掉此前选中的普通相簿，避免中间态落在「相簿 ∩ 收藏」。

## 验证

- `flutter analyze` —— No issues found
- `flutter test test/data/services/gallery/favorite_fast_filter_eligibility_test.dart test/presentation/providers/gallery_album_provider_selection_test.dart` —— 14 passed
- 把 `local_gallery_query.dart` 与 `gallery_album_provider.dart` 回退到 main 版本后重跑，6 个失败（选中收藏后 selectedAlbumId 仍为 `album-a`，期望 null），确认修的是 main 上仍在的问题