### PR TITLE
fix(agent): 修复参考图资源参数并补齐脱敏权限诊断

### DIFF
--- a/lib/core/agent/resources/agent_chat_resource_reference_codec.dart
+++ b/lib/core/agent/resources/agent_chat_resource_reference_codec.dart
@@ -21,6 +21,35 @@ abstract final class AgentChatResourceReferenceCodec {
   static const String mimeType = '$mediaType; version=1';
   static const String uriScheme = 'aaalice-agent-resource';
 
+  /// Tool callers receive one identity, never the surrounding attachment list.
+  static const Map<String, dynamic> jsonSchema = {
+    'type': 'object',
+    'description':
+        'One exact resource_ref object from an application tool or an '
+        'agent-resource-references entry. Do not include references, '
+        'schemaVersion, or available.',
+    'properties': {
+      'version': {
+        'type': 'integer',
+        'enum': [1],
+      },
+      'kind': {'type': 'string'},
+      'source': {'type': 'string'},
+      'resourceId': {'type': 'string'},
+      'mediaId': {'type': 'string'},
+      'display': {
+        'type': 'object',
+        'additionalProperties': {'type': 'string'},
+      },
+      'provenance': {
+        'type': 'object',
+        'additionalProperties': {'type': 'string'},
+      },
+    },
+    'required': ['version', 'kind', 'source', 'resourceId'],
+    'additionalProperties': false,
+  };
+
   static const Set<String> _topLevelFields = {
     'version',
     'kind',

--- a/lib/core/services/diagnostic_agent_audit.dart
+++ b/lib/core/services/diagnostic_agent_audit.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import '../agent/permissions/agent_permission.dart';
+
+/// Export only permission metadata. Tool error text can contain user content,
+/// so it is classified locally and is never copied into the diagnostics ZIP.
+abstract final class DiagnosticAgentAudit {
+  static String sanitizeLine(String line) {
+    try {
+      final value = jsonDecode(line);
+      if (value is! Map<String, dynamic>) {
+        throw const FormatException('Expected an audit object');
+      }
+      final timestamp = DateTime.tryParse('${value['timestamp']}');
+      final result = AgentPermissionDecision.values
+          .where((decision) => decision.name == value['result'])
+          .firstOrNull;
+      if (timestamp == null || result == null) {
+        throw const FormatException('Invalid audit metadata');
+      }
+      final summary = value['summary'];
+      final error = value['error'];
+      final id = '${value['id']}';
+      final phase = RegExp(r'\.(decision|approval|result)$').firstMatch(id);
+      return jsonEncode({
+        'timestamp': timestamp.toUtc().toIso8601String(),
+        'toolCallIdHash': sha256
+            .convert(
+              utf8.encode(phase == null ? id : id.substring(0, phase.start)),
+            )
+            .toString(),
+        if (phase != null) 'phase': phase.group(1),
+        'result': result.name,
+        'summary': summary is String && _summary.hasMatch(summary)
+            ? summary
+            : '[REDACTED AUDIT SUMMARY]',
+        if (error != null) 'errorCategory': _errorCategory(error),
+      });
+    } on FormatException {
+      // A snapshot can end in a partial append; never export its raw content.
+      return jsonEncode({'diagnostic': 'invalid_or_incomplete_audit_record'});
+    }
+  }
+
+  static final _summary = RegExp(
+    r'^[a-z][a-z0-9_]* (?:completed|user approval|permission catalog unavailable|'
+    '(?:${AgentPermissionDomain.values.map((value) => value.name).join('|')})'
+    '/(?:${AgentPermissionOperation.values.map((value) => value.name).join('|')}))\$',
+  );
+
+  static String _errorCategory(Object error) {
+    if (error is! String) return 'tool_error';
+    if (error.contains('blocked by its permission domain policy')) {
+      return 'permission_policy';
+    }
+    if (error.contains('user declined this tool call')) {
+      return 'approval_declined';
+    }
+    if (error.contains('Image path is not permitted')) return 'image_path';
+    if (error.contains('resource_ref') ||
+        error.contains('resource reference') ||
+        error.contains('Lists and byte payloads are not allowed')) {
+      return 'resource_reference';
+    }
+    return 'tool_error';
+  }
+}

--- a/lib/core/services/diagnostic_log_export_service.dart
+++ b/lib/core/services/diagnostic_log_export_service.dart
@@ -11,6 +11,7 @@ import '../agent/private_data_guard.dart';
 import '../constants/app_version.dart';
 import '../utils/app_logger.dart';
 import '../utils/fatal_diagnostics.dart';
+import 'diagnostic_agent_audit.dart';
 import 'file_export_service.dart';
 
 final diagnosticLogExportServiceProvider = Provider<DiagnosticLogExportService>(
@@ -37,6 +38,7 @@ class DiagnosticLogExportService {
   DiagnosticLogExportService({
     Future<List<File>> Function()? loadLogFiles,
     Future<List<File>> Function()? loadCrashFiles,
+    Future<File?> Function()? loadAgentAuditFile,
     Future<void> Function()? flushLogs,
     DiagnosticArchiveExporter? exportArchive,
     DateTime Function()? now,
@@ -47,6 +49,7 @@ class DiagnosticLogExportService {
        assert(maxTotalSourceBytes > 0),
        _loadLogFiles = loadLogFiles ?? AppLogger.getLogFiles,
        _loadCrashFiles = loadCrashFiles ?? _defaultCrashFiles,
+       _loadAgentAuditFile = loadAgentAuditFile ?? _defaultAgentAuditFile,
        _flushLogs = flushLogs ?? AppLogger.flush,
        _exportArchive = exportArchive ?? _defaultExportArchive,
        _now = now ?? DateTime.now,
@@ -61,6 +64,7 @@ class DiagnosticLogExportService {
 
   final Future<List<File>> Function() _loadLogFiles;
   final Future<List<File>> Function() _loadCrashFiles;
+  final Future<File?> Function() _loadAgentAuditFile;
   final Future<void> Function() _flushLogs;
   final DiagnosticArchiveExporter _exportArchive;
   final DateTime Function() _now;
@@ -98,6 +102,11 @@ class DiagnosticLogExportService {
   }) async {
     await _flushLogs();
     final files = await _collectReadableFiles();
+    final auditFile = await _loadAgentAuditFile();
+    final auditPath = auditFile != null && await auditFile.exists()
+        ? auditFile.path
+        : null;
+    if (auditPath != null) files.insert(0, auditFile!);
     if (files.isEmpty) {
       return const DiagnosticLogExportResult(DiagnosticLogExportStatus.noLogs);
     }
@@ -119,6 +128,7 @@ class DiagnosticLogExportService {
               archivePath: archivePath,
               stagingDirectoryPath: stagingDirectory.path,
               sourcePaths: sourcePaths,
+              auditPath: auditPath,
               createdAt: timestamp,
               diagnosticsMetadata: diagnosticsMetadata,
               fileLoggingEnabled: fileLoggingEnabled,
@@ -159,13 +169,14 @@ class DiagnosticLogExportService {
       (left, right) =>
           right.lastModifiedSync().compareTo(left.lastModifiedSync()),
     );
-    return files.take(maxSourceFiles).toList(growable: false);
+    return files.take(maxSourceFiles).toList();
   }
 
   static Future<void> _buildArchive({
     required String archivePath,
     required String stagingDirectoryPath,
     required List<String> sourcePaths,
+    required String? auditPath,
     required DateTime createdAt,
     required String diagnosticsMetadata,
     required bool fileLoggingEnabled,
@@ -209,6 +220,7 @@ class DiagnosticLogExportService {
             maxBytes: archivedBytes,
             snapshotLength: sourceLength,
             wasTruncated: wasTruncated,
+            isAgentAudit: sourcePath == auditPath,
           );
           remainingSourceBytes -= archivedBytes;
           await encoder.addFile(
@@ -263,20 +275,23 @@ class DiagnosticLogExportService {
     required int maxBytes,
     required int snapshotLength,
     required bool wasTruncated,
+    required bool isAgentAudit,
   }) async {
     final sink = target.openWrite(encoding: utf8);
     final startOffset = snapshotLength > maxBytes
         ? snapshotLength - maxBytes
         : 0;
-    var insidePrivateKey = await _privateKeyOpenNearOffset(
-      source,
-      startOffset,
-      snapshotLength,
-    );
+    var insidePrivateKey =
+        !isAgentAudit &&
+        await _privateKeyOpenNearOffset(source, startOffset, snapshotLength);
     var discardFirstPartialLine = await _startsMidLine(source, startOffset);
     try {
       if (wasTruncated) {
-        sink.writeln('[OLDER LOG CONTENT OMITTED]');
+        sink.writeln(
+          isAgentAudit
+              ? jsonEncode({'diagnostic': 'older_audit_content_omitted'})
+              : '[OLDER LOG CONTENT OMITTED]',
+        );
       }
       await for (final line
           in source
@@ -285,6 +300,10 @@ class DiagnosticLogExportService {
               .transform(const LineSplitter())) {
         if (discardFirstPartialLine) {
           discardFirstPartialLine = false;
+          continue;
+        }
+        if (isAgentAudit) {
+          sink.writeln(DiagnosticAgentAudit.sanitizeLine(line));
           continue;
         }
         if (_privateKeyBegin.hasMatch(line)) {
@@ -412,6 +431,11 @@ class DiagnosticLogExportService {
       return rightTime.compareTo(leftTime);
     });
     return files.take(10).toList(growable: false);
+  }
+
+  static Future<File?> _defaultAgentAuditFile() async {
+    final support = await getApplicationSupportDirectory();
+    return File(p.join(support.path, 'agent', 'audit-v1.jsonl'));
   }
 
   static Future<bool> _defaultExportArchive(

--- a/lib/presentation/agent_chat/services/agent_chat_draft_controller.dart
+++ b/lib/presentation/agent_chat/services/agent_chat_draft_controller.dart
@@ -242,7 +242,9 @@ class AgentChatDraftController {
       'references': [
         for (final reference in references)
           {
-            ...AgentChatResourceReferenceCodec.encodeJsonMap(reference),
+            'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(
+              reference,
+            ),
             'available': !unavailable.contains(
               AgentChatResourceReferenceCodec.encodeJson(reference),
             ),
@@ -252,7 +254,10 @@ class AgentChatDraftController {
     return '<agent-resource-references>\n${jsonEncode(payload)}\n'
         '</agent-resource-references>\n'
         'Resolve available references through their owning application '
-        'tools. Do not use references marked unavailable.';
+        'tools. Pass only the selected entry\'s resource_ref object to a '
+        'resource_ref argument (or those objects in resource_refs). Never '
+        'pass this envelope, the references list, or the available flag. '
+        'Do not use references marked unavailable.';
   }
 
   /// 与 read_skill 一致地抹掉正文里的绝对路径；location 保持原样，模型要靠它

--- a/lib/presentation/agent_chat/services/agent_resource_resolver.dart
+++ b/lib/presentation/agent_chat/services/agent_resource_resolver.dart
@@ -60,6 +60,13 @@ class AgentResourceResolver {
     if (value is! Map) {
       throw const FormatException('resource_ref must be an object');
     }
+    if (value.containsKey('references') || value.containsKey('resource_ref')) {
+      throw const FormatException(
+        'resource_ref requires one resource identity. Select the entry\'s '
+        'resource_ref object from agent-resource-references; do not pass '
+        'the attachment envelope or references list.',
+      );
+    }
     return AgentChatResourceReferenceCodec.decodeJsonMap(
       Map<String, dynamic>.from(value),
     );

--- a/lib/presentation/agent_chat/services/generation_tool_definitions.dart
+++ b/lib/presentation/agent_chat/services/generation_tool_definitions.dart
@@ -1,4 +1,5 @@
 import '../../../core/agent/agent_types.dart';
+import '../../../core/agent/resources/agent_chat_resource_reference_codec.dart';
 import '../../../core/constants/api_constants.dart';
 import '../../../core/utils/nai_resolution_adapter.dart';
 import '../../providers/replication_queue_provider.dart';
@@ -55,11 +56,7 @@ class GenerationToolDefinitions {
               'minimum': 1,
               'description': '1-based image index in the latest user message.',
             },
-            'resource_ref': {
-              'type': 'object',
-              'description':
-                  'Exact application image reference supplied by the user or a tool.',
-            },
+            'resource_ref': AgentChatResourceReferenceCodec.jsonSchema,
             'path': {
               'type': 'string',
               'description':

--- a/test/core/services/diagnostic_agent_audit_test.dart
+++ b/test/core/services/diagnostic_agent_audit_test.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nai_launcher/core/services/diagnostic_agent_audit.dart';
+
+void main() {
+  Map<String, dynamic> project(
+    String phase, {
+    String? error,
+    String? summary,
+  }) =>
+      jsonDecode(
+            DiagnosticAgentAudit.sanitizeLine(
+              jsonEncode({
+                'id': 'call-1.$phase',
+                'timestamp': '2026-09-06T13:37:00Z',
+                'result': 'allow',
+                'summary': summary ?? 'interrogate_image generation/read',
+                if (error != null) 'error': error,
+              }),
+            ),
+          )
+          as Map<String, dynamic>;
+
+  test('correlates phases while retaining only controlled metadata', () {
+    final decision = project('decision');
+    final result = project('result', summary: 'interrogate_image completed');
+    expect(decision['toolCallIdHash'], result['toolCallIdHash']);
+    expect(decision['phase'], 'decision');
+    expect(result['phase'], 'result');
+    expect(decision['summary'], 'interrogate_image generation/read');
+    expect(
+      project('result', summary: 'private conversation')['summary'],
+      '[REDACTED AUDIT SUMMARY]',
+    );
+  });
+
+  test(
+    'separates policy, approval, path and resource errors without raw text',
+    () {
+      for (final entry in {
+        'This tool is blocked by its permission domain policy.':
+            'permission_policy',
+        'The user declined this tool call.': 'approval_declined',
+        'Image path is not permitted.': 'image_path',
+        r'Lists and byte payloads are not allowed at $.references':
+            'resource_reference',
+        'private model response with Bearer secret': 'tool_error',
+      }.entries) {
+        final result = project('result', error: entry.key);
+        expect(result['errorCategory'], entry.value);
+        expect(result.containsKey('error'), isFalse);
+      }
+    },
+  );
+}

--- a/test/core/services/diagnostic_log_export_service_test.dart
+++ b/test/core/services/diagnostic_log_export_service_test.dart
@@ -104,6 +104,71 @@ void main() {
     expect(metadata['logs'], ['app.log']);
   });
 
+  test(
+    'exports only projected audit events from the support directory',
+    () async {
+      final agentDirectory = await Directory(
+        p.join(tempDirectory.path, 'agent'),
+      ).create();
+      final audit = File(p.join(agentDirectory.path, 'audit-v1.jsonl'));
+      await audit.writeAsString(
+        '${jsonEncode({
+          'id': 'call.secret-user-text.result',
+          'timestamp': '2026-09-06T13:37:00Z',
+          'result': 'allow',
+          'summary': 'interrogate_image completed',
+          'error': r'Lists and byte payloads are not allowed at $.references '
+              'Bearer secret-token C:/Users/private/image.png private chat text',
+          'messages': ['private chat text'],
+          'image': 'private image bytes',
+        })}\n{"partial":"secret-token',
+      );
+      await File(
+        p.join(agentDirectory.path, 'session.jsonl'),
+      ).writeAsString('private chat text');
+      late Uint8List bytes;
+      final service = DiagnosticLogExportService(
+        loadLogFiles: () async => [],
+        loadCrashFiles: () async => [],
+        flushLogs: () async {},
+        diagnosticsMetadata: () => 'test',
+        exportArchive: (path, _, _) async {
+          bytes = await File(path).readAsBytes();
+          return true;
+        },
+      );
+      expect(
+        (await service.export(dialogTitle: 'Export')).status,
+        DiagnosticLogExportStatus.exported,
+      );
+      final archive = ZipDecoder().decodeBytes(bytes);
+      expect(
+        archive.files.map((file) => file.name),
+        unorderedEquals(['logs/audit-v1.jsonl', 'diagnostics.json']),
+      );
+      final text = utf8.decode(
+        archive.findFile('logs/audit-v1.jsonl')!.content as List<int>,
+      );
+      final records = const LineSplitter()
+          .convert(text)
+          .map(jsonDecode)
+          .toList();
+      expect(records.first['summary'], 'interrogate_image completed');
+      expect(records.first['result'], 'allow');
+      expect(records.first['errorCategory'], 'resource_reference');
+      expect(records.last['diagnostic'], 'invalid_or_incomplete_audit_record');
+      for (final secret in [
+        'secret-user-text',
+        'secret-token',
+        'private',
+        'messages',
+      ]) {
+        expect(text, isNot(contains(secret)));
+      }
+      expect(await audit.readAsString(), contains('secret-token'));
+    },
+  );
+
   test('bounds exported bytes and keeps the newest tail of each log', () async {
     final newer = File(p.join(tempDirectory.path, 'app_newer.log'));
     final older = File(p.join(tempDirectory.path, 'app_older.log'));
@@ -308,4 +373,7 @@ class _TestPathProviderPlatform extends PathProviderPlatform {
 
   @override
   Future<String?> getTemporaryPath() async => temporaryPath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => temporaryPath;
 }

--- a/test/presentation/agent_chat/services/agent_tool_permission_controller_test.dart
+++ b/test/presentation/agent_chat/services/agent_tool_permission_controller_test.dart
@@ -9,6 +9,59 @@ import 'package:nai_launcher/presentation/agent_chat/services/agent_tool_permiss
 import 'package:nai_launcher/presentation/agent_chat/services/agent_tool_registry_builder.dart';
 
 void main() {
+  test(
+    'ask mode permits read-only image interrogation without approval',
+    () async {
+      final descriptor = describeAgentToolPermission('interrogate_image');
+      final audit = MemoryAgentAuditSink();
+      final controller = AgentToolPermissionController(
+        auditSink: audit,
+        estimateAnlas: (_, _) async => throw StateError('Read does not bill'),
+        onApprovalChanged: (_) =>
+            fail('Read should not request write approval'),
+        isMounted: () => true,
+      );
+      addTearDown(controller.dispose);
+      controller.configure(
+        AgentToolRegistry(
+          tools: const [],
+          catalog: AgentToolPermissionCatalog(
+            toolNames: ['interrogate_image'],
+            descriptors: [descriptor],
+          ),
+          policy: agentPermissionPolicy(safeMode: false, fullAccess: false),
+        ),
+      );
+      const call = ToolCallContent(
+        id: 'read',
+        name: 'interrogate_image',
+        arguments: {
+          'resource_ref': {'resourceId': 'library-image'},
+        },
+      );
+      final assistant = AssistantMessage(
+        content: [call],
+        stopReason: StopReason.toolUse,
+      );
+      expect(
+        await controller.beforeToolCall(
+          BeforeToolCallContext(
+            assistantMessage: assistant,
+            toolCall: call,
+            args: call.arguments,
+            context: AgentContext(
+              systemPrompt: '',
+              messages: [assistant],
+              tools: const [],
+            ),
+          ),
+          null,
+        ),
+        isNull,
+      );
+      expect(controller.takeDecision('read'), AgentPermissionDecision.allow);
+    },
+  );
   group('AgentToolPermissionController billing decisions', () {
     test(
       'full access automatically allows an exact zero-cost submit',

--- a/test/presentation/agent_chat/services/generation_interrogation_service_test.dart
+++ b/test/presentation/agent_chat/services/generation_interrogation_service_test.dart
@@ -9,10 +9,16 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nai_launcher/core/agent/agent_types.dart';
 import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference.dart';
 import 'package:nai_launcher/core/agent/resources/agent_chat_resource_reference_codec.dart';
+import 'package:nai_launcher/core/agent/resources/agent_chat_resource_draft_store.dart';
+import 'package:nai_launcher/core/agent/validate_tool_arguments.dart';
 import 'package:nai_launcher/core/storage/local_storage_service.dart';
 import 'package:nai_launcher/core/storage/secure_storage_service.dart';
 import 'package:nai_launcher/data/models/agent/agent_settings.dart';
+import 'package:nai_launcher/data/models/precise_ref/precise_ref_library_entry.dart';
+import 'package:nai_launcher/data/services/precise_ref_library_storage_service.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/agent_resource_resolver.dart';
+import 'package:nai_launcher/presentation/agent_chat/services/agent_chat_draft_controller.dart';
+import 'package:nai_launcher/presentation/agent_chat/providers/agent_chat_state.dart';
 import 'package:nai_launcher/presentation/agent_chat/services/generation_toolbox.dart';
 import 'package:nai_launcher/presentation/agent_settings/providers/agent_settings_provider.dart';
 import 'package:nai_launcher/presentation/prompt_assistant/models/prompt_assistant_models.dart';
@@ -21,6 +27,9 @@ import 'package:nai_launcher/presentation/prompt_assistant/services/prompt_assis
 import 'package:nai_launcher/presentation/prompt_assistant/services/prompt_assistant_service.dart';
 
 class _Dio extends Mock implements Dio {}
+
+class _ReferenceStorage extends Mock
+    implements PreciseRefLibraryStorageService {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -44,6 +53,20 @@ void main() {
   setUp(() async {
     final temporaryRoot = await Directory('tool/.tmp').create(recursive: true);
     root = await temporaryRoot.createTemp('agent-interrogation-test-');
+    final libraryFile = await File(
+      '${root.path}/library.png',
+    ).writeAsBytes(png);
+    final library = _ReferenceStorage();
+    when(() => library.getAllEntries()).thenAnswer(
+      (_) async => [
+        PreciseRefLibraryEntry(
+          id: 'library-image',
+          name: 'Reference image',
+          imagePath: libraryFile.path,
+          createdAt: DateTime(2026),
+        ),
+      ],
+    );
     requests = [];
     final dio = _Dio();
     when(
@@ -71,6 +94,7 @@ void main() {
     });
     container = ProviderContainer(
       overrides: [
+        preciseRefLibraryStorageServiceProvider.overrideWithValue(library),
         localStorageServiceProvider.overrideWithValue(_MemoryStorage()),
         secureStorageServiceProvider.overrideWithValue(_SecureStorage()),
         promptAssistantDioProvider.overrideWithValue(dio),
@@ -135,6 +159,56 @@ void main() {
     await root.delete(recursive: true);
   });
 
+  test('composer resource_ref reaches interrogation unchanged', () async {
+    final draft = AgentChatDraftController(
+      resourceStore: AgentChatResourceDraftStore(
+        File('${root.path}/draft.json'),
+      ),
+      localStorage: _MemoryStorage(),
+      readState: () => const AgentChatState(),
+      writeState: (_) {},
+      createResourceResolver: () => throw StateError('No preview needed'),
+      isMounted: () => true,
+    );
+    final envelope = draft.promptEnvelope(
+      UserMessage(
+        content: [const UserTextContent('Describe this image')],
+        timestamp: 1,
+      ),
+      references: [
+        AgentChatResourceReference(
+          kind: AgentChatResourceKind.preciseRefLibraryEntry,
+          source: 'precise_ref_library',
+          resourceId: 'library-image',
+        ),
+      ],
+    );
+    final prefix = (envelope.blockContent!.first as UserTextContent).text;
+    final payload = jsonDecode(prefix.split('\n')[1]) as Map;
+    final entry = (payload['references'] as List).single as Map;
+    expect(entry['available'], isTrue);
+    final args = <String, dynamic>{'resource_ref': entry['resource_ref']};
+    validateToolArguments(
+      tool,
+      ToolCallContent(id: 'selected', name: tool.name, arguments: args),
+    );
+    expect((await tool.execute('selected', args)).isError, isFalse);
+    expect(requests, hasLength(1));
+    for (final invalid in [payload, entry]) {
+      expect(
+        () => validateToolArguments(
+          tool,
+          ToolCallContent(
+            id: 'invalid',
+            name: tool.name,
+            arguments: {'resource_ref': invalid},
+          ),
+        ),
+        throwsFormatException,
+      );
+    }
+  });
+
   for (final source in ['attachment', 'resource', 'path']) {
     test(
       '$source reaches the vision adapter with the selected image bytes',
@@ -177,6 +251,14 @@ void main() {
     {'attachment_index': 1, 'path': 'test.png'},
     {
       'resource_ref': {'kind': 'invalid'},
+    },
+    {
+      'resource_ref': {
+        'schemaVersion': 1,
+        'references': [
+          AgentChatResourceReferenceCodec.encodeJsonMap(reference),
+        ],
+      },
     },
     {
       'resource_ref': AgentChatResourceReferenceCodec.encodeJsonMap(


### PR DESCRIPTION
## 改动内容

修复 #299 中参考库图片反推工具出现 `Lists and byte payloads are not allowed at $.references` 的资源契约问题。

- 聊天附件清单把可用状态与可直接传入工具的 `resource_ref` 分开，并明确禁止传入整个清单。
- 为 `interrogate_image.resource_ref` 提供具体字段 schema；误传清单时返回如何选择单张引用的错误说明。原有资源 ID、路径及二进制校验保持严格。
- 诊断 ZIP 纳入应用支持目录的 Agent 审计文件。只导出时间、哈希调用关联、阶段、权限结果、受控摘要和错误类别；不复制任意错误正文、聊天字段、凭据、路径或图片。损坏/未写完的行显式标记，仍遵循现有诊断体积限制。

## 验证结果

- 已查看 issue 正文两张截图、全部评论和所附 ZIP。截图报错可定位到资源 JSON 校验；旧 ZIP 没有 Agent 审计事件，不能据此声称模型或权限策略拒绝。
- 同步 main 的 #302 后，`scripts/test_affected.ps1 -NoTestAssets` 执行 6 个测试文件，45 项全部通过（约 8 秒）：诊断导出、审计投影、图片反推、权限控制、资源 codec 与 validator。
- 回归覆盖聊天清单 → 精准参考库真实文件读取 → 视觉适配器收到图片字节；询问模式只读调用无需确认；非法清单/路径被拒绝；审计隐私字段与损坏记录处理。
- 变更文件 `dart analyze` 无问题；`git diff --check`、`scripts/verify_flutter_sources.ps1` 通过。
- 新工作树最初缺少生成代码，完成一次 `build_runner` 环境准备后验证；没有提交生成文件、assets 或 LFS 变化。

## 注意事项

询问模式按现有策略允许只读工具直接执行，本次不新增无必要的确认弹窗，也不放宽权限。未调用真实云端模型，未进行 Windows/Android GUI 验收或完整应用构建；本工作树没有已运行开发会话。按授权不等待 CI，遵守分支保护。

Closes #299
