### PR TITLE
fix(agent): 修复 Responses 推理配置与多工具回放并支持连接重试

### DIFF
--- a/lib/presentation/prompt_assistant/models/assistant_model_capability.dart
+++ b/lib/presentation/prompt_assistant/models/assistant_model_capability.dart
@@ -219,6 +219,7 @@ class AssistantModelCatalog {
       };
     }
 
+    if (rule != null) rule = _ruleForProtocol(provider.protocol, rule);
     if (rule != null && !_protocolSupports(provider.protocol, rule.api)) {
       rule = null;
     }
@@ -255,7 +256,8 @@ class AssistantModelCatalog {
 
     AgentReasoningModelRule? compatible;
     AgentReasoningModelRule? fallback;
-    for (final rule in candidates) {
+    for (final candidate in candidates) {
+      final rule = _ruleForProtocol(protocol, candidate);
       if (fallback == null || rule.contextWindow < fallback.contextWindow) {
         fallback = rule;
       }
@@ -374,6 +376,23 @@ class AssistantModelCatalog {
       if (entry.key.toLowerCase() == normalized) return entry.value;
     }
     return null;
+  }
+
+  // Compatible Responses gateways consume nested effort, not the native
+  // Chat Completions toggle fields. Keep the catalog's supported levels and
+  // explicit off restrictions while adapting only the wire representation.
+  static AgentReasoningModelRule _ruleForProtocol(
+    ProviderProtocol protocol,
+    AgentReasoningModelRule rule,
+  ) {
+    if (protocol == ProviderProtocol.openaiResponses &&
+        (rule.api == AgentReasoningApi.deepSeek ||
+            rule.api == AgentReasoningApi.qwen ||
+            rule.api == AgentReasoningApi.openRouter ||
+            rule.api == AgentReasoningApi.openAiCompletions)) {
+      return rule.withApi(AgentReasoningApi.openAiResponses);
+    }
+    return rule;
   }
 
   static bool _protocolSupports(

--- a/lib/presentation/prompt_assistant/services/provider_adapters/agent_wire_helpers.dart
+++ b/lib/presentation/prompt_assistant/services/provider_adapters/agent_wire_helpers.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
@@ -162,6 +163,80 @@ Stream<Uint8List> agentStreamPost(
   required Map<String, dynamic> headers,
   required CancelToken cancelToken,
   Duration? receiveTimeout = const Duration(minutes: 5),
+}) async* {
+  var receivedBytes = false;
+  for (var attempt = 0; ; attempt++) {
+    if (cancelToken.cancelError case final error?) throw error;
+    try {
+      await for (final chunk in _agentStreamPostOnce(
+        dio,
+        endpoint: endpoint,
+        payload: payload,
+        headers: headers,
+        cancelToken: cancelToken,
+        receiveTimeout: receiveTimeout,
+      )) {
+        if (chunk.isNotEmpty) receivedBytes = true;
+        yield chunk;
+      }
+      return;
+    } on Object catch (error) {
+      if (cancelToken.cancelError case final cancelled?) throw cancelled;
+      // Never replay a stream after bytes have reached its parser, even if
+      // those bytes have not yet produced a visible text or tool event.
+      if (receivedBytes ||
+          attempt >= 2 ||
+          !_isTransientConnectionError(error)) {
+        rethrow;
+      }
+      await _waitForRetry(
+        Duration(milliseconds: 500 * (1 << attempt)),
+        cancelToken,
+      );
+    }
+  }
+}
+
+bool _isTransientConnectionError(Object error) {
+  if (error is DioException) {
+    if (error.response != null) return false;
+    return switch (error.type) {
+      DioExceptionType.connectionTimeout ||
+      DioExceptionType.sendTimeout ||
+      DioExceptionType.receiveTimeout ||
+      DioExceptionType.connectionError => true,
+      DioExceptionType.unknown =>
+        error.error != null && _isTransientConnectionError(error.error!),
+      _ => false,
+    };
+  }
+  if (error is HandshakeException) {
+    // Certificate failures require configuration changes, not another request.
+    return error.message.toLowerCase().contains(
+      'connection terminated during handshake',
+    );
+  }
+  return error is SocketException || error is TimeoutException;
+}
+
+Future<void> _waitForRetry(Duration delay, CancelToken cancelToken) async {
+  final ready = Completer<void>();
+  final timer = Timer(delay, ready.complete);
+  try {
+    await Future.any([ready.future, cancelToken.whenCancel]);
+    if (cancelToken.cancelError case final error?) throw error;
+  } finally {
+    timer.cancel();
+  }
+}
+
+Stream<Uint8List> _agentStreamPostOnce(
+  Dio dio, {
+  required String endpoint,
+  required Object payload,
+  required Map<String, dynamic> headers,
+  required CancelToken cancelToken,
+  required Duration? receiveTimeout,
 }) async* {
   late final Response<ResponseBody> response;
   try {

--- a/lib/presentation/prompt_assistant/services/provider_adapters/openai_responses_adapter.dart
+++ b/lib/presentation/prompt_assistant/services/provider_adapters/openai_responses_adapter.dart
@@ -335,27 +335,26 @@ class OpenAiResponsesAdapter extends PromptAssistantProviderAdapter {
           }
         }
       } else if (message is ToolResultMessage) {
+        final images = toolResultImagesOf(message);
+        // Pi keeps multimodal output on the call itself. A synthetic user
+        // turn here can split the outputs of a parallel tool-call batch.
         input.add({
           'type': 'function_call_output',
           'call_id': message.toolCallId,
-          'output': message.text,
+          'output': images.isEmpty
+              ? message.text
+              : [
+                  if (message.text.isNotEmpty)
+                    {'type': 'input_text', 'text': message.text},
+                  for (final image in images)
+                    if (_openAiImageUrl(image) case final url?)
+                      {
+                        'type': 'input_image',
+                        'image_url': url,
+                        'detail': 'auto',
+                      },
+                ],
         });
-        final images = toolResultImagesOf(message);
-        if (images.isNotEmpty) {
-          input.add({
-            'type': 'message',
-            'role': 'user',
-            'content': [
-              {
-                'type': 'input_text',
-                'text': 'Visual output returned by ${message.toolName}.',
-              },
-              for (final image in images)
-                if (_openAiImageUrl(image) case final url?)
-                  {'type': 'input_image', 'image_url': url, 'detail': 'auto'},
-            ],
-          });
-        }
       }
     }
 

--- a/test/presentation/prompt_assistant/services/provider_adapters/responses_stability_test.dart
+++ b/test/presentation/prompt_assistant/services/provider_adapters/responses_stability_test.dart
@@ -1,0 +1,349 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/agent/agent_types.dart';
+import 'package:nai_launcher/core/agent/harness/harness_messages.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/models/agent_protocol.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/models/assistant_model_capability.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/models/prompt_assistant_models.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/services/provider_adapters/agent_wire_helpers.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/services/provider_adapters/openai_responses_adapter.dart';
+import 'package:nai_launcher/presentation/prompt_assistant/services/provider_adapters/reasoning_payload.dart';
+
+const _provider = ProviderConfig(
+  id: 'gateway',
+  name: 'Gateway',
+  baseUrl: 'https://example.invalid/v1',
+  protocol: ProviderProtocol.openaiResponses,
+);
+
+void main() {
+  for (final model in ['deepseek-v4-flash', 'glm-5']) {
+    test('$model keeps catalog levels across protocol switches', () {
+      final responses = AssistantModelCatalog.resolveProvider(
+        provider: _provider,
+        model: model,
+      );
+      final chat = AssistantModelCatalog.resolveProvider(
+        provider: const ProviderConfig(
+          id: 'gateway',
+          name: 'Gateway',
+          baseUrl: 'https://example.invalid/v1',
+          protocol: ProviderProtocol.openaiChatCompletions,
+        ),
+        model: model,
+      );
+      expect(responses.thinkingLevels, chat.thinkingLevels);
+      expect(responses.thinkingLevels, contains(ThinkingLevel.off));
+      expect(
+        responsesReasoningEffort(responses.resolveReasoningRequest(null), null),
+        'none',
+      );
+      expect(
+        responsesReasoningEffort(
+          responses.resolveReasoningRequest('high'),
+          null,
+        ),
+        'high',
+      );
+      expect(
+        chatReasoningPayload(chat.resolveReasoningRequest(null)),
+        isNotEmpty,
+      );
+    });
+  }
+
+  test('reasoner without off does not acquire an off option', () {
+    final metadata = AssistantModelCatalog.resolveProvider(
+      provider: const ProviderConfig(
+        id: 'deepseek',
+        name: 'DeepSeek',
+        preset: ProviderPreset.deepseek,
+        baseUrl: 'https://example.invalid',
+        protocol: ProviderProtocol.openaiResponses,
+      ),
+      model: 'deepseek-reasoner',
+    );
+    expect(
+      metadata.selectableThinkingLevels,
+      isNot(contains(ThinkingLevel.off)),
+    );
+    expect(
+      responsesReasoningEffort(metadata.resolveReasoningRequest(null), null),
+      isNull,
+    );
+  });
+
+  test(
+    'parallel multimodal outputs stay attached to calls after a failed turn',
+    () async {
+      final transport = _Transport(
+        (options, attempt) async => ResponseBody.fromString(
+          'event: response.completed\ndata: {"response":{}}\n\n',
+          200,
+        ),
+      );
+      final dio = Dio()..httpClientAdapter = transport;
+      addTearDown(dio.close);
+      final messages = <AgentMessage>[
+        UserMessage.text('generate two previews'),
+        AssistantMessage(
+          content: const [
+            ToolCallContent(id: 'first', name: 'preview', arguments: {}),
+            ToolCallContent(id: 'second', name: 'preview', arguments: {}),
+          ],
+          stopReason: StopReason.toolUse,
+        ),
+        for (final id in ['first', 'second'])
+          ToolResultMessage(
+            toolCallId: id,
+            toolName: 'preview',
+            content: [
+              ToolResultTextContent(id),
+              const ToolResultImageContent(
+                ImageContent(
+                  source: ImageSource.base64(
+                    mimeType: 'image/png',
+                    base64Data: 'AA==',
+                  ),
+                ),
+              ),
+            ],
+          ),
+        AssistantMessage(content: const [], stopReason: StopReason.error),
+        UserMessage.text('continue'),
+      ];
+      final metadata = AssistantModelCatalog.resolveProvider(
+        provider: _provider,
+        model: 'deepseek-v4-flash',
+      );
+      final events = await const OpenAiResponsesAdapter()
+          .completeAgent(
+            dio: dio,
+            request: AgentChatRequest(
+              sessionId: 'test',
+              provider: _provider,
+              model: 'deepseek-v4-flash',
+              systemPrompt: '',
+              messages: harnessConvertToLlm(messages),
+              tools: const [],
+              apiKey: null,
+              reasoningRequest: metadata.resolveReasoningRequest(null),
+            ),
+            cancelToken: CancelToken(),
+          )
+          .toList();
+      expect(events.whereType<AgentWireError>(), isEmpty);
+      expect(events.whereType<AgentWireFinish>(), hasLength(1));
+      final payload = transport.payload!;
+      expect((payload['reasoning'] as Map)['effort'], 'none');
+      final input = (payload['input'] as List).cast<Map>();
+      expect(input.map((item) => item['type']), [
+        'message',
+        'function_call',
+        'function_call',
+        'function_call_output',
+        'function_call_output',
+        'message',
+      ]);
+      for (var i = 0; i < 2; i++) {
+        expect(input[3 + i]['call_id'], input[1 + i]['call_id']);
+        expect(input[3 + i]['output'], [
+          {'type': 'input_text', 'text': i == 0 ? 'first' : 'second'},
+          {
+            'type': 'input_image',
+            'image_url': 'data:image/png;base64,AA==',
+            'detail': 'auto',
+          },
+        ]);
+      }
+    },
+  );
+
+  test('handshake termination retries then succeeds', () async {
+    final transport = _Transport((options, attempt) async {
+      if (attempt < 3) {
+        throw const HandshakeException(
+          'Connection terminated during handshake',
+        );
+      }
+      return ResponseBody.fromString('ok', 200);
+    });
+    expect(await _read(transport), isNotEmpty);
+    expect(transport.attempts, 3);
+  });
+
+  test('persistent connection failure stops after three attempts', () async {
+    final transport = _Transport((options, attempt) async {
+      throw const SocketException('reset');
+    });
+    await expectLater(_read(transport), throwsA(isA<DioException>()));
+    expect(transport.attempts, 3);
+  });
+
+  for (final type in [
+    DioExceptionType.connectionTimeout,
+    DioExceptionType.sendTimeout,
+    DioExceptionType.receiveTimeout,
+  ]) {
+    test('$type retries before output', () async {
+      final transport = _Transport((options, attempt) async {
+        if (attempt == 1) {
+          throw DioException(requestOptions: options, type: type);
+        }
+        return ResponseBody.fromString('ok', 200);
+      });
+      expect(await _read(transport), isNotEmpty);
+      expect(transport.attempts, 2);
+    });
+  }
+
+  test('stream failure before the first byte retries', () async {
+    final transport = _Transport((options, attempt) async {
+      if (attempt == 1) {
+        return ResponseBody(
+          Stream<Uint8List>.error(const SocketException('reset')),
+          200,
+        );
+      }
+      return ResponseBody.fromString('ok', 200);
+    });
+    expect(await _read(transport), isNotEmpty);
+    expect(transport.attempts, 2);
+  });
+
+  test('an unknown programming error is not a network retry', () async {
+    final transport = _Transport((options, attempt) async {
+      throw StateError('invalid local state');
+    });
+    await expectLater(_read(transport), throwsA(isA<DioException>()));
+    expect(transport.attempts, 1);
+  });
+
+  test('already cancelled request never reaches transport', () async {
+    final transport = _Transport(
+      (options, attempt) async => ResponseBody.fromString('ok', 200),
+    );
+    final cancel = CancelToken()..cancel();
+    await expectLater(
+      _read(transport, cancel: cancel),
+      throwsA(
+        isA<DioException>().having(
+          (e) => e.type,
+          'type',
+          DioExceptionType.cancel,
+        ),
+      ),
+    );
+    expect(transport.attempts, 0);
+  });
+
+  test('HTTP 400 retains detail and is never retried', () async {
+    final transport = _Transport(
+      (options, attempt) async => ResponseBody.fromString(
+        '{"error":{"message":"No tool output found for tool call second"}}',
+        400,
+      ),
+    );
+    await expectLater(
+      _read(transport),
+      throwsA(
+        isA<DioException>().having(
+          (e) => e.response?.data.toString(),
+          'body',
+          contains('tool call second'),
+        ),
+      ),
+    );
+    expect(transport.attempts, 1);
+  });
+
+  test('certificate rejection is never retried', () async {
+    final transport = _Transport((options, attempt) async {
+      throw const HandshakeException('CERTIFICATE_VERIFY_FAILED');
+    });
+    await expectLater(_read(transport), throwsA(isA<DioException>()));
+    expect(transport.attempts, 1);
+  });
+
+  test(
+    'network failure after even partial SSE bytes is not replayed',
+    () async {
+      final transport = _Transport(
+        (options, attempt) async => ResponseBody(() async* {
+          yield Uint8List.fromList([100]);
+          throw const SocketException('reset');
+        }(), 200),
+      );
+      await expectLater(_read(transport), throwsA(anything));
+      expect(transport.attempts, 1);
+    },
+  );
+
+  test('cancel during backoff prevents the next attempt', () async {
+    final cancel = CancelToken();
+    final failed = Completer<void>();
+    final transport = _Transport((options, attempt) async {
+      failed.complete();
+      throw const SocketException('reset');
+    });
+    final result = _read(transport, cancel: cancel);
+    final assertion = expectLater(
+      result,
+      throwsA(
+        isA<DioException>().having(
+          (e) => e.type,
+          'type',
+          DioExceptionType.cancel,
+        ),
+      ),
+    );
+    await failed.future;
+    await Future<void>.delayed(Duration.zero);
+    cancel.cancel();
+    await assertion;
+    expect(transport.attempts, 1);
+  });
+}
+
+Future<List<Uint8List>> _read(
+  _Transport transport, {
+  CancelToken? cancel,
+}) async {
+  final dio = Dio()..httpClientAdapter = transport;
+  try {
+    return await agentStreamPost(
+      dio,
+      endpoint: 'https://example.invalid',
+      payload: const {},
+      headers: const {},
+      cancelToken: cancel ?? CancelToken(),
+    ).toList();
+  } finally {
+    dio.close();
+  }
+}
+
+class _Transport implements HttpClientAdapter {
+  _Transport(this.respond);
+  final Future<ResponseBody> Function(RequestOptions, int) respond;
+  int attempts = 0;
+  Map<String, dynamic>? payload;
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    if (options.data is Map<String, dynamic>) {
+      payload = options.data as Map<String, dynamic>;
+    }
+    return respond(options, ++attempts);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## 改动内容

修复 #300 的三个子问题：
- DeepSeek、GLM 等已知模型切换到兼容 Responses 协议时，保留 Pi 目录的推理档位及关闭限制，将请求转换为 reasoning.effort；支持关闭的模型明确发送 none，Chat Completions 保持原有字段。
- 流式请求尚未收到任何字节时，对连接重置、连接/发送/接收超时和握手期间连接终止最多重试两次，等待 500ms/1000ms。取消立即结束等待；HTTP 错误、证书错误及已经收到字节的流不会重试，最终错误仍按原路径暴露。
- 对齐本机 Pi 与官方 openai-responses-shared 实现，将图片与文本直接放在对应 function_call_output.output 内，不再插入 user 消息打断多工具结果回放。
- 添加协议切换、关闭限制、多工具图片结果、失败历史续聊、有限重试、取消和不可重试错误回归。

## 验证结果

- 六个针对性测试文件（模型能力、推理目录、请求映射、流适配器、新增稳定性测试、Harness）：119 项通过。
- 补充流开始前断连、预取消和普通程序错误后，稳定性测试单文件 16 项全部通过。
- 四个改动文件 dart analyze：No issues found。
- scripts/verify_flutter_sources.ps1 与 git diff --check 通过。
- 已检查最新 main；未改动 Harness 协议、生成文件、LFS 或 assets。

## 注意事项

- 最初 test_affected 自动纳入 app_test，但新工作树缺少应用级 Freezed/Riverpod 等生成文件，应用级测试无法编译；改为运行直接覆盖本次行为的上述六个测试文件，没有进行全量生成、全量测试或平台构建。
- 未调用真实供应商、未进行 GUI 验收；兼容网关仍需支持标准 reasoning.effort 与多模态 function_call_output。当前工作树无开发会话，未操作其他工作树的会话。
- 依据用户授权，完成实际本地验证后直接合并，无需等待 CI。

参考：[Pi Responses 转换](https://github.com/earendil-works/pi/blob/main/packages/ai/src/api/openai-responses-shared.ts)、[OpenAI Function calling](https://developers.openai.com/api/docs/guides/function-calling)。

Closes #300
